### PR TITLE
Fix the seg fault arising due to x-stagger on x-boundaries and y-stagger on y-boundaries

### DIFF
--- a/Source/IO/ReadFromWRFBdy.cpp
+++ b/Source/IO/ReadFromWRFBdy.cpp
@@ -200,13 +200,13 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
                 const Box pbx_xlo(plo, phi);
 
                 Box xlo_plane_no_stag(pbx_xlo);
-                Box xlo_plane_x_stag = Box(IntVect(-ng+1,lo[1],lo[2]),IntVect(0,hi[1],hi[2]),{1,0,0});
+                //Box xlo_plane_x_stag = Box(IntVect(-ng+1,lo[1],lo[2]),IntVect(0,hi[1],hi[2]),{1,0,0});
                 Box xlo_plane_y_stag = convert(pbx_xlo, {0, 1, 0});
                 Box xlo_plane_z_stag = convert(pbx_xlo, {0, 0, 1});
 
                 if        (first1 == "U") {
                     for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_x_stag, 1)); // U
+                        bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1)); // U
                     }
                 } else if (first1 == "V") {
                     for (int nt(0); nt < ntimes; ++nt) {
@@ -232,13 +232,13 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
                 const Box pbx_xhi(plo, phi);
 
                 Box xhi_plane_no_stag(pbx_xhi);
-                Box xhi_plane_x_stag = Box(IntVect(plo[0],lo[1],lo[2]),IntVect(phi[0],hi[1],hi[2]),{1,0,0});
+                //Box xhi_plane_x_stag = Box(IntVect(plo[0],lo[1],lo[2]),IntVect(phi[0],hi[1],hi[2]),{1,0,0});
                 Box xhi_plane_y_stag = convert(pbx_xhi, {0, 1, 0});
                 Box xhi_plane_z_stag = convert(pbx_xhi, {0, 0, 1});
 
                 if        (first1 == "U") {
                     for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_x_stag, 1)); // U
+                        bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_no_stag, 1)); // U
                     }
                 } else if (first1 == "V") {
                     for (int nt(0); nt < ntimes; ++nt) {
@@ -265,7 +265,7 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
 
                 Box ylo_plane_no_stag(pbx_ylo);
                 Box ylo_plane_x_stag = convert(pbx_ylo, {1, 0, 0});
-                Box ylo_plane_y_stag = Box(IntVect(lo[0],-ng+1,lo[2]),IntVect(hi[0],0,hi[2]),{0,1,0});
+                //Box ylo_plane_y_stag = Box(IntVect(lo[0],-ng+1,lo[2]),IntVect(hi[0],0,hi[2]),{0,1,0});
                 Box ylo_plane_z_stag = convert(pbx_ylo, {0, 0, 1});
 
                 if        (first1 == "U") {
@@ -274,7 +274,7 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
                     }
                 } else if (first1 == "V") {
                     for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_y_stag, 1)); // V
+                        bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1)); // V
                     }
                 } else if (first1 == "W") {
                     for (int nt(0); nt < ntimes; ++nt) {
@@ -297,7 +297,7 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
 
                 Box yhi_plane_no_stag(pbx_yhi);
                 Box yhi_plane_x_stag = convert(pbx_yhi, {1, 0, 0});
-                Box yhi_plane_y_stag = Box(IntVect(lo[0],plo[1],lo[2]),IntVect(hi[0],phi[1],hi[2]),{0,1,0});
+                //Box yhi_plane_y_stag = Box(IntVect(lo[0],plo[1],lo[2]),IntVect(hi[0],phi[1],hi[2]),{0,1,0});
                 Box yhi_plane_z_stag = convert(pbx_yhi, {0, 0, 1});
 
                 if        (first1 == "U") {
@@ -306,7 +306,7 @@ read_from_wrfbdy(std::string nc_bdy_file, const Box& domain,
                     }
                 } else if (first1 == "V") {
                     for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_y_stag, 1)); // V
+                        bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1)); // V
                     }
                 } else if (first1 == "W") {
                     for (int nt(0); nt < ntimes; ++nt) {


### PR DESCRIPTION
While running in serial, error before the fix:

```console
Building FAB for the the NetCDF variable : T_BXS
T AT XLO (-1,0,0) 0 152153.2812
Building FAB for the the NetCDF variable : T_BXE
Building FAB for the the NetCDF variable : T_BYS
T AT YLO (0,-1,0) 0 152153.2812
Building FAB for the the NetCDF variable : T_BYE
Successfully loaded data from the NetCDF file

FILLING RHO THETA BC FROM WRFBDY 1 1 1
FILLING XVEL BC FROM WRFBDY 0 5 1
amrex::Abort::0:: (-1,0,0,0) is out of bound (0:0,0:199,0:175,0:0) !!!
SIGABRT
See Backtrace.0 file for details
--------------------------------------------------------------------------
MPI_ABORT was invoked on rank 0 in communicator MPI_COMM_WORLD
with errorcode 6.

NOTE: invoking MPI_ABORT causes Open MPI to kill all MPI processes.
You may or may not see output from other processes, depending on
exactly when Open MPI kills them.
--------------------------------------------------------------------------
```

After the fix:

```console
Building FAB for the the NetCDF variable : T_BXS
T AT XLO (-1,0,0) 0 152153.2812
Building FAB for the the NetCDF variable : T_BXE
Building FAB for the the NetCDF variable : T_BYS
T AT YLO (0,-1,0) 0 152153.2812
Building FAB for the the NetCDF variable : T_BYE
Successfully loaded data from the NetCDF file

FILLING RHO THETA BC FROM WRFBDY 1 1 1
FILLING XVEL BC FROM WRFBDY 0 5 1
FILLING YVEL BC FROM WRFBDY 0 6 1
FILLING ZVEL BC FROM WRFBDY 0 7 1
Writing plotfile plt00000

TIME= 0 MASS        = 1.22220342e+17
TIME= 0 SCALAR      = 0
FILLING RHO THETA BC FROM WRFBDY 1 1 1
FILLING XVEL BC FROM WRFBDY 0 5 1
FILLING YVEL BC FROM WRFBDY 0 6 1
FILLING ZVEL BC FROM WRFBDY 0 7 1

Coarse STEP 1 starts ...
Based on cfl of 1.0 
Fast  dt at level 0 would be:  0.009314340999
Slow  dt at level 0 would be:  0.009315747439
Fixed dt at level 0       is:  0.5
smallest even ratio is: 68
[Level 0 step 1] ADVANCE from time = 0 to 0.5 with dt = 0.5
FILLING RHO THETA BC FROM WRFBDY 1 1 1
FILLING XVEL BC FROM WRFBDY 0 5 1
FILLING YVEL BC FROM WRFBDY 0 6 1
FILLING ZVEL BC FROM WRFBDY 0 7 1
Starting advance at level 0
Killed
```