### PR TITLE
using isPeriodic(IDIR) in slip and noslip wall boundary condition

### DIFF
--- a/Source/BC/BCNoSlipWall.H
+++ b/Source/BC/BCNoSlipWall.H
@@ -14,7 +14,7 @@ class BCNoSlipWall : public BCBase {
   BCNoSlipWall() = default;
 
   void applyBC (const amrex::Geometry geom, amrex::Vector<MultiFab*>& vars) override {
-    if ((geom.isAllPeriodic(IDIR)) || (vars.size() == 0)) return;
+    if ((geom.isPeriodic(IDIR)) || (vars.size() == 0)) return;
 
     // setup boundary conditions
     for( auto i = 0; i < vars.size(); ++i) {

--- a/Source/BC/BCSlipWall.H
+++ b/Source/BC/BCSlipWall.H
@@ -14,7 +14,7 @@ class BCSlipWall : public BCBase {
   BCSlipWall() = default;
 
   void applyBC (const amrex::Geometry geom, amrex::Vector<MultiFab*>& vars) override {
-    if ((geom.isAllPeriodic(IDIR)) || (vars.size() == 0)) return;
+    if ((geom.isPeriodic(IDIR)) || (vars.size() == 0)) return;
 
     // setup boundary conditions
     for( auto i = 0; i < vars.size(); ++i) {


### PR DESCRIPTION
fix the isperiodic build failure