### PR TITLE
Separate out function calls into separate kernels

### DIFF
--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -85,7 +85,8 @@ jobs:
         # cmake --build ${{runner.workspace}}/ERF/build-${{matrix.sundials_state}}-${{matrix.os}} --parallel ${{env.NPROCS}};
 
         pushd ${{runner.workspace}}/ERF/build-${{matrix.sundials_state}}-${{matrix.os}};
-        make -j ${{env.NPROCS}};
+        #make -j ${{env.NPROCS}};
+        make;
 
     # - name: Regression Tests
     #   run: |

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -86,7 +86,7 @@ jobs:
 
         pushd ${{runner.workspace}}/ERF/build-${{matrix.sundials_state}}-${{matrix.os}};
         #make -j ${{env.NPROCS}};
-        make;
+        make -j 2;
 
     # - name: Regression Tests
     #   run: |

--- a/Source/SpatialStencils/DiffusionSrcForMom_T.cpp
+++ b/Source/SpatialStencils/DiffusionSrcForMom_T.cpp
@@ -67,7 +67,7 @@ DiffusionSrcForMom_T (int level, const Box& bx, const Box& valid_bx, const Box& 
             diff_update = DiffusionSrcForXMomWithTerrain(i, j, k, u, v, w, cell_data,
                                                          dxInv, K_turb, solverChoice,
                                                          z_nd, detJ, domain, bc_ptr);
-        } 
+        }
         rho_u_rhs(i, j, k) += diff_update;
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k)


### PR DESCRIPTION
This is needed on to prevent exceeding the kernel memory size limitation when compiling with HIP.