### PR TITLE
Ekman fix(es)

### DIFF
--- a/Exec/EkmanSpiral/check_convergence.py
+++ b/Exec/EkmanSpiral/check_convergence.py
@@ -35,10 +35,15 @@ def load_soln(pltfile):
 #
 # read all test cases
 #
+#pltfile = 'plt00000'
+pltfile = 'plt00010'
 results = {
-    25.0: load_soln('convergence/dz25.0/plt00010'),
-    12.5: load_soln('convergence/dz12.5/plt00010'),
-    6.25: load_soln('convergence/dz6.25/plt00010'),
+    25.0: load_soln(f'convergence/dz25.0/{pltfile}'),
+    12.5: load_soln(f'convergence/dz12.5/{pltfile}'),
+    6.25: load_soln(f'convergence/dz6.25/{pltfile}'),
+    3.125: load_soln(f'convergence/dz3.125/{pltfile}'),
+    1.5625: load_soln(f'convergence/dz1.5625/{pltfile}'),
+    0.78125: load_soln(f'convergence/dz0.78125/{pltfile}'),
 }
 
 #
@@ -63,6 +68,8 @@ for axi in ax:
 
 fig.savefig('convergence/velocity_profiles.png',bbox_inches='tight')
 
+ax[0].set_ylim((0,50))
+fig.savefig('convergence/velocity_profiles_zoom.png',bbox_inches='tight')
 #
 # plot error profiles
 #

--- a/Exec/EkmanSpiral/run_convergence_study.sh
+++ b/Exec/EkmanSpiral/run_convergence_study.sh
@@ -26,6 +26,9 @@ rm -rf $studydir
 run_case 200 'dz25.0'
 run_case 400 'dz12.5'
 run_case 800 'dz6.25'
+run_case 1600 'dz3.125'
+run_case 3200 'dz1.5625'
+run_case 6400 'dz0.78125'
 
 python check_convergence.py
 

--- a/Source/TimeIntegration/TimeIntegration_rhs.cpp
+++ b/Source/TimeIntegration/TimeIntegration_rhs.cpp
@@ -194,7 +194,7 @@ void erf_rhs (int level,
             // Add Coriolis forcing (that assumes east is +x, north is +y)
             if (solverChoice.use_coriolis)
             {
-                Real rho_v_loc = 0.25 * (rho_u(i,j+1,k) + rho_u(i,j,k) + rho_u(i-1,j+1,k) + rho_u(i-1,j,k));
+                Real rho_v_loc = 0.25 * (rho_v(i,j+1,k) + rho_v(i,j,k) + rho_v(i-1,j+1,k) + rho_v(i-1,j,k));
                 Real rho_w_loc = 0.25 * (rho_w(i,j,k+1) + rho_w(i,j,k) + rho_w(i,j-1,k+1) + rho_w(i,j-1,k));
                 rho_u_rhs(i, j, k) += solverChoice.coriolis_factor *
                         (rho_v_loc * solverChoice.sinphi - rho_w_loc * solverChoice.cosphi);

--- a/Source/TimeIntegration/TimeIntegration_rhs.cpp
+++ b/Source/TimeIntegration/TimeIntegration_rhs.cpp
@@ -297,6 +297,11 @@ void erf_rhs (int level,
                 Real rho_u_loc = 0.25 * (rho_u(i+1,j,k) + rho_u(i,j,k) + rho_u(i+1,j,k-1) + rho_u(i,j,k-1));
                 rho_w_rhs(i, j, k) += solverChoice.coriolis_factor * rho_u_loc * solverChoice.cosphi;
             }
+
+            // Add geostrophic forcing
+            if (solverChoice.abl_driver_type == ABLDriverType::GeostrophicWind)
+                rho_w_rhs(i, j, k) += solverChoice.abl_geo_forcing[2];
+
             } // not on coarse-fine boundary
         });
     }


### PR DESCRIPTION
* Fixed bug with local rho*v used in Coriolis calculation
* Added z geostrophic term for completeness
* Showed convergence towards analytical solution for dz = 25, 12.5, 6.25, 3.125 m
* Increase in error at dz=1.5625 m caused by unexpected near-surface behavior -- possible BC issue?
* Verified that `NoSlipWall` is equivalent to `Dirichlet` with `zlo.velocity=0 0 0`

![error_vs_dz](https://user-images.githubusercontent.com/18267059/142742572-29b7cd39-c26d-4144-8a7a-73c905303514.png)

![velocity_profiles_zoom--with_ringing](https://user-images.githubusercontent.com/18267059/142742524-c0501974-ee19-4084-ae96-a523f5520134.png)

