### PR TITLE
Bug fixes to SlipWall and NoSlipWall functions

### DIFF
--- a/Source/BC/BCBase.H
+++ b/Source/BC/BCBase.H
@@ -16,7 +16,6 @@ namespace math_bcs {
 
     static inline void apply_cell_based(const amrex::Geometry& geom, const Box& b, Array4<Real> data, int ncomp=1) {
       int lo = geom.Domain().smallEnd(IDIR);
- 
       if(b.smallEnd(IDIR) < lo) {
         if (IDIR == 0) {
 
@@ -49,7 +48,6 @@ namespace math_bcs {
     std::enable_if_t<val>
     apply_face_based(const amrex::Geometry& geom, const Box& b, Array4<Real> data, int ncomp=1) {
       int lo = geom.Domain().smallEnd(IDIR);
- 
       if(b.smallEnd(IDIR) < lo) {
         if (IDIR == 0) {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -389,7 +387,7 @@ namespace math_bcs {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {
             if (j < lo) {
-              data(i,j,k,n) = data(i,2*lo-j,k,n);
+              data(i,j,k,n) = -data(i,2*lo-j,k,n);
             } else if (j == lo) {
               data(i,j,k,n) = 0.;
             }
@@ -398,7 +396,7 @@ namespace math_bcs {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {
             if (k < lo) {
-              data(i,j,k,n) = data(i,j,2*lo-k,n);
+              data(i,j,k,n) = -data(i,j,2*lo-k,n);
             } else if (k == lo) {
               data(i,j,k,n) = 0.;
             }
@@ -422,7 +420,6 @@ namespace math_bcs {
 
     static inline void apply_cell_based(const amrex::Geometry& geom, const Box& b, Array4<Real> data, int ncomp=1) {
       int hi = geom.Domain().bigEnd(IDIR);
- 
       if(b.bigEnd(IDIR) > hi) {
         if (IDIR == 0) {
           amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -454,32 +451,32 @@ namespace math_bcs {
     std::enable_if_t<val>
     apply_face_based(const amrex::Geometry& geom, const Box& b, Array4<Real> data, int ncomp=1) {
       int hi = geom.Domain().bigEnd(IDIR);
- 
+
       if(b.bigEnd(IDIR) > hi) {
         if (IDIR == 0) {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {
-             if (i > hi) {
-               data(i,j,k,n) = data(2*hi-i,j,k,n);
-             } else if (i == hi) {
+             if (i > (hi+1)) {
+               data(i,j,k,n) = -data(2*(hi+1)-i,j,k,n);
+             } else if (i == (hi+1)) {
                data(i,j,k,n) = 0.;
              }
            });
         } else if (IDIR == 1) {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {
-             if (j > hi) {
-               data(i,j,k,n) = data(i,2*hi-j,k,n);
-             } else if (j == hi) {
+             if (j > (hi+1)) {
+               data(i,j,k,n) = -data(i,2*(hi+1)-j,k,n);
+             } else if (j == (hi+1)) {
                data(i,j,k,n) = 0.;
              }
            });
         } else if (IDIR == 2) {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {
-             if (k > hi) {
-               data(i,j,k,n) = data(i,j,2*hi-k,n);
-             } else if (k == hi) {
+             if (k > (hi+1)) {
+               data(i,j,k,n) = -data(i,j,2*(hi+1)-k,n);
+             } else if (k == (hi+1)) {
                data(i,j,k,n) = 0.;
              }
            });
@@ -780,11 +777,12 @@ namespace math_bcs {
 
         const auto dxarray = geom.CellSizeArray();
 
+
         if(b.bigEnd(IDIR) > hi) {
           if (IDIR == 0) {
-            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept 
             {
-              if (i > hi) {
+              if (i > hi) {  
                 if (n == Rho_comp) {
                     //  Assume Neumann-type BCs for density (zero gradient, and extrapolation of value beyond first ghost point //
                     data(i,j,k,n) = data(hi,j,k,n);

--- a/Source/BC/BCNoSlipWall.H
+++ b/Source/BC/BCNoSlipWall.H
@@ -19,6 +19,7 @@ class BCNoSlipWall : public BCBase {
     // setup boundary conditions
     for( auto i = 0; i < vars.size(); ++i) {
       int nghost = vars[i]->nGrow();
+      std::cout << "i,nghost:  " << i << " " << nghost << std::endl;
       if(nghost > 0) { 
          for (amrex::MFIter mfi(*vars[i], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             // get the index box
@@ -32,11 +33,11 @@ class BCNoSlipWall : public BCBase {
             if (type == amrex::IntVect::Zero) {  // for state type variable
                math_bcs::wall_scalars<IDIR, Bound>::apply(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(1, 0, 0))) { // for X_VEL 
-               math_bcs::reflect_odd<0, Bound>::template apply_face_based<(IDIR==0)>(geom, b, data, ncomp);
+               math_bcs::reflect_odd<IDIR, Bound>::template apply_face_based<(IDIR==0)>(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(0, 1, 0))) { // for Y_VEL
-               math_bcs::reflect_odd<1, Bound>::template apply_face_based<(IDIR==1)>(geom, b, data, ncomp);
+               math_bcs::reflect_odd<IDIR, Bound>::template apply_face_based<(IDIR==1)>(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(0, 0, 1))) { // for Z_VEL
-               math_bcs::reflect_odd<2, Bound>::template apply_face_based<(IDIR==2)>(geom, b, data, ncomp);
+               math_bcs::reflect_odd<IDIR, Bound>::template apply_face_based<(IDIR==2)>(geom, b, data, ncomp);
             }
          }
       }

--- a/Source/BC/BCSlipWall.H
+++ b/Source/BC/BCSlipWall.H
@@ -32,11 +32,11 @@ class BCSlipWall : public BCBase {
             if (type == amrex::IntVect::Zero) {  // for state type variable
                math_bcs::foextrap<IDIR, Bound>::apply_cell_based(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(1, 0, 0))) { // for X_VEL 
-               math_bcs::foextrap<0, Bound>::template apply_face_based<(IDIR==0)>(geom, b, data, ncomp);
+               math_bcs::foextrap<IDIR, Bound>::template apply_face_based<(IDIR==0)>(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(0, 1, 0))) { // for Y_VEL
-               math_bcs::foextrap<1, Bound>::template apply_face_based<(IDIR==1)>(geom, b, data, ncomp);
+               math_bcs::foextrap<IDIR, Bound>::template apply_face_based<(IDIR==1)>(geom, b, data, ncomp);
             } else if (type == amrex::IntVect(AMREX_D_DECL(0, 0, 1))) { // for Z_VEL
-               math_bcs::foextrap<2, Bound>::template apply_face_based<(IDIR==2)>(geom, b, data, ncomp);
+               math_bcs::foextrap<IDIR, Bound>::template apply_face_based<(IDIR==2)>(geom, b, data, ncomp);
             }
          }
      }


### PR DESCRIPTION
Bug fixes:  1)  Pass "IDIM" as the first argument to the math_bcs functions within BCSlipWall.H and BCNoSlipWall.H; 2) Correct some entries in reflect_odd function implementations that did not reverse the sign of data across the boundary; 3)  For face_centered applications, the high-end valid point is hi+1 instead of hi, and the first ghost point is hi+2, so modify BC application points accordingly.