### PR TITLE
New msf implementation for advection (NO FAST INTEGRATOR)

### DIFF
--- a/Exec/IsentropicVortex/prob.cpp
+++ b/Exec/IsentropicVortex/prob.cpp
@@ -121,7 +121,6 @@ init_custom_prob(
 
       x_vel(i, j, k) = (parms.M_inf * std::cos(parms.alpha)
                      - (y - parms.yc)/parms.R * Omg) * parms.a_inf;
-      x_vel(i, j, k) = x_vel(i,j,k) / mf_u(i,j,0);
   });
 
   // Construct a box that is on y-faces
@@ -139,7 +138,6 @@ init_custom_prob(
 
       y_vel(i, j, k) = (parms.M_inf * std::sin(parms.alpha)
                      + (x - parms.xc)/parms.R * Omg) * parms.a_inf;
-      y_vel(i, j, k) = y_vel(i,j,k) / mf_v(i,j,0);
   });
 
   // Construct a box that is on z-faces

--- a/Exec/ScalarAdvDiff/prob.cpp
+++ b/Exec/ScalarAdvDiff/prob.cpp
@@ -142,7 +142,6 @@ init_custom_prob(
       x_vel(i, j, k) = parms.u_0 + parms.uRef *
                        std::log((z + parms.z0)/parms.z0)/
                        std::log((parms.zRef +parms.z0)/parms.z0);
-      x_vel(i, j, k) = x_vel(i,j,k) / mf_u(i,j,0); //michael
   });
 
   // Construct a box that is on y-faces
@@ -150,7 +149,7 @@ init_custom_prob(
   // Set the y-velocity
   amrex::ParallelFor(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
-      y_vel(i, j, k) = parms.v_0 / mf_v(i,j,0); //michael
+      y_vel(i, j, k) = parms.v_0;
   });
 
   // Construct a box that is on z-faces

--- a/Source/Advection/Advection.H
+++ b/Source/Advection/Advection.H
@@ -25,6 +25,8 @@ void AdvectionSrcForRhoAndTheta (const amrex::Box& bx, const amrex::Box& valid_b
                                  const amrex::Array4<const amrex::Real>& detJ,
                                  const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSize,
                                  const amrex::Array4<const amrex::Real>& mf_m,
+                                 const amrex::Array4<const amrex::Real>& mf_u,
+                                 const amrex::Array4<const amrex::Real>& mf_v,
                                  const int& spatial_order, const int& use_terrain);
 
 void AdvectionSrcForScalars (const amrex::Box& bx,

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -14,6 +14,8 @@ AdvectionSrcForXMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& mf_v,
                        int spatial_order)
 {
+    //used when spatial order > 2
+
     amrex::Real advectionSrc;
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
     amrex::Real rho_u_avg, rho_v_avg, rho_w_avg;
@@ -22,44 +24,31 @@ AdvectionSrcForXMom_N (int i, int j, int k,
     amrex::Real yflux_hi; amrex::Real yflux_lo;
     amrex::Real zflux_hi; amrex::Real zflux_lo;
 
-    if (spatial_order == 2) {
-        xflux_hi = 0.25 * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * mf_m(i  ,j,0);
-        xflux_lo = 0.25 * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * mf_m(i-1,j,0);
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_mid = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i-1,j  ,0);
+    amrex::Real mf_v_inv_1  = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_2   = 1. / mf_v(i-1,j+1,0); amrex::Real mf_v_inv_3  = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_4 = 1. / mf_v(i-1,j  ,0);
+    amrex::Real mf_m_inv_hi = 1. / mf_m(i  ,j  ,0); amrex::Real mf_m_inv_lo  = 1. / mf_m(i-1,j  ,0);
 
-        yflux_hi = 0.25 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k)) * (u(i,j+1,k) + u(i,j,k)) *
-                   0.5 *  (mf_u(i,j,0) + mf_u(i,j+1,0));
-        yflux_lo = 0.25 * (rho_v(i, j  , k) + rho_v(i-1, j  , k)) * (u(i,j-1,k) + u(i,j,k)) *
-                   0.5 *  (mf_u(i,j,0) + mf_u(i,j-1,0));
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_hi + rho_u(i, j, k) * mf_u_inv_mid);
+    xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, u, 0, rho_u_avg, spatial_order);
 
-        zflux_hi = 0.25 * (rho_w(i, j, k+1) + rho_w(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k)); //mapfacs are moved from here to advSource term
-        zflux_lo = 0.25 * (rho_w(i, j, k  ) + rho_w(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k)); //to reduce number of operations
+    rho_u_avg = 0.5 * (rho_u(i-1, j, k) * mf_u_inv_lo + rho_u(i, j, k) * mf_u_inv_mid);
+    xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, u, 0, rho_u_avg, spatial_order);
 
