### PR TITLE
initialize new_drho_u/v/w in the fast rhs

### DIFF
--- a/Source/TimeIntegration/ERF_fast_rhs.cpp
+++ b/Source/TimeIntegration/ERF_fast_rhs.cpp
@@ -80,6 +80,12 @@ void erf_fast_rhs (int level,
     amrex::MultiFab New_rho_v(convert(ba,IntVect(0,1,0)), dm, 1, 1);
     amrex::MultiFab New_rho_w(convert(ba,IntVect(0,0,1)), dm, 1, 1);
 
+    // Initialize New_rho_u/v/w to Delta_rho_u/v/w so that
+    // the ghost cells in New_rho_u/v/w will match old_drho_u/v/w
+    MultiFab::Copy(New_rho_u, Delta_rho_u, 0, 0, 1, 1);
+    MultiFab::Copy(New_rho_v, Delta_rho_v, 0, 0, 1, 1);
+    MultiFab::Copy(New_rho_w, Delta_rho_w, 0, 0, 1, 1);
+
     // *************************************************************************
     // Set gravity as a vector
     const    Array<Real,AMREX_SPACEDIM> grav{0.0, 0.0, -solverChoice.gravity};


### PR DESCRIPTION
The problem before was that we had the ghost cells in the new drho u/v/w fabs uninitialized, so when we tried to use those values we we working with uninitialized data.

This solves that issue by initializing new drho u/v/w with old drho u/v/w, including ghost cells.