### PR TITLE
change PI definition, M_PI with constexpr

### DIFF
--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -1,7 +1,7 @@
 #ifndef _CONSTANTS_H_
 #define _CONSTANTS_H_
 
-constexpr amrex::Real M_PI 3.14159265358979323846264338327950288;
+constexpr amrex::Real PI 3.14159265358979323846264338327950288;
 
 //TODO: Change these types of macros to 'const'
 #define R_d     287.0 // gas constant for dry air [J/(kg-K)]

--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -1,7 +1,7 @@
 #ifndef _CONSTANTS_H_
 #define _CONSTANTS_H_
 
-constexpr amrex::Real PI 3.14159265358979323846264338327950288;
+constexpr amrex::Real PI = 3.14159265358979323846264338327950288;
 
 //TODO: Change these types of macros to 'const'
 #define R_d     287.0 // gas constant for dry air [J/(kg-K)]

--- a/Source/Constants.H
+++ b/Source/Constants.H
@@ -1,7 +1,7 @@
 #ifndef _CONSTANTS_H_
 #define _CONSTANTS_H_
 
-#define PI 3.14159265358979323846264338327950288
+constexpr amrex::Real M_PI 3.14159265358979323846264338327950288;
 
 //TODO: Change these types of macros to 'const'
 #define R_d     287.0 // gas constant for dry air [J/(kg-K)]

--- a/Source/ERF_forcing.cpp
+++ b/Source/ERF_forcing.cpp
@@ -1,8 +1,8 @@
 #include <AMReX_Vector.H>
-#include <AMReX_CONSTANTS.H>
 #include <AMReX_ParmParse.H>
 
 #include "ERF.H"
+#include "Constants.H"
 
 using namespace amrex;
 

--- a/Source/ERF_forcing.cpp
+++ b/Source/ERF_forcing.cpp
@@ -17,7 +17,7 @@ ERF::build_coriolis_forcings()
     amrex::Real rot_time_period = 86400.0;
     pp.query("rotational_time_period", rot_time_period);
 
-    coriolis_factor = 2.0 * 2.0 * M_PI / rot_time_period;
+    coriolis_factor = 2.0 * 2.0 * PI / rot_time_period;
     amrex::Print() << "Coriolis factor = " << coriolis_factor << std::endl;
 
     amrex::Real latitude = 90.0;
@@ -25,7 +25,7 @@ ERF::build_coriolis_forcings()
     AMREX_ALWAYS_ASSERT(amrex::Math::abs(latitude - 90.0) < 1.e-12);
 
     // Convert to radians
-    latitude *= (M_PI/180.);
+    latitude *= (PI/180.);
     sinphi = std::sin(latitude);
     cosphi = std::cos(latitude);
 


### PR DESCRIPTION
Rather than define `PI` via #define, use constexpr amrex::Real `M_PI`. 

Note, `PI` was defined but `M_PI` was being used in the code. 