### PR TITLE
Two apparent bug fixes

### DIFF
--- a/Source/BC/BCBase.H
+++ b/Source/BC/BCBase.H
@@ -576,7 +576,7 @@ namespace math_bcs {
             //    |_______|_______|________|________|________|
             //   lo-2    lo-1    lo       lo+1     lo+2    lo+3
             //
-      if(b.smallEnd(IDIR) < lo) {
+      if(b.smallEnd(IDIR) <= lo) {
         if (IDIR == 0) {
            amrex::ParallelFor(b, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
            {

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -154,7 +154,7 @@ ERF::variableSetUp()
   bool state_data_extrap = false;
   bool store_in_checkpoint;
 
-  int ngrow_state = 2;
+  int ngrow_state = 1;
 
   // NVAR is currently set to 2 in IndexDefines.H
   store_in_checkpoint = true;


### PR DESCRIPTION
1)  Apply last indexing fix from NoSlipWall to SimSlipWall;  2)  Change ngrow_state in Setup.cpp to keep number of ghost points = 1 for all instances of conserved scalars.