-    } else {
-        rho_u_avg = 0.5 * (rho_u(i+1, j, k) + rho_u(i, j, k));
-        xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, u, 0, rho_u_avg, spatial_order) * mf_m(i  ,j,0);
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) * mf_v_inv_1 + rho_v(i-1, j+1, k) * mf_v_inv_2);
+    yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, u, 0, rho_v_avg, spatial_order);
 
-        rho_u_avg = 0.5 * (rho_u(i-1, j, k) + rho_u(i, j, k));
-        xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, u, 0, rho_u_avg, spatial_order) * mf_m(i-1,j,0);
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) * mf_v_inv_3 + rho_v(i-1, j  , k) * mf_v_inv_4);
+    yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, u, 0, rho_v_avg, spatial_order);
 
-        rho_v_avg = 0.5 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k));
-        yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, u, 0, rho_v_avg, spatial_order) *
-                   0.5 *  (mf_u(i,j,0) + mf_u(i,j+1,0));
+    rho_w_avg = 0.5 * (rho_w(i, j, k+1) * mf_m_inv_hi + rho_w(i-1, j, k+1) * mf_m_inv_lo);
+    zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, u, 0, rho_w_avg, spatial_order);
 
-        rho_v_avg = 0.5 * (rho_v(i, j  , k) + rho_v(i-1, j  , k));
-        yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, u, 0, rho_v_avg, spatial_order) *
-                   0.5 *  (mf_u(i,j,0) + mf_u(i,j-1,0));
+    rho_w_avg = 0.5 * (rho_w(i, j, k) * mf_m_inv_hi + rho_w(i-1, j, k) * mf_m_inv_lo);
+    zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , u, 0, rho_w_avg, spatial_order);
 
-        rho_w_avg = 0.5 * (rho_w(i, j, k+1) + rho_w(i-1, j, k+1));
-        zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, u, 0, rho_w_avg, spatial_order);
-
-        rho_w_avg = 0.5 * (rho_w(i, j, k) + rho_w(i-1, j, k));
-        zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , u, 0, rho_w_avg, spatial_order);
-    }
-
-    advectionSrc = (xflux_hi - xflux_lo) * dxInv
-                 + (yflux_hi - yflux_lo) * dyInv
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mf_u(i,j,0)
+                 + (yflux_hi - yflux_lo) * dyInv * mf_u(i,j,0)
                  + (zflux_hi - zflux_lo) * dzInv;
-    advectionSrc *= mf_u(i,j,0);
 
     return advectionSrc;
 }
@@ -84,48 +73,35 @@ AdvectionSrcForYMom_N (int i, int j, int k,
     amrex::Real yflux_hi; amrex::Real yflux_lo;
     amrex::Real zflux_hi; amrex::Real zflux_lo;
 
-    if (spatial_order == 2) {
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_mid = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j-1,0);
+    amrex::Real mf_u_inv_1  = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_2   = 1. / mf_u(i+1,j-1,0); amrex::Real mf_u_inv_3  = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_4 = 1. / mf_u(i  ,j-1,0);
+    amrex::Real mf_m_inv_hi = 1. / mf_m(i  ,j  ,0); amrex::Real mf_m_inv_lo  = 1. / mf_m(i  ,j-1,0);
 
-        xflux_hi = 0.25 * (rho_u(i+1, j, k) + rho_u(i+1, j-1, k)) * (v(i+1,j,k) + v(i,j,k)) *
-                   0.5 *  (mf_v(i,j,0) + mf_v(i+1,j,0));
-        xflux_lo = 0.25 * (rho_u(i  , j, k) + rho_u(i  , j-1, k)) * (v(i-1,j,k) + v(i,j,k)) *
-                   0.5 *  (mf_v(i,j,0) + mf_v(i-1,j,0));
+    //used when spatial order > 2
 
-        yflux_hi = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j+1, k)) * (v(i,j+1,k) + v(i,j,k)) * mf_m(i,j  ,0);
-        yflux_lo = 0.25 * (rho_v(i, j, k  ) + rho_v(i  , j-1, k)) * (v(i,j-1,k) + v(i,j,k)) * mf_m(i,j-1,0);
+    rho_u_avg = 0.5*(rho_u(i+1, j, k) * mf_u_inv_1 + rho_u(i+1, j-1, k) * mf_u_inv_2);
+    xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, v, 0, rho_u_avg, spatial_order);
 
-        zflux_hi = 0.25 * (rho_w(i, j, k+1) + rho_w(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)); //mapfacs are moved from here to advSource term
-        zflux_lo = 0.25 * (rho_w(i, j, k  ) + rho_w(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)); //to reduce number of operations
+    rho_u_avg = 0.5*(rho_u(i  , j, k) * mf_u_inv_3 + rho_u(i  , j-1, k) * mf_u_inv_4);
+    xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, v, 0, rho_u_avg, spatial_order);
 
-    } else {
+    rho_v_avg = 0.5*(rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j+1, k) * mf_v_inv_hi);
+    yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, v, 0, rho_v_avg, spatial_order);
 
