### PR TITLE
Fix problem with eddy viscosity

### DIFF
--- a/Source/Derive.cpp
+++ b/Source/Derive.cpp
@@ -1,5 +1,5 @@
-#include "EOS.H"
 #include "Derive.H"
+#include "EOS.H"
 #include "IndexDefines.H"
 
 //void

--- a/Source/RK3/Diffusion.cpp
+++ b/Source/RK3/Diffusion.cpp
@@ -59,12 +59,12 @@ DiffusionContributionForMom(const int &i, const int &j, const int &k,
     switch (momentumEqn) {
         case MomentumEqn::x:
             Real tau11Next, tau11Prev, tau12Next, tau12Prev, tau13Next, tau13Prev;
-            tau11Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn,DiffusionDir::x, cellSize, nut, solverChoice);
-            tau11Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn,DiffusionDir::x, cellSize, nut, solverChoice);
-            tau12Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn,DiffusionDir::y, cellSize, nut, solverChoice);
-            tau12Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn,DiffusionDir::y, cellSize, nut, solverChoice);
-            tau13Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn,DiffusionDir::z, cellSize, nut, solverChoice);
-            tau13Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn,DiffusionDir::z, cellSize, nut, solverChoice);
+            tau11Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn, DiffusionDir::x, cellSize, nut, solverChoice);
+            tau11Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn, DiffusionDir::x, cellSize, nut, solverChoice);
+            tau12Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn, DiffusionDir::y, cellSize, nut, solverChoice);
+            tau12Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn, DiffusionDir::y, cellSize, nut, solverChoice);
+            tau13Next = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::next, momentumEqn, DiffusionDir::z, cellSize, nut, solverChoice);
+            tau13Prev = ComputeStressTerm(i, j, k, u, v, w, NextOrPrev::prev, momentumEqn, DiffusionDir::z, cellSize, nut, solverChoice);
 
             diffusionContribution = (tau11Next - tau11Prev) / dx  // Contribution to x-mom eqn from diffusive flux in x-dir
                                   + (tau12Next - tau12Prev) / dy  // Contribution to x-mom eqn from diffusive flux in y-dir

--- a/Source/RK3/EddyViscosity.cpp
+++ b/Source/RK3/EddyViscosity.cpp
@@ -23,6 +23,7 @@ ComputeTurbulentViscosity(
 }
 
 //AMREX_GPU_DEVICE
