### PR TITLE
Add code coverage and reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: ERF CI
 on:
   push:
     # branches: [development]
+    paths-ignore:
+      - Docs
+      - README.rst
+      - license.txt
 
   pull_request:
     branches: [development]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Generate coverage report
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
       run: |
-        find . -type f -name '*.gcno' -not -path "**Tests**" -exec gcov -pb {} +
+        find . -type f -name '*.gcno' -not -ipath "**Tests**" -not -ipath "**build**" -exec gcov -pb {} +
         cd ..
         gcovr -g -k -r . --xml regressioncov.xml  # --html --html-details -o regressioncov.html # -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,11 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build ${{runner.workspace}}/build-${{matrix.os}} --parallel ${{env.NPROCS}};
+        cmake --build ${{runner.workspace}}/build-${{matrix.os}} --target erf_isentropic_vortex --parallel ${{env.NPROCS}};
 
     - name: Regression Tests
       run: |
-        ctest -L regression -VV
+        ctest -R IsentropicVortexStationary -VV
       working-directory:
         ${{runner.workspace}}/build-${{matrix.os}}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,11 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build ${{runner.workspace}}/ERF/build-${{matrix.os}} --target erf_isentropic_vortex --parallel ${{env.NPROCS}};
-        cmake --build ${{runner.workspace}}/ERF/build-${{matrix.os}} --target fcompare --parallel ${{env.NPROCS}};
+        cmake --build ${{runner.workspace}}/ERF/build-${{matrix.os}} --parallel ${{env.NPROCS}};
 
     - name: Regression Tests
       run: |
-        ctest -R IsentropicVortexStationary -VV
+        ctest -L regression -VV
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
 
     - name: Generate coverage report
@@ -108,26 +107,13 @@ jobs:
       uses: actions/upload-artifact@v2
       if: success()
       with:
-        name: regression-tests-debug
+        name: build-and-test
         path: |
           ${{runner.workspace}}/ERF/regressioncov.xml
-    - name: Debug Fail
-      if: failure()
-      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
-      run: |
-        echo "** pwd **"
-        pwd
-        echo "** ls cwd **"
-        ls
-        echo "** echo ${{runner.workspace}} **"
-        echo ${{runner.workspace}}
-        echo "** ls ${{runner.workspace}} **"
-        ls ${{runner.workspace}}
-
     - name: Failing test artifacts
       uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: regression-tests-debug
+        name: build-and-test
         path: |
           ${{runner.workspace}}/ERF/regressioncov.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os: [ubuntu-latest]
         include:
         - os: ubuntu-latest
-          install_deps: sudo apt-get install mpich libmpich-dev
+          install_deps: sudo apt-get install mpich libmpich-dev gcovr
           comp: gnu
           procs: $(nproc)
 
@@ -63,7 +63,7 @@ jobs:
         cmake \
           -B${{runner.workspace}}/build-${{matrix.os}} \
           -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
-          -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+          -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_TESTS:BOOL=ON \
@@ -71,6 +71,7 @@ jobs:
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
           -DERF_ENABLE_AMREX_EB:BOOL=ON \
           -DERF_ENABLE_FCOMPARE:BOOL=ON \
+          -DCODECOV:BOOL=ON \
           ${{github.workspace}};
         # ${{matrix.mpipreflags}} \
 
@@ -83,3 +84,50 @@ jobs:
         ctest -L regression -VV
       working-directory:
         ${{runner.workspace}}/build-${{matrix.os}}
+
+    - name: Generate coverage report
+      working-directory: ${{runner.workspace}}/build-${{matrix.os}}
+      run: |
+        find . -type f -name '*.gcno' -not -path "**Tests**" -exec gcov -pb {} +
+        cd ..
+        gcovr -g -k -r . --xml regressioncov.xml  # --html --html-details -o regressioncov.html # -v
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        dry_run: true
+        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+        files: ./regressioncov.xml # optional
+        flags: regtests # optional
+        # name: codecov-umbrella # optional
+        fail_ci_if_error: true # optional (default = false)
+        verbose: true # optional (default = false)
+        directory: ${{runner.workspace}}
+
+    - name: Success artifacts
+      uses: actions/upload-artifact@v2
+      if: success()
+      with:
+        name: regression-tests-debug
+        path: |
+          ${{runner.workspace}}/regressioncov.xml
+    - name: Debug Fail
+      if: failure()
+      working-directory: ${{runner.workspace}}/build-${{matrix.os}}
+      run: |
+        echo "** pwd **"
+        pwd
+        echo "** ls cwd **"
+        ls
+        echo "** echo ${{runner.workspace}} **"
+        echo ${{runner.workspace}}
+        echo "** ls ${{runner.workspace}} **"
+        ls ${{runner.workspace}}
+
+    - name: Failing test artifacts
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: regression-tests-debug
+        path: |
+          ${{runner.workspace}}/regressioncov.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         cmake \
           -B${{runner.workspace}}/build-${{matrix.os}} \
           -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
-          -DCMAKE_BUILD_TYPE:STRING=Debug \
+          -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_TESTS:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
     - name: Configure CMake
       run: |
         cmake \
-          -B${{runner.workspace}}/build-${{matrix.os}} \
-          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
+          -B${{runner.workspace}}/ERF/build-${{matrix.os}} \
+          -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ERF/install \
           -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
