### PR TITLE
Remove unnecessary divide in interpolation

### DIFF
--- a/Source/SpatialStencils/Interpolation.H
+++ b/Source/SpatialStencils/Interpolation.H
@@ -46,7 +46,7 @@ InterpolateFromCellOrFace(
 
     // The value that comes in has not been normalized so we do that here
     if (upw != 0.)
-        scaled_upw = upw / std::abs(upw);
+      scaled_upw = (upw > 0) ? 1. : -1.;
 
     if (coordDir ==  Coord::x) {
         avg1  = (qty(i, j, k, qty_index) + qty(i-1, j, k, qty_index));


### PR DESCRIPTION
PERF showed that divide was a hot-spot. Since scaled_upw is either -1 or 1, we can remove the divide and simply do a ternary operation. PERF showed this removed the hot-spot.