### PR TITLE
WIP: MOST cleanup and documentation

### DIFF
--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -167,54 +167,54 @@ boundary values using ``FillPatch``.
 
 MOST Boundaries
 -------------------
-Monin-Obukhov similarity theory (MOST) is used to describe the atmospheric surface layer (ASL), The MOST theory assumes that the ASL is in a steady state and horizontally homogenous, and the turbulent stresses :math:`\overline{u^{'}w^{'}}` and :math:`\overline{w^{'}v^{'}}` are assumed to be constant with height. Based on these assumptions,
-the MOST theory can be written as:
+Monin-Obukhov similarity theory (MOST) is used to describe the atmospheric surface layer (ASL). The implementation of MOST in ERF follows that in `AMR-Wind <https://github.com/Exawind/amr-wind/>`_, which is based on the surface layer profiles presented in `P. van der Laan, et al., Wind Energy, 2017 <https://doi.org/10.1002/we.2017>`_ and `D. Etling, "Modeling the vertical ABL structure", 1999 <https://doi.org/10.1142/9789814447164_0003>`_.
+
+To derive MOST, it is assumed that the ASL is in a steady state and horizontally homogenous, and the turbulent stresses (:math:`\overline{u^{'}w^{'}}` , :math:`\overline{w^{'}v^{'}}`) and heat flux (:math:`\overline{w^{'}\theta^{'}}`) are constant with height. These assumptions can be written as:
 
 .. math::
 
-  \overline{u^{'}} \overline{w^{'}} = const = -u^{2}_{\star},
+  \overline{u^{'} w^{'}} = const = -u^{2}_{\star},
+  
+  \overline{w^{'} \theta^{'}} = const = -u_{\star}\theta_{\star},
 
-  \overline{w^{'}} \overline{\theta^{'}} = const = -u_{\star}\theta_{\star},
+where :math:`u_{\star}` is the friction velocity and :math:`\theta_{\star}` is the surface layer characteristic temperature scale, bars indicate horizontal averages and primes indicate fluctuations. Then, based on dimensional arguments, universal similarity laws can be proposed for the vertical gradient components:
+  
+.. math::
+	  
+  \Phi_{m}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \mathbf{\bar{u}}}{\partial z},
 
-  \Theta_{m}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \mathbf{U}}{\partial z},
+  \Phi_{h}(\zeta) = \frac{\kappa z}{\theta_{\star}} \frac{\partial \bar{\theta}}{\partial z}
 
-  \Theta_{h}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \theta}{\partial z}
-
-
-Here :math:`u_{\star}` is the friction velocity, :math:`\theta_{\star}` is the surface temperature,
-and :math:`\theta_{0}` is the potential temperature near surface in the ASL.
-
-The MOST stability parameter is given by :math:`\zeta = \frac{\mathbf{z}}{L} = -\frac{\kappa z}{u_{\star}^{3}} \frac{g}{\theta_{0}} \overline{w^{'}\theta^{'}}`,
-where :math:`L` is the Monin-Okukhov length.
+where the MOST stability parameter is given by :math:`\zeta = \frac{\mathbf{z}}{L} = -\frac{\kappa z}{u_{\star}^{3}} \frac{g}{\theta_{0}} \overline{w^{'}\theta^{'}}`,  :math:`L` is the Monin-Okukhov length, :math:`\kappa` is the von Karman constant (taken to be :math:`0.41`), and :math:`\theta_{0}` is the surface potential temperature.
 
 Integration of the MOST assumption equations give the classical MOST profiles of mean velocity and potential temperature
 
 .. math::
 
-  \mathbf{U}(\zeta)    &= \frac{u_{\star}}{\kappa} [ \mathrm{ln} (\frac{z}{z_0})-\Psi_m(\zeta)],
+  \mathbf{\bar{u}}(\zeta)    &= \frac{u_{\star}}{\kappa} [ \mathrm{ln} (\frac{z}{z_0})-\Psi_m(\zeta)],
 
-  \Theta(z) - \theta_0 &= \frac{\theta_{\star}}{\kappa} [ \mathrm{ln}(\frac{z}{z_0})-\Psi_{h}(\zeta) ]
+  \bar{\theta}(z) - \theta_0 &= \frac{\theta_{\star}}{\kappa} [ \mathrm{ln}(\frac{z}{z_0})-\Psi_{h}(\zeta) ]
 
 
-where the integrated similarity functions,
+where :math:`z_0` is a characteristic roughness height and the integrated similarity functions,
 
 .. math::
 
