### PR TITLE
fix advection msf implementation

### DIFF
--- a/Exec/IsentropicVortex/inputs_advecting_no_msf
+++ b/Exec/IsentropicVortex/inputs_advecting_no_msf
@@ -52,8 +52,7 @@ erf.spatial_order = 2
 # PROBLEM PARAMETERS
 prob.p_inf = 1e5  # reference pressure [Pa]
 prob.T_inf = 300. # reference temperature [K]
-prob.M_inf = 1.1952286093343936  # freestream Mach number [-]
-#prob.M_inf = 2.3904572186687872  # freestream Mach number [-]
+prob.M_inf = 2.3904572186687872  # freestream Mach number [-]
 prob.alpha = 0.7853981633974483  # inflow angle, 0 --> x-aligned [rad]
 prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
 prob.R     = 2.0  # characteristic length scale for grid [m]

--- a/Exec/IsentropicVortex/inputs_stationary_msf
+++ b/Exec/IsentropicVortex/inputs_stationary_msf
@@ -5,13 +5,12 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
-erf.test_mapfactor = 1
-erf.use_terrain = 1
+erf.test_mapfactor    = 1
+erf.use_terrain      = 0
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_lo     = -12  -12  -1
-geometry.prob_hi     =  12   12   1
-amr.n_cell           =  48   48   4
+geometry.prob_extent = 64   64   64  
+amr.n_cell           = 64   64   64  # Consider reducing n_cell in z-dir
 
 geometry.is_periodic = 1 1 0
 
@@ -19,13 +18,14 @@ zlo.type = "SlipWall"
 zhi.type = "SlipWall"
 
 # TIME STEP CONTROL
-erf.no_substepping  = 1
-erf.fixed_dt        = 0.0003
+erf.no_substepping     = 1
+erf.fixed_dt           = 0.004
+#erf.fixed_mri_dt_ratio = 4
 
 # DIAGNOSTICS & VERBOSITY
-erf.sum_interval    = 1       # timesteps between computing mass
-erf.v               = 1       # verbosity in ERF.cpp
-amr.v               = 1       # verbosity in Amr.cpp
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v                = 1       # verbosity in Amr.cpp
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed
@@ -36,7 +36,7 @@ erf.check_int       = -100        # number of timesteps between checkpoints
 
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
-erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_int_1      = 1         # number of timesteps between plotfiles
 erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta temp
 
 # SOLVER CHOICE
@@ -53,8 +53,8 @@ erf.spatial_order = 2
 # PROBLEM PARAMETERS
 prob.p_inf = 1e5  # reference pressure [Pa]
 prob.T_inf = 300. # reference temperature [K]
-prob.M_inf = 2.3904572186687872  # freestream Mach number [-]
-prob.alpha = 0.7853981633974483  # inflow angle, 0 --> x-aligned [rad]
-prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
+prob.M_inf = 0.0  # freestream Mach number [-]
+prob.alpha = 0.0  # inflow angle, 0 --> x-aligned [rad]
+prob.gamma = 1.4  # specific heat ratio [-]
+prob.beta = 0.05  # non-dimensional max perturbation strength [-]
 prob.R     = 1.0  # characteristic length scale for grid [m]
-prob.sigma = 1.0  # Gaussian standard deviation [-]

--- a/Exec/IsentropicVortex/inputs_stationary_no_msf
+++ b/Exec/IsentropicVortex/inputs_stationary_no_msf
@@ -5,13 +5,11 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
-erf.test_mapfactor = 1
-erf.use_terrain = 1
+erf.use_terrain      = 0
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_lo     = -12  -12  -1
-geometry.prob_hi     =  12   12   1
-amr.n_cell           =  48   48   4
+geometry.prob_extent = 128  128  64  
+amr.n_cell           = 64   64   64  # Consider reducing n_cell in z-dir
 
 geometry.is_periodic = 1 1 0
 
@@ -19,13 +17,14 @@ zlo.type = "SlipWall"
 zhi.type = "SlipWall"
 
 # TIME STEP CONTROL
-erf.no_substepping  = 1
-erf.fixed_dt        = 0.0003
+erf.no_substepping     = 1
+erf.fixed_dt           = 0.004
+#erf.fixed_mri_dt_ratio = 4
 
 # DIAGNOSTICS & VERBOSITY
