### PR TITLE
Most turbdiff

### DIFF
--- a/Source/ABLMost.H
+++ b/Source/ABLMost.H
@@ -76,10 +76,10 @@ public:
     amrex::Real surf_temp;           ///< Instantaneous surface temperature
     amrex::Real ref_temp;            ///< Reference temperature
 
-    amrex::Real gamma_m{5.0};
-    amrex::Real gamma_h{5.0};
-    amrex::Real beta_m{16.0};
-    amrex::Real beta_h{16.0};
+    amrex::Real beta_m{5.0}; // Constants from Dyer, BLM, 1974
+    amrex::Real beta_h{5.0}; // https://doi.org/10.1007/BF00240838
+    amrex::Real gamma_m{16.0};
+    amrex::Real gamma_h{16.0};
 
     enum ThetaCalcType {
         HEAT_FLUX = 0,      ///< Heat-flux specified
@@ -116,9 +116,9 @@ public:
     amrex::Real calc_psi_m(amrex::Real zeta) const
     {
         if (zeta > 0) {
-            return -gamma_m * zeta;
+            return -beta_m * zeta;
         } else {
-            amrex::Real x = std::sqrt(std::sqrt(1 - beta_m * zeta));
+            amrex::Real x = std::sqrt(std::sqrt(1 - gamma_m * zeta));
             return 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
                    2.0 * std::atan(x) + 1.57;
         }
@@ -128,9 +128,9 @@ public:
     amrex::Real calc_psi_h(amrex::Real zeta) const
     {
         if (zeta > 0) {
-            return -gamma_h * zeta;
+            return -beta_h * zeta;
         } else {
-            amrex::Real x = std::sqrt(1 - beta_h * zeta);
+            amrex::Real x = std::sqrt(1 - gamma_h * zeta);
             return 2.0 * std::log(0.5 * (1 + x));
         }
     }
@@ -149,10 +149,10 @@ public:
         amrex::Print() << " surf_temp_flux: " << surf_temp_flux << "\n";
         amrex::Print() << " surf_temp: " << surf_temp << "\n";
         amrex::Print() << " ref_temp: " << ref_temp << "\n";
-        amrex::Print() << " gamma_m: " << gamma_m << "\n";
-        amrex::Print() << " gamma_h: " << gamma_h << "\n";
         amrex::Print() << " beta_m: " << beta_m << "\n";
         amrex::Print() << " beta_h: " << beta_h << "\n";
+        amrex::Print() << " gamma_m: " << gamma_m << "\n";
+        amrex::Print() << " gamma_h: " << gamma_h << "\n";
     }
 
     private:

--- a/Source/ABLMost.cpp
+++ b/Source/ABLMost.cpp
@@ -140,9 +140,7 @@ ABLMost::impose_most_bcs(const int lev, const Box& bx,
                 vely  = 0.5*(vely_arr(iy,jy,zlo)+vely_arr(iy,jy+1,zlo));
                 rho   = cons_arr(ie,je,zlo,Rho_comp);
                 theta = cons_arr(ie,je,zlo,RhoTheta_comp)/rho;
-
-                // TODO: Verify this is the correct Diff component
-                eta   = eta_arr(ie,je,zlo,EddyDiff::Mom_h);
+                eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v);
 
                 Real vmag    = sqrt(velx*velx+vely*vely);
                 Real num1    = (theta-d_thM)*d_vmM;
@@ -182,8 +180,8 @@ ABLMost::impose_most_bcs(const int lev, const Box& bx,
                               +vely_arr(iylo,jy,zlo)+vely_arr(iylo,jy+1,zlo));
                 rho   = 0.5*(cons_arr(ie-1,je,zlo,Rho_comp)+
                              cons_arr(ie  ,je,zlo,Rho_comp));
-                eta   = 0.5*( eta_arr(ie-1,je,zlo,EddyDiff::Mom_h)+
-                              eta_arr(ie  ,je,zlo,EddyDiff::Mom_h));
+                eta   = 0.5*( eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)+
+                              eta_arr(ie  ,je,zlo,EddyDiff::Mom_v));
 
                 Real vmag  = sqrt(velx*velx+vely*vely);
                 Real vgx   = ((velx-d_vxM)*d_vmM + vmag*d_vxM)/
@@ -222,8 +220,8 @@ ABLMost::impose_most_bcs(const int lev, const Box& bx,
                 vely  = vely_arr(i,j,zlo);
                 rho   = 0.5*(cons_arr(ie,je-1,zlo,Rho_comp)+
                              cons_arr(ie,je  ,zlo,Rho_comp));
-                eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_h)+
-                             eta_arr(ie,je  ,zlo,EddyDiff::Mom_h));
+                eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)+
+                             eta_arr(ie,je  ,zlo,EddyDiff::Mom_v));
                 Real vmag  = sqrt(velx*velx+vely*vely);
                 Real vgy   = ((vely-d_vyM)*d_vmM + vmag*d_vyM) /
                              (d_vmM*d_vmM)*d_utau*d_utau;

--- a/Source/ERF_PhysBCFunct.H
+++ b/Source/ERF_PhysBCFunct.H
@@ -16,6 +16,7 @@
 #include <TimeInterpolatedData.H>
 #include <IndexDefines.H>
 #include <DataStruct.H>
+#include <PBLModels.H>
 #include <EddyViscosity.H>
 #include <ABLMost.H>
 
@@ -91,11 +92,20 @@ public:
                                                  solverChoice.les_type == LESType::Deardorff   ||
                                                  solverChoice.pbl_type == PBLType::MYNN25,
                                                  "Must use an LES or PBL model to compute turbulent viscosity for MOST boundaries");
-                ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
-                                          m_data.get_var(Vars::yvel),
-                                          m_data.get_var(Vars::zvel),
-                                          cons_mf, m_viscosity, geom, solverChoice,
-                                          domain_bcs_type_d);
+
+                // PBL or PBL+LES - get vertical viscosity component with PBL model. LES - get it with LES model
+                if (solverChoice.pbl_type != PBLType::None) {
+                    ComputeTurbulentViscosityPBL(m_data.get_var(Vars::xvel),
+                                                 m_data.get_var(Vars::yvel),
+                                                 m_data.get_var(Vars::zvel),
+                                                 cons_mf, m_viscosity, geom, solverChoice, m_most);
+                } else {
+                    ComputeTurbulentViscosity(m_data.get_var(Vars::xvel),
+                                              m_data.get_var(Vars::yvel),
+                                              m_data.get_var(Vars::zvel),
+                                              cons_mf, m_viscosity, geom, solverChoice,
+                                              domain_bcs_type_d);
+                }
             }
         }
 


### PR DESCRIPTION
Use vertical turbulent diffusion coefficients in MOST and also use the theta component where appropriate. Was part of https://github.com/erf-model/ERF/pull/444