+// TODO: should the input xvel,yvel,zvel,cons_in be const?
 void ComputeTurbulentViscosity(MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
                                MultiFab& cons_in, MultiFab& eddyViscosity,
                                const GpuArray<Real, AMREX_SPACEDIM>& cellSize,
@@ -79,6 +80,7 @@ void ComputeTurbulentViscosity(MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
 } // function call
 
 /// Compute K (i-1/2, j+1/2, k) etc given K(i, j, k) or nut (i, j, k) is known
+// Note: This should be at edges for momEqnDir != diffDir, cell centers otherwise
 AMREX_GPU_DEVICE
 Real
 InterpolateTurbulentViscosity(const int &i, const int &j, const int &k,
@@ -89,7 +91,6 @@ InterpolateTurbulentViscosity(const int &i, const int &j, const int &k,
                               const GpuArray<Real, AMREX_SPACEDIM>& cellSize,
                               const Array4<Real>& nut) {
   // Assuming we already have 'nut' computed for all (i, j, k)
-// TODO: Check exactly where we should compute 'nut'
   Real turbViscInterpolated = 1.0;
 
   switch (momentumEqn) {

--- a/Source/RK3/RK3_stage.cpp
+++ b/Source/RK3/RK3_stage.cpp
@@ -43,7 +43,13 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
     yvel.FillBoundary(geom.periodicity());
     zvel.FillBoundary(geom.periodicity());
 
-    // **************************************************************************************
+    // Apply BC on state data at cells
+    // Apply BC on velocity data on faces
+    // Note that in RK3_advance, the BC was applied on momentum
+    amrex::Vector<MultiFab*> vars{&cons_old, &xmom_old, &ymom_old, &zmom_old, &xvel, &yvel, &zvel};
+    ERF::applyBCs(geom, vars);
+
+    // *************************************************************************
     // Deal with gravity
     Real gravity = solverChoice.use_gravity? CONST_GRAV: 0.0;
     // CONST_GRAV is a positive constant, but application of grav_gpu to the vertical momentum
@@ -78,13 +84,8 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
         eddyViscosity.FillBoundary(geom.periodicity());
     }
 
-    // **************************************************************************************
-    // Apply BC on state data at cells
-    // Apply BC on velocity data on faces
-    // Note that in RK3_advance, the BC was applied on momentum
-    amrex::Vector<MultiFab*> vars{&cons_old, &xmom_old, &ymom_old, &zmom_old, &xvel, &yvel, &zvel, &eddyViscosity};
-
-    ERF::applyBCs(geom, vars);
+    amrex::Vector<MultiFab*> eddyvisc_update{&eddyViscosity};
+    ERF::applyBCs(geom, eddyvisc_update);
 
     // **************************************************************************************
     // Define updates in the current RK stage, fluxes are computed here itself

--- a/Source/RK3/RK3_stage.cpp
+++ b/Source/RK3/RK3_stage.cpp
@@ -80,7 +80,10 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 
     MultiFab eddyViscosity(cons_old.boxArray(),cons_old.DistributionMap(),1,1);
     if (solverChoice.use_smagorinsky)
+    {
         ComputeTurbulentViscosity(xvel, yvel, zvel, cons_old, eddyViscosity, dx, solverChoice);
+        eddyViscosity.FillBoundary(geom.periodicity());
+    }
 
     // **************************************************************************************
     // Define updates in the current RK stage, fluxes are computed here itself

--- a/Source/RK3/RK3_stage.cpp
+++ b/Source/RK3/RK3_stage.cpp
@@ -30,9 +30,9 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 
     const GpuArray<Real, AMREX_SPACEDIM> dx = geom.CellSizeArray();
 
-    // ************************************************************************************
+    // *************************************************************************
     // Fill the ghost cells/faces of the MultiFabs we will need
-    // ************************************************************************************ 
+    // *************************************************************************
     cons_old.FillBoundary(geom.periodicity());
 
     xmom_old.FillBoundary(geom.periodicity());
@@ -58,10 +58,10 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
     const    Array<Real,AMREX_SPACEDIM> grav{0.0, 0.0, -gravity};
     const GpuArray<Real,AMREX_SPACEDIM> grav_gpu{grav[0], grav[1], grav[2]};
 
-    // **************************************************************************************
+    // *************************************************************************
     // Calculate face-based fluxes to update cell-centered quantities, and 
     //           edge-based and cell-based fluxes to update face-centered quantities
-    // **************************************************************************************
+    // *************************************************************************
     // TODO: No need for 'CalcAdvFlux'. Remove/clean this
 //    CalcAdvFlux(cons_old, xmom_old, ymom_old, zmom_old,
 //                xvel    , yvel    , zvel    ,
@@ -77,6 +77,15 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 //                 solverChoice);
 //#endif
 
+    // *************************************************************************
+    // Calculate cell-centered eddy viscosity
+    //
+    // Notes:
+    // 1. Need to apply BC on velocity field so that ComputeStrainRate works
+    //    properly
+    // 2. Need to call FillBoundary and applyBCs to set ghost values on all
+    //    boundaries so that InterpolateTurbulentViscosity works properly
+    // *************************************************************************
     MultiFab eddyViscosity(cons_old.boxArray(),cons_old.DistributionMap(),1,1);
     if (solverChoice.use_smagorinsky)
     {
@@ -87,12 +96,12 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
     amrex::Vector<MultiFab*> eddyvisc_update{&eddyViscosity};
     ERF::applyBCs(geom, eddyvisc_update);
 
-    // **************************************************************************************
+    // *************************************************************************
     // Define updates in the current RK stage, fluxes are computed here itself
     //TODO: Benchmarking of performance. We are computing the fluxes on the fly.
     //If the performance slows, consider saving all the fluxes apriori and accessing them here.
 
-    // ************************************************************************************** 
+    // *************************************************************************
     for ( MFIter mfi(cons_old,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         
         const Box& bx = mfi.tilebox();
@@ -146,9 +155,9 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 //                + dt*source_fab(i,j,k,n);
 //        });
 
-        // **************************************************************************************
+        // *********************************************************************
         // Define updates in the RHS of continuity, temperature, and scalar equations
-        // **************************************************************************************
+        // *********************************************************************
         amrex::ParallelFor(bx, cons_old.nComp(),
        [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
             cell_data_upd(i, j, k, n) = 0.0; // Initialize the updated state eqn term to zero.
@@ -173,9 +182,9 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 //        if (solverChoice.use_smagorinsky) // Compute nut, otherwise remains whatever it's initialized to
 //            ComputeTurbulentViscosity(u, v, w, dx,nut);
 
-        // **************************************************************************************
+        // *********************************************************************
         // Define updates in the RHS of {x, y, z}-momentum equations
-        // **************************************************************************************
+        // *********************************************************************
         amrex::ParallelFor(tbx, tby, tbz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) { // x-momentum equation
 //            rho_u_upd(i,j,k) =

--- a/Source/RK3/RK3_stage.cpp
+++ b/Source/RK3/RK3_stage.cpp
@@ -32,7 +32,6 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
 
     // ************************************************************************************
     // Fill the ghost cells/faces of the MultiFabs we will need
-    // Apply BC on state data at cells
     // ************************************************************************************ 
     cons_old.FillBoundary(geom.periodicity());
 
@@ -40,15 +39,9 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
     ymom_old.FillBoundary(geom.periodicity());
     zmom_old.FillBoundary(geom.periodicity());
 
-    // Apply BC on velocity data on faces
-    // Note that in RK3_advance, the BC was applied on momentum
     xvel.FillBoundary(geom.periodicity());
     yvel.FillBoundary(geom.periodicity());
     zvel.FillBoundary(geom.periodicity());
-
-    amrex::Vector<MultiFab*> vars{&cons_old, &xmom_old, &ymom_old, &zmom_old, &xvel, &yvel, &zvel};
-
-    ERF::applyBCs(geom, vars);
 
     // **************************************************************************************
     // Deal with gravity
@@ -84,6 +77,14 @@ void RK3_stage  (MultiFab& cons_old,  MultiFab& cons_upd,
         ComputeTurbulentViscosity(xvel, yvel, zvel, cons_old, eddyViscosity, dx, solverChoice);
         eddyViscosity.FillBoundary(geom.periodicity());
     }
+
+    // **************************************************************************************
+    // Apply BC on state data at cells
+    // Apply BC on velocity data on faces
+    // Note that in RK3_advance, the BC was applied on momentum
+    amrex::Vector<MultiFab*> vars{&cons_old, &xmom_old, &ymom_old, &zmom_old, &xvel, &yvel, &zvel, &eddyViscosity};
+
+    ERF::applyBCs(geom, vars);
 
     // **************************************************************************************
     // Define updates in the current RK stage, fluxes are computed here itself


### PR DESCRIPTION
Running with multiple grids on a single processor reveals issue with ghost cells. This is manifested in the integrated mass being reported as "nan" and an arithmetic error when writing out a plotfile. After the fix, the same test case (`ABL_brian` with zero perturbation magnitude) on a single processor produces identical results for a single grid and 16 grids (analogous to an MPI run). 

The issue was caused by `InterpolateTurbulentViscosity()` operating on ghost values of the cell-centered `eddyViscosity` multifab that were uninitialized (nan). This is fixed by calling `FillBoundary()` and `applyBC()` after calling `ComputeTurbulentViscosity()`.

Note: This also **updates AMReX to the latest release** (21.10) to make the `AMReX_TESTING` CMake option (and corresponding GNU `TEST=TRUE` option) available to follow best practices for debugging described at https://amrex-codes.github.io/amrex/docs_html/Basics.html#debugging. 