-  \Psi_{m}(\zeta) &= \int _{\frac{z_{0}}{L}} ^{\frac{z}{L}} [1-\Theta_{m}(\zeta)]d \mathrm{ln}(\zeta),
+  \Psi_{m}(\zeta) &= \int _{\frac{z_{0}}{L}} ^{\frac{z}{L}} [1-\Phi_{m}(\zeta)]d \mathrm{ln}(\zeta),
 
-  \Psi_{h}(\zeta) &= \int _{\frac{z_{0}}{L}} ^{\frac{z}{L}} [1-\Theta_{h}(\zeta)]d \mathrm{ln}(\zeta)
+  \Psi_{h}(\zeta) &= \int _{\frac{z_{0}}{L}} ^{\frac{z}{L}} [1-\Phi_{h}(\zeta)]d \mathrm{ln}(\zeta),
 
-are calculated analytically for stable and unstable stratifications.
+are calculated analytically for stable and unstable stratifications, as indicated below.
 
 Unstable: :math:`(-2 < \zeta < 0)`
 
 .. math::
 
-  \Theta_{m} &= (1-\gamma_{1}\eta)^{-\frac{1}{4}}, \quad
-  \Psi_{m}    = \mathrm{ln}[\frac{1}{g}(1+\Psi_{m}^{2})(1+\Psi_{m}^{-1})^{2}]-2\arctan(\Theta_{m}^{-1})+\frac{\pi}{2},
+  \Phi_{m} &= (1-\gamma_{1}\zeta)^{-\frac{1}{4}}, \quad
+  \Psi_{m}    = \mathrm{ln}[\frac{1}{8}(1+\Phi_{m}^{-2})(1+\Phi_{m}^{-1})^{2}]-2\arctan(\Phi_{m}^{-1})+\frac{\pi}{2},
 
