### PR TITLE
Add total mass on level 0 as diagnostic 

### DIFF
--- a/Source/RK3/Advection.cpp
+++ b/Source/RK3/Advection.cpp
@@ -345,8 +345,8 @@ AdvectionContributionForState(const int &i, const int &j, const int &k,
     }
     // Assemble advection contribution
     advectionContribution = (xFaceFluxNext - xFaceFluxPrev)/ dx  // Advective flux in x-dir
-                               + (yFaceFluxNext - yFaceFluxPrev)/ dy  // Advective flux in y-dir
-                               + (zFaceFluxNext - zFaceFluxPrev)/ dz; // Advective flux in z-dir
+                          + (yFaceFluxNext - yFaceFluxPrev)/ dy  // Advective flux in y-dir
+                          + (zFaceFluxNext - zFaceFluxPrev)/ dz; // Advective flux in z-dir
 
     return advectionContribution;
 }

--- a/Source/SumIQ.cpp
+++ b/Source/SumIQ.cpp
@@ -15,18 +15,28 @@ ERF::sum_integrated_quantities()
   int finest_level = parent->finestLevel();
   amrex::Real time = state[State_Type].curTime();
 
-  amrex::Real mass = 0.0;
+  amrex::Real mass      = 0.0;
   int datwidth = 14;
   int datprecision = 6;
 
+  // Compute sum on all levels -- this uses the data at
+  //    the finest level available
   for (int lev = 0; lev <= finest_level; lev++) {
-    ERF& erf_lev = getLevel(lev);
-    mass += erf_lev.volWgtSum("density", time, local_flag);
+      ERF& erf_lev = getLevel(lev);
+      mass += erf_lev.volWgtSum("density", time, local_flag);
+  }
+
+  // Compute sum on coarsest level only -- this definition of
+  //    mass is conserved with OneWay coupling.
+  amrex::Real mass_crse;
+  {
+      ERF& erf_lev = getLevel(0);
+      mass_crse = erf_lev.volWgtSum("density", time, local_flag, false);
   }
 
   if (verbose > 0) {
-    const int nfoo = 1;
-    amrex::Real foo[nfoo] = {mass};
+    const int nfoo = 2;
+    amrex::Real foo[nfoo] = {mass,mass_crse};
 #ifdef AMREX_LAZY
     Lazy::QueueReduction([=]() mutable {
 #endif
@@ -34,11 +44,11 @@ ERF::sum_integrated_quantities()
         foo, nfoo, amrex::ParallelDescriptor::IOProcessorNumber());
 
       if (amrex::ParallelDescriptor::IOProcessor()) {
-        int i = 0;
-        mass = foo[i++];
+        mass      = foo[0];
+        mass_crse = foo[1];
 
         amrex::Print() << '\n';
-        amrex::Print() << "TIME= " << time << " MASS        = " << mass << '\n';
+        amrex::Print() << "TIME= " << time << " MASS (all levels / level 0) = " << mass << " " << mass_crse << '\n';
 
         if (parent->NumDataLogs() > 0) {
           std::ostream& data_log1 = parent->DataLog(0);
@@ -46,12 +56,13 @@ ERF::sum_integrated_quantities()
             if (time == 0.0) {
               data_log1 << std::setw(datwidth) << "          time";
               data_log1 << std::setw(datwidth) << "          mass";
+              data_log1 << std::setw(datwidth) << "     mass_crse";
             }
 
             // Write the quantities at this time
             data_log1 << std::setw(datwidth) << time;
-            data_log1 << std::setw(datwidth) << std::setprecision(datprecision)
-                      << mass;
+            data_log1 << std::setw(datwidth) << std::setprecision(datprecision) << mass;
+            data_log1 << std::setw(datwidth) << std::setprecision(datprecision) << mass_crse;
             data_log1 << std::endl;
           }
         }


### PR DESCRIPTION
(This is conserved in one way coupling while the multilevel mass is not.)