### PR TITLE
Change badge links in README to erf-model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,10 +11,10 @@ Test Status
 Regression Tests    |regtests|     |regtest-coverage|
 =================  =============  ====================
 
-.. |regtests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
+.. |regtests| image:: https://github.com/erf-model/ERF/actions/workflows/ci.yml/badge.svg?branch=development
 .. |regtest-coverage| image:: https://codecov.io/gh/erf-model/ERF/branch/development/graph/badge.svg?token=74S5Q66M1M
     :target: https://codecov.io/gh/erf-model/ERF
-.. |unittests| image:: https://github.com/rafmudaf/ERF/actions/workflows/ci.yml/badge.svg?branch=add_testing
+.. |unittests| image:: https://github.com/erf-model/ERF/actions/workflows/ci.yml/badge.svg?branch=development
 
 
 Getting Started


### PR DESCRIPTION
This pull request fixes a bug in the README where the CI status badges were pointing to the wrong repository. They now point to `erf-model/ERF`. Note that I've changed two links here: one for regression tests and one for unit tests. However, only one badge is displayed in the README. This structure was in anticipation of reporting CI status for the two levels of tests individually. 

See https://github.com/erf-model/ERF/issues/104.