-erf.sum_interval    = 1       # timesteps between computing mass
-erf.v               = 1       # verbosity in ERF.cpp
-amr.v               = 1       # verbosity in Amr.cpp
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v                = 1       # verbosity in Amr.cpp
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed
@@ -36,7 +35,7 @@ erf.check_int       = -100        # number of timesteps between checkpoints
 
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
-erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_int_1      = 1         # number of timesteps between plotfiles
 erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta temp
 
 # SOLVER CHOICE
@@ -53,8 +52,8 @@ erf.spatial_order = 2
 # PROBLEM PARAMETERS
 prob.p_inf = 1e5  # reference pressure [Pa]
 prob.T_inf = 300. # reference temperature [K]
-prob.M_inf = 2.3904572186687872  # freestream Mach number [-]
-prob.alpha = 0.7853981633974483  # inflow angle, 0 --> x-aligned [rad]
-prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
-prob.R     = 1.0  # characteristic length scale for grid [m]
-prob.sigma = 1.0  # Gaussian standard deviation [-]
+prob.M_inf = 0.0  # freestream Mach number [-]
+prob.alpha = 0.0  # inflow angle, 0 --> x-aligned [rad]
+prob.gamma = 1.4  # specific heat ratio [-]
+prob.beta = 0.05  # non-dimensional max perturbation strength [-]
+prob.R     = 2.0  # characteristic length scale for grid [m]

--- a/Exec/ScalarAdvDiff/inputs_advect_uniformU_msf
+++ b/Exec/ScalarAdvDiff/inputs_advect_uniformU_msf
@@ -1,0 +1,63 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 10
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+erf.test_mapfactor = 1
+erf.use_terrain = 0
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_extent = 1     1    1
+amr.n_cell           = 64    64   4
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.no_substepping = 1
+#erf.use_lowM_dt    = 1
+#erf.cfl            = 0.9     # cfl number for hyperbolic system
+erf.fixed_dt = 0.0005
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v                = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = -100       # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta scalar
+
+# SOLVER CHOICE
+erf.alpha_T = 0.0
+erf.alpha_C = 0.0
+erf.use_gravity = false
+
+erf.les_type         = "None"
+erf.molec_diff_type  = "None"
+erf.dynamicViscosity = 0.0
+
+erf.spatial_order = 2
+
+# PROBLEM PARAMETERS
+prob.rho_0 = 1.0
+prob.T_0   = 1.0
+prob.A_0   = 1.0
+prob.u_0   = 10.0
+prob.v_0   = 5.0
+prob.rad_0 = 0.125
+prob.uRef  = 0.0
+
+prob.prob_type = 11

--- a/Exec/ScalarAdvDiff/inputs_advect_uniformU_no_msf
+++ b/Exec/ScalarAdvDiff/inputs_advect_uniformU_no_msf
@@ -1,17 +1,15 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 8
+max_step = 10
 
 amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
-erf.test_mapfactor = 1
-erf.use_terrain = 1
+erf.use_terrain = 0
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_lo     = -12  -12  -1
-geometry.prob_hi     =  12   12   1
-amr.n_cell           =  48   48   4
+geometry.prob_extent = 2   2   1
+amr.n_cell           = 64  64  4
 
 geometry.is_periodic = 1 1 0
 
@@ -19,13 +17,15 @@ zlo.type = "SlipWall"
 zhi.type = "SlipWall"
 
 # TIME STEP CONTROL
-erf.no_substepping  = 1
-erf.fixed_dt        = 0.0003
+erf.no_substepping = 1
+#erf.use_lowM_dt    = 1
+#erf.cfl            = 0.9     # cfl number for hyperbolic system
+erf.fixed_dt = 0.0005
 
 # DIAGNOSTICS & VERBOSITY
-erf.sum_interval    = 1       # timesteps between computing mass
-erf.v               = 1       # verbosity in ERF.cpp
-amr.v               = 1       # verbosity in Amr.cpp
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v                = 1       # verbosity in Amr.cpp
 
 # REFINEMENT / REGRIDDING
 amr.max_level       = 0       # maximum level number allowed
@@ -37,7 +37,7 @@ erf.check_int       = -100        # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
 erf.plot_int_1      = 1          # number of timesteps between plotfiles
-erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta temp
+erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta scalar
 
 # SOLVER CHOICE
 erf.alpha_T = 0.0
