### PR TITLE
Precompute stress tensor.

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -96,6 +96,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/Diffusion/DiffusionSrcForMom_N.H
        ${SRC_DIR}/Diffusion/DiffusionSrcForMom_T.H
        ${SRC_DIR}/Diffusion/EddyViscosity.H
+       ${SRC_DIR}/Diffusion/ComputeStress_N.cpp
        ${SRC_DIR}/Utils/ERF_Math.H
        ${SRC_DIR}/Utils/Interpolation.H
        ${SRC_DIR}/Diffusion/Diffusion.H

--- a/Exec/Make.ERF
+++ b/Exec/Make.ERF
@@ -70,6 +70,10 @@ ifeq ($(USE_MULTIBLOCK), TRUE)
   DEFINES += -DERF_USE_MULTIBLOCK
 endif
 
+ifeq ($(USE_OPTIMDIFF), TRUE)
+  DEFINES += -DERF_DIFF_OPTIM
+endif
+
 #turn on NetCDF macro define
 ifeq ($(USE_NETCDF), TRUE)
   DEFINES += -DERF_USE_NETCDF

--- a/Source/Diffusion/ComputeStress_N.cpp
+++ b/Source/Diffusion/ComputeStress_N.cpp
@@ -1,0 +1,390 @@
+#include <Diffusion.H>
+
+using namespace amrex;
+
+
+void
+ComputeStressConsVisc_N(Box& bxcc, Box& tbxxy, Box& tbxxz, Box& tbxyz, Real mu_eff,
+                        const Array4<const Real>& u, const Array4<const Real>& v, const Array4<const Real>& w,
+                        Array4<Real>& tau11, Array4<Real>& tau22, Array4<Real>& tau33,
+                        Array4<Real>& tau12, Array4<Real>& tau13, Array4<Real>& tau23,
+                        const Array4<const Real>& er_arr,
+                        const BCRec* bc_ptr, const GpuArray<Real, AMREX_SPACEDIM>& dxInv)
+{
+    Real OneThird   = (1./3.);
+
+    // Dirichlet on left or right plane
+    bool xl_v_dir = ( (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_ingested) );
+    bool xh_v_dir = ( (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_ingested) );
+
+    bool xl_w_dir = ( (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_ingested) );
+    bool xh_w_dir = ( (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_ingested) );
+
+    // Dirichlet on front or back plane
+    bool yl_u_dir = ( (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_ingested) );
+    bool yh_u_dir = ( (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_ingested) );
+
+    bool yl_w_dir = ( (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_ingested) );
+    bool yh_w_dir = ( (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_ingested) );
+
+    // Dirichlet on top or bottom plane
+    bool zl_u_dir = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir_ingested) );
+    bool zh_u_dir = ( (bc_ptr[BCVars::xvel_bc].hi(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].hi(2) == ERFBCType::ext_dir_ingested) );
+
+    bool zl_v_dir = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir_ingested) );
+    bool zh_v_dir = ( (bc_ptr[BCVars::yvel_bc].hi(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].hi(2) == ERFBCType::ext_dir_ingested) );
+
+
+    // X-Dirichlet
+    //***********************************************************************************
+    if (xl_v_dir) {
+        Box planexy = tbxxy; planexy.setBig(0, planexy.smallEnd(0) );
+        tbxxy.growLo(0,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau12(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                                            (-(8./3.) * v(i-1,j,k) + 3. * v(i,j,k) - (1./3.) * v(i+1,j,k))*dxInv[0] );
+        });
+    }
+    if (xh_v_dir) {
+        Box planexy = tbxxy; planexy.setSmall(0, planexy.bigEnd(0) );
+        tbxxy.growHi(0,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau12(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                                            -(-(8./3.) * v(i,j,k) + 3. * v(i-1,j,k) - (1./3.) * v(i-2,j,k))*dxInv[0] );
+        });
+    }
+
+    if (xl_w_dir) {
+        Box planexz = tbxxz; planexz.setBig(0, planexz.smallEnd(0) );
+        tbxxz.growLo(0,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau13(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] +
+                                            (-(8./3.) * w(i-1,j,k) + 3. * w(i,j,k) - (1./3.) * w(i+1,j,k))*dxInv[0]);
+        });
+    }
+    if (xh_w_dir) {
+        Box planexz = tbxxz; planexz.setSmall(0, planexz.bigEnd(0) );
+        tbxxz.growHi(0,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau13(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] +
+                                            -(-(8./3.) * w(i,j,k) + 3. * w(i-1,j,k) - (1./3.) * w(i-2,j,k))*dxInv[0]);
+        });
+    }
+
+    // Y-Dirichlet
+    //***********************************************************************************
+    if (yl_u_dir) {
+        Box planexy = tbxxy; planexy.setBig(1, planexy.smallEnd(1) );
+        tbxxy.growLo(1,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau12(i,j,k) = 0.5 * mu_eff * ( (-(8./3.) * u(i,j-1,k) + 3. * u(i,j,k) - (1./3.) * u(i,j+1,k))*dxInv[1] +
+                                            (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+        });
+    }
+    if (yh_u_dir) {
+        Box planexy = tbxxy; planexy.setSmall(1, planexy.bigEnd(1) );
+        tbxxy.growHi(1,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau12(i,j,k) = 0.5 * mu_eff * ( -(-(8./3.) * u(i,j,k) + 3. * u(i,j-1,k) - (1./3.) * u(i,j-2,k))*dxInv[1] +
+                                            (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+        });
+    }
+
+    if (yl_w_dir) {
+        Box planeyz = tbxyz; planeyz.setBig(1, planeyz.smallEnd(1) );
+        tbxyz.growLo(1,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau23(i,j,k) = 0.5 * mu_eff * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] +
+                                            (-(8./3.) * w(i,j-1,k) + 3. * w(i,j  ,k) - (1./3.) * w(i,j+1,k))*dxInv[1] );
+        });
+    }
+    if (yh_w_dir) {
+        Box planeyz = tbxyz; planeyz.setSmall(1, planeyz.bigEnd(1) );
+        tbxyz.growHi(1,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau23(i,j,k) = 0.5 * mu_eff * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] +
+                                            -(-(8./3.) * w(i,j  ,k) + 3. * w(i,j-1,k) - (1./3.) * w(i,j-2,k))*dxInv[1] );
+        });
+    }
+
+    // Z-Dirichlet
+    //***********************************************************************************
+    if (zl_u_dir) {
+        Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
+        tbxxz.growLo(2,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau13(i,j,k) = 0.5 * mu_eff * ( (-(8./3.) * u(i,j,k-1) + 3. * u(i,j,k) - (1./3.) * u(i,j,k+1))*dxInv[2] +
+                                            (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+        });
+    }
+    if (zh_u_dir) {
+        Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
+        tbxxz.growHi(2,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau13(i,j,k) = 0.5 * mu_eff * ( -(-(8./3.) * u(i,j,k) + 3. * u(i,j,k-1) - (1./3.) * u(i,j,k-2))*dxInv[2] +
+                                            (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+        });
+    }
+
+    if (zl_v_dir) {
+        Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
+        tbxyz.growLo(2,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau23(i,j,k) = 0.5 * mu_eff * ( (-(8./3.) * v(i,j,k-1) + 3. * v(i,j,k  ) - (1./3.) * v(i,j,k+1))*dxInv[2] +
+                                            (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+        });
+    }
+    if (zh_v_dir) {
+        Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
+        tbxyz.growHi(2,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            tau23(i,j,k) = 0.5 * mu_eff * ( -(-(8./3.) * v(i,j,k  ) + 3. * v(i,j,k-1) - (1./3.) * v(i,j,k-2))*dxInv[2] +
+                                            (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+        });
+    }
+
+    // Fill the remaining cells
+    //***********************************************************************************
+    // Cell centered strains
+    amrex::ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        tau11(i,j,k) = mu_eff * ( (u(i+1, j  , k  ) - u(i, j, k))*dxInv[0] - OneThird*er_arr(i,j,k) );
+        tau22(i,j,k) = mu_eff * ( (v(i  , j+1, k  ) - v(i, j, k))*dxInv[1] - OneThird*er_arr(i,j,k) );
+        tau33(i,j,k) = mu_eff * ( (w(i  , j  , k+1) - w(i, j, k))*dxInv[2] - OneThird*er_arr(i,j,k) );
+    });
+
+    // Off-diagonal strains
+    amrex::ParallelFor(tbxxy,tbxxz,tbxyz,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        tau12(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+    },
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        tau13(i,j,k) = 0.5 * mu_eff * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] + (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+    },
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        tau23(i,j,k) = 0.5 * mu_eff * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] + (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+    });
+
+}
+
+
+void
+ComputeStressVarVisc_N(Box& bxcc, Box& tbxxy, Box& tbxxz, Box& tbxyz, Real mu_eff,
+                       const Array4<const Real>& K_turb,
+                       const Array4<const Real>& u, const Array4<const Real>& v, const Array4<const Real>& w,
+                       Array4<Real>& tau11, Array4<Real>& tau22, Array4<Real>& tau33,
+                       Array4<Real>& tau12, Array4<Real>& tau13, Array4<Real>& tau23,
+                       const Array4<const Real>& er_arr,
+                       const BCRec* bc_ptr, const GpuArray<Real, AMREX_SPACEDIM>& dxInv)
+{
+    Real OneThird   = (1./3.);
+
+    // Dirichlet on left or right plane
+    bool xl_v_dir = ( (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_ingested) );
+    bool xh_v_dir = ( (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_ingested) );
+
+    bool xl_w_dir = ( (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_ingested) );
+    bool xh_w_dir = ( (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_ingested) );
+
+    // Dirichlet on front or back plane
+    bool yl_u_dir = ( (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_ingested) );
+    bool yh_u_dir = ( (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_ingested) );
+
+    bool yl_w_dir = ( (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_ingested) );
+    bool yh_w_dir = ( (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_ingested) );
+
+    // Dirichlet on top or bottom plane
+    bool zl_u_dir = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir_ingested) );
+    bool zh_u_dir = ( (bc_ptr[BCVars::xvel_bc].hi(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::xvel_bc].hi(2) == ERFBCType::ext_dir_ingested) );
+
+    bool zl_v_dir = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir_ingested) );
+    bool zh_v_dir = ( (bc_ptr[BCVars::yvel_bc].hi(2) == ERFBCType::ext_dir)          ||
+                      (bc_ptr[BCVars::yvel_bc].hi(2) == ERFBCType::ext_dir_ingested) );
+
+
+    // X-Dirichlet
+    //***********************************************************************************
+    if (xl_v_dir) {
+        Box planexy = tbxxy; planexy.setBig(0, planexy.smallEnd(0) );
+        tbxxy.growLo(0,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_12 = mu_eff + 0.25*( K_turb(i-1, j  , k, EddyDiff::Mom_h) + K_turb(i, j  , k, EddyDiff::Mom_h)
+                                       + K_turb(i-1, j-1, k, EddyDiff::Mom_h) + K_turb(i, j-1, k, EddyDiff::Mom_h) );
+            tau12(i,j,k) = 0.5 * mu_12 * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                                           (-(8./3.) * v(i-1,j,k) + 3. * v(i,j,k) - (1./3.) * v(i+1,j,k))*dxInv[0] );
+        });
+    }
+    if (xh_v_dir) {
+        Box planexy = tbxxy; planexy.setSmall(0, planexy.bigEnd(0) );
+        tbxxy.growHi(0,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_12 = mu_eff + 0.25*( K_turb(i-1, j  , k, EddyDiff::Mom_h) + K_turb(i, j  , k, EddyDiff::Mom_h)
+                                       + K_turb(i-1, j-1, k, EddyDiff::Mom_h) + K_turb(i, j-1, k, EddyDiff::Mom_h) );
+            tau12(i,j,k) = 0.5 * mu_12 * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                                           -(-(8./3.) * v(i,j,k) + 3. * v(i-1,j,k) - (1./3.) * v(i-2,j,k))*dxInv[0] );
+        });
+    }
+
+    if (xl_w_dir) {
+        Box planexz = tbxxz; planexz.setBig(0, planexz.smallEnd(0) );
+        tbxxz.growLo(0,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_13 = mu_eff + 0.25*( K_turb(i-1, j, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i-1, j, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau13(i,j,k) = 0.5 * mu_13 * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] +
+                                           (-(8./3.) * w(i-1,j,k) + 3. * w(i,j,k) - (1./3.) * w(i+1,j,k))*dxInv[0]);
+        });
+    }
+    if (xh_w_dir) {
+        Box planexz = tbxxz; planexz.setSmall(0, planexz.bigEnd(0) );
+        tbxxz.growHi(0,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_13 = mu_eff + 0.25*( K_turb(i-1, j, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i-1, j, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau13(i,j,k) = 0.5 * mu_13 * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] +
+                                           -(-(8./3.) * w(i,j,k) + 3. * w(i-1,j,k) - (1./3.) * w(i-2,j,k))*dxInv[0]);
+        });
+    }
+
+    // Y-Dirichlet
+    //***********************************************************************************
+    if (yl_u_dir) {
+        Box planexy = tbxxy; planexy.setBig(1, planexy.smallEnd(1) );
+        tbxxy.growLo(1,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_12 = mu_eff + 0.25*( K_turb(i-1, j  , k, EddyDiff::Mom_h) + K_turb(i, j  , k, EddyDiff::Mom_h)
+                                       + K_turb(i-1, j-1, k, EddyDiff::Mom_h) + K_turb(i, j-1, k, EddyDiff::Mom_h) );
+            tau12(i,j,k) = 0.5 * mu_12 * ( (-(8./3.) * u(i,j-1,k) + 3. * u(i,j,k) - (1./3.) * u(i,j+1,k))*dxInv[1] +
+                                           (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+        });
+    }
+    if (yh_u_dir) {
+        Box planexy = tbxxy; planexy.setSmall(1, planexy.bigEnd(1) );
+        tbxxy.growHi(1,-1);
+        amrex::ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_12 = mu_eff + 0.25*( K_turb(i-1, j  , k, EddyDiff::Mom_h) + K_turb(i, j  , k, EddyDiff::Mom_h)
+                                       + K_turb(i-1, j-1, k, EddyDiff::Mom_h) + K_turb(i, j-1, k, EddyDiff::Mom_h) );
+            tau12(i,j,k) = 0.5 * mu_12 * ( -(-(8./3.) * u(i,j,k) + 3. * u(i,j-1,k) - (1./3.) * u(i,j-2,k))*dxInv[1] +
+                                           (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+        });
+    }
+
+    if (yl_w_dir) {
+        Box planeyz = tbxyz; planeyz.setBig(1, planeyz.smallEnd(1) );
+        tbxyz.growLo(1,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_23 = mu_eff + 0.25*( K_turb(i, j-1, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i, j-1, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau23(i,j,k) = 0.5 * mu_23 * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] +
+                                           (-(8./3.) * w(i,j-1,k) + 3. * w(i,j  ,k) - (1./3.) * w(i,j+1,k))*dxInv[1] );
+        });
+    }
+    if (yh_w_dir) {
+        Box planeyz = tbxyz; planeyz.setSmall(1, planeyz.bigEnd(1) );
+        tbxyz.growHi(1,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_23 = mu_eff + 0.25*( K_turb(i, j-1, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i, j-1, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau23(i,j,k) = 0.5 * mu_23 * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] +
+                                           -(-(8./3.) * w(i,j  ,k) + 3. * w(i,j-1,k) - (1./3.) * w(i,j-2,k))*dxInv[1] );
+        });
+    }
+
+    // Z-Dirichlet
+    //***********************************************************************************
+    if (zl_u_dir) {
+        Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
+        tbxxz.growLo(2,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_13 = mu_eff + 0.25*( K_turb(i-1, j, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i-1, j, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau13(i,j,k) = 0.5 * mu_13 * ( (-(8./3.) * u(i,j,k-1) + 3. * u(i,j,k) - (1./3.) * u(i,j,k+1))*dxInv[2] +
+                                           (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+        });
+    }
+    if (zh_u_dir) {
+        Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
+        tbxxz.growHi(2,-1);
+        amrex::ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_13 = mu_eff + 0.25*( K_turb(i-1, j, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i-1, j, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau13(i,j,k) = 0.5 * mu_13 * ( -(-(8./3.) * u(i,j,k) + 3. * u(i,j,k-1) - (1./3.) * u(i,j,k-2))*dxInv[2] +
+                                           (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+        });
+    }
+
+    if (zl_v_dir) {
+        Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
+        tbxyz.growLo(2,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_23 = mu_eff + 0.25*( K_turb(i, j-1, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i, j-1, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau23(i,j,k) = 0.5 * mu_23 * ( (-(8./3.) * v(i,j,k-1) + 3. * v(i,j,k  ) - (1./3.) * v(i,j,k+1))*dxInv[2] +
+                                           (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+        });
+    }
+    if (zh_v_dir) {
+        Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
+        tbxyz.growHi(2,-1);
+        amrex::ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_23 = mu_eff + 0.25*( K_turb(i, j-1, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                       + K_turb(i, j-1, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+            tau23(i,j,k) = 0.5 * mu_23 * ( -(-(8./3.) * v(i,j,k  ) + 3. * v(i,j,k-1) - (1./3.) * v(i,j,k-2))*dxInv[2] +
+                                           (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+        });
+    }
+
+    // Fill the remaining cells
+    //***********************************************************************************
+    // Cell centered strains
+    amrex::ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mu_11 = mu_eff + K_turb(i, j, k, EddyDiff::Mom_h);
+        Real mu_22 = mu_11;
+        Real mu_33 = mu_eff + K_turb(i, j, k, EddyDiff::Mom_v);
+        tau11(i,j,k) = mu_11 * ( (u(i+1, j  , k  ) - u(i, j, k))*dxInv[0] - OneThird*er_arr(i,j,k) );
+        tau22(i,j,k) = mu_22 * ( (v(i  , j+1, k  ) - v(i, j, k))*dxInv[1] - OneThird*er_arr(i,j,k) );
+        tau33(i,j,k) = mu_33 * ( (w(i  , j  , k+1) - w(i, j, k))*dxInv[2] - OneThird*er_arr(i,j,k) );
+    });
+
+    // Off-diagonal strains
+    amrex::ParallelFor(tbxxy,tbxxz,tbxyz,
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mu_12 = mu_eff + 0.25*( K_turb(i-1, j  , k, EddyDiff::Mom_h) + K_turb(i, j  , k, EddyDiff::Mom_h)
+                                   + K_turb(i-1, j-1, k, EddyDiff::Mom_h) + K_turb(i, j-1, k, EddyDiff::Mom_h) );
+        tau12(i,j,k) = 0.5 * mu_12 * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
+    },
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mu_13 = mu_eff + 0.25*( K_turb(i-1, j, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                   + K_turb(i-1, j, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+        tau13(i,j,k) = 0.5 * mu_13 * ( (u(i, j, k) - u(i, j, k-1))*dxInv[2] + (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
+    },
+    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mu_23 = mu_eff + 0.25*( K_turb(i, j-1, k  , EddyDiff::Mom_v) + K_turb(i, j, k  , EddyDiff::Mom_v)
+                                   + K_turb(i, j-1, k-1, EddyDiff::Mom_v) + K_turb(i, j, k-1, EddyDiff::Mom_v) );
+        tau23(i,j,k) = 0.5 * mu_23 * ( (v(i, j, k) - v(i, j, k-1))*dxInv[2] + (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
+    });
+
+
+}

--- a/Source/Diffusion/Diffusion.H
+++ b/Source/Diffusion/Diffusion.H
@@ -9,6 +9,13 @@
 #include <IndexDefines.H>
 #include <ABLMost.H>
 
+#ifdef ERF_DIFF_OPTIM
+void DiffusionSrcForMom_N (const amrex::Box& bxx, const amrex::Box& bxy, const amrex::Box& bxz,
+                           const amrex::Array4<      amrex::Real>& rho_u_rhs, const amrex::Array4<      amrex::Real>& rho_v_rhs, const amrex::Array4<      amrex::Real>& rho_w_rhs,
+                           const amrex::Array4<const amrex::Real>& tau11    , const amrex::Array4<const amrex::Real>& tau22    , const amrex::Array4<const amrex::Real>& tau33    ,
+                           const amrex::Array4<const amrex::Real>& tau12    , const amrex::Array4<const amrex::Real>& tau13    , const amrex::Array4<const amrex::Real>& tau23    ,
+                           const amrex::Array4<const amrex::Real>& cell_data, const SolverChoice& solverChoice,  const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv);
+#else
 void DiffusionSrcForMom_N (const amrex::Box& bxx, const amrex::Box& bxy, const amrex::Box& bxz, const amrex::Box& domain,
                            const amrex::Array4<      amrex::Real>& rho_u_rhs, const amrex::Array4<      amrex::Real>& rho_v_rhs,
                            const amrex::Array4<      amrex::Real>& rho_w_rhs,
@@ -17,6 +24,7 @@ void DiffusionSrcForMom_N (const amrex::Box& bxx, const amrex::Box& bxy, const a
                            const amrex::Array4<const amrex::Real>& cell_data, const amrex::Array4<const amrex::Real>& er_arr,
                            const SolverChoice& solverChoice                 , const amrex::BCRec* bc_ptr,
                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv);
+#endif
 
 void DiffusionSrcForMom_T (const amrex::Box& bxx, const amrex::Box& bxy, const amrex::Box& bxz, const amrex::Box& domain,
                            const amrex::Array4<      amrex::Real>& rho_u_rhs, const amrex::Array4<      amrex::Real>& rho_v_rhs,
@@ -45,4 +53,23 @@ void DiffusionSrcForState (const amrex::Box& bx, const amrex::Box& domain, int n
                            const amrex::Real& theta_mean,
                            const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                            const amrex::BCRec* bc_ptr);
+
+void ComputeStressConsVisc_N(amrex::Box& bxcc, amrex::Box& tbxxy, amrex::Box& tbxxz, amrex::Box& tbxyz, amrex::Real mu_eff,
+                             const amrex::Array4<const amrex::Real>& u,
+                             const amrex::Array4<const amrex::Real>& v,
+                             const amrex::Array4<const amrex::Real>& w,
+                             amrex::Array4<amrex::Real>& tau11, amrex::Array4<amrex::Real>& tau22, amrex::Array4<amrex::Real>& tau33,
+                             amrex::Array4<amrex::Real>& tau12, amrex::Array4<amrex::Real>& tau13, amrex::Array4<amrex::Real>& tau23,
+                             const amrex::Array4<const amrex::Real>& er_arr,
+                             const amrex::BCRec* bc_ptr, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv);
+
+void ComputeStressVarVisc_N(amrex::Box& bxcc, amrex::Box& tbxxy, amrex::Box& tbxxz, amrex::Box& tbxyz, amrex::Real mu_eff,
+                            const amrex::Array4<const amrex::Real>& K_turb,
+                            const amrex::Array4<const amrex::Real>& u,
+                            const amrex::Array4<const amrex::Real>& v,
+                            const amrex::Array4<const amrex::Real>& w,
+                            amrex::Array4<amrex::Real>& tau11, amrex::Array4<amrex::Real>& tau22, amrex::Array4<amrex::Real>& tau33,
+                            amrex::Array4<amrex::Real>& tau12, amrex::Array4<amrex::Real>& tau13, amrex::Array4<amrex::Real>& tau23,
+                            const amrex::Array4<const amrex::Real>& er_arr,
+                            const amrex::BCRec* bc_ptr, const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv);
 #endif

--- a/Source/Diffusion/DiffusionSrcForMom_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForMom_N.cpp
@@ -4,6 +4,74 @@
 
 using namespace amrex;
 
+#ifdef ERF_DIFF_OPTIM
+void
+DiffusionSrcForMom_N (const Box& bxx, const Box& bxy , const Box& bxz,
+                      const Array4<Real>& rho_u_rhs  ,
+                      const Array4<Real>& rho_v_rhs  ,
+                      const Array4<Real>& rho_w_rhs  ,
+                      const Array4<const Real>& tau11, const Array4<const Real>& tau22,
+                      const Array4<const Real>& tau33, const Array4<const Real>& tau12,
+                      const Array4<const Real>& tau13, const Array4<const Real>& tau23,
+                      const Array4<const Real>& cons , const SolverChoice& solverChoice,
+                      const GpuArray<Real, AMREX_SPACEDIM>& dxInv)
+{
+    BL_PROFILE_VAR("DiffusionSrcForMom_N()",DiffusionSrcForMom_N);
+
+    auto dxinv = dxInv[0], dyinv = dxInv[1], dzinv = dxInv[2];
+
+    if (solverChoice.molec_diff_type == MolecDiffType::ConstantAlpha)
+    {
+        amrex::ParallelFor(bxx, bxy, bxz,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            Real diffContrib  = ( (tau11(i  , j  , k  ) - tau11(i-1, j  ,k  )) * dxinv    // Contribution to x-mom eqn from diffusive flux in x-dir
+                                + (tau12(i  , j+1, k  ) - tau12(i  , j  ,k  )) * dyinv    // Contribution to x-mom eqn from diffusive flux in y-dir
+                                + (tau13(i  , j  , k+1) - tau13(i  , j  ,k  )) * dzinv ); // Contribution to x-mom eqn from diffusive flux in z-dir;
+            diffContrib      *= 0.5 * (cons(i,j,k,Rho_comp) + cons(i-1,j,k,Rho_comp))  / solverChoice.rho0_trans;
+            rho_u_rhs(i,j,k) += diffContrib;
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            Real diffContrib  = ( (tau12(i+1, j  , k  ) - tau12(i  , j  , k  )) * dxinv    // Contribution to y-mom eqn from diffusive flux in x-dir
+                                + (tau22(i  , j  , k  ) - tau22(i  , j-1, k  )) * dyinv    // Contribution to y-mom eqn from diffusive flux in y-dir
+                                + (tau23(i  , j  , k+1) - tau23(i  , j  , k  )) * dzinv ); // Contribution to y-mom eqn from diffusive flux in z-dir;
+            diffContrib      *= 0.5 * (cons(i,j,k,Rho_comp) + cons(i,j-1,k,Rho_comp))  / solverChoice.rho0_trans;
+            rho_v_rhs(i,j,k) += diffContrib;
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            Real diffContrib  = ( (tau13(i+1, j  , k  ) - tau13(i  , j  , k  )) * dxinv    // Contribution to z-mom eqn from diffusive flux in x-dir
+                                + (tau23(i  , j+1, k  ) - tau23(i  , j  , k  )) * dyinv    // Contribution to z-mom eqn from diffusive flux in y-dir
+                                + (tau33(i  , j  , k  ) - tau33(i  , j  , k-1)) * dzinv ); // Contribution to z-mom eqn from diffusive flux in z-dir;
+            diffContrib      *= 0.5 * (cons(i,j,k,Rho_comp) + cons(i,j,k-1,Rho_comp))  / solverChoice.rho0_trans;
+            rho_w_rhs(i,j,k) += diffContrib;
+        });
+
+    } else {
+        amrex::ParallelFor(bxx, bxy, bxz,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            rho_u_rhs(i,j,k) += ( (tau11(i  , j  , k  ) - tau11(i-1, j  ,k  )) * dxinv    // Contribution to x-mom eqn from diffusive flux in x-dir
+                                + (tau12(i  , j+1, k  ) - tau12(i  , j  ,k  )) * dyinv    // Contribution to x-mom eqn from diffusive flux in y-dir
+                                + (tau13(i  , j  , k+1) - tau13(i  , j  ,k  )) * dzinv ); // Contribution to x-mom eqn from diffusive flux in z-dir;
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            rho_v_rhs(i,j,k) += ( (tau12(i+1, j  , k  ) - tau12(i  , j  , k  )) * dxinv    // Contribution to y-mom eqn from diffusive flux in x-dir
+                                + (tau22(i  , j  , k  ) - tau22(i  , j-1, k  )) * dyinv    // Contribution to y-mom eqn from diffusive flux in y-dir
+                                + (tau23(i  , j  , k+1) - tau23(i  , j  , k  )) * dzinv ); // Contribution to y-mom eqn from diffusive flux in z-dir;
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            rho_w_rhs(i,j,k) += ( (tau13(i+1, j  , k  ) - tau13(i  , j  , k  )) * dxinv    // Contribution to z-mom eqn from diffusive flux in x-dir
+                                + (tau23(i  , j+1, k  ) - tau23(i  , j  , k  )) * dyinv    // Contribution to z-mom eqn from diffusive flux in y-dir
+                                + (tau33(i  , j  , k  ) - tau33(i  , j  , k-1)) * dzinv ); // Contribution to z-mom eqn from diffusive flux in z-dir;
+        });
+    }
+}
+
+#else
 void
 DiffusionSrcForMom_N (const Box& bxx, const Box& bxy, const Box& bxz, const Box& domain,
                       const Array4<      Real>& rho_u_rhs, const Array4<      Real>& rho_v_rhs,
@@ -30,7 +98,6 @@ DiffusionSrcForMom_N (const Box& bxx, const Box& bxy, const Box& bxz, const Box&
     // *********************************************************************
     // Define diffusive updates in the RHS of {x, y, z}-momentum equations
     // *********************************************************************
-#if 1
     amrex::ParallelFor(bxx,
     [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {
@@ -54,68 +121,6 @@ DiffusionSrcForMom_N (const Box& bxx, const Box& bxy, const Box& bxz, const Box&
                                         domain, bc_ptr, er_arr);
         rho_w_rhs(i, j, k) += temp;
     });
-# else
-    auto dxinv = dxInv[0], dyinv = dxInv[1], dzinv = dxInv[2];
-    Real OneThird = (1./3.);
-
-    amrex::ParallelFor(bxx, bxy, bxz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
-    {
-        amrex::Real tau11Next, tau11Prev, tau12Next, tau12Prev, tau13Next, tau13Prev;
-
-        tau11Prev = (u(i  , j, k) - u(i-1, j, k))*dxinv - OneThird*er_arr(i-1, j, k);
-        tau11Next = (u(i+1, j, k) - u(i  , j, k))*dxinv - OneThird*er_arr(i  , j, k);
-
-        // SAVE
-        tau12Prev = (u(i, j  , k) - u(i, j-1, k))*dyinv + (v(i, j  , k) - v(i-1, j  , k)) * dxinv;
-        tau12Next = (u(i, j+1, k) - u(i, j  , k))*dyinv + (v(i, j+1, k) - v(i-1, j+1, k)) * dxinv;
-
-        // SAVE
-        tau13Prev = (u(i, j, k  ) - u(i, j, k-1))*dzinv + (w(i, j, k  ) - w(i-1, j, k  )) * dxinv;
-        tau13Next = (u(i, j, k+1) - u(i, j, k  ))*dzinv + (w(i, j, k+1) - w(i-1, j, k+1)) * dxinv;
-
-        rho_u_rhs(i, j, k) +=        (tau11Next - tau11Prev) * dxinv  // Contribution to x-mom eqn from diffusive flux in x-dir
-                             + 0.5 * (tau12Next - tau12Prev) * dyinv  // Contribution to x-mom eqn from diffusive flux in y-dir
-                             + 0.5 * (tau13Next - tau13Prev) * dzinv; // Contribution to x-mom eqn from diffusive flux in z-dir;
-    },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
-    {
-        amrex::Real tau21Next, tau21Prev, tau22Next, tau22Prev, tau23Next, tau23Prev;
-
-        // RE-USE
-        tau21Prev = (u(i  , j, k) - u(i  , j-1, k))*dyinv + (v(i  , j, k) - v(i-1, j, k)) * dxinv;
-        tau21Next = (u(i+1, j, k) - u(i+1, j-1, k))*dyinv + (v(i+1, j, k) - v(i  , j, k)) * dxinv;
-
-        tau22Prev = (v(i, j  , k) - v(i, j-1, k))*dyinv - OneThird*er_arr(i, j-1, k);
-        tau22Next = (v(i, j+1, k) - v(i, j  , k))*dyinv - OneThird*er_arr(i, j  , k);
-
-        // SAVE
-        tau23Prev = (v(i, j, k  ) - v(i, j, k-1))*dzinv + (w(i, j, k  ) - w(i, j-1, k  )) * dyinv;
-        tau23Next = (v(i, j, k+1) - v(i, j, k  ))*dzinv + (w(i, j, k+1) - w(i, j-1, k+1)) * dyinv;
-
-        rho_v_rhs(i, j, k) +=  0.5 * (tau21Next - tau21Prev) * dxinv  // Contribution to y-mom eqn from diffusive flux in x-dir
-                             +       (tau22Next - tau22Prev) * dyinv  // Contribution to y-mom eqn from diffusive flux in y-dir
-                             + 0.5 * (tau23Next - tau23Prev) * dzinv; // Contribution to y-mom eqn from diffusive flux in z-dir;
-    },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
-    {
-        amrex::Real tau31Next, tau31Prev, tau32Next, tau32Prev, tau33Next, tau33Prev;
-
-        // RE-USE
-        tau31Prev = (u(i  , j, k) - u(i  , j, k-1))*dzinv + (w(i  , j, k) - w(i-1, j, k)) * dxinv;
-        tau31Next = (u(i+1, j, k) - u(i+1, j, k-1))*dzinv + (w(i+1, j, k) - w(i  , j, k)) * dxinv;
-
-        // RE-USE
-        tau32Prev = (v(i, j  , k) - v(i, j  , k-1))*dzinv + (w(i, j  , k) - w(i, j-1, k)) * dyinv;
-        tau32Next = (v(i, j+1, k) - v(i, j+1, k-1))*dzinv + (w(i, j+1, k) - w(i, j  , k)) * dyinv;
-
-        tau33Prev = (w(i, j, k  ) - w(i, j, k-1))*dzinv - OneThird*er_arr(i, j, k-1);
-        tau33Next = (w(i, j, k+1) - w(i, j, k  ))*dzinv - OneThird*er_arr(i, j, k  );
-
-        rho_w_rhs(i, j, k) +=  0.5 * (tau31Next - tau31Prev) * dxinv  // Contribution to z-mom eqn from diffusive flux in x-dir
-                             + 0.5 * (tau32Next - tau32Prev) * dyinv  // Contribution to z-mom eqn from diffusive flux in y-dir
-                             +       (tau33Next - tau33Prev) * dzinv; // Contribution to z-mom eqn from diffusive flux in z-dir;
-    });
-#endif
     }
 }
+#endif

--- a/Source/Diffusion/Make.package
+++ b/Source/Diffusion/Make.package
@@ -2,6 +2,7 @@ CEXE_sources += ComputeTurbulentViscosity.cpp
 CEXE_sources += DiffusionSrcForMom_N.cpp
 CEXE_sources += DiffusionSrcForMom_T.cpp
 CEXE_sources += DiffusionSrcForState.cpp
+CEXE_sources += ComputeStress_N.cpp 
 CEXE_sources += PBLModels.cpp
 
 CEXE_headers += DiffusionSrcForMom_N.H

--- a/Source/TimeIntegration/ERF_fast_rhs_N.cpp
+++ b/Source/TimeIntegration/ERF_fast_rhs_N.cpp
@@ -356,10 +356,10 @@ void erf_fast_rhs_N (int step, int level, const Real /*time*/,
 
             // lines 3-5 residuals (order dtau^2) 1.0 <-> beta_2
             Real R1_tmp =  halfg * (-slow_rhs_cons(i,j,k  ,Rho_comp)
-                                    -slow_rhs_cons(i,j,k-1,Rho_comp) 
+                                    -slow_rhs_cons(i,j,k-1,Rho_comp)
                                     +temp_rhs_arr(i,j,k,0) + temp_rhs_arr(i,j,k-1) )
-                          + ( coeff_P * (slow_rhs_cons(i,j,k  ,RhoTheta_comp) - temp_rhs_arr(i,j,k  ,RhoTheta_comp)) +
-                              coeff_Q * (slow_rhs_cons(i,j,k-1,RhoTheta_comp) - temp_rhs_arr(i,j,k-1,RhoTheta_comp)) );
+                + ( coeff_P * (slow_rhs_cons(i,j,k  ,RhoTheta_comp) - temp_rhs_arr(i,j,k  ,RhoTheta_comp)) +
+                    coeff_Q * (slow_rhs_cons(i,j,k-1,RhoTheta_comp) - temp_rhs_arr(i,j,k-1,RhoTheta_comp)) );
 
             // lines 6&7 consolidated (reuse Omega & metrics) (order dtau^2)
             R1_tmp +=  beta_1 * dzi * ( (Omega_kp1 - Omega_km1)                         * halfg


### PR DESCRIPTION
1.  Precompute tau in erf_slow_rhs
2. New file added: ComputeStress_N
3. Default behavior is to NOT use diff optimization
4. This passed all the CI tests
5. Need to further test (speed up on 1 proc was observed with the beta version)