-  \Theta_{h} &= \sigma_{\theta}(1-\gamma_{2}\zeta)^{-\frac{1}{2}}, \quad
-  \Psi_{h}    = (1+\sigma_{\theta}) \mathrm{ln}[\frac{1}{2}(1+\Theta_{h}^{-1}]+(1-\sigma_{\theta}) {\mathrm{ln}} [\frac{1}{2}(-1+\Theta_{h}^{-1})]
+  \Phi_{h} &= \sigma_{\theta}(1-\gamma_{2}\zeta)^{-\frac{1}{2}}, \quad
+  \Psi_{h}    = (1+\sigma_{\theta}) \mathrm{ln}[\frac{1}{2}(1+\Phi_{h}^{-1}]+(1-\sigma_{\theta}) {\mathrm{ln}} [\frac{1}{2}(-1+\Phi_{h}^{-1})]
 
 Stable: :math:`(0 < \zeta < 1)`
 
@@ -223,7 +223,7 @@ Stable: :math:`(0 < \zeta < 1)`
 
   \Theta_{h} &= \sigma_{\theta}+\beta \zeta, \quad \Psi_{h}=(1-\sigma_{\theta})\mathrm{ln}(\zeta)-\beta \zeta
 
-and the constants are defined as:
+Where the constants take the values proposed in `Dyer, Boundary Layer Meteorology, 1974 <https://doi.org/10.1007/BF00240838>`_:
 
 .. math::
   \sigma_{\theta}=1, \quad \beta = 5, \quad \gamma_{1}=16, \quad \gamma_{2}=16
@@ -236,27 +236,56 @@ Inverting the equations above, the MOST stability parameter,
 is determined by the friction velocity
 
 .. math::
-  u_{\star} =\kappa U/[\mathrm{ln}(z/z_0)-\Psi_{m}(\frac{z}{L})]
+  u_{\star} =\kappa \bar{u}/[\mathrm{ln}(z/z_0)-\Psi_{m}(\frac{z}{L})]
 
 and the surface temperature
 
 .. math::
-  \theta_{\star} = \kappa (\theta_{a}-\theta_{g})/[\mathrm{ln}(z / z_0)-\Psi_{h}(z/L)]
+  \theta_{\star} = \kappa (\bar{\theta} -\theta_{0})/[\mathrm{ln}(z / z_0)-\Psi_{h}(z/L)]
 
-Assuming that :math:`\theta_{\star}, u_{\star}, q_{\star}` are constant with height, the wind speed, temperature and moisture at surface can be derived as:
+In ERF, when the MOST boundary condition is applied, velocity and temperature in the ghost cells are set to give stresses that are consistent with the MOST equations laid out above. The code is structured to allow either the surface temperature (:math:`\theta_0`) or surface temperature flux (:math:`\overline{w^{'}\theta^{'}}`) to be enforced. To apply the MOST boundary, the following algorithm is applied:
 
-.. math::
+#. Horizontal (planar) averages :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are computed at a reference height :math:`z_{ref}` assumed to be within the surface layer.
 
-  \mu\frac{\partial u}{\partial z} &= -\rho u_{\star}^{2} \frac{ (u-\bar{u}) \bar{|\mathbf{U}|} +
-                             \sqrt{u^2+v^2} \; \bar{u}  }{\bar{|\mathbf{U}|}^{2}},
+#. Initially, neutral conditions (:math:`L=\infty, \zeta=0`) are assumed and used to compute a provisional :math:`u_{\star}` using the equation given above. If :math:`\theta_0` is specified, the above equation for :math:`\theta_{\star}` is applied and then the surface flux is computed :math:`\overline{w^{'}\theta^{'}} = -u_{\star} \theta_{\star}`. If :math:`\overline{w^{'}\theta^{'}}` is specified, :math:`\theta_{\star}` is computed as :math:`-\overline{w^{'}\theta^{'}}/u_{\star}` and the previous equation is inverted to compute :math:`\theta_0`.
 
- \mu\frac{\partial v}{\partial z} &= -\rho u_{\star}^{2} \frac{ (v-\bar{v}) \bar{|\mathbf{U}|} +
-                             \sqrt{u^2+v^2} \; \bar{v}  }{\bar{|\mathbf{U}|}^{2}},
+#. The stability parameter :math:`\zeta` is recomputed using the equation given above based on the provisional values of :math:`u_{\star}` and :math:`\theta_{\star}`.
 
-  \mu\frac{\partial \theta }{\partial z} &= \rho \frac{\bar{|\mathbf{U}|} (\theta - \overline{\theta}) +
-                                             \sqrt{u^2+v^2}  (\overline{\theta}-\theta_{\star}) }{\Theta_{h} \bar{|\mathbf{U}|}}
+#. The previous two steps are repeated iteratively, sequentially updating the values of :math:`u_{\star}` and :math:`\zeta`, until the change in the value of :math:`u_{\star}` on each iteration falls below a specified tolerance.
 
-where :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are the plane averaged values of the
-two horizontal velocity components and the potential temperature, respectively, and
-:math:`\bar{|\mathbf{U}|}` is the plane averaged magnitude of horizontal velocity. :math:`\mu` is the eddy visocisity.
+#. Once the MOST iterations have converged, and the planar average surface flux values are known, the approach from `Moeng, Journal of the Atmospheric Sciences, 1984 <https://ui.adsabs.harvard.edu/link_gateway/1984JAtS...41.2052M/doi:10.1175/1520-0469(1984)041%3C2052:ALESMF%3E2.0.CO;2>`_ is applied to consistently compute local surface-normal stress/flux values (e.g., :math:`\tau_{xz} = - \rho \overline{u^{'}w^{'}}`):
 
+   .. math::
+
+     \left. \frac{\tau_{xz}}{\rho} \right|_0 &= u_{\star}^{2} \frac{(u - \bar{u})|\mathbf{\bar{u}}| +  \bar{u}\sqrt{u^2 + v^2} }{|\mathbf{\bar{u}}|^2},
+
+     \left. \frac{\tau_{yz}}{\rho}  \right|_0 &= u_{\star}^{2}  \frac{(v - \bar{v})|\mathbf{\bar{u}}| +  \bar{v}\sqrt{u^2 + v^2} }{|\mathbf{\bar{u}}|^2},
+
+     \left.  \frac{\tau_{\theta z}}{\rho} \right|_0  &= \theta_\star u_{\star} \frac{|\mathbf{\bar{u}}| (\overline{\theta} - \theta_0) +
+                                                \sqrt{u^2+v^2}  (\theta - \overline{\theta}) }{ |\mathbf{\bar{u}}| (\overline{\theta} -\theta_0) } =
+						u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| (\overline{\theta} - \theta_0) +
+                                                \sqrt{u^2+v^2}  (\theta - \overline{\theta}) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
+
+   where :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are the plane averaged values (at :math:`z_{ref}`) of the
+   two horizontal velocity components and the potential temperature, respectively, and
+   :math:`|\mathbf{\bar{u}}|` is the plane averaged magnitude of horizontal velocity (plane averaged wind speed). We note a slight variation in the denominator
+   of the velocity terms from the form of the
+   equations presented in Moeng to match the form implemented in AMR-Wind.
+
+#. These local flux values are used to populate values in the ghost cells that will lead to appropiate fluxes, assuming the fluxes are computed from the turbulent transport coefficients (in the vertical direction, if applicable) :math:`K_{m,v}` and :math:`K_{\theta,v}` as follows:
+
+   .. math::
+
+      \tau_{xz} = K_{m,v} \frac{\partial u}{\partial z}
+   
+      \tau_{yz} = K_{m,v} \frac{\partial v}{\partial z}
+      
+      \tau_{\theta z} = K_{\theta,v} \frac{\partial \theta}{\partial z}.
+
+   This implies that, for example, the value set for the conserved :math:`\rho\theta` variable in the :math:`-n\mathrm{th}` ghost cell is
+
+   .. math::
+
+      (\rho \theta)_{i,j,-n} = \rho_{i,j,-n} \left[ \frac{(\rho\theta)_{i,j,0}}{\rho_{i,j,0}} - \left. \frac{\tau_{\theta z}}{\rho} \right|_{i,j,0} \frac{\rho_{i,j,0}}{K_{\theta,v,(i,j,0)}} n \Delta z \right]
+
+   

--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -261,10 +261,10 @@ In ERF, when the MOST boundary condition is applied, velocity and temperature in
 
      \left. \frac{\tau_{yz}}{\rho}  \right|_0 &= u_{\star}^{2}  \frac{(v - \bar{v})|\mathbf{\bar{u}}| +  \bar{v}\sqrt{u^2 + v^2} }{|\mathbf{\bar{u}}|^2},
 
-     \left.  \frac{\tau_{\theta z}}{\rho} \right|_0  &= \theta_\star u_{\star} \frac{|\mathbf{\bar{u}}| (\overline{\theta} - \theta_0) +
-                                                \sqrt{u^2+v^2}  (\theta - \overline{\theta}) }{ |\mathbf{\bar{u}}| (\overline{\theta} -\theta_0) } =
-						u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| (\overline{\theta} - \theta_0) +
-                                                \sqrt{u^2+v^2}  (\theta - \overline{\theta}) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
+     \left.  \frac{\tau_{\theta z}}{\rho} \right|_0  &= \theta_\star u_{\star} \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta}) +
+                                                \sqrt{u^2+v^2}  (\overline{\theta} - \theta_0) }{ |\mathbf{\bar{u}}| (\overline{\theta} -\theta_0) } =
+						u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta})  +
+                                                \sqrt{u^2+v^2} (\overline{\theta} - \theta_0) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
 
    where :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are the plane averaged values (at :math:`z_{ref}`) of the
    two horizontal velocity components and the potential temperature, respectively, and

