### PR TITLE
Create base state arrays

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -407,6 +407,10 @@ protected:
 
   static amrex::Vector<int> src_list;
 
+  // Base state quantities: density and pressure, 1 array per AMR level
+  static amrex::Vector<amrex::Vector<amrex::Real> > dens_hse;
+  static amrex::Vector<amrex::Vector<amrex::Real> > pres_hse;
+
 /* problem-specific includes */
 #include <Problem.H>
 


### PR DESCRIPTION
This adds `ERF::dens_hse` and `ERF::pres_hse` as vectors of length `max_level` where at each level `dens_hse[lev]` is of length `geom.Domain().length(2)` aka the number of cells in the z-dimension at that level.

Right now they're initialized to hold 0's with commented hooks where we will supply the function to calculate these arrays from the multifabs.