### PR TITLE
Update multilevel functionality so we fillpatch all the data we

### DIFF
--- a/Exec/IsentropicVortex/inputs_ref
+++ b/Exec/IsentropicVortex/inputs_ref
@@ -1,0 +1,83 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 1000
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.is_periodic = 1 1 1
+geometry.prob_lo     =  0    0    0
+geometry.prob_hi     = 64   64   64  
+amr.n_cell           = 32   32   32
+
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+# Interior, UserBC, Symmetry, SlipWall, NoSlipWall
+# >>>>>>>>>>>>>  BC KEYWORDS <<<<<<<<<<<<<<<<<<<<<<
+erf.lo_bc       = "Interior"   "Interior"   "Interior"
+erf.hi_bc       = "Interior"   "Interior"   "Interior"
+
+# WHICH PHYSICS
+erf.do_hydro = 1
+
+# TIME STEP CONTROL
+#erf.cfl            = 0.9     # cfl number for hyperbolic system
+#erf.init_shrink    = 1.0     # scale back initial timestep
+#erf.change_max     = 1.05    # scale back initial timestep
+#erf.dt_cutoff      = 5.e-20  # level 0 timestep below which we halt
+erf.fixed_dt       = 0.001
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v                = 1       # verbosity in Amr.cpp
+amr.data_log         = datlog
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+amr.ref_ratio       = 2 2 2 2 # refinement ratio
+amr.regrid_int      = 2 2 2 2 # how often to regrid
+amr.blocking_factor = 4       # block factor in grid generation
+amr.max_grid_size   = 64
+amr.n_error_buf     = 2 2 2 2 # number of buffer cells in error est
+
+# CHECKPOINT FILES
+amr.checkpoint_files_output = 0
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+amr.plot_files_output = 1
+amr.plot_file       = plt        # root name of plotfile
+amr.plot_int        = 10         # number of timesteps between plotfiles
+amr.plot_vars        =  density
+amr.derive_plot_vars = pressure theta temp x_velocity y_velocity z_velocity
+
+# SOLVER CHOICE
+erf.use_state_advection = true
+erf.use_momentum_advection = true
+erf.use_thermal_diffusion = false
+erf.alpha_T = 0.0
+erf.use_scalar_diffusion = false
+erf.alpha_C = 0.0
+erf.use_momentum_diffusion = false
+erf.dynamicViscosity = 0.0
+erf.use_smagorinsky   = false
+erf.use_pressure = true
+erf.use_gravity = false
+erf.spatial_order = 2
+
+# PROBLEM PARAMETERS
+prob.p_inf = 1e5  # reference pressure [Pa]
+prob.T_inf = 300. # reference temperature [K]
+prob.M_inf = 0.0  # freestream Mach number [-]
+prob.alpha = 0.0  # inflow angle, 0 --> x-aligned [rad]
+prob.gamma = 1.4  # specific heat ratio [-]
+prob.beta = 0.05  # non-dimensional max perturbation strength [-]
+
+amr.max_level       = 1       # maximum level number allowed
+tagging.tag_region = true
+tagging.region_lo = 16. 16. 16.
+tagging.region_hi = 48. 48. 48.
+amr.n_error_buf   = 0 0 0 0
+amr.regrid_int    = -1

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -334,6 +334,7 @@ protected:
   static bool dump_old;
   static int verbose;
 
