### PR TITLE
Move SRI & MRI integrator data into the main ERF class

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -34,6 +34,8 @@
 #include <Derive.H>
 #include <ERF_ReadBndryPlanes.H>
 #include <ERF_WriteBndryPlanes.H>
+#include <ERF_SRI.H>
+#include <ERF_MRI.H>
 
 #ifdef ERF_USE_NETCDF
 #include "NCWpsFile.H"

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -442,6 +442,8 @@ private:
     amrex::Vector<amrex::Vector<amrex::MultiFab> > vars_new;
     amrex::Vector<amrex::Vector<amrex::MultiFab> > vars_old;
 #endif
+    amrex::Vector<std::unique_ptr<MRISplitIntegrator<amrex::Vector<amrex::MultiFab> > > > mri_integrator_mem;
+    amrex::Vector<std::unique_ptr<SRIIntegrator<amrex::Vector<amrex::MultiFab> > > > sri_integrator_mem;
 
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> z_phys_nd;
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> z_phys_cc;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -138,6 +138,9 @@ ERF::ERF ()
         vars_old[lev].resize(Vars::NumTypes);
     }
 
+    mri_integrator_mem.resize(nlevs_max);
+    sri_integrator_mem.resize(nlevs_max);
+
     flux_registers.resize(nlevs_max);
 
     // Initialize tagging criteria for mesh refinement
@@ -527,9 +530,9 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     // Initialize the integrator memory
     amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
     int_state.push_back(MultiFab(lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
-    int_state.push_back(MultiFab(lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
-    int_state.push_back(MultiFab(lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
-    int_state.push_back(MultiFab(lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, lev_new[Vars::xvel].nGrow())); // xmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, lev_new[Vars::yvel].nGrow())); // ymom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, 1, lev_new[Vars::zvel].nGrow())); // zmom
     int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes
@@ -579,9 +582,9 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
     // Initialize the integrator memory
     amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
     int_state.push_back(MultiFab(temp_lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
-    int_state.push_back(MultiFab(temp_lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
-    int_state.push_back(MultiFab(temp_lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
-    int_state.push_back(MultiFab(temp_lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, temp_lev_new[Vars::xvel].nGrow())); // xmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, temp_lev_new[Vars::yvel].nGrow())); // ymom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, 1, temp_lev_new[Vars::zvel].nGrow())); // zmom
     int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes
@@ -688,9 +691,9 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
     // Initialize the integrator memory
     amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
     int_state.push_back(MultiFab(lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
-    int_state.push_back(MultiFab(lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
-    int_state.push_back(MultiFab(lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
-    int_state.push_back(MultiFab(lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, 1, lev_new[Vars::xvel].nGrow())); // xmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, 1, lev_new[Vars::yvel].nGrow())); // ymom
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, 1, lev_new[Vars::zvel].nGrow())); // zmom
     int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
     int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -523,6 +523,21 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     t_old[lev] = time - 1.e200;
 
     FillCoarsePatchAllVars(lev, time, vars_new[lev]);
+
+    // Initialize the integrator memory
+    amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
+    int_state.push_back(MultiFab(lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
+    int_state.push_back(MultiFab(lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
+    int_state.push_back(MultiFab(lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
+    int_state.push_back(MultiFab(lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes
+    if (use_native_mri) {
+        mri_integrator_mem[lev] = std::make_unique<MRISplitIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
+    } else {
+        sri_integrator_mem[lev] = std::make_unique<SRIIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
+    }
 }
 
 // Remake an existing level using provided BoxArray and DistributionMapping and
@@ -560,6 +575,21 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
 
     t_new[lev] = time;
     t_old[lev] = time - 1.e200;
+
+    // Initialize the integrator memory
+    amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
+    int_state.push_back(MultiFab(temp_lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
+    int_state.push_back(MultiFab(temp_lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
+    int_state.push_back(MultiFab(temp_lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
+    int_state.push_back(MultiFab(temp_lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes
+    if (use_native_mri) {
+        mri_integrator_mem[lev] = std::make_unique<MRISplitIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
+    } else {
+        sri_integrator_mem[lev] = std::make_unique<SRIIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
+    }
 }
 
 // Delete level data
@@ -570,6 +600,13 @@ ERF::ClearLevel (int lev)
     for (int var_idx = 0; var_idx < Vars::NumTypes; ++var_idx) {
         vars_new[lev][var_idx].clear();
         vars_old[lev][var_idx].clear();
+    }
+
+    // Clears the integrator memory
+    if (use_native_mri) {
+        mri_integrator_mem[lev].reset();
+    } else {
+        sri_integrator_mem[lev].reset();
     }
 }
 
@@ -646,6 +683,21 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
         z_phys_nd[lev] = nullptr;
         z_phys_cc[lev] = nullptr;
           detJ_cc[lev] = nullptr;
+    }
+
+    // Initialize the integrator memory
+    amrex::Vector<amrex::MultiFab> int_state; // integration state data structure example
+    int_state.push_back(MultiFab(lev_new[Vars::cons], amrex::make_alias, 0, Cons::NumVars)); // cons
+    int_state.push_back(MultiFab(lev_new[Vars::xvel], amrex::make_alias, 0, 1)); // xmom
+    int_state.push_back(MultiFab(lev_new[Vars::yvel], amrex::make_alias, 0, 1)); // ymom
+    int_state.push_back(MultiFab(lev_new[Vars::zvel], amrex::make_alias, 0, 1)); // zmom
+    int_state.push_back(MultiFab(convert(ba,IntVect(1,0,0)), dm, Cons::NumVars, 1)); // x-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,1,0)), dm, Cons::NumVars, 1)); // y-fluxes
+    int_state.push_back(MultiFab(convert(ba,IntVect(0,0,1)), dm, Cons::NumVars, 1)); // z-fluxes
+    if (use_native_mri) {
+        mri_integrator_mem[lev] = std::make_unique<MRISplitIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
+    } else {
+        sri_integrator_mem[lev] = std::make_unique<SRIIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
     }
 }
 

--- a/Source/TimeIntegration/TimeIntegration_driver.cpp
+++ b/Source/TimeIntegration/TimeIntegration_driver.cpp
@@ -228,7 +228,7 @@ void ERF::erf_advance(int level,
     // Setup the integrator and integrate for a single timestep
     // **************************************************************************************
     if (use_native_mri) {
-      MRISplitIntegrator<Vector<MultiFab> > mri_integrator(state_old);
+      MRISplitIntegrator<Vector<MultiFab> >& mri_integrator = *mri_integrator_mem[level];
 
       // Define rhs and 'post update' utility function that is called after calculating
       // any state data (e.g. at RK stages or at the end of a timestep)
@@ -242,7 +242,7 @@ void ERF::erf_advance(int level,
       mri_integrator.advance(state_old, state_new, old_time, dt_advance);
 
     } else {
-      SRIIntegrator<Vector<MultiFab> > sri_integrator(state_old);
+      SRIIntegrator<Vector<MultiFab> >& sri_integrator = *sri_integrator_mem[level];
 
       sri_integrator.set_rhs(slow_rhs_fun);
       sri_integrator.set_post_update(post_update_fun);


### PR DESCRIPTION
The idea here is to save time allocating memory within each level advance for the integrator, since it requires a lot of memory.

