### PR TITLE
Update document for stress strain theory

### DIFF
--- a/Docs/sphinx_doc/NavierStokes_Discretization.rst
+++ b/Docs/sphinx_doc/NavierStokes_Discretization.rst
@@ -1,7 +1,7 @@
 #########################################
 Discretization of Navier-Stokes Equations
 #########################################
-Last update: 2021-10-29
+Last update: 2021-11-13
 
 NOTE: For the sake of simplicity, the discretized equations mention time levels :math:`n` and :math:`n+1`. They should be treated as initial and final states of each RK3 stage.
 
@@ -233,7 +233,8 @@ The schematic below shows the definition of strain-rate components.
 .. image:: figures/grid_discretization/StrainRate.PNG
   :width: 400
 
-
+Strain-Rate Components for X-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. math::
 
    \begin{array}{ll}
@@ -245,8 +246,8 @@ The schematic below shows the definition of strain-rate components.
    S_{13,k - \frac{1}{2}} = & \frac{1}{2}\left\lbrack \frac{1}{\Delta z}\left( u_{i,j,k} - u_{i,j,k - 1} \right) + \frac{1}{\Delta x}\left( w_{i,j,k} - w_{i - 1,j,k} \right) \right\rbrack \\
    \end{array}
 
-
-
+Strain-Rate Components for Y-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. math::
 
    \begin{array}{ll}
@@ -258,8 +259,8 @@ The schematic below shows the definition of strain-rate components.
    S_{23,k - \frac{1}{2}} = & \frac{1}{2}\left\lbrack \frac{1}{\Delta z}\left( v_{i,j,k} - v_{i,j,k - 1} \right) + \frac{1}{\Delta y}\left( w_{i,j,k} - w_{i,j - 1,k} \right) \right\rbrack \\
    \end{array}
 
-
-
+Strain-Rate Components for Z-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. math::
 
    \begin{array}{ll}
@@ -270,6 +271,20 @@ The schematic below shows the definition of strain-rate components.
    S_{33,k + \frac{1}{2}} = & \frac{1}{\Delta z}\left( w_{i,j,k + 1} - w_{i,j,k} \right) \\
    S_{33,k - \frac{1}{2}} = & \frac{1}{\Delta z}\left( w_{i,j,k} - w_{i,j,k - 1} \right) \\
    \end{array}
+
+Expansion-Rate Tensor
+------------------
+Place holder....
+... to be updated
+
+Expansion-Rate Components for X-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Expansion-Rate Components for Y-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Expansion-Rate Components for Z-Momentum Equation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Momentum Conservation – U Momentum viscous stress divergence

--- a/Docs/sphinx_doc/NavierStokes_Discretization.rst
+++ b/Docs/sphinx_doc/NavierStokes_Discretization.rst
@@ -372,6 +372,16 @@ Difference Equation
 .. math::
 
    \begin{matrix}
