### PR TITLE
NetCDF: Use `pkg-config` to find libs

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -110,8 +110,8 @@ function(build_erf_lib erf_lib_name)
   if(ERF_ENABLE_NETCDF)
     if(NETCDF_FOUND)
       #Link our executable to the NETCDF libraries, etc
-      target_link_libraries(${erf_lib_name} PUBLIC ${NETCDF_LIBRARIES_C})
-      target_include_directories(${erf_lib_name} PUBLIC ${NETCDF_INCLUDES})
+      target_link_libraries(${erf_lib_name} PUBLIC ${NETCDF_LINK_LIBRARIES})
+      target_include_directories(${erf_lib_name} PUBLIC ${NETCDF_INCLUDE_DIRS})
     endif()
   endif()
 

--- a/CMake/FindNetCDF.cmake
+++ b/CMake/FindNetCDF.cmake
@@ -1,71 +1,32 @@
 # - Find NetCDF
 # Find the native NetCDF includes and library
 #
-#  NETCDF_INCLUDES    - where to find netcdf.h, etc
-#  NETCDF_LIBRARIES   - Link these libraries when using NetCDF
-#  NETCDF_FOUND       - True if NetCDF found including required interfaces (see below)
-#
-# Your package can require certain interfaces to be FOUND by setting these
-#
-#  NETCDF_CXX         - require the C++ interface and link the C++ library
-#  NETCDF_F77         - require the F77 interface and link the fortran library
-#  NETCDF_F90         - require the F90 interface and link the fortran library
+#  NETCDF_INCLUDE_DIRS - where to find netcdf.h, etc
+#  NETCDF_FOUND        - True if NetCDF found
 #
 # The following are not for general use and are included in
 # NETCDF_LIBRARIES if the corresponding option above is set.
 #
-#  NETCDF_LIBRARIES_C    - Just the C interface
-#  NETCDF_LIBRARIES_CXX  - C++ interface, if available
-#  NETCDF_LIBRARIES_F77  - Fortran 77 interface, if available
-#  NETCDF_LIBRARIES_F90  - Fortran 90 interface, if available
+#  NETCDF_LIBRARIES      - only the libraries (without the '-l')
+#  NETCDF_LINK_LIBRARIES - the libraries and their absolute paths
+#  NETCDF_LDFLAGS        - all required linker flags
 #
 # Normal usage would be:
 #  find_package (NetCDF REQUIRED)
-#  target_link_libraries (uses_f90_interface ${NETCDF_LIBRARIES})
-#  target_link_libraries (only_uses_c_interface ${NETCDF_LIBRARIES_C})
+#  target_link_libraries (target_name PUBLIC ${NETCDF_LINK_LIBRARIES})
 
 if (NETCDF_INCLUDES AND NETCDF_LIBRARIES)
   # Already in cache, be silent
   set (NETCDF_FIND_QUIETLY TRUE)
 endif (NETCDF_INCLUDES AND NETCDF_LIBRARIES)
 
-find_path (NETCDF_INCLUDES netcdf.h
-  HINTS NETCDF_DIR ENV NETCDF_DIR)
-
-find_library (NETCDF_LIBRARIES_C       NAMES netcdf)
-mark_as_advanced(NETCDF_LIBRARIES_C)
-
-set (NetCDF_has_interfaces "YES") # will be set to NO if we're missing any interfaces
-set (NetCDF_libs "${NETCDF_LIBRARIES_C}")
-
-get_filename_component (NetCDF_lib_dirs "${NETCDF_LIBRARIES_C}" PATH)
-
-macro (NetCDF_check_interface lang header libs)
-  if (NETCDF_${lang})
-    find_path (NETCDF_INCLUDES_${lang} NAMES ${header}
-      HINTS "${NETCDF_INCLUDES}" NO_DEFAULT_PATH)
-    find_library (NETCDF_LIBRARIES_${lang} NAMES ${libs}
-      HINTS "${NetCDF_lib_dirs}" NO_DEFAULT_PATH)
-    mark_as_advanced (NETCDF_INCLUDES_${lang} NETCDF_LIBRARIES_${lang})
-    if (NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
-      list (INSERT NetCDF_libs 0 ${NETCDF_LIBRARIES_${lang}}) # prepend so that -lnetcdf is last
-    else (NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
-      set (NetCDF_has_interfaces "NO")
-      message (STATUS "Failed to find NetCDF interface for ${lang}")
-    endif (NETCDF_INCLUDES_${lang} AND NETCDF_LIBRARIES_${lang})
-  endif (NETCDF_${lang})
-endmacro (NetCDF_check_interface)
-
-NetCDF_check_interface (CXX netcdfcpp.h netcdf_c++)
-NetCDF_check_interface (F77 netcdf.inc  netcdff)
-NetCDF_check_interface (F90 netcdf.mod  netcdff)
-
-set (NETCDF_LIBRARIES "${NetCDF_libs}" CACHE STRING "All NetCDF libraries required for interface level")
+find_package(PkgConfig REQUIRED QUIET)
+pkg_check_modules(NETCDF REQUIRED IMPORTED_TARGET netcdf)
 
 # handle the QUIETLY and REQUIRED arguments and set NETCDF_FOUND to TRUE if
 # all listed variables are TRUE
 include (FindPackageHandleStandardArgs)
-find_package_handle_standard_args (NetCDF DEFAULT_MSG NETCDF_LIBRARIES NETCDF_INCLUDES NetCDF_has_interfaces)
+find_package_handle_standard_args (NetCDF DEFAULT_MSG NETCDF_LIBRARIES NETCDF_LINK_LIBRARIES NETCDF_INCLUDE_DIRS)
 
 mark_as_advanced (NETCDF_LIBRARIES NETCDF_INCLUDES)
 


### PR DESCRIPTION
The current logic only adds `libnetcdf` to the link line, but no transitive libs. This can cause link issues, e.g., when `libnetcdf` is dynamic and has transitive dependencies, as it often has to HDF5, zlib, etc.

Both `nc-config` and `pkg-config` provide this information to populate transitive libs and thus symbols during linking. We pick the latter, since it will also work when you cross-compile for a different architecture.

Here is the helper function in CMake that we use to query `pkg-config --libs` et al.:
  https://cmake.org/cmake/help/latest/module/FindPkgConfig.html

CC @WeiqunZhang @asalmgren 