-        rho_u_avg = 0.5*(rho_u(i+1, j, k) + rho_u(i+1, j-1, k));
-        xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, v, 0, rho_u_avg, spatial_order) *
-                   0.5 *  (mf_v(i,j,0) + mf_v(i+1,j,0));
+    rho_v_avg = 0.5*(rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j-1, k) * mf_v_inv_lo);
+    yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, v, 0, rho_v_avg, spatial_order);
 
-        rho_u_avg = 0.5*(rho_u(i  , j, k) + rho_u(i  , j-1, k));
-        xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, v, 0, rho_u_avg, spatial_order) *
-                   0.5 *  (mf_v(i,j,0) + mf_v(i-1,j,0));
+    rho_w_avg = 0.5*(rho_w(i, j, k+1) * mf_m_inv_hi + rho_w(i, j-1, k+1) * mf_m_inv_lo);
+    zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, v, 0, rho_w_avg, spatial_order);
 
-        rho_v_avg = 0.5*(rho_v(i, j, k) + rho_v(i, j+1, k));
-        yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, v, 0, rho_v_avg, spatial_order) * mf_m(i,j  ,0);
+    rho_w_avg = 0.5*(rho_w(i, j, k) * mf_m_inv_hi + rho_w(i, j-1, k) * mf_m_inv_lo);
+    zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , v, 0, rho_w_avg, spatial_order);
 
-        rho_v_avg = 0.5*(rho_v(i, j, k) + rho_v(i, j-1, k));
-        yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, v, 0, rho_v_avg, spatial_order) * mf_m(i,j-1,0);
-
-        rho_w_avg = 0.5*(rho_w(i, j, k+1) + rho_w(i, j-1, k+1));
-        zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, v, 0, rho_w_avg, spatial_order);
-
-        rho_w_avg = 0.5*(rho_w(i, j, k) + rho_w(i, j-1, k));
-        zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , v, 0, rho_w_avg, spatial_order);
-    }
-
-    advectionSrc = (xflux_hi - xflux_lo) * dxInv
-                 + (yflux_hi - yflux_lo) * dyInv
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mf_v(i,j,0)
+                 + (yflux_hi - yflux_lo) * dyInv * mf_v(i,j,0)
                  + (zflux_hi - zflux_lo) * dzInv;
-    advectionSrc *= mf_v(i,j,0);
 
-    return advectionSrc;
+   return advectionSrc;
 }
 
 AMREX_GPU_DEVICE
@@ -140,6 +116,7 @@ AdvectionSrcForZMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& mf_v,
                        int spatial_order, int domhi_z)
 {
+
     amrex::Real advectionSrc;
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
     amrex::Real rho_u_avg, rho_v_avg, rho_w_avg;
@@ -148,60 +125,49 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     amrex::Real yflux_hi; amrex::Real yflux_lo;
     amrex::Real zflux_hi; amrex::Real zflux_lo;
 
-    if (spatial_order == 2) {
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i  ,j  ,0);
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j  ,0);
+    amrex::Real mf_m_inv    = 1. / mf_m(i  ,j  ,0);
 
-        xflux_hi = 0.25*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) * mf_u(i+1,j,0);
-        xflux_lo = 0.25*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) * mf_u(i  ,j,0);
+    //used when spatial order > 2
 
-        yflux_hi = 0.25*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) * mf_v(i,j+1,0);
-        yflux_lo = 0.25*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) * mf_v(i,j  ,0);
+    rho_u_avg = 0.5*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv_hi;
+    xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, w, 0, rho_u_avg, spatial_order);
 
-        zflux_lo = (k == 0) ? rho_w(i,j,k) * w(i,j,k) :
-            0.25 * (rho_w(i,j,k) + rho_w(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1)); //mapfacs are moved from here to advSource term
-                                                                              //to reduce number of operations
-        zflux_hi = (k == domhi_z+1) ? rho_w(i,j,k) * w(i,j,k) :
-            0.25 * (rho_w(i,j,k) + rho_w(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1));
+    rho_u_avg = 0.5*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv_lo;
+    xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, w, 0, rho_u_avg, spatial_order);
 
