### PR TITLE
Fix gp_zeta in Plotfile, ERF_slow_rhs, and ERF_fast_rhs

### DIFF
--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -347,7 +347,7 @@ ERF::WritePlotFile ()
                       gp_zeta_on_iface_lo = 0.5 * dxInv[2] * (
                                                               p_arr(i-1,j,k+1) + p_arr(i,j,k+1)
                                                             - p_arr(i-1,j,k  ) - p_arr(i,j,k  ) );
-                    } else if(k==bx.bigEnd(2)) {
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
                       gp_zeta_on_iface_lo = 0.5 * dxInv[2] * (
                                                               p_arr(i-1,j,k  ) + p_arr(i,j,k  )
                                                             - p_arr(i-1,j,k-1) - p_arr(i,j,k-1) );
@@ -367,7 +367,7 @@ ERF::WritePlotFile ()
                       gp_zeta_on_iface_hi = 0.5 * dxInv[2] * (
                                                               p_arr(i+1,j,k+1) + p_arr(i,j,k+1)
                                                             - p_arr(i+1,j,k  ) - p_arr(i,j,k  ) );
-                    } else if(k==bx.bigEnd(2)) {
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
                       gp_zeta_on_iface_hi = 0.5 * dxInv[2] * (
                                                               p_arr(i+1,j,k  ) + p_arr(i,j,k  )
                                                             - p_arr(i+1,j,k-1) - p_arr(i,j,k-1) );
@@ -419,21 +419,39 @@ ERF::WritePlotFile ()
                     Real met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo;
                     ComputeMetricAtJface(i,j,k,met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo,dxInv,z_nd,TerrainMet::h_eta_zeta);
                     Real gp_eta_lo = dxInv[1] * (p_arr(i,j,k) - p_arr(i,j-1,k));
-                    Real gp_zeta_on_jface_lo = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                          p_arr(i,j,k+1) + p_arr(i,j-1,k+1) - p_arr(i,j,k) - p_arr(i,j-1,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i,j,k+1) + p_arr(i,j-1,k+1) - p_arr(i,j,k-1) - p_arr(i,j-1,k-1));
+                    Real gp_zeta_on_jface_lo;
+                    if(k==0) {
+                      gp_zeta_on_jface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j,k+1) + p_arr(i,j-1,k+1)
+                                                            - p_arr(i,j,k  ) - p_arr(i,j-1,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_jface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j,k  ) + p_arr(i,j-1,k  )
+                                                            - p_arr(i,j,k-1) - p_arr(i,j-1,k-1) );
+                    } else {
+                      gp_zeta_on_jface_lo = 0.25 * dxInv[2] * (
+                                                               p_arr(i,j,k+1) + p_arr(i,j-1,k+1)
+                                                             - p_arr(i,j,k-1) - p_arr(i,j-1,k-1) );
+                    }
                     amrex::Real gpy_lo = gp_eta_lo - (met_h_eta_lo / met_h_zeta_lo) * gp_zeta_on_jface_lo;
 
                     Real met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi;
                     ComputeMetricAtJface(i,j+1,k,met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi,dxInv,z_nd,TerrainMet::h_eta_zeta);
                     Real gp_eta_hi = dxInv[1] * (p_arr(i,j+1,k) - p_arr(i,j,k));
-                    Real gp_zeta_on_jface_hi = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                          p_arr(i,j+1,k+1) + p_arr(i,j,k+1) - p_arr(i,j+1,k) - p_arr(i,j,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i,j+1,k+1) + p_arr(i,j,k+1) - p_arr(i,j+1,k-1) - p_arr(i,j,k-1));
+                    Real gp_zeta_on_jface_hi;
+                    if(k==0) {
+                      gp_zeta_on_jface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j+1,k+1) + p_arr(i,j,k+1)
+                                                            - p_arr(i,j+1,k  ) - p_arr(i,j,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_jface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j+1,k  ) + p_arr(i,j,k  )
+                                                            - p_arr(i,j+1,k-1) - p_arr(i,j,k-1) );
+                    } else {
+                      gp_zeta_on_jface_hi = 0.25 * dxInv[2] * (
+                                                               p_arr(i,j+1,k+1) + p_arr(i,j,k+1)
+                                                             - p_arr(i,j+1,k-1) - p_arr(i,j,k-1) );
+                    }
                     amrex::Real gpy_hi = gp_eta_hi - (met_h_eta_hi / met_h_zeta_hi) * gp_zeta_on_jface_hi;
 
                     derdat(i ,j ,k, mf_comp) = 0.5 * (gpy_lo + gpy_hi);