+   \left( \rho \theta \right)_{i,j,k}^{n + 1} & = & \left( \rho \theta \right)_{i,j,k}^{n} & + & \Delta t \alpha_{T} & \left\{ \frac{1}{{\Delta x}^{2}}\ \left\lbrack (\rho \theta)_{i + 1,j,k}^{n} - \ 2 (\rho \theta)_{i,j,k}^{n} + \ (\rho \theta)_{i - 1,j,k}^{n} \right\rbrack \right.\  \\
+    & & & & & + \frac{1}{{\Delta y}^{2}}\left\lbrack (\rho \theta)_{i,j + 1,k}^{n} - \ 2 (\rho \theta)_{i,j,k}^{n} + \ (\rho \theta)_{i, j - 1,k}^{n} \right\rbrack \\
+    & & & & & + \left. \frac{1}{{\Delta z}^{2}}\left\lbrack (\rho \theta)_{i,j,k + 1}^{n} - \ 2 (\rho \theta)_{i,j,k}^{n} + \ (\rho \theta)_{i,j,k - 1}^{n} \right\rbrack \right\}
+   \end{matrix}
+
+.. note:: Other consideration discussed but not implemented is shown below:
+
+.. math::
+
+   \begin{matrix}
    \left( \rho \theta \right)_{i,j,k}^{n + 1} & = & \left( \rho \theta \right)_{i,j,k}^{n} & + & \Delta t\rho_{i,j,k}\alpha_{T} & \left\{ \frac{1}{{\Delta x}^{2}}\ \left\lbrack \theta_{i + 1,j,k}^{n} - \ {2\theta}_{i,j,k}^{n} + \ \theta_{i - 1,j,k}^{n} \right\rbrack \right.\  \\
     & & & & & + \frac{1}{{\Delta y}^{2}}\left\lbrack \theta_{i,j + 1,k}^{n} - \ 2\theta_{i,j,k}^{n} + \ \theta_{i,j - 1,k}^{n} \right\rbrack \\
     & & & & & + \left. \frac{1}{{\Delta z}^{2}}\left\lbrack \theta_{i,j,k + 1}^{n} - \ {2\theta}_{i,j,k}^{n} + \ \theta_{i,j,k - 1}^{n} \right\rbrack \right\}
@@ -387,9 +397,19 @@ Difference Equation
 .. math::
 
    \begin{matrix}
-   \left( \rho C \right)_{i,j,k}^{n + 1} & = & \left( \rho C \right)_{i,j,k}^{n} & + & \Delta t\rho_{i,j,k}\alpha_{S} & \left\{ \frac{1}{{\Delta x}^{2}}\ \left\lbrack C_{i + 1,j,k}^{n} - \ {2C}_{i,j,k}^{n} + \ C_{i - 1,j,k}^{n} \right\rbrack \right.\  \\
+   \left( \rho C \right)_{i,j,k}^{n + 1} & = & \left( \rho C \right)_{i,j,k}^{n} & + & \Delta t \alpha_{C} & \left\{ \frac{1}{{\Delta x}^{2}}\ \left\lbrack (\rho C)_{i + 1,j,k}^{n} - \ 2 (\rho C)_{i,j,k}^{n} + \ (\rho C)_{i - 1,j,k}^{n} \right\rbrack \right.\  \\
+    & & & & & + \frac{1}{{\Delta y}^{2}}\left\lbrack (\rho C)_{i,j + 1,k}^{n} - \ 2 (\rho C)_{i,j,k}^{n} + \ (\rho C)_{i,j - 1,k}^{n} \right\rbrack \\
+    & & & & & + \left. \frac{1}{{\Delta z}^{2}}\left\lbrack (\rho C)_{i,j,k + 1}^{n} - \ 2 (\rho C)_{i,j,k}^{n} + \ (\rho C)_{i,j,k - 1}^{n} \right\rbrack \right\}
+   \end{matrix}
+
+.. note:: Other consideration discussed but not implemented is shown below:
+
+.. math::
+
+   \begin{matrix}
+   \left( \rho C \right)_{i,j,k}^{n + 1} & = & \left( \rho C \right)_{i,j,k}^{n} & + & \Delta t\rho_{i,j,k}\alpha_{C} & \left\{ \frac{1}{{\Delta x}^{2}}\ \left\lbrack C_{i + 1,j,k}^{n} - \ 2C_{i,j,k}^{n} + \ C_{i - 1,j,k}^{n} \right\rbrack \right.\  \\
     & & & & & + \frac{1}{{\Delta y}^{2}}\left\lbrack C_{i,j + 1,k}^{n} - \ 2C_{i,j,k}^{n} + \ C_{i,j - 1,k}^{n} \right\rbrack \\
-    & & & & & + \left. \frac{1}{{\Delta z}^{2}}\left\lbrack C_{i,j,k + 1}^{n} - \ {2C}_{i,j,k}^{n} + \ C_{i,j,k - 1}^{n} \right\rbrack \right\}
+    & & & & & + \left. \frac{1}{{\Delta z}^{2}}\left\lbrack C_{i,j,k + 1}^{n} - \ 2C_{i,j,k}^{n} + \ C_{i,j,k - 1}^{n} \right\rbrack \right\}
    \end{matrix}
 
 Momentum, Thermal, and Scalar Diffusion Contribution to LES

