### PR TITLE
Remove Codecov integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,9 @@ jobs:
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
           -DERF_ENABLE_AMREX_EB:BOOL=ON \
           -DERF_ENABLE_FCOMPARE:BOOL=ON \
-          # -DCODECOVERAGE:BOOL=ON \
           ${{github.workspace}};
         # ${{matrix.mpipreflags}} \
+        # -DCODECOVERAGE:BOOL=ON \
 
     - name: Build
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
           -DERF_ENABLE_AMREX_EB:BOOL=ON \
           -DERF_ENABLE_FCOMPARE:BOOL=ON \
-          -DCODECOV:BOOL=ON \
+          # -DCODECOVERAGE:BOOL=ON \
           ${{github.workspace}};
         # ${{matrix.mpipreflags}} \
 
@@ -92,36 +92,27 @@ jobs:
         ctest -L regression -VV
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
 
-    - name: Generate coverage report
-      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
-      run: |
-        find . -type f -name '*.gcno' -path "**Source**" -exec gcov -pb {} +
-        cd ..
-        gcovr -g -k -r . --xml regressioncov.xml  # -v
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v2
-      with:
-        dry_run: false
-        # token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-        files: ./regressioncov.xml # optional
-        flags: regtests # optional
-        # name: codecov-umbrella # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
-        directory: ${{runner.workspace}}/ERF
-
-    - name: Success artifacts
-      uses: actions/upload-artifact@v2
-      if: success()
-      with:
-        name: build-and-test
-        path: |
-          ${{runner.workspace}}/ERF/regressioncov.xml
-    - name: Failing test artifacts
-      uses: actions/upload-artifact@v2
-      if: failure()
-      with:
-        name: build-and-test
-        path: |
-          ${{runner.workspace}}/ERF/regressioncov.xml
+    # Raf: disabled Codecov since the dashboard and GitHub comments were buggy,
+    # but it may be useful to post the gcov coverage reports to GitHub Actions
+    # artifacts.
+    # Note: if reenabling Codecov, the reports must be in xml format not html.
+    # - name: Generate coverage report
+    #   working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
+    #   run: |
+    #     find . -type f -name '*.gcno' -path "**Source**" -exec gcov -pb {} +
+    #     cd ..
+    #     gcovr -g -k -r . --xml regressioncov.html  # -v
+    # - name: Success artifacts
+    #   uses: actions/upload-artifact@v2
+    #   if: success()
+    #   with:
+    #     name: build-and-test
+    #     path: |
+    #       ${{runner.workspace}}/ERF/regressioncov.html
+    # - name: Failing test artifacts
+    #   uses: actions/upload-artifact@v2
+    #   if: failure()
+    #   with:
+    #     name: build-and-test
+    #     path: |
+    #       ${{runner.workspace}}/ERF/regressioncov.html

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,14 +41,14 @@ if(NOT ERF_DIM EQUAL 3)
 endif()
 
 # Configure measuring code coverage in tests
-option(CODECOV "Enable code coverage profiling" OFF)
-if(CODECOV)
+option(CODECOVERAGE "Enable code coverage profiling" OFF)
+if(CODECOVERAGE)
   # Only supports GNU
   if(NOT CMAKE_CXX_COMPILER_ID MATCHES GNU)
-    message(WARNING "CODECOV is only support with GNU Compilers. The current C++ compiler is ${CMAKE_CXX_COMPILER_ID}")
+    message(WARNING "CODECOVERAGE is only support with GNU Compilers. The current C++ compiler is ${CMAKE_CXX_COMPILER_ID}")
   endif()
   if(NOT CMAKE_C_COMPILER_ID MATCHES GNU)
-    message(WARNING "CODECOV is only support with GNU Compilers. The current C compiler is ${CMAKE_C_COMPILER_ID}")
+    message(WARNING "CODECOVERAGE is only support with GNU Compilers. The current C compiler is ${CMAKE_C_COMPILER_ID}")
   endif()
 
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")

--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,11 @@ for massively parallel block-structured applications.
 Test Status
 ~~~~~~~~~~~
 
-=================  =============  ====================
-Regression Tests    |regtests|     |regtest-coverage|
-=================  =============  ====================
+=================  =============
+Regression Tests    |regtests|  
+=================  =============
 
 .. |regtests| image:: https://github.com/erf-model/ERF/actions/workflows/ci.yml/badge.svg?branch=development
-.. |regtest-coverage| image:: https://codecov.io/gh/erf-model/ERF/branch/development/graph/badge.svg?token=74S5Q66M1M
-    :target: https://codecov.io/gh/erf-model/ERF
 .. |unittests| image:: https://github.com/erf-model/ERF/actions/workflows/ci.yml/badge.svg?branch=development
 
 

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Test Status
 ~~~~~~~~~~~
 
 =================  =============
-Regression Tests    |regtests|  
+Regression Tests    |regtests|
 =================  =============
 
 .. |regtests| image:: https://github.com/erf-model/ERF/actions/workflows/ci.yml/badge.svg?branch=development


### PR DESCRIPTION
This pull request removes the Codecov integration in the automated testing system. It also disables but does not remove the infrastructure for generating coverage reports with gcov and gcovr. I left these in place because it may be useful to enable and post these reports to the Actions dashboard in the future.