+    rho_v_avg = 0.5*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv_hi;
+    yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, w, 0, rho_v_avg, spatial_order);
+
+    rho_v_avg = 0.5*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv_lo;
+    yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, w, 0, rho_v_avg, spatial_order);
+
+    // If k == 1 and spatial_order >= 3 we would reach to k = -1 so we set to spatial_order = min(spatial_order,2)
+    // If k == 2 and spatial_order >= 5 we would reach to k = -1 so we set to spatial_order = min(spatial_order,4)
+    int l_spatial_order_lo = std::min(std::min(spatial_order, 2*(domhi_z+2-k)), 2*k);
+
+    if (k == 0) {
+        zflux_lo = rho_w(i,j,k) * mf_m_inv * w(i,j,k);
     } else {
-
-        rho_u_avg = 0.5*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1));
-        xflux_hi = rho_u_avg * InterpolateInX(i+1, j, k, w, 0, rho_u_avg, spatial_order) * mf_u(i+1,j,0);
-
-        rho_u_avg = 0.5*(rho_u(i  , j, k) + rho_u(i  , j, k-1));
-        xflux_lo = rho_u_avg * InterpolateInX(i  , j, k, w, 0, rho_u_avg, spatial_order) * mf_u(i  ,j,0);
-
-        rho_v_avg = 0.5*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1));
-        yflux_hi = rho_v_avg * InterpolateInY(i, j+1, k, w, 0, rho_v_avg, spatial_order) * mf_v(i,j+1,0);
-
-        rho_v_avg = 0.5*(rho_v(i, j  , k) + rho_v(i, j  , k-1));
-        yflux_lo = rho_v_avg * InterpolateInY(i, j  , k, w, 0, rho_v_avg, spatial_order) * mf_v(i,j  ,0);
-
-        int local_spatial_order = spatial_order;
-        if (k <= 1 || k >= domhi_z) {
-                local_spatial_order = std::min(local_spatial_order,2);
-        } else if (k == 2 || k == domhi_z-1) {
-            local_spatial_order = std::min(local_spatial_order,4);
-        }
-
-        if (k == 0) {
-            zflux_lo = rho_w(i,j,k) * w(i,j,k);
-        } else {
-            rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1));
-            zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , w, 0, rho_w_avg, local_spatial_order);
-        }
-
-        if (k == domhi_z+1) {
-            zflux_hi =  rho_w(i,j,k) * w(i,j,k);
-        } else {
-            rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
-            zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, w, 0, rho_w_avg, local_spatial_order);
-        }
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1)) * mf_m_inv;
+        zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , w, 0, rho_w_avg, l_spatial_order_lo);
     }
 
-    advectionSrc = (xflux_hi - xflux_lo) * dxInv
-                 + (yflux_hi - yflux_lo) * dyInv
-                 + (zflux_hi - zflux_lo) * dzInv;
-    advectionSrc *= mf_m(i,j,0);
+    // If k+1 == domhi_z   and spatial_order >= 3 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,2)
+    // If k+1 == domhi_z-1 and spatial_order >= 5 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,4)
+    int l_spatial_order_hi = std::min(std::min(spatial_order, 2*(domhi_z+1-k)), 2*(k+1));
 
-    return advectionSrc;
+    if (k == domhi_z+1) {
+        zflux_hi =  rho_w(i,j,k) * mf_m_inv * w(i,j,k);
+    } else {
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1)) * mf_m_inv;
+        zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, w, 0, rho_w_avg, l_spatial_order_hi);
+    }
+
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mf_m(i,j,0)
+                 + (yflux_hi - yflux_lo) * dyInv * mf_m(i,j,0)
+                 + (zflux_hi - zflux_lo) * dzInv;
+
+   return advectionSrc;
 }

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -228,12 +228,12 @@ AdvectionSrcForZMom_T (int i, int j, int k,
 
     // If k == domhi_z   and spatial_order >= 3 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,2)
     // If k == domhi_z-1 and spatial_order >= 5 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,4)
-    int l_spatial_order_hi = std::min(std::min(spatial_order, 2*(domhi_z+1-k)), 2*(k+1));    
+    int l_spatial_order_hi = std::min(std::min(spatial_order, 2*(domhi_z+1-k)), 2*(k+1));
     centFluxZZNext *= (k == domhi_z+1) ? w(i,j,k) :
         InterpolateInZ(i, j, k+1, w, 0, Omega_avg, l_spatial_order_hi);
-    
+
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-    
+
     Omega_avg = (k == 0) ? Omega(i,j,k) : 0.5 * (Omega(i,j,k) + Omega(i,j,k-1));
     amrex::Real centFluxZZPrev = Omega_avg * mf_m_inv;
 

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -14,27 +14,33 @@ AdvectionSrcForXMom_T (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& mf_v,
                        int spatial_order)
 {
+    //used when spatial order > 2
+
     amrex::Real advectionSrc;
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
     amrex::Real rho_u_avg, rho_v_avg, Omega_avg_lo, Omega_avg_hi;
 
     amrex::Real met_h_zeta;
 
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_mid = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i-1,j  ,0);
+    amrex::Real mf_v_inv_1  = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_2   = 1. / mf_v(i-1,j+1,0); amrex::Real mf_v_inv_3  = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_4 = 1. / mf_v(i-1,j  ,0);
+    amrex::Real mf_m_inv_hi = 1. / mf_m(i  ,j  ,0); amrex::Real mf_m_inv_lo  = 1. / mf_m(i-1,j  ,0);
+
     // ****************************************************************************************
     // X-fluxes (at cell centers)
     // ****************************************************************************************
 
     met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5 * (rho_u(i+1, j, k) + rho_u(i, j, k));
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_hi + rho_u(i, j, k) * mf_u_inv_mid);
     amrex::Real centFluxXXNext = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i+1, j, k, u, 0, rho_u_avg, spatial_order) * mf_m(i  ,j,0);
