### PR TITLE
Cleanup NoSlipWall, SlipWall, and insert IDIR argument.

### DIFF
--- a/Source/BC/BCNoSlipWall.H
+++ b/Source/BC/BCNoSlipWall.H
@@ -14,12 +14,11 @@ class BCNoSlipWall : public BCBase {
   BCNoSlipWall() = default;
 
   void applyBC (const amrex::Geometry geom, amrex::Vector<MultiFab*>& vars) override {
-    if ((geom.isAllPeriodic()) || (vars.size() == 0)) return;
+    if ((geom.isAllPeriodic(IDIR)) || (vars.size() == 0)) return;
 
     // setup boundary conditions
     for( auto i = 0; i < vars.size(); ++i) {
       int nghost = vars[i]->nGrow();
-      std::cout << "i,nghost:  " << i << " " << nghost << std::endl;
       if(nghost > 0) { 
          for (amrex::MFIter mfi(*vars[i], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             // get the index box

--- a/Source/BC/BCSlipWall.H
+++ b/Source/BC/BCSlipWall.H
@@ -14,7 +14,7 @@ class BCSlipWall : public BCBase {
   BCSlipWall() = default;
 
   void applyBC (const amrex::Geometry geom, amrex::Vector<MultiFab*>& vars) override {
-    if ((geom.isAllPeriodic()) || (vars.size() == 0)) return;
+    if ((geom.isAllPeriodic(IDIR)) || (vars.size() == 0)) return;
 
     // setup boundary conditions
     for( auto i = 0; i < vars.size(); ++i) {


### PR DESCRIPTION
…Insert 'IDIR' within geom.isAllPeriodic() calls for BCNoSlipWall.H and BCSlipWall.H, and remove diagnostic print statement.