@@ -460,21 +478,39 @@ ERF::WritePlotFile ()
                     Real met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo;
                     ComputeMetricAtIface(i,j,k,met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo,dxInv,z_nd,TerrainMet::h_xi_zeta);
                     Real gp_xi_lo = dxInv[0] * (p_arr(i,j,k) - p_arr(i-1,j,k));
-                    Real gp_zeta_on_iface_lo = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                        p_arr(i,j,k+1) + p_arr(i-1,j,k+1) - p_arr(i,j,k) - p_arr(i-1,j,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i,j,k+1) + p_arr(i-1,j,k+1) - p_arr(i,j,k-1) - p_arr(i-1,j,k-1));
+                    Real gp_zeta_on_iface_lo;
+                    if(k==0) {
+                      gp_zeta_on_iface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i-1,j,k+1) + p_arr(i,j,k+1)
+                                                            - p_arr(i-1,j,k  ) - p_arr(i,j,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_iface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i-1,j,k  ) + p_arr(i,j,k  )
+                                                            - p_arr(i-1,j,k-1) - p_arr(i,j,k-1) );
+                    } else {
+                      gp_zeta_on_iface_lo = 0.25 * dxInv[2] * (
+                                                               p_arr(i-1,j,k+1) + p_arr(i,j,k+1)
+                                                             - p_arr(i-1,j,k-1) - p_arr(i,j,k-1) );
+                    }
                     amrex::Real gpx_lo = gp_xi_lo - (met_h_xi_lo/ met_h_zeta_lo) * gp_zeta_on_iface_lo;
 
                     Real met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi;
                     ComputeMetricAtIface(i+1,j,k,met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi,dxInv,z_nd,TerrainMet::h_xi_zeta);
                     Real gp_xi_hi = dxInv[0] * (p_arr(i+1,j,k) - p_arr(i,j,k));
-                    Real gp_zeta_on_iface_hi = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                        p_arr(i+1,j,k+1) + p_arr(i,j,k+1) - p_arr(i+1,j,k) - p_arr(i,j,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i+1,j,k+1) + p_arr(i,j,k+1) - p_arr(i+1,j,k-1) - p_arr(i,j,k-1));
+                    Real gp_zeta_on_iface_hi;
+                    if(k==0) {
+                      gp_zeta_on_iface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i+1,j,k+1) + p_arr(i,j,k+1)
+                                                            - p_arr(i+1,j,k  ) - p_arr(i,j,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_iface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i+1,j,k  ) + p_arr(i,j,k  )
+                                                            - p_arr(i+1,j,k-1) - p_arr(i,j,k-1) );
+                    } else {
+                      gp_zeta_on_iface_hi = 0.25 * dxInv[2] * (
+                                                               p_arr(i+1,j,k+1) + p_arr(i,j,k+1)
+                                                             - p_arr(i+1,j,k-1) - p_arr(i,j,k-1) );
+                    }
                     amrex::Real gpx_hi = gp_xi_hi - (met_h_xi_hi/ met_h_zeta_hi) * gp_zeta_on_iface_hi;
 
                     derdat(i ,j ,k, mf_comp) = 0.5 * (gpx_lo + gpx_hi);
@@ -496,21 +532,39 @@ ERF::WritePlotFile ()
                     Real met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo;
                     ComputeMetricAtJface(i,j,k,met_h_xi_lo,met_h_eta_lo,met_h_zeta_lo,dxInv,z_nd,TerrainMet::h_eta_zeta);
                     Real gp_eta_lo = dxInv[1] * (p_arr(i,j,k) - p_arr(i,j-1,k));
