### PR TITLE
Exner fun in fast_rhs

### DIFF
--- a/Source/EOS.H
+++ b/Source/EOS.H
@@ -8,7 +8,7 @@
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real getTgivenRandRTh(const amrex::Real rho, const amrex::Real rhotheta)
 {
-    amrex::Real p_loc = p_0 * std::pow(R_d * rhotheta / p_0, Gamma);
+    amrex::Real p_loc = p_0 * std::pow(R_d * rhotheta * ip_0, Gamma);
     return p_loc / (R_d * rho);
 }
 
@@ -16,7 +16,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real getThgivenRandT(const amrex::Real rho, const amrex::Real T)
 {
     amrex::Real p_loc = rho * R_d * T;
-    return T * std::pow((p_0/p_loc),(R_d/c_p));
+    return T * std::pow((p_0/p_loc),rdOcp);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -24,18 +24,18 @@ amrex::Real getPgivenRTh(const amrex::Real rhotheta)
 {
     // diagnostic relation for the full pressure
     // see https://erf.readthedocs.io/en/latest/theory/NavierStokesEquations.html
-    return p_0 * std::pow(R_d * rhotheta / p_0, Gamma);
+    return p_0 * std::pow(R_d * rhotheta * ip_0, Gamma);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real getRhoGivenThetaPress (const amrex::Real theta, const amrex::Real p) {
-    return std::pow(p_0, R_d/c_p) * std::pow(p, 1.0/Gamma) / (R_d * theta);
+    return std::pow(p_0, rdOcp) * std::pow(p, iGamma) / (R_d * theta);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real getdPdRgivenConstantTheta(const amrex::Real rho, const amrex::Real theta)
 {
-    return Gamma * p_0 * std::pow( (R_d * theta / p_0), Gamma) * std::pow(rho, Gamma-1.0) ;
+    return Gamma * p_0 * std::pow( (R_d * theta * ip_0), Gamma) * std::pow(rho, Gamma-1.0) ;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -43,14 +43,14 @@ amrex::Real getPprimegivenRTh(const amrex::Real rhotheta, const amrex::Real pres
 {
     // diagnostic relation for the full pressure
     // see https://erf.readthedocs.io/en/latest/theory/NavierStokesEquations.html
-    return p_0 * std::pow(R_d * rhotheta / p_0, Gamma) - pres_hse_at_k;
+    return p_0 * std::pow(R_d * rhotheta * ip_0, Gamma) - pres_hse_at_k;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real getExnergivenRTh(const amrex::Real rhotheta)
 {
     // Exner function pi in terms of (rho theta)
-    return std::pow(R_d * rhotheta / p_0, Gamma*R_d/c_p);
+    return std::pow(R_d * rhotheta * ip_0, Gamma * rdOcp);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -58,7 +58,7 @@ amrex::Real getRhoThetagivenP(const amrex::Real p)
 {
     // diagnostic relation for the full pressure
     // see https://erf.readthedocs.io/en/latest/theory/NavierStokesEquations.html
-    return std::pow(p*std::pow(p_0, Gamma-1), 1.0 / Gamma)/ R_d;
+    return std::pow(p*std::pow(p_0, Gamma-1), iGamma) * iR_d;
 }
 #endif
 

--- a/Source/ERF_Constants.H
+++ b/Source/ERF_Constants.H
@@ -6,12 +6,18 @@
 constexpr amrex::Real PI = 3.14159265358979323846264338327950288;
 
 //TODO: Change these types of macros to 'const'
-#define R_d     287.0 // gas constant for dry air [J/(kg-K)]
-#define R_v     461.6 // gas constant for dry air [J/(kg-K)]
-#define c_p    1004.5 // specific heat at constant pressure for dry air [J/(kg-K)]
-#define p_0    1.0e5 // reference surface pressure [Pa]
-#define Gamma  1.4   // C_p/C_v [-]
-#define KAPPA  0.41  // von Karman constant
+#define R_d      287.0   // gas constant for dry air [J/(kg-K)]
+#define R_v      461.6   // gas constant for dry air [J/(kg-K)]
+#define c_p     1004.5   // specific heat at constant pressure for dry air [J/(kg-K)]
+#define p_0        1.0e5 // reference surface pressure [Pa]
+#define Gamma      1.4   // C_p/C_v [-]
+#define KAPPA      0.41  // von Karman constant
 #define CONST_GRAV 9.81
+
+// Derived Constants
+#define ip_0    1./p_0
+#define iR_d    1./R_d
+#define iGamma  1./Gamma
+#define rdOcp   R_d/c_p
 
 #endif


### PR DESCRIPTION
Save exner function in erf_fast_rhs to reduce std:pow calls. Also, small stuff in EOS to reduce divides.