### PR TITLE
Precompute scalar diffusion fluxes before source term

### DIFF
--- a/Source/SpatialStencils/Diffusion.cpp
+++ b/Source/SpatialStencils/Diffusion.cpp
@@ -656,6 +656,22 @@ DiffusionSrcForState(const amrex::Box& bx, const amrex::Box& domain, int qty_ind
 
       const int l_use_terrain = solverChoice.use_terrain;
 
+      const Box bxx = surroundingNodes(bx,0);
+      const Box bxy = surroundingNodes(bx,1);
+      const Box bxz = surroundingNodes(bx,2);
+
+      amrex::ParallelFor(bxx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+          xflux(i  ,j,k,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dx_inv, K_turb, solverChoice, Coord::x);
+      });
+      amrex::ParallelFor(bxy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+          yflux(i,j  ,k,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dy_inv, K_turb, solverChoice, Coord::y);
+      });
+      amrex::ParallelFor(bxz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      {
+          zflux(i,j,k  ,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dz_inv, K_turb, solverChoice, Coord::z);
+      });
       amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
 

--- a/Source/SpatialStencils/Diffusion.cpp
+++ b/Source/SpatialStencils/Diffusion.cpp
@@ -674,17 +674,6 @@ DiffusionSrcForState(const amrex::Box& bx, const amrex::Box& domain, int qty_ind
       });
       amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
-
-          // TODO : could be more efficient to compute and save all fluxes before taking divergence (now all fluxes are computed 2x);
-          xflux(i+1,j,k,qty_index) = ComputeDiffusionFluxForState(i+1, j  , k  , cell_data, cell_prim, prim_index, dx_inv, K_turb, solverChoice, Coord::x);
-          xflux(i  ,j,k,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dx_inv, K_turb, solverChoice, Coord::x);
-
-          yflux(i,j+1,k,qty_index) = ComputeDiffusionFluxForState(i  , j+1, k  , cell_data, cell_prim, prim_index, dy_inv, K_turb, solverChoice, Coord::y);
-          yflux(i,j  ,k,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dy_inv, K_turb, solverChoice, Coord::y);
-
-          zflux(i,j,k+1,qty_index) = ComputeDiffusionFluxForState(i  , j  , k+1, cell_data, cell_prim, prim_index, dz_inv, K_turb, solverChoice, Coord::z);
-          zflux(i,j,k  ,qty_index) = ComputeDiffusionFluxForState(i  , j  , k  , cell_data, cell_prim, prim_index, dz_inv, K_turb, solverChoice, Coord::z);
-
           cell_rhs(i, j, k, qty_index) +=
                (xflux(i+1,j  ,k  ,qty_index) - xflux(i, j, k, qty_index)) * dx_inv   // Diffusive flux in x-dir
               +(yflux(i  ,j+1,k  ,qty_index) - yflux(i, j, k, qty_index)) * dy_inv   // Diffusive flux in y-dir


### PR DESCRIPTION
This is similar to what https://github.com/erf-model/ERF/pull/631 did for advection. 

Testing with the ABL case on Eagle: 

- 15% computational time reduction for `erf_slow_rhs` and 5% overall on CPUs

- Minimal effect on GPU performance, but this might be a hair quicker