-                    Real gp_zeta_on_jface_lo = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                          p_arr(i,j,k+1) + p_arr(i,j-1,k+1) - p_arr(i,j,k) - p_arr(i,j-1,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i,j,k+1) + p_arr(i,j-1,k+1) - p_arr(i,j,k-1) - p_arr(i,j-1,k-1));
+                    Real gp_zeta_on_jface_lo;
+                    if(k==0) {
+                      gp_zeta_on_jface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j,k+1) + p_arr(i,j-1,k+1)
+                                                            - p_arr(i,j,k  ) - p_arr(i,j-1,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_jface_lo = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j,k  ) + p_arr(i,j-1,k  )
+                                                            - p_arr(i,j,k-1) - p_arr(i,j-1,k-1) );
+                    } else {
+                      gp_zeta_on_jface_lo = 0.25 * dxInv[2] * (
+                                                               p_arr(i,j,k+1) + p_arr(i,j-1,k+1)
+                                                             - p_arr(i,j,k-1) - p_arr(i,j-1,k-1) );
+                    }
                     amrex::Real gpy_lo = gp_eta_lo - (met_h_eta_lo / met_h_zeta_lo) * gp_zeta_on_jface_lo;
 
                     Real met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi;
                     ComputeMetricAtJface(i,j+1,k,met_h_xi_hi,met_h_eta_hi,met_h_zeta_hi,dxInv,z_nd,TerrainMet::h_eta_zeta);
                     Real gp_eta_hi = dxInv[1] * (p_arr(i,j+1,k) - p_arr(i,j,k));
-                    Real gp_zeta_on_jface_hi = (k == 0) ?
-                        0.5 * dxInv[2] * (
-                          p_arr(i,j+1,k+1) + p_arr(i,j,k+1) - p_arr(i,j+1,k) - p_arr(i,j,k)):
-                        0.25 * dxInv[2] * (
-                          p_arr(i,j+1,k+1) + p_arr(i,j,k+1) - p_arr(i,j+1,k-1) - p_arr(i,j,k-1));
+                    Real gp_zeta_on_jface_hi;
+                    if(k==0) {
+                      gp_zeta_on_jface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j+1,k+1) + p_arr(i,j,k+1)
+                                                            - p_arr(i,j+1,k  ) - p_arr(i,j,k  ) );
+                    } else if(k==geom[lev].Domain().bigEnd(2)) {
+                      gp_zeta_on_jface_hi = 0.5 * dxInv[2] * (
+                                                              p_arr(i,j+1,k  ) + p_arr(i,j,k  )
+                                                            - p_arr(i,j+1,k-1) - p_arr(i,j,k-1) );
+                    } else {
+                      gp_zeta_on_jface_hi = 0.25 * dxInv[2] * (
+                                                               p_arr(i,j+1,k+1) + p_arr(i,j,k+1)
+                                                             - p_arr(i,j+1,k-1) - p_arr(i,j,k-1) );
+                    }
                     amrex::Real gpy_hi = gp_eta_hi - (met_h_eta_hi / met_h_zeta_hi) * gp_zeta_on_jface_hi;
 
                     derdat(i ,j ,k, mf_comp) = 0.5 * (gpy_lo + gpy_hi);

