### PR TITLE
correct MOST theta_mean (not RhoTheta_mean)

### DIFF
--- a/Source/ABLMost.cpp
+++ b/Source/ABLMost.cpp
@@ -5,17 +5,17 @@
 using namespace amrex;
 
 void ABLMost::update_fluxes(int lev,
-                            amrex::MultiFab& S_new, amrex::MultiFab& U_new,
+                            amrex::MultiFab& Theta_new, amrex::MultiFab& U_new,
                             amrex::MultiFab& V_new, amrex::MultiFab& W_new,
                             int max_iters)
 {
-    PlaneAverage ssave(&S_new, m_geom[lev], 2, true);
+    PlaneAverage Thave(&Theta_new, m_geom[lev], 2, true);
     PlaneAverage vxave(&U_new, m_geom[lev], 2, true);
     PlaneAverage vyave(&V_new, m_geom[lev], 2, true);
     PlaneAverage vzave(&W_new, m_geom[lev], 2, true);
     VelPlaneAverage vmagave({&U_new,&V_new,&W_new}, m_geom[lev], 2, true);
 
-    ssave.compute_averages(ZDir(), ssave.field());
+    Thave.compute_averages(ZDir(), Thave.field());
     vxave.compute_averages(ZDir(), vxave.field());
     vyave.compute_averages(ZDir(), vyave.field());
     vzave.compute_averages(ZDir(), vzave.field());
@@ -25,7 +25,7 @@ void ABLMost::update_fluxes(int lev,
     vel_mean[1] = vyave.line_average_interpolated(zref, 0);
     vel_mean[2] = vzave.line_average_interpolated(zref, 0);
     vmag_mean   = vmagave.line_hvelmag_average_interpolated(zref);
-    theta_mean  = ssave.line_average_interpolated(zref, Cons::RhoTheta);
+    theta_mean  = Thave.line_average_interpolated(zref, 0);
 
     constexpr amrex::Real eps = 1.0e-16;
     amrex::Real zeta = 0.0;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -929,7 +929,12 @@ ERF::setupABLMost (int lev)
     MultiFab& V_new = vars_new[lev][Vars::yvel];
     MultiFab& W_new = vars_new[lev][Vars::zvel];
 
-    m_most->update_fluxes(lev,S_new,U_new,V_new,W_new);
+    // Multifab to store primitive Theta, which is what we want to average
+    MultiFab Theta_prim(S_new.boxArray(), S_new.DistributionMap(), 1, 0);
+    MultiFab::Copy(Theta_prim, S_new, Cons::RhoTheta, 0, 1, 0);
+    MultiFab::Divide(Theta_prim, S_new, Cons::Rho, 0, 1, 0);
+
+    m_most->update_fluxes(lev,Theta_prim,U_new,V_new,W_new);
 }
 
 #ifdef ERF_USE_NETCDF


### PR DESCRIPTION
This implementation computes primitive Theta from RhoTheta before planar averaging. An alternative would be to average RhoTheta and Rho, then compute RhoTheta_mean/Rho_mean.