@@ -51,10 +51,12 @@ erf.dynamicViscosity = 0.0
 erf.spatial_order = 2
 
 # PROBLEM PARAMETERS
-prob.p_inf = 1e5  # reference pressure [Pa]
-prob.T_inf = 300. # reference temperature [K]
-prob.M_inf = 2.3904572186687872  # freestream Mach number [-]
-prob.alpha = 0.7853981633974483  # inflow angle, 0 --> x-aligned [rad]
-prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
-prob.R     = 1.0  # characteristic length scale for grid [m]
-prob.sigma = 1.0  # Gaussian standard deviation [-]
+prob.rho_0 = 1.0
+prob.T_0   = 1.0
+prob.A_0   = 1.0
+prob.u_0   = 10.0
+prob.v_0   = 5.0
+prob.rad_0 = 0.125
+prob.uRef  = 0.0
+
+prob.prob_type = 11

--- a/Source/Advection/AdvectionSrcForMom.cpp
+++ b/Source/Advection/AdvectionSrcForMom.cpp
@@ -30,16 +30,16 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real met_h_zeta_xhi = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * met_h_zeta_xhi;
+            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * met_h_zeta_xhi * mf_m(i,j,0);
 
             Real met_h_zeta_xlo = Compute_h_zeta_AtCellCenter(i-1,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * met_h_zeta_xlo;
+            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * met_h_zeta_xlo * mf_m(i-1,j,0);
 
             Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterK(i  ,j+1,k  ,cellSizeInv,z_nd);
-            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (u(i,j+1,k) + u(i,j,k)) * met_h_zeta_yhi;
+            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (u(i,j+1,k) + u(i,j,k)) * met_h_zeta_yhi * 0.5 *  (mf_u(i,j,0) + mf_u(i,j+1,0));
 
             Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (u(i,j-1,k) + u(i,j,k)) * met_h_zeta_ylo;
+            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (u(i,j-1,k) + u(i,j,k)) * met_h_zeta_ylo * 0.5 *  (mf_u(i,j,0) + mf_u(i,j-1,0));
 
             Real zflux_hi = 0.25 * (Omega(i, j, k+1) + Omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
             Real zflux_lo = 0.25 * (Omega(i, j, k  ) + Omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
@@ -47,6 +47,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_u(i,j,0);
 
             rho_u_rhs(i, j, k) = -advectionSrc / (0.5 * (detJ(i,j,k) + detJ(i-1,j,k)));
 
@@ -54,16 +55,16 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterK(i+1,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (v(i+1,j,k) + v(i,j,k)) * met_h_zeta_xhi;
+            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (v(i+1,j,k) + v(i,j,k)) * met_h_zeta_xhi * 0.5 *  (mf_v(i,j,0) + mf_v(i+1,j,0));
 
             Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (v(i-1,j,k) + v(i,j,k)) * met_h_zeta_xlo;
+            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (v(i-1,j,k) + v(i,j,k)) * met_h_zeta_xlo * 0.5 *  (mf_v(i,j,0) + mf_v(i-1,j,0));
 
             Real met_h_zeta_yhi = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (v(i,j+1,k) + v(i,j,k)) * met_h_zeta_yhi;
+            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (v(i,j+1,k) + v(i,j,k)) * met_h_zeta_yhi * mf_m(i,j  ,0);
 
             Real met_h_zeta_ylo = Compute_h_zeta_AtCellCenter(i  ,j-1,k  ,cellSizeInv,z_nd);
-            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (v(i,j-1,k) + v(i,j,k)) * met_h_zeta_ylo;
+            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (v(i,j-1,k) + v(i,j,k)) * met_h_zeta_ylo * mf_m(i,j-1,0);
 
             Real zflux_hi = 0.25 * (Omega(i, j, k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
             Real zflux_lo = 0.25 * (Omega(i, j, k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
@@ -71,21 +72,22 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_v(i,j,0);
             rho_v_rhs(i, j, k) = -advectionSrc / (0.5 * (detJ(i,j,k) + detJ(i,j-1,k)));
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_hi = 0.25*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi;
+            Real xflux_hi = 0.25*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi * mf_u(i+1,j,0);
 
             Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real xflux_lo = 0.25*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) * met_h_zeta_xlo;
+            Real xflux_lo = 0.25*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) * met_h_zeta_xlo * mf_u(i  ,j,0);
 
             Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd);
-            Real yflux_hi = 0.25*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) * met_h_zeta_yhi;
+            Real yflux_hi = 0.25*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) * met_h_zeta_yhi * mf_v(i,j+1,0);
 
             Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd);
-            Real yflux_lo = 0.25*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) * met_h_zeta_ylo;
+            Real yflux_lo = 0.25*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) * met_h_zeta_ylo * mf_v(i,j  ,0);
 
             Real zflux_lo = 0.25 * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
 
