### PR TITLE
Fixes for z vel BC

### DIFF
--- a/Source/Advection/AdvectionSrcForState.cpp
+++ b/Source/Advection/AdvectionSrcForState.cpp
@@ -51,8 +51,8 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
 
            Real z_t_zlo = (z_t) ? z_t(i,j,k  ) : 0.;
            Real z_t_zhi = (z_t) ? z_t(i,j,k+1) : 0.;
-                zflux_lo = (k == 0) ? -z_t_zlo : (OmegaFromW(i,j,k  ,rho_w(i,j,k  ),rho_u,rho_v,z_nd,cellSizeInv) - z_t_zlo);
-                zflux_hi =                       (OmegaFromW(i,j,k+1,rho_w(i,j,k+1),rho_u,rho_v,z_nd,cellSizeInv) - z_t_zhi);
+                zflux_lo = (k == 0) ? 0. : (OmegaFromW(i,j,k  ,rho_w(i,j,k  ),rho_u,rho_v,z_nd,cellSizeInv) - z_t_zlo);
+                zflux_hi =                 (OmegaFromW(i,j,k+1,rho_w(i,j,k+1),rho_u,rho_v,z_nd,cellSizeInv) - z_t_zhi);
 
            avg_xmom(i  ,j,k) += fac*xflux_lo;
            if (i == vbx_hi.x)

--- a/Source/BoundaryConditions/ERF_PhysBCFunct.cpp
+++ b/Source/BoundaryConditions/ERF_PhysBCFunct.cpp
@@ -81,9 +81,6 @@ void ERFPhysBCFunct::operator() (MultiFab& mf, int icomp, int ncomp, IntVect con
                 Array4<const Real> velx_arr;
                 Array4<const Real> vely_arr;
 
-                // For single proc, the bx will coincide with gdomain for zvel with x&y periodic
-                //bool fill_zvel = ( (gdomain == bx) && (m_var_idx == Vars::zvel) );
-
                 if (m_z_phys_nd)
                 {
                     BoxArray mf_nodal_grids = mf.boxArray();
@@ -104,8 +101,7 @@ void ERFPhysBCFunct::operator() (MultiFab& mf, int icomp, int ncomp, IntVect con
                 //! if there are cells not in the valid + periodic grown box
                 //! we need to fill them here
                 //!
-                //if (!gdomain.contains(bx) || fill_zvel)
-                if (!gdomain.contains(bx))
+                if (!gdomain.contains(bx) || (m_var_idx == Vars::zvel))
                 {
                     if (m_var_idx == Vars::xvel) {
                         AMREX_ALWAYS_ASSERT(ncomp == 1 && icomp == 0);

--- a/Source/TimeIntegration/TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/TI_slow_rhs_fun.H
@@ -60,7 +60,7 @@
                              xvel_new, yvel_new, zvel_new, z_t_rk[level],
                              source, eddyDiffs, diffflux,
                              fine_geom, ifr, solverChoice, m_most, domain_bcs_type_d,
-                             z_phys_nd_new[level], detJ_cc_new[level], r0, p0,
+                             z_phys_nd[level], detJ_cc[level], r0, p0,
                              dptr_rayleigh_tau, dptr_rayleigh_ubar,
                              dptr_rayleigh_vbar, dptr_rayleigh_thetabar);
         } else {


### PR DESCRIPTION
We don't want to miss z vel BCs with x & y periodic. The bug arises from the fact we have no ghost cells in the z-dir and test whether the domain contains the box to fill.