--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -180,7 +180,7 @@ To derive MOST, it is assumed that the ASL is in a steady state and horizontally
 where :math:`u_{\star}` is the friction velocity and :math:`\theta_{\star}` is the surface layer characteristic temperature scale, bars indicate horizontal averages and primes indicate fluctuations. Then, based on dimensional arguments, universal similarity laws can be proposed for the vertical gradient components:
   
 .. math::
-	  
+
   \Phi_{m}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \mathbf{\bar{u}}}{\partial z},
 
   \Phi_{h}(\zeta) = \frac{\kappa z}{\theta_{\star}} \frac{\partial \bar{\theta}}{\partial z}
@@ -263,7 +263,7 @@ In ERF, when the MOST boundary condition is applied, velocity and temperature in
 
      \left.  \frac{\tau_{\theta z}}{\rho} \right|_0  &= \theta_\star u_{\star} \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta}) +
                                                 \sqrt{u^2+v^2}  (\overline{\theta} - \theta_0) }{ |\mathbf{\bar{u}}| (\overline{\theta} -\theta_0) } =
-						u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta})  +
+                                                u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta})  +
                                                 \sqrt{u^2+v^2} (\overline{\theta} - \theta_0) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
 
    where :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are the plane averaged values (at :math:`z_{ref}`) of the

--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -174,11 +174,11 @@ To derive MOST, it is assumed that the ASL is in a steady state and horizontally
 .. math::
 
   \overline{u^{'} w^{'}} = const = -u^{2}_{\star},
-  
+
   \overline{w^{'} \theta^{'}} = const = -u_{\star}\theta_{\star},
 
 where :math:`u_{\star}` is the friction velocity and :math:`\theta_{\star}` is the surface layer characteristic temperature scale, bars indicate horizontal averages and primes indicate fluctuations. Then, based on dimensional arguments, universal similarity laws can be proposed for the vertical gradient components:
-  
+
 .. math::
 
   \Phi_{m}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \mathbf{\bar{u}}}{\partial z},