--- a/Source/TimeIntegration/ERF_fast_rhs.cpp
+++ b/Source/TimeIntegration/ERF_fast_rhs.cpp
@@ -217,9 +217,20 @@ void erf_fast_rhs (int level,
                 Real met_h_xi,met_h_eta,met_h_zeta;
                 ComputeMetricAtIface(i,j,k,met_h_xi,met_h_eta,met_h_zeta,dxInv,z_nd,TerrainMet::h_xi_zeta);
                 Real gp_xi = (drho_theta_hi - drho_theta_lo) * dxi;
-                Real gp_zeta_on_iface = 0.25 * dzi * (
-                  extrap_arr(i  ,j,k+1) + extrap_arr(i-1,j,k+1)
-                 -extrap_arr(i  ,j,k-1) - extrap_arr(i-1,j,k-1));
+                Real gp_zeta_on_iface;
+                if(k==0) {
+                    gp_zeta_on_iface = 0.5 * dzi * (
+                                                   extrap_arr(i-1,j,k+1) + extrap_arr(i,j,k+1)
+                                                 - extrap_arr(i-1,j,k  ) - extrap_arr(i,j,k  ) );
+                } else if(k==domhi_z) {
+                    gp_zeta_on_iface = 0.5 * dzi * (
+                                                   extrap_arr(i-1,j,k  ) + extrap_arr(i,j,k  )
+                                                 - extrap_arr(i-1,j,k-1) - extrap_arr(i,j,k-1) );
+                } else {
+                    gp_zeta_on_iface = 0.25 * dzi * (
+                                                    extrap_arr(i-1,j,k+1) + extrap_arr(i,j,k+1)
+                                                  - extrap_arr(i-1,j,k-1) - extrap_arr(i,j,k-1) );
+                }
                 Real gpx = gp_xi - (met_h_xi / met_h_zeta) * gp_zeta_on_iface;
 #else
                 Real gpx = (drho_theta_hi - drho_theta_lo)*dxi;
@@ -265,9 +276,20 @@ void erf_fast_rhs (int level,
                 Real met_h_xi,met_h_eta,met_h_zeta;
                 ComputeMetricAtJface(i,j,k,met_h_xi,met_h_eta,met_h_zeta,dxInv,z_nd,TerrainMet::h_eta_zeta);
                 Real gp_eta = (drho_theta_hi - drho_theta_lo) * dyi;
-                Real gp_zeta_on_jface = 0.25 * dzi * (
-                   extrap_arr(i,j  ,k+1) + extrap_arr(i,j-1,k+1)
-                 - extrap_arr(i,j  ,k-1) - extrap_arr(i,j-1,k-1) );
+                Real gp_zeta_on_jface;
+                if(k==0) {
+                    gp_zeta_on_jface = 0.5 * dzi * (
+                                                   extrap_arr(i,j,k+1) + extrap_arr(i,j-1,k+1)
+                                                 - extrap_arr(i,j,k  ) - extrap_arr(i,j-1,k  ) );
+                } else if(k==domhi_z) {
+                    gp_zeta_on_jface = 0.5 * dzi * (
+                                                   extrap_arr(i,j,k  ) + extrap_arr(i,j-1,k  )
+                                                 - extrap_arr(i,j,k-1) - extrap_arr(i,j-1,k-1) );
+                } else {
+                    gp_zeta_on_jface = 0.25 * dzi * (
+                                                    extrap_arr(i,j,k+1) + extrap_arr(i,j-1,k+1)
+                                                  - extrap_arr(i,j,k-1) - extrap_arr(i,j-1,k-1) );
+                }
                 Real gpy = gp_eta - (met_h_eta / met_h_zeta) * gp_zeta_on_jface;
 #else
                 Real gpy = (drho_theta_hi - drho_theta_lo)*dyi;

--- a/Source/TimeIntegration/ERF_slow_rhs.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs.cpp
@@ -359,11 +359,20 @@ void erf_slow_rhs (int level,
             Real met_h_xi,met_h_eta,met_h_zeta;
             ComputeMetricAtIface(i,j,k,met_h_xi,met_h_eta,met_h_zeta,dxInv,z_nd,TerrainMet::h_xi_zeta);
             Real gp_xi = dxInv[0] * (pp_arr(i,j,k) - pp_arr(i-1,j,k));
-            Real gp_zeta_on_iface = (k == 0) ?
-                0.5 * dxInv[2] * (
-                pp_arr(i,j,k+1) + pp_arr(i-1,j,k+1) - pp_arr(i,j,k) - pp_arr(i-1,j,k)):
-                0.25 * dxInv[2] * (
-                  pp_arr(i,j,k+1) + pp_arr(i-1,j,k+1) - pp_arr(i,j,k-1) - pp_arr(i-1,j,k-1));
+            Real gp_zeta_on_iface;
+            if(k==0) {
+                gp_zeta_on_iface = 0.5 * dxInv[2] * (
+                                                    pp_arr(i-1,j,k+1) + pp_arr(i,j,k+1)
+                                                  - pp_arr(i-1,j,k  ) - pp_arr(i,j,k  ) );
+            } else if(k==domhi_z) {
+                gp_zeta_on_iface = 0.5 * dxInv[2] * (
+                                                    pp_arr(i-1,j,k  ) + pp_arr(i,j,k  )
+                                                  - pp_arr(i-1,j,k-1) - pp_arr(i,j,k-1) );
+            } else {
+                gp_zeta_on_iface = 0.25 * dxInv[2] * (
+                                                     pp_arr(i-1,j,k+1) + pp_arr(i,j,k+1)
+                                                   - pp_arr(i-1,j,k-1) - pp_arr(i,j,k-1) );
+            }
             amrex::Real gpx = gp_xi - (met_h_xi/ met_h_zeta) * gp_zeta_on_iface;
 #else
             amrex::Real gpx = dxInv[0] * (pp_arr(i,j,k) - pp_arr(i-1,j,k));
@@ -437,11 +446,20 @@ void erf_slow_rhs (int level,
             Real met_h_xi,met_h_eta,met_h_zeta;
             ComputeMetricAtJface(i,j,k,met_h_xi,met_h_eta,met_h_zeta,dxInv,z_nd,TerrainMet::h_eta_zeta);
             Real gp_eta = dxInv[1] * (pp_arr(i,j,k) - pp_arr(i,j-1,k));
-            Real gp_zeta_on_jface = (k == 0) ?
-                0.5 * dxInv[2] * (
-                  pp_arr(i,j,k+1) + pp_arr(i,j-1,k+1) - pp_arr(i,j,k) - pp_arr(i,j-1,k)):
-                0.25 * dxInv[2] * (
-                  pp_arr(i,j,k+1) + pp_arr(i,j-1,k+1) - pp_arr(i,j,k-1) - pp_arr(i,j-1,k-1));
+            Real gp_zeta_on_jface;
+            if(k==0) {
+                gp_zeta_on_jface = 0.5 * dxInv[2] * (
+                                                    pp_arr(i,j,k+1) + pp_arr(i,j-1,k+1)
+                                                  - pp_arr(i,j,k  ) - pp_arr(i,j-1,k  ) );
+            } else if(k==domhi_z) {
+                gp_zeta_on_jface = 0.5 * dxInv[2] * (
+                                                    pp_arr(i,j,k  ) + pp_arr(i,j-1,k  )
+                                                  - pp_arr(i,j,k-1) - pp_arr(i,j-1,k-1) );
+            } else {
+                gp_zeta_on_jface = 0.25 * dxInv[2] * (
+                                                     pp_arr(i,j,k+1) + pp_arr(i,j-1,k+1)
+                                                   - pp_arr(i,j,k-1) - pp_arr(i,j-1,k-1) );
+            }
             amrex::Real gpy = gp_eta - (met_h_eta / met_h_zeta) * gp_zeta_on_jface;
 #else
             amrex::Real gpy = dxInv[1] * (pp_arr(i,j,k) - pp_arr(i,j-1,k));


### PR DESCRIPTION
A fix was implemented for the gp_zeta computation in Plotfile.cpp previously, but the same term appeared in several regions of the code and needed to be implemented in these other places as well.

The functionality is the same as:
Merge pull request https://github.com/erf-model/ERF/pull/511 from AMLattanzi/dpdx_Fix
commit 7dcc62b2f23666d66c4b59d4b74e499bf53ba1e2

Also, the top k boundary is now determined in a way that is slightly better/less prone to freak errors.