+  static std::string coupling_type;
   static int do_reflux;
   static int do_avg_down;
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -148,8 +148,8 @@ ERF::read_params()
   {
       do_reflux = 0;
       do_avg_down = 0;
-  } 
-  else if (coupling_type == "TwoWay") 
+  }
+  else if (coupling_type == "TwoWay")
   {
       do_reflux = 1;
       do_avg_down = 1;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -30,6 +30,7 @@ amrex::Real ERF::fixed_dt    = -1.0;
 amrex::Real ERF::max_dt      =  1.e20;
 amrex::Real ERF::dt_cutoff   =  0.0;
 
+std::string ERF::coupling_type = "OneWay";
 int         ERF::do_reflux     = 0;
 int         ERF::do_avg_down   = 0;
 int         ERF::sum_interval  = -1;
@@ -142,8 +143,19 @@ ERF::read_params()
   pp.query("sum_interval", sum_interval);
   pp.query("dump_old", dump_old);
 
-  pp.query("do_reflux"  , do_reflux);
-  pp.query("do_avg_down", do_avg_down);
+  pp.query("coupling_type",coupling_type);
+  if (coupling_type == "OneWay")
+  {
+      do_reflux = 0;
+      do_avg_down = 0;
+  } 
+  else if (coupling_type == "TwoWay") 
+  {
+      do_reflux = 1;
+      do_avg_down = 1;
+  } else {
+      amrex::Error("Unknown coupling type");
+  }
 
   // Time step controls
   pp.query("cfl", cfl);

--- a/Source/Make.package
+++ b/Source/Make.package
@@ -10,6 +10,7 @@ CEXE_sources += main.cpp
 CEXE_sources += SumIQ.cpp
 CEXE_sources += SumUtils.cpp
 CEXE_sources += Tagging.cpp
+CEXE_sources += Utils.cpp
 
 #C++ headers
 CEXE_headers += EOS.H
@@ -18,3 +19,6 @@ CEXE_headers += Problem.H
 CEXE_headers += ProblemDerive.H
 CEXE_headers += Constants.H
 CEXE_headers += IndexDefines.H
+
+CEXE_headers += utils.H
+CEXE_headers += utils_K.H

--- a/Source/RK3/MomentumToVelocity.cpp
+++ b/Source/RK3/MomentumToVelocity.cpp
@@ -7,6 +7,7 @@ using namespace amrex;
 void MomentumToVelocity( MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
                          MultiFab& cons_in,
                          MultiFab& xmom_in, MultiFab& ymom_in, MultiFab& zmom_in,
+                         int ng,
                          const SolverChoice& solverChoice)
 {
     BL_PROFILE_VAR("MomentumToVelocity()",MomentumToVelocity);
@@ -14,9 +15,9 @@ void MomentumToVelocity( MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
     // Loop over boxes
     for ( MFIter mfi(cons_in,TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
-        const Box& tbx = mfi.nodaltilebox(0);
-        const Box& tby = mfi.nodaltilebox(1);
-        const Box& tbz = mfi.nodaltilebox(2);
+        const Box& tbx = amrex::grow(mfi.nodaltilebox(0),IntVect(0,ng,ng));
+        const Box& tby = amrex::grow(mfi.nodaltilebox(1),IntVect(ng,0,ng));
+        const Box& tbz = amrex::grow(mfi.nodaltilebox(2),IntVect(ng,ng,0));
 
         // Conserved variables on cell centers -- we use this for density
         const Array4<Real>& cons = cons_in.array(mfi);

--- a/Source/RK3/RK3.H
+++ b/Source/RK3/RK3.H
@@ -33,7 +33,7 @@ void RK3_advance(int level,
                  MultiFab& source,
                  std::array<MultiFab, AMREX_SPACEDIM>& faceflux,
                  const amrex::Geometry geom,
-                 const amrex::IntVect ref_ratio, 
+                 const amrex::IntVect ref_ratio,
                  const amrex::Real* dxp, const amrex::Real dt, // InterpFaceRegister* ifr,
                  const SolverChoice& solverChoice);
 

--- a/Source/RK3/RK3.H
+++ b/Source/RK3/RK3.H
@@ -17,6 +17,7 @@ using namespace amrex;
 void MomentumToVelocity(MultiFab& xvel_out, MultiFab& yvel_out, MultiFab& zvel_out,
                         MultiFab& cons_in,
                         MultiFab& xmom_in, MultiFab& ymom_in, MultiFab& zmom_in,
+                        int ngrow,
                         const SolverChoice& solverChoice);
 
 void VelocityToMomentum(MultiFab& xvel_in , MultiFab& yvel_in, MultiFab& zvel_in,
@@ -31,8 +32,9 @@ void RK3_advance(int level,
                  MultiFab& xmom_crse, MultiFab& ymom_crse, MultiFab& zmom_crse,
                  MultiFab& source,
                  std::array<MultiFab, AMREX_SPACEDIM>& faceflux,
-                 const amrex::Geometry geom, const amrex::Real* dxp, const amrex::Real dt,
-                 //InterpFaceRegister* ifr,
+                 const amrex::Geometry geom,
+                 const amrex::IntVect ref_ratio, 
+                 const amrex::Real* dxp, const amrex::Real dt, // InterpFaceRegister* ifr,
                  const SolverChoice& solverChoice);
 
 void RK3_stage  (int level,
@@ -43,7 +45,7 @@ void RK3_stage  (int level,
                  MultiFab& source,
                  std::array<MultiFab, AMREX_SPACEDIM>& faceflux,
                  const amrex::Geometry geom, const amrex::Real* dxp, const amrex::Real dt,
-                 //InterpFaceRegister* ifr,
+                 // InterpFaceRegister* ifr,
                  const SolverChoice& solverChoice);
 
 AMREX_GPU_DEVICE

--- a/Source/RK3/RK3_driver.cpp
+++ b/Source/RK3/RK3_driver.cpp
@@ -15,7 +15,7 @@ void RK3_advance(int level,
                  MultiFab& xmom_crse, MultiFab& ymom_crse, MultiFab& zmom_crse,
                  MultiFab& source,
                  std::array< MultiFab, AMREX_SPACEDIM>& faceflux,
-                 const amrex::Geometry geom, 
+                 const amrex::Geometry geom,
                  const amrex::IntVect ref_ratio,
                  const amrex::Real* dxp, const amrex::Real dt,
                  //InterpFaceRegister* ifr,
@@ -75,7 +75,7 @@ void RK3_advance(int level,
     VelocityToMomentum(xvel_old, yvel_old, zvel_old, cons_old, xmom_old, ymom_old, zmom_old, solverChoice);
 
     // **************************************************************************************
-    // HACK HACK HACK -- We copy all of S_old into 
+    // HACK HACK HACK -- We copy all of S_old into
     //     cons_upd_1 and cons_upd_2 just so that we can
     //     have values defined in the ghost cells.
     // TODO:  we need to fix this so that cons_upd_1 and cons_upd_2

--- a/Source/RK3/RK3_driver.cpp
+++ b/Source/RK3/RK3_driver.cpp
@@ -4,6 +4,7 @@
 #include <AMReX_BC_TYPES.H>
 
 #include <RK3.H>
+#include <utils.H>
 
 using namespace amrex;
 
@@ -14,7 +15,9 @@ void RK3_advance(int level,
                  MultiFab& xmom_crse, MultiFab& ymom_crse, MultiFab& zmom_crse,
                  MultiFab& source,
                  std::array< MultiFab, AMREX_SPACEDIM>& faceflux,
-                 const amrex::Geometry geom, const amrex::Real* dxp, const amrex::Real dt,
+                 const amrex::Geometry geom, 
+                 const amrex::IntVect ref_ratio,
+                 const amrex::Real* dxp, const amrex::Real dt,
                  //InterpFaceRegister* ifr,
                  const SolverChoice& solverChoice)
 {
@@ -66,9 +69,24 @@ void RK3_advance(int level,
     // **************************************************************************************
     cons_old.FillBoundary(geom.periodicity());
 
+    // **************************************************************************************
     // Convert old velocity available on faces to old momentum on faces to be used in time integration
     // **************************************************************************************
     VelocityToMomentum(xvel_old, yvel_old, zvel_old, cons_old, xmom_old, ymom_old, zmom_old, solverChoice);
+
+    // **************************************************************************************
+    // HACK HACK HACK -- We copy all of S_old into 
+    //     cons_upd_1 and cons_upd_2 just so that we can
+    //     have values defined in the ghost cells.
+    // TODO:  we need to fix this so that cons_upd_1 and cons_upd_2
+    //        have interpolated values at the correct time -- not the old time
+    // **************************************************************************************
+    if (level > 0)
+    {
+        MultiFab::Copy(cons_upd_1,cons_old,0,0,nvars,ngc);
+        MultiFab::Copy(cons_upd_2,cons_old,0,0,nvars,ngc);
+        MultiFab::Copy(cons_new  ,cons_old,0,0,nvars,ngc);
+    }
 
     // Apply BC on old momentum data on faces before stage 1
     // **************************************************************************************
@@ -77,12 +95,21 @@ void RK3_advance(int level,
     zmom_old.FillBoundary(geom.periodicity());
 
 #if 0
-    // Interpolate from coarse faces to fine faces *only* on the coarse-fine boundary
     if (level > 0)
     {
-        amrex::Array<const MultiFab*,3> cmf{&xmom_crse, &ymom_crse, &zmom_crse};
-        amrex::Array<      MultiFab*,3> fmf{&xmom_old , &ymom_old , &zmom_old};
-        ifr->interp(fmf,cmf,0,1);
+        amrex::Array<const MultiFab*,3> cmf_const{&xmom_crse, &ymom_crse, &zmom_crse};
+        amrex::Array<MultiFab*,3> fmf{&xmom_old , &ymom_old , &zmom_old};
+
+        // Interpolate from coarse faces to fine faces *only* on the coarse-fine boundary
+        ifr->interp(fmf,cmf_const,0,1);
+
+        amrex::Array<MultiFab*,3> cmf{&xmom_crse, &ymom_crse, &zmom_crse};
+
+        int nGrow = 1;
+        BoxArray fine_grids(cons_old.boxArray());
+
+        // Interpolate from coarse faces on fine faces outside the fine region
+        create_umac_grown(level, nGrow, fine_grids, geom, cmf, fmf, ref_ratio);
     }
 #endif
 
@@ -149,7 +176,6 @@ void RK3_advance(int level,
             // Now momz_up1 holds the first intermediate solution
         });
     }
-    // TODO: Check if the order of applying BC on cell-centered state or face-centered mom makes any difference
     // Apply BC on updated momentum data on faces after stage 1 and before stage 2
     // **************************************************************************************
     xmom_update_1.FillBoundary(geom.periodicity());
@@ -164,9 +190,30 @@ void RK3_advance(int level,
 
     ERF::applyBCs(geom, vars1);
 
-    // Convert updated momentum to updated velocity on faces after stage 1 and before stage 2
+#if 0
+    if (level > 0)
+    {
+        amrex::Array<const MultiFab*,3> cmf_const{&xmom_crse, &ymom_crse, &zmom_crse};
+        amrex::Array<MultiFab*,3> fmf{&xmom_update_1 , &ymom_update_1 , &zmom_update_1};
+
+        // Interpolate from coarse faces to fine faces *only* on the coarse-fine boundary
+        ifr->interp(fmf,cmf_const,0,1);
+
+        amrex::Array<MultiFab*,3> cmf{&xmom_crse, &ymom_crse, &zmom_crse};
+
+        int nGrow = 1;
+        BoxArray fine_grids(cons_old.boxArray());
+
+        // Interpolate from coarse faces on fine faces outside the fine region
+        create_umac_grown(level, nGrow, fine_grids, geom, cmf, fmf, ref_ratio);
+    }
+#endif
+
     // **************************************************************************************
-    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_upd_1, xmom_update_1, ymom_update_1, zmom_update_1, solverChoice);
+    // Convert updated momentum to updated velocity on faces after stage 1 and before stage 2
+    // Make sure we have filled the ghost cells of cons_upd_1 and *mom_update_1 before this call!
+    // **************************************************************************************
+    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_upd_1, xmom_update_1, ymom_update_1, zmom_update_1, 1, solverChoice);
 
     // **************************************************************************************
     // RK3 stage 2: Return update in the cons_upd_2 and [x,y,z]mom_update_2 MultiFabs
@@ -248,9 +295,30 @@ void RK3_advance(int level,
 
     ERF::applyBCs(geom, vars2);
 
-    // Convert updated momentum to updated velocity on faces after stage 2 and before stage 3
+#if 0
+    if (level > 0)
+    {
+        amrex::Array<const MultiFab*,3> cmf_const{&xmom_crse, &ymom_crse, &zmom_crse};
+        amrex::Array<MultiFab*,3> fmf{&xmom_update_2 , &ymom_update_2 , &zmom_update_2};
+
+        // Interpolate from coarse faces to fine faces *only* on the coarse-fine boundary
+        ifr->interp(fmf,cmf_const,0,1);
+
+        amrex::Array<MultiFab*,3> cmf{&xmom_crse, &ymom_crse, &zmom_crse};
+
+        int nGrow = 1;
+        BoxArray fine_grids(cons_old.boxArray());
+
+        // Interpolate from coarse faces on fine faces outside the fine region
+        create_umac_grown(level, nGrow, fine_grids, geom, cmf, fmf, ref_ratio);
+    }
+#endif
+
     // **************************************************************************************
-    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_upd_2, xmom_update_2, ymom_update_2, zmom_update_2, solverChoice);
+    // Convert updated momentum to updated velocity on faces after stage 2 and before stage 3
+    // Make sure we have filled the ghost cells of cons_upd_2 and *mom_update_2 before this call!
+    // **************************************************************************************
+    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_upd_2, xmom_update_2, ymom_update_2, zmom_update_2, 1, solverChoice);
 
     // **************************************************************************************
     // RK3 stage 3: Return update in the cons_new and [x,y,z]mom_new MultiFabs
@@ -335,9 +403,11 @@ void RK3_advance(int level,
 
     ERF::applyBCs(geom, vars_new);
 
+    // **************************************************************************************
     // Convert updated momentum to updated velocity on faces after stage 3 and before going to next time step
     // **************************************************************************************
-    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_new, xmom_new, ymom_new, zmom_new, solverChoice);
+    if (level == 1) print_state(xmom_new,IntVect(8,8,8));
+    MomentumToVelocity(xvel_new, yvel_new, zvel_new, cons_new, xmom_new, ymom_new, zmom_new, 0, solverChoice);
 
     // One final application of non-periodic BCs after all RK3 stages have been called, this time on velocities
 

--- a/Source/RK3/RK3_stage.cpp
+++ b/Source/RK3/RK3_stage.cpp
@@ -110,12 +110,21 @@ void RK3_stage  (int level,
         int vlo_z = valid_bx.smallEnd(2);
         int vhi_z = valid_bx.bigEnd(2);
 
+#if 1
+        auto mlo_x = Array4<const int>{};
+        auto mhi_x = Array4<const int>{};
+        auto mlo_y = Array4<const int>{};
+        auto mhi_y = Array4<const int>{};
+        auto mlo_z = Array4<const int>{};
+        auto mhi_z = Array4<const int>{};
+#else
         auto mlo_x = (level > 0) ? mlo_mf_x->const_array(mfi) : Array4<const int>{};
         auto mhi_x = (level > 0) ? mhi_mf_x->const_array(mfi) : Array4<const int>{};
-        auto mlo_y = (level > 0) ? mhi_mf_y->const_array(mfi) : Array4<const int>{};
+        auto mlo_y = (level > 0) ? mlo_mf_y->const_array(mfi) : Array4<const int>{};
         auto mhi_y = (level > 0) ? mhi_mf_y->const_array(mfi) : Array4<const int>{};
         auto mlo_z = (level > 0) ? mlo_mf_z->const_array(mfi) : Array4<const int>{};
         auto mhi_z = (level > 0) ? mhi_mf_z->const_array(mfi) : Array4<const int>{};
+#endif
 
         const Array4<Real> & cell_data_old     = cons_old.array(mfi);
         const Array4<Real> & cell_data_upd     = cons_upd.array(mfi);

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -1,0 +1,183 @@
+/** \addtogroup Utilities
+ * @{
+ */
+
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_BCRec.H>
+#include <utils.H>
+#include <utils_K.H>
+#include <AMReX_PhysBCFunct.H>
+#include <AMReX_FillPatchUtil.H>
+
+using namespace amrex;
+
+void
+create_umac_grown (int lev, int nGrow, BoxArray& fine_grids,
+                   const Geometry& fine_geom,
+                   const Array<MultiFab*,AMREX_SPACEDIM> u_mac_crse,
+                   const Array<MultiFab*,AMREX_SPACEDIM> u_mac_fine,
+                   const IntVect& crse_ratio)
+{
+    BL_PROFILE("create_umac_grown()");
+
+    if (lev > 0)
+    {
+        BoxList bl = amrex::GetBndryCells(fine_grids,nGrow);
+
+        BoxArray f_bnd_ba(std::move(bl));
+
+        BoxArray c_bnd_ba = f_bnd_ba; c_bnd_ba.coarsen(crse_ratio);
+
+        c_bnd_ba.maxSize(32);
+
+        f_bnd_ba = c_bnd_ba; f_bnd_ba.refine(crse_ratio);
+
+        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim)
+        {
+            //
+            // crse_src & fine_src must have same parallel distribution.
+            // We'll use the KnapSack distribution for the fine_src_ba.
+            // Since fine_src_ba should contain more points, this'll lead
+            // to a better distribution.
+            //
+            BoxArray crse_src_ba(c_bnd_ba), fine_src_ba(f_bnd_ba);
+
+            crse_src_ba.surroundingNodes(idim);
+            fine_src_ba.surroundingNodes(idim);
+
+            const int N = fine_src_ba.size();
+
+            std::vector<long> wgts(N);
+
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+            for (int i = 0; i < N; i++)
+                wgts[i] = fine_src_ba[i].numPts();
+
+            DistributionMapping dm;
+            // This DM won't be put into the cache.
+            dm.KnapSackProcessorMap(wgts,ParallelDescriptor::NProcs());
+
+            // FIXME
+            // Declaring in this way doesn't work. I think it's because the box arrays
+            // have been changed and each src box is not completely contained within a
+            // single box in the Factory's BA
+            // For now, coarse-fine boundary doesn't intersect EB, so should be okay...
+            // MultiFab crse_src(crse_src_ba, dm, 1, 0, MFInfo(), getLevel(lev-1).Factory());
+            // MultiFab fine_src(fine_src_ba, dm, 1, 0, MFInfo(), Factory());
+            MultiFab crse_src(crse_src_ba, dm, 1, 0);
+            MultiFab fine_src(fine_src_ba, dm, 1, 0);
+
+            crse_src.setVal(1.e200);
+            fine_src.setVal(1.e200);
+            //
+            // We want to fill crse_src from lower level u_mac including u_mac's grow cells.
+            //
+            const MultiFab& u_macLL = *u_mac_crse[idim];
+            crse_src.ParallelCopy(u_macLL,0,0,1,u_macLL.nGrow(),0);
+
+	    const amrex::GpuArray<int,AMREX_SPACEDIM> c_ratio = {AMREX_D_DECL(crse_ratio[0],crse_ratio[1],crse_ratio[2])};
+
+	    //
+	    // Fill fine values with piecewise-constant interp of coarse data.
+	    // Operate only on faces that overlap--ie, only fill the fine faces that make up each
+	    // coarse face, leave the in-between faces alone.
+	    //
+#ifdef _OPENMP
+#pragma omp parallel
+#endif
+            for (MFIter mfi(crse_src); mfi.isValid(); ++mfi)
+            {
+                const Box& box       = crse_src[mfi].box();
+                auto const& crs_arr  = crse_src.array(mfi);
+                auto const& fine_arr = fine_src.array(mfi);
+
+                ParallelFor(box,[crs_arr,fine_arr,idim,c_ratio]
+                AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+		   int idx[3] = {AMREX_D_DECL(i*c_ratio[0],j*c_ratio[1],k*c_ratio[2])};
+#if ( AMREX_SPACEDIM == 2 )
+                   // dim1 are the complement of idim
+                   int dim1 = ( idim == 0 ) ? 1 : 0;
+                   for (int n1 = 0; n1 < c_ratio[dim1]; n1++) {
+                      int id[3] = {idx[0],idx[1]};
+                      id[dim1] += n1;
+                      fine_arr(id[0],id[1],0) = crs_arr(i,j,k);
+                   }
+#elif ( AMREX_SPACEDIM == 3 )
+                   // dim1 and dim2 are the complements of idim
+                   int dim1 = ( idim != 0 ) ? 0 : 1 ;
+                   int dim2 = ( idim != 0 ) ? ( ( idim == 2 ) ? 1 : 2 ) : 2 ;
+                   for (int n1 = 0; n1 < c_ratio[dim1]; n1++) {
+                      for (int n2 = 0; n2 < c_ratio[dim2]; n2++) {
+                         int id[3] = {idx[0],idx[1],idx[2]};
+                         id[dim1] += n1;
+                         id[dim2] += n2;
+                         fine_arr(id[0],id[1],id[2]) = crs_arr(i,j,k);
+                      }
+                   }
+#endif
+                });
+            }
+            crse_src.clear();
+            //
+            // Replace pc-interpd fine data with preferred u_mac data at
+            // this level u_mac valid only on surrounding faces of valid
+            // region - this op will not fill grow region.
+            //
+            fine_src.ParallelCopy(*u_mac_fine[idim]);
+            //
+            // Interpolate unfilled grow cells using best data from
+            // surrounding faces of valid region, and pc-interpd data
+            // on fine faces overlaying coarse edges.
+            //
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+            for (MFIter mfi(fine_src); mfi.isValid(); ++mfi)
+            {
+                const int  nComp = 1;
+                const Box& fbox  = fine_src[mfi].box();
+                auto const& fine_arr = fine_src.array(mfi);
+
+		if (fbox.type(0) == IndexType::NODE)
+	        {
+		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+		  {
+		    face_interp_x(i,j,k,n,fine_arr,c_ratio);
+		  });
+		}
+		else if (fbox.type(1) == IndexType::NODE)
+		{
+		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+		  {
+		    face_interp_y(i,j,k,n,fine_arr,c_ratio);
+		  });
+		}
+#if (AMREX_SPACEDIM == 3)
+		else
+		{
+		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+                  {
+		    face_interp_z(i,j,k,n,fine_arr,c_ratio);
+		  });
+		}
+#endif
+            }
+
+            MultiFab u_mac_save(u_mac_fine[idim]->boxArray(),u_mac_fine[idim]->DistributionMap(),1,0,MFInfo(),
+                                u_mac_fine[idim]->Factory());
+            u_mac_save.ParallelCopy(*u_mac_fine[idim]);
+            u_mac_fine[idim]->ParallelCopy(fine_src,0,0,1,0,nGrow);
+            u_mac_fine[idim]->ParallelCopy(u_mac_save);
+        }
+    }
+
+    for (int n = 0; n < BL_SPACEDIM; ++n)
+    {
+	u_mac_fine[n]->FillBoundary(fine_geom.periodicity());
+    }
+}
+
+/** @}*/

--- a/Source/Utils.cpp
+++ b/Source/Utils.cpp
@@ -77,13 +77,13 @@ create_umac_grown (int lev, int nGrow, BoxArray& fine_grids,
             const MultiFab& u_macLL = *u_mac_crse[idim];
             crse_src.ParallelCopy(u_macLL,0,0,1,u_macLL.nGrow(),0);
 
-	    const amrex::GpuArray<int,AMREX_SPACEDIM> c_ratio = {AMREX_D_DECL(crse_ratio[0],crse_ratio[1],crse_ratio[2])};
+        const amrex::GpuArray<int,AMREX_SPACEDIM> c_ratio = {AMREX_D_DECL(crse_ratio[0],crse_ratio[1],crse_ratio[2])};
 
-	    //
-	    // Fill fine values with piecewise-constant interp of coarse data.
-	    // Operate only on faces that overlap--ie, only fill the fine faces that make up each
-	    // coarse face, leave the in-between faces alone.
-	    //
+        //
+        // Fill fine values with piecewise-constant interp of coarse data.
+        // Operate only on faces that overlap--ie, only fill the fine faces that make up each
+        // coarse face, leave the in-between faces alone.
+        //
 #ifdef _OPENMP
 #pragma omp parallel
 #endif
@@ -96,7 +96,7 @@ create_umac_grown (int lev, int nGrow, BoxArray& fine_grids,
                 ParallelFor(box,[crs_arr,fine_arr,idim,c_ratio]
                 AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-		   int idx[3] = {AMREX_D_DECL(i*c_ratio[0],j*c_ratio[1],k*c_ratio[2])};
+           int idx[3] = {AMREX_D_DECL(i*c_ratio[0],j*c_ratio[1],k*c_ratio[2])};
 #if ( AMREX_SPACEDIM == 2 )
                    // dim1 are the complement of idim
                    int dim1 = ( idim == 0 ) ? 1 : 0;
@@ -141,28 +141,28 @@ create_umac_grown (int lev, int nGrow, BoxArray& fine_grids,
                 const Box& fbox  = fine_src[mfi].box();
                 auto const& fine_arr = fine_src.array(mfi);
 
-		if (fbox.type(0) == IndexType::NODE)
-	        {
-		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
-		  {
-		    face_interp_x(i,j,k,n,fine_arr,c_ratio);
-		  });
-		}
-		else if (fbox.type(1) == IndexType::NODE)
-		{
-		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
-		  {
-		    face_interp_y(i,j,k,n,fine_arr,c_ratio);
-		  });
-		}
+        if (fbox.type(0) == IndexType::NODE)
+            {
+          AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+          {
+            face_interp_x(i,j,k,n,fine_arr,c_ratio);
+          });
+        }
+        else if (fbox.type(1) == IndexType::NODE)
+        {
+          AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+          {
+            face_interp_y(i,j,k,n,fine_arr,c_ratio);
+          });
+        }
 #if (AMREX_SPACEDIM == 3)
-		else
-		{
-		  AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
+        else
+        {
+          AMREX_HOST_DEVICE_PARALLEL_FOR_4D(fbox,nComp,i,j,k,n,
                   {
-		    face_interp_z(i,j,k,n,fine_arr,c_ratio);
-		  });
-		}
+            face_interp_z(i,j,k,n,fine_arr,c_ratio);
+          });
+        }
 #endif
             }
 
@@ -176,7 +176,7 @@ create_umac_grown (int lev, int nGrow, BoxArray& fine_grids,
 
     for (int n = 0; n < BL_SPACEDIM; ++n)
     {
-	u_mac_fine[n]->FillBoundary(fine_geom.periodicity());
+    u_mac_fine[n]->FillBoundary(fine_geom.periodicity());
     }
 }
 

--- a/Source/utils.H
+++ b/Source/utils.H
@@ -1,0 +1,53 @@
+/** \addtogroup Utilities
+ * @{
+ */
+
+#ifndef UTILS_H
+#define UTILS_H
+
+#include <AMReX_MultiFabUtil.H>
+#include <AMReX_BCRec.H>
+
+/**
+ * Collection of utility functions
+ *
+ */
+
+void
+create_umac_grown (int lev, int nGrow, amrex::BoxArray& fine_grids,
+                   const amrex::Geometry& fine_geom,
+                   const amrex::Array<amrex::MultiFab*,AMREX_SPACEDIM> u_mac_crse,
+                   const amrex::Array<amrex::MultiFab*,AMREX_SPACEDIM> u_mac_fine,
+                   const amrex::IntVect& crse_ratio);
+
+// A placeholder for filling dirichlet boundary conditions on u_mac.
+struct FCFillExtDirDummy
+{
+    AMREX_GPU_HOST
+    constexpr FCFillExtDirDummy( ) {}
+
+    AMREX_GPU_DEVICE
+    void operator()(
+       const amrex::IntVect& /*iv*/,
+       amrex::Array4<amrex::Real> const& /*dummy*/,
+       const int /*dcomp*/,
+       const int numcomp,
+       amrex::GeometryData const& /*geom*/,
+       const amrex::Real /*time*/,
+       const amrex::BCRec* bcr,
+       const int bcomp,
+       const int /*orig_comp*/) const
+    {
+        // Abort if an calling this function was supposed to fill an ext_dir BC. 
+        for (int n = bcomp; n < bcomp+numcomp; ++n) {
+            const amrex::BCRec& bc = bcr[n];
+            if ( AMREX_D_TERM(   bc.lo(0) == amrex::BCType::ext_dir || bc.hi(0) == amrex::BCType::ext_dir,
+                              || bc.lo(1) == amrex::BCType::ext_dir || bc.hi(1) == amrex::BCType::ext_dir,
+                              || bc.lo(2) == amrex::BCType::ext_dir || bc.hi(2) == amrex::BCType::ext_dir ) ) { 
+               amrex::Abort("FCFillExtDirDummy is a dummy placeholder and should not be used in combination with BCType::ext_dir");
+            }
+        }
+    }
+};
+#endif
+/** @}*/

--- a/Source/utils.H
+++ b/Source/utils.H
@@ -38,12 +38,12 @@ struct FCFillExtDirDummy
        const int bcomp,
        const int /*orig_comp*/) const
     {
-        // Abort if an calling this function was supposed to fill an ext_dir BC. 
+        // Abort if an calling this function was supposed to fill an ext_dir BC.
         for (int n = bcomp; n < bcomp+numcomp; ++n) {
             const amrex::BCRec& bc = bcr[n];
             if ( AMREX_D_TERM(   bc.lo(0) == amrex::BCType::ext_dir || bc.hi(0) == amrex::BCType::ext_dir,
                               || bc.lo(1) == amrex::BCType::ext_dir || bc.hi(1) == amrex::BCType::ext_dir,
-                              || bc.lo(2) == amrex::BCType::ext_dir || bc.hi(2) == amrex::BCType::ext_dir ) ) { 
+                              || bc.lo(2) == amrex::BCType::ext_dir || bc.hi(2) == amrex::BCType::ext_dir ) ) {
                amrex::Abort("FCFillExtDirDummy is a dummy placeholder and should not be used in combination with BCType::ext_dir");
             }
         }