@@ -277,9 +277,9 @@ In ERF, when the MOST boundary condition is applied, velocity and temperature in
    .. math::
 
       \tau_{xz} = K_{m,v} \frac{\partial u}{\partial z}
-   
+
       \tau_{yz} = K_{m,v} \frac{\partial v}{\partial z}
-      
+
       \tau_{\theta z} = K_{\theta,v} \frac{\partial \theta}{\partial z}.
 
    This implies that, for example, the value set for the conserved :math:`\rho\theta` variable in the :math:`-n\mathrm{th}` ghost cell is
@@ -288,4 +288,4 @@ In ERF, when the MOST boundary condition is applied, velocity and temperature in
 
       (\rho \theta)_{i,j,-n} = \rho_{i,j,-n} \left[ \frac{(\rho\theta)_{i,j,0}}{\rho_{i,j,0}} - \left. \frac{\tau_{\theta z}}{\rho} \right|_{i,j,0} \frac{\rho_{i,j,0}}{K_{\theta,v,(i,j,0)}} n \Delta z \right]
 
-   
+

--- a/Exec/ABL/inputs_smagorinsky
+++ b/Exec/ABL/inputs_smagorinsky
@@ -22,7 +22,7 @@ erf.fixed_dt           = 0.1  # fixed time step depending on grid resolution
 erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v                = 1       # verbosity in Amr.cpp
-amr.data_log         = datlog
+# amr.data_log         = datlog
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed

--- a/Source/ABLMost.H
+++ b/Source/ABLMost.H
@@ -35,7 +35,7 @@ struct ABLMost
     amrex::Real surf_temp;           ///< Instantaneous surface temperature
     amrex::Real ref_temp;            ///< Reference temperature
 
-    amrex::Real beta_m{5.0};  // Constants from Dyer, BLM, 1974 
+    amrex::Real beta_m{5.0};  // Constants from Dyer, BLM, 1974
     amrex::Real beta_h{5.0};  // https://doi.org/10.1007/BF00240838
     amrex::Real gamma_m{16.0};
     amrex::Real gamma_h{16.0};

--- a/Source/ABLMost.H
+++ b/Source/ABLMost.H
@@ -35,10 +35,10 @@ struct ABLMost
     amrex::Real surf_temp;           ///< Instantaneous surface temperature
     amrex::Real ref_temp;            ///< Reference temperature
 
-    amrex::Real gamma_m{5.0};
-    amrex::Real gamma_h{5.0};
-    amrex::Real beta_m{16.0};
-    amrex::Real beta_h{16.0};
+    amrex::Real beta_m{5.0};  // Constants from Dyer, BLM, 1974 
+    amrex::Real beta_h{5.0};  // https://doi.org/10.1007/BF00240838
+    amrex::Real gamma_m{16.0};
+    amrex::Real gamma_h{16.0};
 
     ThetaCalcType alg_type{HEAT_FLUX};
 
@@ -57,10 +57,10 @@ struct ABLMost
         amrex::Print() << " surf_temp_flux: " << surf_temp_flux << "\n";
         amrex::Print() << " surf_temp: " << surf_temp << "\n";
         amrex::Print() << " ref_temp: " << ref_temp << "\n";
-        amrex::Print() << " gamma_m: " << gamma_m << "\n";
-        amrex::Print() << " gamma_h: " << gamma_h << "\n";
         amrex::Print() << " beta_m: " << beta_m << "\n";
         amrex::Print() << " beta_h: " << beta_h << "\n";
+        amrex::Print() << " gamma_m: " << gamma_m << "\n";
+        amrex::Print() << " gamma_h: " << gamma_h << "\n";
     }
 
     AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -91,11 +91,11 @@ struct ABLMost
     amrex::Real calc_psi_m(amrex::Real zeta) const
     {
         if (zeta > 0) {
-            return -gamma_m * zeta;
+            return -beta_m * zeta;
         } else {
-            amrex::Real x = std::sqrt(std::sqrt(1 - beta_m * zeta));
+            amrex::Real x = std::sqrt(std::sqrt(1 - gamma_m * zeta));
             return 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
-                   2.0 * std::atan(x) + 1.57;
+                   2.0 * std::atan(x) + 0.5*PI;
         }
     }
 
