### PR TITLE
set default for AMREX_HOME path in Make.ERF

### DIFF
--- a/Docs/sphinx_doc/GettingStarted.rst
+++ b/Docs/sphinx_doc/GettingStarted.rst
@@ -17,6 +17,13 @@ Then download the ERF repository by typing:
 
              git clone https://github.com/erf-model/ERF.git
 
+Or, to automatically include the necessary submodules when downloading ERF,
+type:
+
+   .. code:: shell
+
+             git clone --recursive https://github.com/erf-model/ERF.git
+
 .. include:: building.rst
 
 

--- a/Docs/sphinx_doc/building.rst
+++ b/Docs/sphinx_doc/building.rst
@@ -17,13 +17,15 @@ Using the GNU Make build system involves first setting environment variables for
    export ERF_HOME=${HOME}/ERF
    export AMREX_HOME=${ERF_HOME}/Submodules/AMReX
 
-Note that one could also use an external version of AMReX, downloaded by typing
+The GNU Make system is set up to use the path to AMReX submodule by default, so it is not necessary to set
+these paths explicitly, unless it is desired to do so. It is also possible to use an external version of
+AMReX, downloaded by running
 
    .. code:: shell
 
              git clone https://github.com/amrex-codes/amrex.git
 
-and then, if using bash shell,
+in which case the ``AMREX_HOME`` environment variable must point to the location where AMReX has been downloaded, which will take precedence over the default path to the submodule. If using bash shell,
 
 ::
 

--- a/Exec/Make.ERF
+++ b/Exec/Make.ERF
@@ -1,3 +1,4 @@
+AMREX_HOME      ?= $(ERF_HOME)/Submodules/AMReX
 include $(AMREX_HOME)/Tools/GNUMake/Make.defs
 
 EBASE = ERF

--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,6 @@ To clone the source code of `ERF`:
     export ERF_HOME=<location for ERF code>
     git clone --recursive git@github.com:ERF-model/ERF.git ${ERF_HOME}
 
-    export AMREX_HOME=${ERF_HOME}/Submodules/AMReX # w.r.t. ERF_HOME
-
-Note that the path ``AMREX_HOME`` is dependent on ``ERF_HOME``.
-
 Alternatively, one can set environment variable ``AMREX_HOME`` to use ``AMReX`` repo from external locations independent of ``ERF_HOME``: ::
 
 1. Set the environment variable ``AMREX_HOME`` and clone a copy of ``AMReX`` there: ::


### PR DESCRIPTION
When compiling with GNUmake, the path to the AMReX submodule will automatically be used by default. 

If the AMREX_HOME environment variable is defined, that takes precedence, so this does not affect the ability to compile using AMReX downloaded in other locations if the user so desires. 