--- a/Source/utils_K.H
+++ b/Source/utils_K.H
@@ -1,0 +1,62 @@
+/** \addtogroup Utilities
+ * @{
+ */
+
+#ifndef HYDRO_UTILS_K_H_
+#define HYDRO_UTILS_K_H_
+
+#include <AMReX_REAL.H>
+#include <AMReX_FArrayBox.H>
+#include <cmath>
+
+//
+// Do linear in dir, pc transverse to dir, leave alone the fine values
+// lining up with coarse edges--assume these have been set to hold the
+// values you want to interpolate to the rest.
+//
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_interp_x (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
+	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+{
+    int rmod = i%ratio[0];
+
+    if ( rmod != 0 )
+    {
+      int ii = amrex::coarsen(i,ratio[0]);
+      amrex::Real const w = static_cast<amrex::Real>(i-ii*ratio[0]) * (amrex::Real(1.)/ratio[0]);
+      ii = i < 0 ? i-(ratio[0]+rmod) : i+(ratio[0]-rmod);
+      fine(i,j,k,n) = (amrex::Real(1.)-w) * fine(i-rmod,j,k,n) + w * fine(ii,j,k,n);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_interp_y (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
+	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+{
+    int rmod = j%ratio[1];
+
+    if ( rmod != 0 )
+    {
+      int jj = amrex::coarsen(j,ratio[1]);
+      amrex::Real const w = static_cast<amrex::Real>(j-jj*ratio[1]) * (amrex::Real(1.)/ratio[1]);
+      jj = j < 0 ? j-(ratio[1]+rmod) : j+(ratio[1]-rmod);
+      fine(i,j,k,n) = (amrex::Real(1.)-w) * fine(i,j-rmod,k,n) + w * fine(i,jj,k,n);
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
+face_interp_z (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
+	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+{
+    int rmod = k%ratio[2];
+
+    if ( rmod != 0 )
+    {
+      int kk = amrex::coarsen(k,ratio[2]);
+      amrex::Real const w = static_cast<amrex::Real>(k-kk*ratio[2]) * (amrex::Real(1.)/ratio[2]);
+      kk = k < 0 ? k-(ratio[2]+rmod) : k+(ratio[2]-rmod);
+      fine(i,j,k,n) = (amrex::Real(1.)-w) * fine(i,j,k-rmod,n) + w * fine(i,j,kk,n);
+    }
+}
+#endif
+/** @}*/

--- a/Source/utils_K.H
+++ b/Source/utils_K.H
@@ -16,7 +16,7 @@
 //
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
 face_interp_x (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
-	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+           amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
 {
     int rmod = i%ratio[0];
 
@@ -31,7 +31,7 @@ face_interp_x (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fin
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
 face_interp_y (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
-	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+           amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
 {
     int rmod = j%ratio[1];
 
@@ -46,7 +46,7 @@ face_interp_y (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fin
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE void
 face_interp_z (int i, int j, int k, int n, amrex::Array4<amrex::Real> const& fine,
-	       amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
+           amrex::GpuArray<int,AMREX_SPACEDIM>   const& ratio) noexcept
 {
     int rmod = k%ratio[2];
 


### PR DESCRIPTION
need at the fine level.  NOTE: this is still algorithmically incorrect
since we are only using coarse data the coarse "old time", which is
not correct for the intermediate stages of the first level 1 step,
or at any of the stages in the second level 1 step.