### PR TITLE
Inline interpolation functions

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -43,7 +43,7 @@ function(build_erf_lib erf_lib_name)
   if(ERF_ENABLE_HDF5)
     target_compile_definitions(${erf_lib_name} PUBLIC ERF_USE_HDF5)
   endif()
- 
+
   target_sources(${erf_lib_name}
      PRIVATE
        ${SRC_DIR}/DataStruct.H
@@ -85,11 +85,11 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/SpatialStencils/ExpansionRate.H
        ${SRC_DIR}/SpatialStencils/StrainRate.H
        ${SRC_DIR}/SpatialStencils/StressTerm.H
-       ${SRC_DIR}/SpatialStencils/Interpolation.cpp
+       ${SRC_DIR}/SpatialStencils/Interpolation.H
        ${SRC_DIR}/SpatialStencils/ComputeTurbulentViscosity.cpp
        ${SRC_DIR}/SpatialStencils/MomentumToVelocity.cpp
        ${SRC_DIR}/SpatialStencils/VelocityToMomentum.cpp
-       ${SRC_DIR}/SpatialStencils/TerrainMetrics.H 
+       ${SRC_DIR}/SpatialStencils/TerrainMetrics.H
        ${SRC_DIR}/SpatialStencils/TerrainMetrics.cpp
        ${SRC_DIR}/TimeIntegration/ERF_ComputeTimestep.cpp
        ${SRC_DIR}/TimeIntegration/ERF_TimeStepping.cpp
@@ -155,7 +155,7 @@ function(build_erf_lib erf_lib_name)
     CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   endif()
 
-  #Define what we want to be installed during a make install 
+  #Define what we want to be installed during a make install
   install(TARGETS ${erf_lib_name}
           RUNTIME DESTINATION bin
           ARCHIVE DESTINATION lib
@@ -191,7 +191,7 @@ function(build_erf_exe erf_exe_name)
     CUDA_RESOLVE_DEVICE_SYMBOLS ON)
   endif()
 
-  install(TARGETS ${erf_exe_name} 
+  install(TARGETS ${erf_exe_name}
           RUNTIME DESTINATION bin
           ARCHIVE DESTINATION lib
           LIBRARY DESTINATION lib)

--- a/Source/SpatialStencils/Advection.cpp
+++ b/Source/SpatialStencils/Advection.cpp
@@ -1,6 +1,7 @@
 #include <IndexDefines.H>
 #include <SpatialStencils.H>
 #include <TerrainMetrics.H>
+#include <Interpolation.H>
 
 using namespace amrex;
 

--- a/Source/SpatialStencils/Diffusion.cpp
+++ b/Source/SpatialStencils/Diffusion.cpp
@@ -1,5 +1,6 @@
 #include <SpatialStencils.H>
 #include <StressTerm.H>
+#include <Interpolation.H>
 
 using namespace amrex;
 

--- a/Source/SpatialStencils/Interpolation.H
+++ b/Source/SpatialStencils/Interpolation.H
@@ -3,7 +3,7 @@
 using namespace amrex;
 
 AMREX_GPU_DEVICE
-Real
+inline Real
 interpolatedVal(const Real& avg1, const Real& avg2, const Real& avg3,
                 const Real& diff1, const Real& diff2, const Real& diff3,
                 const Real& scaled_upw, const int& spatial_order)
@@ -31,23 +31,7 @@ interpolatedVal(const Real& avg1, const Real& avg2, const Real& avg3,
 }
 
 AMREX_GPU_DEVICE
-Real
-InterpolateDensityPertFromCellToFace(
-  const int& i,
-  const int& j,
-  const int& k,
-  const Array4<const Real>& cons_in,
-  const Real& upw,
-  const Coord& coordDir,
-  const int& spatial_order,
-  const Array4<const Real>& r0_arr)
-{
-  return InterpolatePertFromCell(
-    i, j, k, cons_in, Rho_comp, upw, coordDir, spatial_order, r0_arr);
-}
-
-AMREX_GPU_DEVICE
-Real
+inline Real
 InterpolateFromCellOrFace(
   const int& i, const int& j, const int& k,
   const Array4<const Real>& qty,
@@ -110,7 +94,7 @@ InterpolateFromCellOrFace(
 
 
 AMREX_GPU_DEVICE
-Real
+inline Real
 InterpolatePertFromCell(
   const int& i, const int& j, const int& k,
   const Array4<const Real>& qty,
@@ -184,3 +168,19 @@ InterpolatePertFromCell(
     return interpolatedVal(avg1,avg2,avg3,diff1,diff2,diff3,scaled_upw,spatial_order);
 }
 
+
+AMREX_GPU_DEVICE
+inline Real
+InterpolateDensityPertFromCellToFace(
+  const int& i,
+  const int& j,
+  const int& k,
+  const Array4<const Real>& cons_in,
+  const Real& upw,
+  const Coord& coordDir,
+  const int& spatial_order,
+  const Array4<const Real>& r0_arr)
+{
+  return InterpolatePertFromCell(
+    i, j, k, cons_in, Rho_comp, upw, coordDir, spatial_order, r0_arr);
+}

--- a/Source/SpatialStencils/Make.package
+++ b/Source/SpatialStencils/Make.package
@@ -1,15 +1,14 @@
 CEXE_sources += ComputeTurbulentViscosity.cpp
 CEXE_sources += MomentumToVelocity.cpp
 CEXE_sources += VelocityToMomentum.cpp
-CEXE_sources += Interpolation.cpp
 CEXE_sources += Advection.cpp
 CEXE_sources += Diffusion.cpp
 
+CEXE_headers += Interpolation.H
 CEXE_headers += ExpansionRate.H
 CEXE_headers += StrainRate.H
 CEXE_headers += StressTerm.H
 CEXE_headers += EddyViscosity.H
 
 CEXE_headers += TerrainMetrics.H
-CEXE_sources += TerrainMetrics.cpp    
-
+CEXE_sources += TerrainMetrics.cpp

--- a/Source/SpatialStencils/SpatialStencils.H
+++ b/Source/SpatialStencils/SpatialStencils.H
@@ -30,33 +30,6 @@ void VelocityToMomentum(const amrex::MultiFab& xvel_in,
                         amrex::MultiFab& ymom_out,
                         amrex::MultiFab& zmom_out);
 
-
-AMREX_GPU_DEVICE
-amrex::Real InterpolateFromCellOrFace(
-                       const int &i, const int &j, const int &k,
-                       const amrex::Array4<const amrex::Real>& qty, const int & qty_index,
-                       const amrex::Real& uadv,
-                       const enum Coord& coordDir,
-                       const int& spatial_order);
-
-AMREX_GPU_DEVICE
-amrex::Real InterpolatePertFromCell(
-                       const int &i, const int &j, const int &k,
-                       const amrex::Array4<const amrex::Real>& qty, const int & qty_index,
-                       const amrex::Real& uadv,
-                       const enum Coord& coordDir,
-                       const int& spatial_order,
-                       const amrex::Array4<const amrex::Real>& r0_arr);
-
-AMREX_GPU_DEVICE
-amrex::Real InterpolateDensityPertFromCellToFace(
-                       const int &i, const int &j, const int &k,
-                       const amrex::Array4<const amrex::Real>& cons_in,
-                       const amrex::Real& uadv,
-                       const enum Coord& coordDir,
-                       const int& spatial_order,
-                       const amrex::Array4<const amrex::Real>& r0_arr);
-
 /** Meant for {x, y, z}- momentum equations */
 AMREX_GPU_DEVICE
 amrex::Real AdvectionSrcForXMom(

--- a/Source/TimeIntegration/ERF_slow_rhs.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs.cpp
@@ -13,6 +13,7 @@
 
 #include <TerrainMetrics.H>
 #include <IndexDefines.H>
+#include <Interpolation.H>
 
 using namespace amrex;
 


### PR DESCRIPTION
I noticed that the interpolation kernels did not have inline directives. Adding these appears to make the code ~5% faster on CPU and 15% faster on GPU based on some quick tests that I did.