@@ -103,9 +103,9 @@ struct ABLMost
     amrex::Real calc_psi_h(amrex::Real zeta) const
     {
         if (zeta > 0) {
-            return -gamma_h * zeta;
+            return -beta_h * zeta;
         } else {
-            amrex::Real x = std::sqrt(1 - beta_h * zeta);
+            amrex::Real x = std::sqrt(1 - gamma_h * zeta);
             return 2.0 * std::log(0.5 * (1 + x));
         }
     }

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -920,7 +920,7 @@ ERF::setupABLMost (int lev)
     MultiFab Theta_prim(S_new.boxArray(), S_new.DistributionMap(), 1, 0);
     MultiFab::Copy(Theta_prim, S_new, Cons::RhoTheta, 0, 1, 0);
     MultiFab::Divide(Theta_prim, S_new, Cons::Rho, 0, 1, 0);
-    
+
     PlaneAverage save (&Theta_prim, geom[0], 2, true);
     PlaneAverage vxave(&U_new, geom[0], 2, true);
     PlaneAverage vyave(&V_new, geom[0], 2, true);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -916,7 +916,12 @@ ERF::setupABLMost (int lev)
     MultiFab& V_new = vars_new[lev][Vars::yvel];
     MultiFab& W_new = vars_new[lev][Vars::zvel];
 
-    PlaneAverage save (&S_new, geom[0], 2, true);
+    // Multifab to store primitive Theta, which is what we want to average
+    MultiFab Theta_prim(S_new.boxArray(), S_new.DistributionMap(), 1, 0);
+    MultiFab::Copy(Theta_prim, S_new, Cons::RhoTheta, 0, 1, 0);
+    MultiFab::Divide(Theta_prim, S_new, Cons::Rho, 0, 1, 0);
+    
+    PlaneAverage save (&Theta_prim, geom[0], 2, true);
     PlaneAverage vxave(&U_new, geom[0], 2, true);
     PlaneAverage vyave(&V_new, geom[0], 2, true);
     PlaneAverage vzave(&W_new, geom[0], 2, true);
@@ -934,7 +939,7 @@ ERF::setupABLMost (int lev)
     most.vel_mean[1] = vyave.line_average_interpolated(most.zref, 0);
     most.vel_mean[2] = vzave.line_average_interpolated(most.zref, 0);
     most.vmag_mean   = vmagave.line_hvelmag_average_interpolated(most.zref);
-    most.theta_mean  = save.line_average_interpolated(most.zref, Cons::RhoTheta);
+    most.theta_mean  = save.line_average_interpolated(most.zref, 0);
 
     printf("vmag_mean=%13.6e,theta_mean=%13.6e, zref=%13.6e, dx=%13.6e\n",most.vmag_mean,most.theta_mean,most.zref,dx[2]);
 

--- a/Source/ERF_PhysBCFunct.H
+++ b/Source/ERF_PhysBCFunct.H
@@ -86,22 +86,22 @@ public:
                 const auto& cons_mf = m_data.get_var(Vars::cons);
                 m_viscosity.define(cons_mf.boxArray(), cons_mf.DistributionMap(), EddyDiff::NumDiffs, cons_mf.nGrowVect());
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(solverChoice.les_type == LESType::Smagorinsky ||
-                                                 solverChoice.les_type == LESType::Deardorff ||,
+                                                 solverChoice.les_type == LESType::Deardorff ||
                                                  solverChoice.pbl_type != PBLType::None,
                                                  "Must use an LES or PBL model to compute turbulent viscosity for MOST boundaries");
-		// PBL or PBL+LES - get vertical viscosity component with PBL model. LES - get it with LES model
-		if (solverChoice.pbl_type != PBLType::None) {
-		  ComputeTurbulentViscosityPBL(m_data.get_var(Vars::xvel),
-					       m_data.get_var(Vars::yvel),
-					       m_data.get_var(Vars::zvel),
-					       cons_mf, m_viscosity, geom, solverChoice, m_most);
-		} else {
-		  ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
-					    m_data.get_var(Vars::yvel),
-					    m_data.get_var(Vars::zvel),
-					    cons_mf, m_viscosity, geom, solverChoice,
-					    domain_bcs_type_d);
-		}
+            // PBL or PBL+LES - get vertical viscosity component with PBL model. LES - get it with LES model
+            if (solverChoice.pbl_type != PBLType::None) {
+                ComputeTurbulentViscosityPBL(m_data.get_var(Vars::xvel),
+                                             m_data.get_var(Vars::yvel),
+                                             m_data.get_var(Vars::zvel),
+                                             cons_mf, m_viscosity, geom, solverChoice, m_most);
+            } else {
+                ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
+                                          m_data.get_var(Vars::yvel),
+                                          m_data.get_var(Vars::zvel),
+                                          cons_mf, m_viscosity, geom, solverChoice,
+                                          domain_bcs_type_d);
+                }
             }
         }
 

