### PR TITLE
Bugfix when regridding at the start of a simulation

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -344,7 +344,14 @@ ERF::init(AmrLevel& old)
   setTimeLevel(cur_time, dt_old, dt_new);
 
   amrex::MultiFab& S_new = get_new_data(State_Type);
+  amrex::MultiFab& U_new = get_new_data(X_Vel_Type);
+  amrex::MultiFab& V_new = get_new_data(Y_Vel_Type);
+  amrex::MultiFab& W_new = get_new_data(Z_Vel_Type);
+
   FillPatch(old, S_new, 0, cur_time, State_Type, 0, NVAR);
+  FillPatch(old, U_new, 0, cur_time, X_Vel_Type, 0, 1);
+  FillPatch(old, V_new, 0, cur_time, Y_Vel_Type, 0, 1);
+  FillPatch(old, W_new, 0, cur_time, Z_Vel_Type, 0, 1);
 }
 
 /**

--- a/Source/Setup.cpp
+++ b/Source/Setup.cpp
@@ -182,6 +182,12 @@ ERF::variableSetUp()
   //     and for all conserved quantities as well
   //     (unnecessary right now but convenient)
   //
+  amrex::StateDescriptor::BndryFunc bndryfunc_null(erf_nullfill);
+  bndryfunc_null.setRunOnGPU(true);
+  amrex::Vector<amrex::BCRec> vel_bcs(1);
+  amrex::Vector<std::string> vel_name(1);
+  vel_bcs[0] = bc;
+
   store_in_checkpoint = true;
   amrex::IndexType xface(amrex::IntVect(1,0,0));
   desc_lst.addDescriptor(X_Vel_Type, xface,
@@ -189,17 +195,26 @@ ERF::variableSetUp()
                          interp, state_data_extrap,
                          store_in_checkpoint);
 
+  vel_name[0] = "x_velocity";
+  desc_lst.setComponent(X_Vel_Type, 0, vel_name, vel_bcs, bndryfunc_null);
+
   amrex::IndexType yface(amrex::IntVect(0,1,0));
   desc_lst.addDescriptor(Y_Vel_Type, yface,
                          amrex::StateDescriptor::Point, 1, 1,
                          interp, state_data_extrap,
                          store_in_checkpoint);
 
+  vel_name[0] = "y_velocity";
+  desc_lst.setComponent(Y_Vel_Type, 0, vel_name, vel_bcs, bndryfunc_null);
+
   amrex::IndexType zface(amrex::IntVect(0,0,1));
   desc_lst.addDescriptor(Z_Vel_Type, zface,
                          amrex::StateDescriptor::Point, 1, 1,
                          interp, state_data_extrap,
                          store_in_checkpoint);
+
+  vel_name[0] = "z_velocity";
+  desc_lst.setComponent(Z_Vel_Type, 0, vel_name, vel_bcs, bndryfunc_null);
 
   num_state_type = desc_lst.size();
 


### PR DESCRIPTION
Previously when regridding on the start of the simulation (e.g. ABL) using `amr.regrid_on_restart=1` would lead to invalid data and segfaults (even if we're not actually restarting from a checkpoint file, this can trigger a re-initialization of the AmrLevel in `Amr::regrid_level_0_on_restart`).

The reason is that we were not initializing X, Y, and Z velocities along with the cell centered data in `ERF::init(AmrLevel&)` so when we were given a pre-existing `AmrLevel` (with correct velocities) we only were FillPatching the cell centered data and not the velocities too. This left the new velocities undefined.

This fix FillPatches the velocities in `ERF::init(AmrLevel&)` and registers a null boundary function for them in `Setup.cpp` which we'll have to update later if we ever want external dirichlet BCs for velocities.