--- a/Docs/sphinx_doc/theory/NavierStokesEquations.rst
+++ b/Docs/sphinx_doc/theory/NavierStokesEquations.rst
@@ -16,24 +16,93 @@ Compressible Navier-Stokes Equations
 ERF advances the following set of equations in DNS mode:
 
 .. math::
-
   \frac{\partial \rho}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u}),
 
   \frac{\partial (\rho \mathbf{u})}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} \mathbf{u} + pI) +\rho \mathbf{g} + \nabla \cdot \tau + \mathbf{F},
 
-  \frac{\partial (\rho \theta)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} \theta) + \rho \alpha_{T}\ \nabla^2 \theta,
+  \frac{\partial (\rho \theta)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} \theta) + \nabla \cdot (\alpha_{T}\ \nabla (\rho \theta)),
 
-  \frac{\partial (\rho C)}{\partial t}      &=& - \nabla \cdot (\rho \mathbf{u} C)      + \rho \alpha_{C}\ \nabla^2 C
+  \frac{\partial (\rho C)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} C) + \nabla \cdot (\alpha_{C}\ \nabla (\rho C))
 
-where :math:`\tau` is the stress tensor and :math:`\mathbf{F}` are the forcing terms described in :ref:`Forcings`.
+Here :math:`\tau_{ij}` is the stress tensor and is related to shear-rate tensor, :math:`\sigma_{ij}`,  by:
 
-When run in DNS mode, :math:`\tau = 2 \mu S` where :math:`\mu` is the user-specified dynamic viscosity and
-:math:`S` is the strain-rate tensor.  When using the Smagorinsky model, the turbulent viscosity
-:math:`K = 2 (C_s \Delta)^2 (\sqrt{2 S S} \rho)` is used in place of :math:`2 \mu,` where
+.. math::
+   \tau_{ij} = 2\mu\sigma_{ij}
 
-:math:`C_s` is the Smagorinsky constant and :math:`\Delta` is the mesh spacing.
+The shear-rate tensor, :math:`\sigma_{ij}`, is further expressed as:
 