--- a/Source/ERF_PhysBCFunct.H
+++ b/Source/ERF_PhysBCFunct.H
@@ -17,6 +17,7 @@
 #include <IndexDefines.H>
 #include <DataStruct.H>
 #include <EddyViscosity.H>
+#include <PBLModels.H>
 #include <ABLMost.H>
 #ifdef ERF_USE_TERRAIN
 #include <SpatialStencils.H>
@@ -85,13 +86,22 @@ public:
                 const auto& cons_mf = m_data.get_var(Vars::cons);
                 m_viscosity.define(cons_mf.boxArray(), cons_mf.DistributionMap(), EddyDiff::NumDiffs, cons_mf.nGrowVect());
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(solverChoice.les_type == LESType::Smagorinsky ||
-                                                 solverChoice.les_type == LESType::Deardorff,
-                                                 "Must use an LES model to compute turbulent viscosity for MOST boundaries");
-                ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
-                                          m_data.get_var(Vars::yvel),
-                                          m_data.get_var(Vars::zvel),
-                                          cons_mf, m_viscosity, geom, solverChoice,
-                                          domain_bcs_type_d);
+                                                 solverChoice.les_type == LESType::Deardorff ||,
+                                                 solverChoice.pbl_type != PBLType::None,
+                                                 "Must use an LES or PBL model to compute turbulent viscosity for MOST boundaries");
+		// PBL or PBL+LES - get vertical viscosity component with PBL model. LES - get it with LES model
+		if (solverChoice.pbl_type != PBLType::None) {
+		  ComputeTurbulentViscosityPBL(m_data.get_var(Vars::xvel),
+					       m_data.get_var(Vars::yvel),
+					       m_data.get_var(Vars::zvel),
+					       cons_mf, m_viscosity, geom, solverChoice, m_most);
+		} else {
+		  ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
+					    m_data.get_var(Vars::yvel),
+					    m_data.get_var(Vars::zvel),
+					    cons_mf, m_viscosity, geom, solverChoice,
+					    domain_bcs_type_d);
+		}
             }
         }
 

--- a/Source/ERF_PhysBCFunct.cpp
+++ b/Source/ERF_PhysBCFunct.cpp
@@ -501,8 +501,8 @@
                                               +vely_arr(iylo,jy,zlo)+vely_arr(iylo,jy+1,zlo));
                                 rho   = 0.5*(cons_arr(ie-1,je,zlo,Rho_comp)+
                                              cons_arr(ie  ,je,zlo,Rho_comp));
-                                eta   = 0.5*( eta_arr(ie-1,je,zlo,EddyDiff::Mom_h)+
-                                              eta_arr(ie  ,je,zlo,EddyDiff::Mom_h));
+                                eta   = 0.5*( eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)+
+                                              eta_arr(ie  ,je,zlo,EddyDiff::Mom_v));
 
                                 Real vmag  = sqrt(velx*velx+vely*vely);
                                 Real vgx   = ((velx-m_most.vel_mean[0])*m_most.vmag_mean + vmag*m_most.vel_mean[0])/
@@ -538,8 +538,8 @@
                                 vely  = vely_arr(i,j,zlo);
                                 rho   = 0.5*(cons_arr(ie,je-1,zlo,Rho_comp)+
                                              cons_arr(ie,je  ,zlo,Rho_comp));
-                                eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_h)+
-                                             eta_arr(ie,je  ,zlo,EddyDiff::Mom_h));
+                                eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)+
+                                             eta_arr(ie,je  ,zlo,EddyDiff::Mom_v));
                                 Real vmag  = sqrt(velx*velx+vely*vely);
                                 Real vgy   = ((vely-m_most.vel_mean[1])*m_most.vmag_mean + vmag*m_most.vel_mean[1]) /
                                              (m_most.vmag_mean*m_most.vmag_mean)*m_most.utau*m_most.utau;

--- a/Source/ERF_PhysBCFunct.cpp
+++ b/Source/ERF_PhysBCFunct.cpp
@@ -464,8 +464,7 @@
                                 rho   = cons_arr(ie,je,zlo,Rho_comp);
                                 theta = cons_arr(ie,je,zlo,RhoTheta_comp)/rho;
 
-                                // TODO: Verify this is the correct Diff component
-                                eta   = eta_arr(ie,je,zlo,EddyDiff::Mom_h);
+                                eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v);
 
                                 Real vmag    = sqrt(velx*velx+vely*vely);
                                 Real num1    = (theta-m_most.theta_mean)*m_most.vmag_mean;