+                          InterpolateInX(i+1, j, k, u, 0, rho_u_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     met_h_zeta = Compute_h_zeta_AtCellCenter(i-1,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5 * (rho_u(i-1, j, k) + rho_u(i, j, k));
+    rho_u_avg = 0.5 * (rho_u(i-1, j, k) * mf_u_inv_lo + rho_u(i, j, k) * mf_u_inv_mid);
     amrex::Real centFluxXXPrev = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i  , j, k, u, 0, rho_u_avg, spatial_order) * mf_m(i-1,j,0);
+                          InterpolateInX(i  , j, k, u, 0, rho_u_avg, spatial_order);
 
     // ****************************************************************************************
     // Y-fluxes (at edges in k-direction)
@@ -42,38 +48,34 @@ AdvectionSrcForXMom_T (int i, int j, int k,
 
     // Metric is at edge and center Z (red pentagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j+1,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5 * (rho_v(i, j+1, k) + rho_v(i-1, j+1, k));
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) * mf_v_inv_1 + rho_v(i-1, j+1, k) * mf_v_inv_2);
     amrex::Real edgeFluxXYNext = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i, j+1, k, u, 0, rho_v_avg, spatial_order) *
-                0.5 * (mf_u(i,j,0) + mf_u(i,j+1,0));
+                          InterpolateInY(i, j+1, k, u, 0, rho_v_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     // Metric is at edge and center Z (red pentagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5 * (rho_v(i, j  , k) + rho_v(i-1, j  , k));
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) * mf_v_inv_3 + rho_v(i-1, j  , k) * mf_v_inv_4);
     amrex::Real edgeFluxXYPrev = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i, j  , k, u, 0, rho_v_avg, spatial_order) *
-                0.5 * (mf_u(i,j,0) + mf_u(i,j-1,0));
+                          InterpolateInY(i, j  , k, u, 0, rho_v_avg, spatial_order);
 
     // ****************************************************************************************
     // Z-fluxes (at edges in j-direction)
     // ****************************************************************************************
 
-    Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i-1, j, k+1));
-    amrex::Real edgeFluxXZNext = Omega_avg_hi * InterpolateInZ(i,j,k+1,u,0,Omega_avg_hi,spatial_order); //mapfacs are moved from here to advSource term
-                                                                                                        //to reduce number of operations
+    Omega_avg_hi = 0.5 * (Omega(i, j, k+1) * mf_m_inv_hi + Omega(i-1, j, k+1) * mf_m_inv_lo);
+    amrex::Real edgeFluxXZNext = Omega_avg_hi * InterpolateInZ(i,j,k+1,u,0,Omega_avg_hi,spatial_order);
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-    Omega_avg_lo = 0.5 * (Omega(i, j, k) + Omega(i-1, j, k));
+    Omega_avg_lo = 0.5 * (Omega(i, j, k) * mf_m_inv_hi + Omega(i-1, j, k) * mf_m_inv_lo);
     amrex::Real edgeFluxXZPrev = Omega_avg_lo * InterpolateInZ(i,j,k  ,u,0,Omega_avg_lo,spatial_order);
 
     // ****************************************************************************************
 
-    advectionSrc = (centFluxXXNext - centFluxXXPrev) * dxInv
-                 + (edgeFluxXYNext - edgeFluxXYPrev) * dyInv
+    advectionSrc = (centFluxXXNext - centFluxXXPrev) * dxInv * mf_u(i,j,0)
+                 + (edgeFluxXYNext - edgeFluxXYPrev) * dyInv * mf_u(i,j,0)
                  + (edgeFluxXZNext - edgeFluxXZPrev) * dzInv;
-    advectionSrc *= mf_u(i,j,0);
     advectionSrc /= 0.5*(detJ(i,j,k) + detJ(i-1,j,k));
 
     return advectionSrc;
@@ -97,63 +99,63 @@ AdvectionSrcForYMom_T (int i, int j, int k,
 
     amrex::Real met_h_zeta;
 
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_mid = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j-1,0);
+    amrex::Real mf_u_inv_1  = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_2   = 1. / mf_u(i+1,j-1,0); amrex::Real mf_u_inv_3  = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_4 = 1. / mf_u(i  ,j-1,0);
+    amrex::Real mf_m_inv_hi = 1. / mf_m(i  ,j  ,0); amrex::Real mf_m_inv_lo  = 1. / mf_m(i  ,j-1,0);
+
     // ****************************************************************************************
     // x-fluxes (at edges in k-direction)
     // ****************************************************************************************
 
     // Metric is at edge and center Z (red pentagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i+1,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j-1, k));
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_1 + rho_u(i+1, j-1, k) * mf_u_inv_2);
     amrex::Real edgeFluxYXNext = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i+1, j, k, v, 0, rho_u_avg, spatial_order) *
