### PR TITLE
Remove google test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "Submodules/AMReX"]
 	path = Submodules/AMReX
 	url = https://github.com/amrex-codes/amrex.git
-[submodule "Submodules/GoogleTest"]
-	path = Submodules/GoogleTest
-	url = https://github.com/google/googletest.git
 [submodule "Submodules/SUNDIALS"]
 	path = Submodules/SUNDIALS
 	url = https://github.com/llnl/SUNDIALS.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,6 @@ add_subdirectory(Exec)
 
 if(ERF_ENABLE_TESTS)
   include(CTest)
-  add_subdirectory("Submodules/GoogleTest")
   add_subdirectory(Tests)
 endif()
 


### PR DESCRIPTION
Looks like we're not using the Google Test submodule.

If all the CI tests pass fine without it, this PR removes the submodule.