--- a/Source/ERF_PhysBCFunct.cpp
+++ b/Source/ERF_PhysBCFunct.cpp
@@ -469,12 +469,13 @@
                                 Real vmag    = sqrt(velx*velx+vely*vely);
                                 Real num1    = (theta-m_most.theta_mean)*m_most.vmag_mean;
                                 Real num2    = (m_most.theta_mean-m_most.surf_temp)*vmag;
-                                Real motheta = (num1+num2)*m_most.utau*m_most.kappa/m_most.phi_h();
+                                Real moflux  = (num1+num2)*m_most.utau*m_most.kappa/m_most.phi_h()/m_most.vmag_mean;
+                                Real deltaz  = m_geom.CellSize(2) * (zlo - k);
 
                                 if (!var_is_derived) {
-                                    dest_array(i,j,k,icomp+n) = rho*(m_most.surf_temp + motheta*rho/eta);
+                                    dest_array(i,j,k,icomp+n) = rho*(theta - moflux*rho/eta * deltaz);
                                 } else {
-                                    dest_array(i,j,k,icomp+n) = m_most.surf_temp + motheta/eta;
+                                    dest_array(i,j,k,icomp+n) = theta - moflux*rho/eta * deltaz;
                                 }
                             });
 
@@ -505,13 +506,14 @@
                                               eta_arr(ie  ,je,zlo,EddyDiff::Mom_v));
 
                                 Real vmag  = sqrt(velx*velx+vely*vely);
-                                Real vgx   = ((velx-m_most.vel_mean[0])*m_most.vmag_mean + vmag*m_most.vel_mean[0])/
-                                              (m_most.vmag_mean*m_most.vmag_mean) * m_most.utau*m_most.utau;
+                                Real stressx = ((velx-m_most.vel_mean[0])*m_most.vmag_mean + vmag*m_most.vel_mean[0])/
+                                                (m_most.vmag_mean*m_most.vmag_mean) * m_most.utau*m_most.utau;
+                                Real deltaz  = m_geom.CellSize(2) * (zlo - k);
 
                                 if (!var_is_derived) {
-                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - vgx*rho/eta;
+                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - rho*rho*stressx/eta * deltaz;
                                 } else {
-                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - vgx/eta;
+                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - rho*stressx/eta * deltaz;
                                 }
                             });
 
@@ -541,13 +543,14 @@
                                 eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)+
                                              eta_arr(ie,je  ,zlo,EddyDiff::Mom_v));
                                 Real vmag  = sqrt(velx*velx+vely*vely);
-                                Real vgy   = ((vely-m_most.vel_mean[1])*m_most.vmag_mean + vmag*m_most.vel_mean[1]) /
-                                             (m_most.vmag_mean*m_most.vmag_mean)*m_most.utau*m_most.utau;
+                                Real stressy = ((vely-m_most.vel_mean[1])*m_most.vmag_mean + vmag*m_most.vel_mean[1]) /
+                                               (m_most.vmag_mean*m_most.vmag_mean)*m_most.utau*m_most.utau;
+                                Real deltaz  = m_geom.CellSize(2) * (zlo - k);
 
                                 if (!var_is_derived) {
-                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - vgy*rho/eta;
+                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - rho*rho*stressy/eta * deltaz;
                                 } else {
-                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - vgy/eta;
+                                    dest_array(i,j,k,icomp) = dest_array(i,j,zlo,icomp) - rho*stressy/eta * deltaz;
                                 }
                             });
 


### PR DESCRIPTION
Draft PR for now as this is ongoing, but creating to allow discussion. @xyuan and @dwillcox, please chime in if anything doesn't seem right to you.

Changes so far:

- [x] Currently, the computed theta_mean is actually rhoTheta_mean. I modified it to be the planar_average(theta), but I'm not sure whether that or the mass-weighted version [planar_average(rhoTheta)/planar_average(rho)] would be more physically appropriate.
- [x] Use the theta turbulent diffusivity instead of viscosity when applying MOST for theta
- [x] Compute and use vertical turbulent diffusivity components when the PBL model is active

Other outstanding issues planned to be part of this PR:

- [x] Documentation of how shear stress/flux boundary conditions are applied (why turbulent visc/diff shows up)
- [x] Verify dimensional consistency when applying boundary conditions
- [ ] I think it might be possible to avoid pre-computing turbulent visc/diff - more on this later
- [ ] the `setupABLMost` function is called one per timestep at the beginning of `ERF::Advance()`, but I believe it should be called at each slow substep 
