### PR TITLE
Put ERF_ENABLE_ALL_WARNINGS compiler flags back.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,6 @@ jobs:
   WIN32-MSVC10:
     name: WIN32 MSVC@19.29
     runs-on: windows-latest
-    # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}
     steps:
     - uses: actions/checkout@v2.4.0
       with:
@@ -24,7 +23,7 @@ jobs:
           -DERF_DIM:STRING=3 `
           -DERF_ENABLE_MPI:BOOL=OFF `
           -DERF_ENABLE_TESTS:BOOL=ON `
-          -DERF_ENABLE_ALL_WARNINGS:BOOL=ON `
+          -DERF_ENABLE_ALL_WARNINGS:BOOL=OFF `
           -DERF_ENABLE_AMREX_EB:BOOL=ON `
           -DERF_ENABLE_FCOMPARE:BOOL=ON `
           ${{github.workspace}};

--- a/CMake/SetERFCompileFlags.cmake
+++ b/CMake/SetERFCompileFlags.cmake
@@ -2,7 +2,7 @@ function(set_erf_compile_flags target)
 # Logic for handling warnings
 if(ERF_ENABLE_ALL_WARNINGS)
   # GCC, Clang, and Intel seem to accept these
-  # list(APPEND ERF_CXX_FLAGS "-Wall" "-Wextra" "-pedantic")
+    list(APPEND ERF_CXX_FLAGS "-Wall" "-Wextra" "-pedantic")
   if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Intel")
     # ifort doesn't like -Wall
     list(APPEND ERF_Fortran_FLAGS "-Wall")


### PR DESCRIPTION
In the last PR I disabled some of the compiler warnings. I meant to put them back, but forgot. So I'm testing it now with this PR. 