@@ -77,16 +77,16 @@ jobs:
 
     - name: Build
       run: |
-        cmake --build ${{runner.workspace}}/build-${{matrix.os}} --target erf_isentropic_vortex --parallel ${{env.NPROCS}};
+        cmake --build ${{runner.workspace}}/ERF/build-${{matrix.os}} --target erf_isentropic_vortex --parallel ${{env.NPROCS}};
+        cmake --build ${{runner.workspace}}/ERF/build-${{matrix.os}} --target fcompare --parallel ${{env.NPROCS}};
 
     - name: Regression Tests
       run: |
         ctest -R IsentropicVortexStationary -VV
-      working-directory:
-        ${{runner.workspace}}/build-${{matrix.os}}
+      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
 
     - name: Generate coverage report
-      working-directory: ${{runner.workspace}}/build-${{matrix.os}}
+      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
       run: |
         find . -type f -name '*.gcno' -not -path "**Tests**" -exec gcov -pb {} +
         cd ..
@@ -102,7 +102,7 @@ jobs:
         # name: codecov-umbrella # optional
         fail_ci_if_error: true # optional (default = false)
         verbose: true # optional (default = false)
-        directory: ${{runner.workspace}}
+        directory: ${{runner.workspace}}/ERF
 
     - name: Success artifacts
       uses: actions/upload-artifact@v2
@@ -110,10 +110,10 @@ jobs:
       with:
         name: regression-tests-debug
         path: |
-          ${{runner.workspace}}/regressioncov.xml
+          ${{runner.workspace}}/ERF/regressioncov.xml
     - name: Debug Fail
       if: failure()
-      working-directory: ${{runner.workspace}}/build-${{matrix.os}}
+      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
       run: |
         echo "** pwd **"
         pwd
@@ -130,4 +130,4 @@ jobs:
       with:
         name: regression-tests-debug
         path: |
-          ${{runner.workspace}}/regressioncov.xml
+          ${{runner.workspace}}/ERF/regressioncov.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
-        dry_run: true
+        dry_run: false
         # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
         files: ./regressioncov.xml # optional
         flags: regtests # optional

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,20 @@ if(ERF_ENABLE_TESTS)
   add_subdirectory(Tests)
 endif()
 
+# Configure measuring code coverage in tests
+if(CODECOV)
+  # Only supports GNU
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    message(WARNING "CODECOV is only support with GNU Compilers. The current C++ compiler is ${CMAKE_CXX_COMPILER_ID}")
+  endif()
+  if(NOT CMAKE_C_COMPILER_ID MATCHES GNU)
+    message(WARNING "CODECOV is only support with GNU Compilers. The current C compiler is ${CMAKE_C_COMPILER_ID}")
+  endif()
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+endif()
+
 if(ERF_ENABLE_DOCUMENTATION)
    add_subdirectory(Docs)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,20 @@ if(NOT ERF_DIM EQUAL 3)
   message(FATAL_ERROR "ERF is only supported in 3D.")
 endif()
 
+# Configure measuring code coverage in tests
+if(CODECOV)
+  # Only supports GNU
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES GNU)
+    message(WARNING "CODECOV is only support with GNU Compilers. The current C++ compiler is ${CMAKE_CXX_COMPILER_ID}")
+  endif()
+  if(NOT CMAKE_C_COMPILER_ID MATCHES GNU)
+    message(WARNING "CODECOV is only support with GNU Compilers. The current C compiler is ${CMAKE_C_COMPILER_ID}")
+  endif()
+
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+endif()
+
 ########################### AMReX #####################################
 
 set(AMREX_SUBMOD_LOCATION "${CMAKE_SOURCE_DIR}/Submodules/AMReX")
@@ -92,20 +106,6 @@ if(ERF_ENABLE_TESTS)
   include(CTest)
   add_subdirectory("Submodules/GoogleTest")
   add_subdirectory(Tests)
-endif()
-
-# Configure measuring code coverage in tests
-if(CODECOV)
-  # Only supports GNU
-  if(NOT CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    message(WARNING "CODECOV is only support with GNU Compilers. The current C++ compiler is ${CMAKE_CXX_COMPILER_ID}")
-  endif()
-  if(NOT CMAKE_C_COMPILER_ID MATCHES GNU)
-    message(WARNING "CODECOV is only support with GNU Compilers. The current C compiler is ${CMAKE_C_COMPILER_ID}")
-  endif()
-
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
 endif()
 
 if(ERF_ENABLE_DOCUMENTATION)

--- a/README.rst
+++ b/README.rst
@@ -7,11 +7,13 @@ for massively parallel block-structured applications.
 Test Status
 ~~~~~~~~~~~
 
-=================  =============
-Regression Tests    |regtests|
-=================  =============
+=================  =============  ====================
+Regression Tests    |regtests|     |regtest-coverage|
+=================  =============  ====================
 
 .. |regtests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
+.. |regtest-coverage| image:: https://codecov.io/gh/rafmudaf/ERF/branch/codecov/graph/badge.svg?token=JLTrZVMPto
+    :target: https://codecov.io/gh/rafmudaf/ERF
 .. |unittests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
 
 


### PR DESCRIPTION
This pull request adds code coverage measurement for the regression tests. It also submits the coverage reports to codecov.io.

Note: the badge on the README currently links to my account on codecov.io but when a new one is created for the `erf-model/ERF` repo I'll update that link.