### PR TITLE
Fix CUDA compile where lambda capture could not capture class members

### DIFF
--- a/Source/ERF_PhysBCFunct.H
+++ b/Source/ERF_PhysBCFunct.H
@@ -185,7 +185,7 @@ public:
                     int zhi = m_geom.Domain().bigEnd(2);
 
                     // Fill here all the "generic" ext_dir bc's
-                    ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+                    ParallelFor(bx, ncomp, [=,m_var_idx=m_var_idx,m_most=m_most] AMREX_GPU_DEVICE (int i, int j, int k, int n)
                     {
                         if (i < dom_lo.x && bc_ptr[n].lo(0) == ERFBCType::ext_dir)
                             dest_array(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][0];


### PR DESCRIPTION
This fixes two issues where the code would not compile for GPUs because the extended lambda in the physical BCs function could not capture class members via `this` pointer.

Fixes the issue by explicitly capturing the class members by value in the lambda capture statement.