### PR TITLE
Fix relative path error for build doc script

### DIFF
--- a/Docs/BuildDocs.sh
+++ b/Docs/BuildDocs.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# exit immediately on error
+set -e
+
+# To avoid issues when calling the script from different directories
+# sets the directory to the location of the script
+cd $(dirname $0)
 
 # This short script builds both the doxygen and sphinx documentation
 


### PR DESCRIPTION
Allows the documentation build script to be called from different locations without breaking. 