### PR TITLE
Run clang tidy

### DIFF
--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -1,0 +1,36 @@
+name: cpp-linter
+
+on: [pull_request]
+jobs:
+  cpp-linter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y -qq
+          sudo apt-get -qq -y install curl clang-tidy cmake jq clang cppcheck clang-format bear g++>=9.3.0 gfortran>=9.3.0
+
+      - name: Get cpp linter repo
+        run: |
+          cd Submodules
+          git clone https://github.com/AMReX-Astro/cpp-linter-action.git
+          cd ..
+
+      - name: Check header includes
+        run: |
+          echo 'HEADER_INCLUDES=$(grep -rIE --include="*.cpp" --include="*.H" --exclude-dir=Submodules "#\s?include\s+\"\w+\.\w+\"")' >> $GITHUB_ENV
+          echo $HEADER_INCLUDES
+          if [[ -n "${HEADER_INCLUDES}" ]]; then exit 1; fi
+
+      - name: Run cpp linter
+        run: python3 Submodules/cpp-linter-action/run_on_changed_files.py ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -header-filter=ERF -ignore-files="AMReX|GoogleTest" -run-linter
+
+      - name: Archive clang tidy report
+        uses: actions/upload-artifact@v1
+        with:
+          name: clang-tidy-report
+          path: clang-tidy-report.txt

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -27,7 +27,7 @@ jobs:
           if [[ -n "${HEADER_INCLUDES}" ]]; then exit 1; fi
 
       - name: Run cpp linter
-        run: python3 Submodules/cpp-linter-action/run_on_changed_files.py ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -header-filter=ERF -ignore-files="AMReX|GoogleTest" -run-linter
+        run: python3 Submodules/cpp-linter-action/run_on_changed_files.py ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }} -header-filter=Source/ -ignore-files="AMReX|GoogleTest" -run-linter
 
       - name: Archive clang tidy report
         uses: actions/upload-artifact@v1

--- a/.github/workflows/c-linter.yml
+++ b/.github/workflows/c-linter.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Get cpp linter repo
         run: |
           cd Submodules
-          git clone https://github.com/AMReX-Astro/cpp-linter-action.git
+          git clone https://github.com/dwillcox/cpp-linter-action.git
           cd ..
 
       - name: Check header includes


### PR DESCRIPTION
This runs clang tidy on our Source files.

At the moment, there are loads of warning messages for C++ styling for our existing codebase, so until we make all those changes this won't only check new changes we make.