@@ -95,6 +97,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_m(i,j,0);
 
             rho_w_rhs(i, j, k) = -advectionSrc / (0.5*(detJ(i,j,k) + detJ(i,j,k-1)));
         });
@@ -104,11 +107,11 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
         ParallelFor(bxx, bxy, bxz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k));
-            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k));
+            Real xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * mf_m(i,j,0);
+            Real xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * mf_m(i-1,j,0);
 
-            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (u(i,j+1,k) + u(i,j,k));
-            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (u(i,j-1,k) + u(i,j,k));
+            Real yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (u(i,j+1,k) + u(i,j,k)) * 0.5 * (mf_u(i,j,0) + mf_u(i,j+1,0));
+            Real yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (u(i,j-1,k) + u(i,j,k)) * 0.5 * (mf_u(i,j,0) + mf_u(i,j-1,0));
 
             Real zflux_hi = 0.25 * (Omega(i, j, k+1) + Omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
             Real zflux_lo = 0.25 * (Omega(i, j, k  ) + Omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
@@ -116,15 +119,16 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_u(i,j,0);
             rho_u_rhs(i, j, k) = -advectionSrc;
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real xflux_hi = 0.25 * (rho_u(i+1, j, k) + rho_u(i+1, j-1, k)) * (v(i+1,j,k) + v(i,j,k));
-            Real xflux_lo = 0.25 * (rho_u(i  , j, k) + rho_u(i  , j-1, k)) * (v(i-1,j,k) + v(i,j,k));
+            Real xflux_hi = 0.25 * (rho_u(i+1, j, k) + rho_u(i+1, j-1, k)) * (v(i+1,j,k) + v(i,j,k)) * 0.5 *  (mf_v(i,j,0) + mf_v(i+1,j,0));
+            Real xflux_lo = 0.25 * (rho_u(i  , j, k) + rho_u(i  , j-1, k)) * (v(i-1,j,k) + v(i,j,k)) * 0.5 *  (mf_v(i,j,0) + mf_v(i-1,j,0));
 
-            Real yflux_hi = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j+1, k)) * (v(i,j+1,k) + v(i,j,k));
-            Real yflux_lo = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j-1, k)) * (v(i,j-1,k) + v(i,j,k));
+            Real yflux_hi = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j+1, k)) * (v(i,j+1,k) + v(i,j,k)) * mf_m(i,j  ,0);
+            Real yflux_lo = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j-1, k)) * (v(i,j-1,k) + v(i,j,k)) * mf_m(i,j-1,0);
 
             Real zflux_hi = 0.25 * (Omega(i, j, k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
             Real zflux_lo = 0.25 * (Omega(i, j, k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
@@ -132,15 +136,16 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_v(i,j,0);
             rho_v_rhs(i, j, k) = -advectionSrc;
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real xflux_hi = 0.25*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k));
-            Real xflux_lo = 0.25*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k));
+            Real xflux_hi = 0.25*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) * mf_u(i+1,j,0);
+            Real xflux_lo = 0.25*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) * mf_u(i  ,j,0);
 
-            Real yflux_hi = 0.25*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k));
-            Real yflux_lo = 0.25*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k));
+            Real yflux_hi = 0.25*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) * mf_v(i,j+1,0);
+            Real yflux_lo = 0.25*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) * mf_v(i,j  ,0);
 
             Real zflux_lo = 0.25 * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
 
@@ -150,6 +155,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
             Real advectionSrc = (xflux_hi - xflux_lo) * dxInv
                               + (yflux_hi - yflux_lo) * dyInv
                               + (zflux_hi - zflux_lo) * dzInv;
+            advectionSrc *= mf_m(i,j,0);
             rho_w_rhs(i, j, k) = -advectionSrc;
         });
 


### PR DESCRIPTION
The msf terms were not incorporated into AdvectionSrcForMom, which is used for spatial order 2