-                0.5 * (mf_v(i,j,0) + mf_v(i+1,j,0));
+                          InterpolateInX(i+1, j, k, v, 0, rho_u_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     // Metric is at edge and center Z (red pentagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5 * (rho_u(i, j, k) + rho_u(i, j-1, k));
+    rho_u_avg = 0.5 * (rho_u(i  , j, k) * mf_u_inv_3 + rho_u(i  , j-1, k) * mf_u_inv_4);
     amrex::Real edgeFluxYXPrev = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i  , j, k, v, 0, rho_u_avg, spatial_order) *
-                0.5 * (mf_v(i,j,0) + mf_v(i-1,j,0));
+                          InterpolateInX(i  , j, k, v, 0, rho_u_avg, spatial_order);
 
     // ****************************************************************************************
     // y-fluxes (at cell centers)
     // ****************************************************************************************
 
     met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j, k));
+    rho_v_avg = 0.5 * (rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j+1, k) * mf_v_inv_hi);
     amrex::Real centFluxYYNext = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i, j+1, k, v, 0, rho_v_avg, spatial_order) * mf_m(i,j  ,0);
+                          InterpolateInY(i, j+1, k, v, 0, rho_v_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j-1,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5 * (rho_v(i, j-1, k) + rho_v(i, j, k));
+    rho_v_avg = 0.5 * (rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j-1, k) * mf_v_inv_lo);
     amrex::Real centFluxYYPrev = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i  , j, k, v, 0, rho_v_avg, spatial_order) * mf_m(i,j-1,0);
+                          InterpolateInY(i  , j, k, v, 0, rho_v_avg, spatial_order);
 
 
     // ****************************************************************************************
     // Z-fluxes (at edges in j-direction)
     // ****************************************************************************************
 
-    Omega_avg_hi = 0.5*(Omega(i, j, k+1) + Omega(i, j-1, k+1));
+    Omega_avg_hi = 0.5 * (Omega(i, j, k+1) * mf_m_inv_hi + Omega(i, j-1, k+1) * mf_m_inv_lo);
     amrex::Real edgeFluxYZNext = Omega_avg_hi *
-                          InterpolateInZ(i, j, k+1, v, 0, Omega_avg_hi, spatial_order); //mapfacs are moved from here to advSource term
-                                                                                        //to reduce number of operations
+                          InterpolateInZ(i, j, k+1, v, 0, Omega_avg_hi, spatial_order);
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-    Omega_avg_lo = 0.5 * (Omega(i, j, k) + Omega(i, j-1, k));
+    Omega_avg_lo = 0.5 * (Omega(i, j, k) * mf_m_inv_hi + Omega(i, j-1, k) * mf_m_inv_lo);
     amrex::Real edgeFluxYZPrev = Omega_avg_lo*
                           InterpolateInZ(i, j, k  , v, 0, Omega_avg_lo, spatial_order);
 
     // ****************************************************************************************
 
-    advectionSrc = (edgeFluxYXNext - edgeFluxYXPrev) * dxInv
-                 + (centFluxYYNext - centFluxYYPrev) * dyInv
+    advectionSrc = (edgeFluxYXNext - edgeFluxYXPrev) * dxInv * mf_v(i,j,0)
+                 + (centFluxYYNext - centFluxYYPrev) * dyInv * mf_v(i,j,0)
                  + (edgeFluxYZNext - edgeFluxYZPrev) * dzInv;
-    advectionSrc *= mf_v(i,j,0);
     advectionSrc /= 0.5*(detJ(i,j,k) + detJ(i,j-1,k));
 
     return advectionSrc;
@@ -177,23 +179,27 @@ AdvectionSrcForZMom_T (int i, int j, int k,
 
     amrex::Real met_h_zeta;
 
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i  ,j  ,0);
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j  ,0);
+    amrex::Real mf_m_inv    = 1. / mf_m(i  ,j  ,0);
+
     // ****************************************************************************************
     // x-fluxes (at edges in j-direction)
     // ****************************************************************************************
 
     // Metric is at edge and center Y (magenta cross)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5*(rho_u(i+1,j,k) + rho_u(i+1,j,k-1));
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv_hi;
     amrex::Real edgeFluxZXNext = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i+1, j, k, w, 0, rho_u_avg, spatial_order) * mf_u(i+1,j,0);
+                          InterpolateInX(i+1, j, k, w, 0, rho_u_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     // Metric is at edge and center Y (magenta cross)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_u_avg = 0.5*(rho_u(i,j,k) + rho_u(i,j,k-1));
+    rho_u_avg = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv_lo;
     amrex::Real edgeFluxZXPrev = rho_u_avg * met_h_zeta *
-                          InterpolateInX(i  , j, k, w, 0, rho_u_avg, spatial_order) * mf_u(i  ,j,0);
+                          InterpolateInX(i  , j, k, w, 0, rho_u_avg, spatial_order);
 
     // ****************************************************************************************
     // y-fluxes (at edges in i-direction)
@@ -201,41 +207,46 @@ AdvectionSrcForZMom_T (int i, int j, int k,
 
     // Metric is at edge and center I (purple hexagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5*(rho_v(i,j+1,k) + rho_v(i,j+1,k-1));
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv_hi;
     amrex::Real edgeFluxZYNext = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i, j+1, k, w, 0, rho_v_avg, spatial_order) * mf_v(i,j+1,0);
+                          InterpolateInY(i, j+1, k, w, 0, rho_v_avg, spatial_order);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
     // Metric is at edge and center I (purple hexagon)
     met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd);
