### PR TITLE
CI for HIP dependency download gpg key from https instead of http

### DIFF
--- a/.github/workflows/dependencies/dependencies_hip.sh
+++ b/.github/workflows/dependencies/dependencies_hip.sh
@@ -13,9 +13,9 @@
 set -eu -o pipefail
 
 # Ref.: https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu
-wget -q -O - http://repo.radeon.com/rocm/rocm.gpg.key \
+wget -q -O - https://repo.radeon.com/rocm/rocm.gpg.key \
   | sudo apt-key add -
-echo 'deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
+echo 'deb [arch=amd64] https://repo.radeon.com/rocm/apt/debian/ ubuntu main' \
   | sudo tee /etc/apt/sources.list.d/rocm.list
 
 echo 'export PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/opt/rocm/profiler/bin:/opt/rocm/opencl/bin:$PATH' \


### PR DESCRIPTION
Sometimes the HIP CI fails due to an error with gpg key download. This PR follows the updated guidance from https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation-Guide.html#ubuntu and changes the urls to use https.