-Note that :math:`\alpha_{T}` is in general variable for a general compressible flow. However, for low Mach number atmospheric flows it are assumed to be constant.
+.. math::
+   \sigma_{ij} = S_{ij} -D_{ij},
+
+where :math:`S_{ij}` is the strain-rate tensor and :math:`D_{ij}` is the expansion-rate tensor.
+
+.. math::
+   S_{ij} = \frac{1}{2} \left(  \frac{\partial u_i}{\partial x_j} + \frac{\partial u_j}{\partial x_i}   \right)
+
+.. math::
+   D_{ij} = \frac{1}{3}  S_{kk} \delta_{ij} = \frac{1}{3} (\nabla \cdot \mathbf{u}) \delta_{ij}
+
+.. note:: For an incompressible flow :math:`\nabla \cdot \mathbf{u} = 0`,
+   where as for compressible flow :math:`\nabla \cdot \mathbf{u} \neq 0` in general,
+   thus leading to a non-negligible :math:`D_{ij}`.
+
+This leads to:
+
+.. math::
+   \tau_{ij} = 2\mu \left( S_{ij} - \frac{1}{3} S_{kk} \delta_{ij} \right), \hspace{24pt}
+
+.. note:: The bulk viscosity contribution to :math:`\tau_{ij}`, i.e., :math:`\kappa S_{kk} \delta_{ij}` has been ignored
+   in the current implementation.
+
+.. note:: The diffusion coefficients, :math:`\alpha_{T}` and :math:`\alpha_{C}` for energy and scalar equations respectively,
+   are in general variable for compressible flow. However, for low Mach number atmospheric flows they are assumed to be constant.
+
+For low Mach number atmospheric flows the energy and scalar equations reduce to:
+
+.. math::
+  \frac{\partial (\rho \theta)}{\partial t} &=& - \nabla \cdot (\rho \mathbf{u} \theta) + \alpha_{T}\ \nabla^2 (\rho \theta)
+
+  \frac{\partial (\rho C)}{\partial t}      &=& - \nabla \cdot (\rho \mathbf{u} C)      + \alpha_{C}\ \nabla^2 (\rho C)
+
+DNS and LES
+------------
+
+DNS
+~~~
+When run in DNS mode, it is assumed that the mesh is fine enough to resolve Kolmogorov scales of turbulence.
+The viscosity, :math:`\mu`, used in computing the stress term, :math:`\tau_{ij}`, is the dynamic viscosity (molecular).
+:math:`\mu` is assumed to be constant for low Mach number atmospheric flows and is provided by the user.
+
+LES
+~~~
+When using the LES model, it is assumed that mesh is coarser than those used for DNS and Kolmogorov scales are not resolved.
+The scales that are resolved are represented by the filtered equations and the unresolved scales are modeled.
+The LES models essentially attempt to account for the effect of unresolved scales on the viscosity where
+:math:`\mu` is replaced by a modeled turbulent viscosity, :math:`\mu_{t}`.
+
+There are several approaches to model :math:`\mu_{t}`. Smagorinsky and Deardorff models are commonly used.
+
+Smagorinsky Model
+~~~~~~~~~~~~~~~~~~
+.. math::
+   \mu_{t} = (C_s \Delta)^2 (\sqrt{2 S S}) \rho
+:math:`C_s` is the Smagorinsky constant and :math:`\Delta` is the cube root of cell volume, the representative mesh spacing.
+
+.. math::
+   \tau_{ij} = 2\mu_{t} \sigma_{ij} = K \sigma_{ij}
+
+where :math:`K = 2\mu_{t}`
+
+In Smagorisnky model, modeling of :math:`\mu_{t}` doesn't account for the turbulent kinetic energy (TKE) corresponding to
+unresolved scales and no extra equation for TKE is solved.
+
+Deardorff Model
+~~~~~~~~~~~~~~~~~~
+Unlike Smagorinsky model, Deardorff model accounts for the contribution of TKE in modeling :math:`\mu_{t}` and equation
+for TKE is solved, i.e., TKE is prognosed.
+
+
+:math:`\mathbf{F}` are the forcing terms described in :ref:`Forcings`.
 
 These equations can be re-written in perturbational form by replacing the z-momentum equation with
 

--- a/Docs/sphinx_doc/theory/NavierStokesEquations.rst
+++ b/Docs/sphinx_doc/theory/NavierStokesEquations.rst
@@ -101,9 +101,13 @@ Deardorff Model
 Unlike Smagorinsky model, Deardorff model accounts for the contribution of TKE in modeling :math:`\mu_{t}` and equation
 for TKE is solved, i.e., TKE is prognosed.
 
-
+Forcings
+------------
 :math:`\mathbf{F}` are the forcing terms described in :ref:`Forcings`.
 
+
+Equations in Perturbation Form
+-------------------------------
 These equations can be re-written in perturbational form by replacing the z-momentum equation with
 
 .. math::
@@ -129,6 +133,9 @@ and
   \frac{d \overline{p}}{d z} = - \overline{\rho} g
 
 with velocity :math:`\mathbf{u} = (u,v,w)` and gravity :math:`\mathbf{g} = (0,0,-g)`.
+
+Diagnostic Relationships
+-------------------------
 
 The relationship between potential temperature and temperature is given by
 


### PR DESCRIPTION
- Account for expansion rate for compressible flow when computing shear-rate used in stress term.
- Discretization of the additional term for expansion-rate will follow in the next PR.