-    rho_v_avg = 0.5*(rho_v(i,j,k) + rho_v(i,j,k-1));
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv_lo;
     amrex::Real edgeFluxZYPrev = rho_v_avg * met_h_zeta *
-                          InterpolateInY(i, j  , k, w, 0, rho_v_avg, spatial_order) * mf_v(i,j  ,0);
+                          InterpolateInY(i, j  , k, w, 0, rho_v_avg, spatial_order);
 
     // ****************************************************************************************
     // z-fluxes (at cell centers)
     // ****************************************************************************************
 
     Omega_avg = (k == domhi_z+1) ? Omega(i,j,k) : 0.5 * (Omega(i,j,k) + Omega(i,j,k+1));
-    amrex::Real centFluxZZNext = Omega_avg;
+    amrex::Real centFluxZZNext = Omega_avg * mf_m_inv;
 
+    // If k == domhi_z   and spatial_order >= 3 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,2)
+    // If k == domhi_z-1 and spatial_order >= 5 we would reach to k = domhi_z+2 so we set to spatial_order = min(spatial_order,4)
+    int l_spatial_order_hi = std::min(std::min(spatial_order, 2*(domhi_z+1-k)), 2*(k+1));    
     centFluxZZNext *= (k == domhi_z+1) ? w(i,j,k) :
-        InterpolateInZ(i, j, k+1, w, 0, Omega_avg, spatial_order); //mapfacs are moved from here to advSource term
-                                                                   //to reduce number of operations
+        InterpolateInZ(i, j, k+1, w, 0, Omega_avg, l_spatial_order_hi);
+    
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
-
+    
     Omega_avg = (k == 0) ? Omega(i,j,k) : 0.5 * (Omega(i,j,k) + Omega(i,j,k-1));
-    amrex::Real centFluxZZPrev = Omega_avg;
+    amrex::Real centFluxZZPrev = Omega_avg * mf_m_inv;
 
-    centFluxZZPrev *= (k == 0) ? w(i,j,k) : InterpolateInZ(i, j, k  , w, 0, Omega_avg, spatial_order);
+    // If k == 1 and spatial_order >= 3 we would reach to k = -1 so we set to spatial_order = min(spatial_order,2)
+    // If k == 2 and spatial_order >= 5 we would reach to k = -1 so we set to spatial_order = min(spatial_order,4)
+    int l_spatial_order_lo = std::min(std::min(spatial_order, 2*(domhi_z+2-k)), 2*k);
+    centFluxZZPrev *= (k == 0) ? w(i,j,k) : InterpolateInZ(i, j, k  , w, 0, Omega_avg, l_spatial_order_lo);
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 
-    advectionSrc = (edgeFluxZXNext - edgeFluxZXPrev) * dxInv
-                 + (edgeFluxZYNext - edgeFluxZYPrev) * dyInv
+    advectionSrc = (edgeFluxZXNext - edgeFluxZXPrev) * dxInv * mf_m(i,j,0)
+                 + (edgeFluxZYNext - edgeFluxZYPrev) * dyInv * mf_m(i,j,0)
                  + (centFluxZZNext - centFluxZZPrev) * dzInv;
-    advectionSrc *= mf_m(i,j,0);
 
     amrex::Real denom = 0.5*(detJ(i,j,k) + detJ(i,j,k-1));
     advectionSrc /= denom;

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -131,15 +131,11 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
 
             average_face_to_cellcenter(mf[lev],mf_comp,
                 Array<const MultiFab*,3>{&vars_new[lev][Vars::xvel],&vars_new[lev][Vars::yvel],&vars_new[lev][Vars::zvel]});
-            //
-            // Convert the map-factor-scaled-velocities back to velocities
-            //
+
             MultiFab dmf(mf[lev], make_alias, mf_comp, AMREX_SPACEDIM);
             for (MFIter mfi(dmf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 const Box& bx = mfi.validbox();
-                const Array4<Real> vel_arr = dmf.array(mfi);
-                const Array4<Real> msf_arr = mapfac_m[lev]->array(mfi);
 
                 /*
                 // Moving terrain ANALYTICAL
@@ -147,13 +143,10 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                 const Array4<Real const>& z_nd = z_phys_nd[lev]->const_array(mfi);
                 */
 
+                /*
                 ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    vel_arr(i,j,k,0) *= msf_arr(i,j,0);
-                    vel_arr(i,j,k,1) *= msf_arr(i,j,0);
-                    vel_arr(i,j,k,2) *= msf_arr(i,j,0);
 
-                    /*
                     // Moving terrain ANALYTICAL
                     Real H           = 400.;
                     Real Ampl        = 0.16;
@@ -176,8 +169,9 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
 
                       vel_arr(i,j,k,2) -= Ampl * omega * fac * std::cos(kp * x - omega * t_new[lev]);
                     }
-                    */
+
                 });
