### PR TITLE
Enable all regression tests in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,6 @@ jobs:
 
     - name: Regression Tests
       run: |
-        ctest -R IsentropicVortex -VV
+        ctest -L regression -VV
       working-directory:
         ${{runner.workspace}}/build-${{matrix.os}}


### PR DESCRIPTION
Currently, the command to run the regression tests only runs the isentropic vortex cases. This change runs all tests with the label "regression".