### PR TITLE
Fix restart issues in FillIntermediatePatch

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -172,13 +172,15 @@ private:
     // works for single level and 2-level cases (fill fine grid ghost by interpolating from coarse)
     void FillPatch (int lev, amrex::Real time, amrex::MultiFab& mf, int icomp, int ncomp, int var_idx);
 
-    // compute a new multifab by coping in data from valid region and filling ghost cells
+    // compute new multifabs by coping in data from valid region and filling ghost cells
     // works for single level and 2-level cases (fill fine grid ghost by interpolating from coarse)
-    // unlike FillPatch, FillIntermediatePatch will use the supplied multifab instead of fine level data.
+    // unlike FillPatch, FillIntermediatePatch will use the supplied multifabs instead of fine level data.
     // This is to support filling boundary cells at an intermediate time between old/new times
     // on the fine level when valid data at a specific time is already available (such as
     // at each RK stage when integrating between initial and final times at a given level).
-    void FillIntermediatePatch (int lev, Real time, MultiFab& mf, int icomp, int ncomp, int var_idx);
+    // NOTE: mfs should always contain {cons, xvel, yvel, zvel} multifab data.
+    // if which_var is supplied, then only fill the specified variable in the vector of mfs
+    void FillIntermediatePatch (int lev, Real time, Vector<std::reference_wrapper<MultiFab> > mfs, int which_var = -1);
 
     // fill an entire multifab by interpolating from the coarser level
     // this comes into play when a new level of refinement appears

--- a/Source/TimeIntegration/TimeIntegration_driver.cpp
+++ b/Source/TimeIntegration/TimeIntegration_driver.cpp
@@ -143,13 +143,13 @@ void ERF::erf_advance(int level,
         }
 
         // ***************************************************************************************
-        // Call the FillPatch routines for cell-centered variables only.
+        // Call FillPatch routines for cell-centered data
         // This fills ghost cells/faces from
         //     1) coarser level if lev > 0
         //     2) physical boundaries
         //     3) other grids at the same level
         // ***************************************************************************************
-        FillIntermediatePatch(level, time_for_fp, S_data[IntVar::cons], 0, Cons::NumVars, Vars::cons);
+        FillIntermediatePatch(level, time_for_fp, {S_data[IntVar::cons], xvel_new, yvel_new, zvel_new}, Vars::cons);
 
         // Here we don't use include any of the ghost region because we have only updated
         //      momentum on valid faces
@@ -160,16 +160,16 @@ void ERF::erf_advance(int level,
                            S_data[IntVar::zmom],
                            IntVect::TheZeroVector());
 
-        // **************************************************************************************
-        // Call the FillPatch routines for face-centered velocity components only.
+        // ***************************************************************************************
+        // Call FillPatch routines for face-centered velocity components
         // This fills ghost cells/faces from
         //     1) coarser level if lev > 0
         //     2) physical boundaries
         //     3) other grids at the same level
-        // **************************************************************************************
-        FillIntermediatePatch(level, time_for_fp, xvel_new, 0, 1, Vars::xvel);
-        FillIntermediatePatch(level, time_for_fp, yvel_new, 0, 1, Vars::yvel);
-        FillIntermediatePatch(level, time_for_fp, zvel_new, 0, 1, Vars::zvel);
+        // ***************************************************************************************
+        FillIntermediatePatch(level, time_for_fp, {S_data[IntVar::cons], xvel_new, yvel_new, zvel_new}, Vars::xvel);
+        FillIntermediatePatch(level, time_for_fp, {S_data[IntVar::cons], xvel_new, yvel_new, zvel_new}, Vars::yvel);
+        FillIntermediatePatch(level, time_for_fp, {S_data[IntVar::cons], xvel_new, yvel_new, zvel_new}, Vars::zvel);
 
         // Now we can convert back to momentum on valid+ghost since we have
         //     filled the ghost regions for both velocity and density
@@ -250,8 +250,5 @@ void ERF::erf_advance(int level,
 
     // One final BC fill
     amrex::Real new_time = old_time + dt_advance;
-    FillIntermediatePatch(level, new_time, cons_new, 0, Cons::NumVars, Vars::cons);
-    FillIntermediatePatch(level, new_time, xvel_new, 0, 1, Vars::xvel);
-    FillIntermediatePatch(level, new_time, yvel_new, 0, 1, Vars::yvel);
-    FillIntermediatePatch(level, new_time, zvel_new, 0, 1, Vars::zvel);
+    FillIntermediatePatch(level, new_time, {cons_new, xvel_new, yvel_new, zvel_new});
 }


### PR DESCRIPTION
Modifies FillIntermediatePatch so we always use cons, xvel, yvel, and zvel at the current time in the phys bc function at the current fine level.

An optional final argument to FillIntermediatePatch allows specifying which of those kinds of variables to actually fill, otherwise all are filled.

Passes tests & successful restart verified in non-debug mode and debug mode.