### PR TITLE
Fix OpenMP compilation and execution

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -534,15 +534,15 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba,
 #endif
 
     // Loop over grids at this level to initialize our grid data
-#ifdef _OPENMP
-#pragma omp parallel
-#endif
     lev_new[Vars::cons].setVal(0.0);
     lev_new[Vars::xvel].setVal(0.0);
     lev_new[Vars::yvel].setVal(0.0);
     lev_new[Vars::zvel].setVal(0.0);
 
     if (init_type == "ideal") {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
         for ( MFIter mfi(lev_new[Vars::cons], TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
           const Box& bx = mfi.tilebox();
@@ -559,7 +559,10 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba,
 #endif
 #ifdef ERF_USE_NETCDF
     } else if (init_type == "real") {
-        for ( MFIter mfi(lev_new[Vars::cons], false); mfi.isValid(); ++mfi )
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for ( MFIter mfi(lev_new[Vars::cons], TilingIfNotGPU()); mfi.isValid(); ++mfi )
         {
           const Box& bx = mfi.tilebox();
           FArrayBox& cons_fab = lev_new[Vars::cons][mfi];

--- a/Source/IO/ERF_WriteBndryPlanes.cpp
+++ b/Source/IO/ERF_WriteBndryPlanes.cpp
@@ -12,7 +12,7 @@ void br_shift(amrex::OrientationIter oit, const amrex::BndryRegister& b1, amrex:
     int ncomp = b1[ori].nComp();
     if (ori.coordDir() < 2) {
 #ifdef AMREX_USE_OMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
         for (amrex::FabSetIter bfsi(b1[ori]); bfsi.isValid(); ++bfsi) {
             int idx = bfsi.index();


### PR DESCRIPTION
* Fixes a namespace issue for the `Gpu` namespace that blocked compilation with OpenMP
* Relocate a couple of OpenMP pragmas to the correct scopes relative to their respective for loops that previously triggered a backtrace since the compiler thought both MFIters were being addressed with the same pragma.