### PR TITLE
CUDA CI - Ignore some files and run on all branches 

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -2,7 +2,12 @@ name: ERF CUDA CI
 
 on:
   push:
-    branches: [development]
+    # branches: [development]
+    paths-ignore:
+      - Docs
+      - README.rst
+      - license.txt
+
   pull_request:
     branches: [development]
 


### PR DESCRIPTION
This pull request adds the same path and branch filtering in the main CI into the CUDA CI workflow. It's minor, but saves some time when the only modifications are documentation.