+                */
             }
             mf_comp += AMREX_SPACEDIM;
         }

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -154,6 +154,11 @@ void erf_slow_rhs_pre (int level, int nrk,
         const Array4<const Real>& rho_v = S_data[IntVar::ymom].array(mfi);
         const Array4<const Real>& rho_w = S_data[IntVar::zmom].array(mfi);
 
+        // Map factors
+        const Array4<const Real>& mf_m   = mapfac_m->const_array(mfi);
+        const Array4<const Real>& mf_u   = mapfac_u->const_array(mfi);
+        const Array4<const Real>& mf_v   = mapfac_v->const_array(mfi);
+
         const Array4<      Real>& omega_arr = Omega.array(mfi);
 
         Array4<const Real> z_t;
@@ -175,11 +180,6 @@ void erf_slow_rhs_pre (int level, int nrk,
         // Base state
         const Array4<      Real>& r0_arr = r0->array(mfi);
         const Array4<      Real>& p0_arr = p0->array(mfi);
-
-        // Map factors
-        const Array4<const Real>& mf_m   = mapfac_m->const_array(mfi);
-        const Array4<const Real>& mf_u   = mapfac_u->const_array(mfi);
-        const Array4<const Real>& mf_v   = mapfac_v->const_array(mfi);
 
         const Box& gbx = mfi.growntilebox(1);
         const Array4<Real> & pp_arr  = pprime.array(mfi);
@@ -377,7 +377,7 @@ void erf_slow_rhs_pre (int level, int nrk,
                                    rho_u, rho_v, omega_arr, fac,
                                    avg_xmom, avg_ymom, avg_zmom, // these are being defined from the rho fluxes
                                    cell_prim, z_nd, detJ,
-                                   dxInv, mf_m, l_spatial_order, l_use_terrain);
+                                   dxInv, mf_m, mf_u, mf_v, l_spatial_order, l_use_terrain);
 
         if (l_use_diff) {
             Array4<Real> diffflux_x = dflux_x->array(mfi);
@@ -720,7 +720,7 @@ void erf_slow_rhs_pre (int level, int nrk,
           [=] AMREX_GPU_DEVICE (int i, int j, int k)
           { // z-momentum equation
 
-                Real gpz = dxInv[2] * (pp_arr(i,j,k) - pp_arr(i,j,k-1));
+                Real gpz = dxInv[2] * (pp_arr(i,j,k) - pp_arr(i,j,k-1)) / mf_m(i,j,0);
 
 #ifdef ERF_USE_MOISTURE
                 Real q = 0.5 * ( cell_prim(i,j,k,PrimQv_comp) + cell_prim(i,j,k-1,PrimQv_comp)

--- a/Source/TimeIntegration/TI_no_substep_fun.H
+++ b/Source/TimeIntegration/TI_no_substep_fun.H
@@ -45,6 +45,8 @@
                 Array4<Real>*  ssum =  ssum_d.dataPtr();
                 Array4<Real>* fslow = fslow_d.dataPtr();
 
+                Array4<Real> mf_m = mapfac_m[level]->array(mfi);
+
                 // Moving terrain
                 if ( solverChoice.use_terrain && solverChoice.terrain_type == 1 )
                 {
@@ -103,19 +105,18 @@
                         ssum[IntVar::cons](i,j,k,n) = sold[IntVar::cons](i,j,k,n) + slow_dt *
                            ( fslow[IntVar::cons](i,j,k,n) );
                     });
-
                     ParallelFor(tbx, tby, tbz,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         ssum[IntVar::xmom](i,j,k) = sold[IntVar::xmom](i,j,k) + slow_dt *
-                           ( fslow[IntVar::xmom](i,j,k) );
+                            ( fslow[IntVar::xmom](i,j,k)*mf_m(i,j,0) );
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         ssum[IntVar::ymom](i,j,k) = sold[IntVar::ymom](i,j,k) + slow_dt *
-                           ( fslow[IntVar::ymom](i,j,k) );
+                            ( fslow[IntVar::ymom](i,j,k)*mf_m(i,j,0) );
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         ssum[IntVar::zmom](i,j,k) = sold[IntVar::zmom](i,j,k) + slow_dt *
-                           ( fslow[IntVar::zmom](i,j,k) );
+                            ( fslow[IntVar::zmom](i,j,k)*mf_m(i,j,0) );
                     });
                 }
             }


### PR DESCRIPTION
This update includes msf terms in the advection physics, EXCPET THE FAST INTEGRATOR
-For msf to work properly, use erf.no_substepping = 1 and erf.test_mapfac = 1