### PR TITLE
Test setup improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         cmake \
           -B${{runner.workspace}}/ERF/build-${{matrix.os}} \
           -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/ERF/install \
-          -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+          -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_TESTS:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,9 +91,9 @@ jobs:
     - name: Generate coverage report
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
       run: |
-        find . -type f -name '*.gcno' -not -ipath "**Tests**" -not -ipath "**build**" -exec gcov -pb {} +
+        find . -type f -name '*.gcno' -path "**Source**" -exec gcov -pb {} +
         cd ..
-        gcovr -g -k -r . --xml regressioncov.xml  # --html --html-details -o regressioncov.html # -v
+        gcovr -g -k -r . --xml regressioncov.xml  # -v
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,7 @@ if(NOT ERF_DIM EQUAL 3)
 endif()
 
 # Configure measuring code coverage in tests
+option(CODECOV "Enable code coverage profiling" OFF)
 if(CODECOV)
   # Only supports GNU
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES GNU)

--- a/README.rst
+++ b/README.rst
@@ -12,8 +12,8 @@ Regression Tests    |regtests|     |regtest-coverage|
 =================  =============  ====================
 
 .. |regtests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
-.. |regtest-coverage| image:: https://codecov.io/gh/rafmudaf/ERF/branch/codecov/graph/badge.svg?token=JLTrZVMPto
-    :target: https://codecov.io/gh/rafmudaf/ERF
+.. |regtest-coverage| image:: https://codecov.io/gh/erf-model/ERF/branch/development/graph/badge.svg?token=74S5Q66M1M
+    :target: https://codecov.io/gh/erf-model/ERF
 .. |unittests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
 
 

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -38,8 +38,7 @@ function(add_test_r TEST_NAME TEST_EXE PLTFILE)
     set(TEST_EXE ${CMAKE_BINARY_DIR}/Exec/${TEST_EXE})
     set(FCOMPARE_TOLERANCE "-r 1e-10 --abs_tol 1.0e-12")
     set(FCOMPARE_FLAGS "-a ${FCOMPARE_TOLERANCE}")
-    # TODO: Check if we need MPI_COMMANDS for running FCOMPARE_EXE
-    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${MPI_COMMANDS} ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${PLOT_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
+    set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i ${RUNTIME_OPTIONS} > ${TEST_NAME}.log && ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${PLOT_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
 
     add_test(${TEST_NAME} ${test_command})
     set_tests_properties(${TEST_NAME}


### PR DESCRIPTION
See the commits, but generally
- Remove code coverage from Exec and Submodules
- Update Codecov badge on readme
- Add Codecov CMake flag as an option (for use with ccmake)
- Simplify regression test command