### PR TITLE
MOSTAvg 2D data structures

### DIFF
--- a/Exec/ABL/inputs_most
+++ b/Exec/ABL/inputs_most
@@ -16,8 +16,8 @@ zhi.type = "SlipWall"
 
 erf.most.z0 = 100.0
 erf.most.zref = 200.0
-erf.most.surf_temp = 301.1
-
+#erf.most.surf_temp = 301.0
+#erf.most.surf_temp_flux = 8.14165
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.2  # fixed time step depending on grid resolution
 

--- a/Exec/ABL/inputs_most
+++ b/Exec/ABL/inputs_most
@@ -11,13 +11,15 @@ amr.n_cell           =    64       64      64
 
 geometry.is_periodic = 1 1 0
 
-zlo.type = "Most"
 zhi.type = "SlipWall"
 
-erf.most.z0 = 100.0
+# MOST BOUNDARY (DEFAULT IS ADIABATIC FOR THETA)
+zlo.type      = "Most"
+erf.most.z0   = 100.0
 erf.most.zref = 200.0
-#erf.most.surf_temp = 301.0
-#erf.most.surf_temp_flux = 8.14165
+#erf.most.surf_temp      = 301.0   # SPECIFIED SURFACE TEMP
+#erf.most.surf_temp_flux = 8.14165 # SPECIFIED SURFACE FLUX
+
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.2  # fixed time step depending on grid resolution
 

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -116,11 +116,11 @@ public:
             pp.query("most.surf_temp_flux", surf_temp_flux);
             alg_type = HEAT_FLUX;
         }
-        
+
         int nlevs = m_geom.size();
 
         z_0.resize(nlevs);
-        
+
         u_mean.resize(nlevs);
         v_mean.resize(nlevs);
         w_mean.resize(nlevs);
@@ -161,7 +161,7 @@ public:
                 const int ncomp  = 1;
                 const int incomp = 2;
                 const amrex::IntVect& ng = mf.nGrowVect();
-                
+
                 u_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 u_mean[lev]->setVal(1.E34);
                 x_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
@@ -179,7 +179,7 @@ public:
                 const int ncomp  = 1;
                 const int incomp = 2;
                 const amrex::IntVect& ng = mf.nGrowVect();
-                
+
                 v_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 v_mean[lev]->setVal(1.E34);
                 y_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
@@ -197,7 +197,7 @@ public:
                 const int ncomp  = 1;
                 const int incomp = 2;
                 const amrex::IntVect& ng = mf.nGrowVect();
-                
+
                 w_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 w_mean[lev]->setVal(1.E34);
                 z_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
@@ -215,7 +215,7 @@ public:
                 const int ncomp  = 1;
                 const int incomp = 2;
                 const amrex::IntVect& ng = mf.nGrowVect();
-                
+
                 t_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 t_mean[lev]->setVal(1.E34);
 
@@ -234,7 +234,7 @@ public:
                 } else {
                     t_surf[lev]->setVal(0.0);
                 }
-                
+
                 cc_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
             }
 
@@ -311,7 +311,7 @@ public:
 
         amrex::Vector<amrex::Geometry> m_geom;
         amrex::Vector<amrex::FArrayBox> z_0;
-    
+
         amrex::Vector<amrex::MultiFab*> u_mean;
         amrex::Vector<amrex::MultiFab*> v_mean;
         amrex::Vector<amrex::MultiFab*> w_mean;

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -31,17 +31,16 @@ public:
     amrex::Real kappa{KAPPA};        ///< von Karman constant
     amrex::Real gravity{CONST_GRAV}; ///< Acceleration due to gravity (m/s^2)
     amrex::Real obukhov_len{1.0e16}; ///< Non-dimensional Obukhov length
+    amrex::Real surf_temp_flux{0.0}; ///< Heat flux
 
     // THIS BECOMES REDUNDANT WITH THE NEW 2D MFs
-    amrex::Real utau;                     ///< Friction velocity (m/s)
     amrex::Real vel_mean[AMREX_SPACEDIM]; ///< Mean velocity (at zref)
     amrex::Real vmag_mean;                ///< Mean wind speed (at zref)
     amrex::Real theta_mean;               ///< Mean potential temperature
-    // END REDUNDANT CODE
 
-    amrex::Real surf_temp_flux{0.0}; ///< Heat flux
-    amrex::Real surf_temp;           ///< Instantaneous surface temperature
-    amrex::Real ref_temp;            ///< Reference temperature
+    amrex::Real surf_temp;                ///< Instantaneous surface temperature
+    amrex::Real utau;                     ///< Friction velocity (m/s)
+    // END REDUNDANT CODE
 
     amrex::Real beta_m{5.0}; // Constants from Dyer, BLM, 1974
     amrex::Real beta_h{5.0}; // https://doi.org/10.1007/BF00240838
@@ -78,9 +77,9 @@ public:
         if (zeta > 0) {
             return -beta_m * zeta;
         } else {
-            amrex::Real x = std::sqrt(std::sqrt(1 - gamma_m * zeta));
-            return 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1 + x * x)) -
-                   2.0 * std::atan(x) + 1.57;
+            amrex::Real x = std::sqrt(std::sqrt(1.0 - gamma_m * zeta));
+            return 2.0 * std::log(0.5 * (1.0 + x)) + log(0.5 * (1.0 + x * x)) -
+                   2.0 * std::atan(x) + PIoTwo;
         }
     }
 
@@ -90,8 +89,8 @@ public:
         if (zeta > 0) {
             return -beta_h * zeta;
         } else {
-            amrex::Real x = std::sqrt(1 - gamma_h * zeta);
-            return 2.0 * std::log(0.5 * (1 + x));
+            amrex::Real x = std::sqrt(1.0 - gamma_h * zeta);
+            return 2.0 * std::log(0.5 * (1.0 + x));
         }
     }
 };
@@ -106,10 +105,18 @@ public:
                      const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_new) : m_geom(geom)
     {
         amrex::ParmParse pp("erf");
-        pp.query("most.surf_temp", surf_temp);
         pp.query("most.zref"     , zref);
         pp.query("most.z0"       , z0_const);
 
+        // Specify surface temperature or surface flux
+        auto erf_st = pp.query("most.surf_temp", surf_temp);
+        if (erf_st) {
+            alg_type = SURFACE_TEMPERATURE;
+        } else {
+            pp.query("most.surf_temp_flux", surf_temp_flux);
+            alg_type = HEAT_FLUX;
+        }
+        
         int nlevs = m_geom.size();
 
         z_0.resize(nlevs);
@@ -119,7 +126,9 @@ public:
         w_mean.resize(nlevs);
         t_mean.resize(nlevs);
         u_mag_mean.resize(nlevs);
-        u_tau.resize(nlevs);
+        u_star.resize(nlevs);
+        t_star.resize(nlevs);
+        t_surf.resize(nlevs);
 
         x_nd_k.resize(nlevs);
         y_nd_k.resize(nlevs);
@@ -151,11 +160,11 @@ public:
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
                 const int ncomp  = 1;
                 const int incomp = 2;
-                const amrex::IntVect& ngrow = mf.nGrowVect();
+                const amrex::IntVect& ng = mf.nGrowVect();
                 
-                u_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                u_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 u_mean[lev]->setVal(1.E34);
-                x_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
+                x_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
             }
             { // Nodal in y
                 auto& mf = vars_new[lev][Vars::yvel];
@@ -169,11 +178,11 @@ public:
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
                 const int ncomp  = 1;
                 const int incomp = 2;
-                const amrex::IntVect& ngrow = mf.nGrowVect();
+                const amrex::IntVect& ng = mf.nGrowVect();
                 
-                v_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                v_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 v_mean[lev]->setVal(1.E34);
-                y_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
+                y_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
             }
             { // Nodal in z
                 auto& mf = vars_new[lev][Vars::zvel];
@@ -187,11 +196,11 @@ public:
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
                 const int ncomp  = 1;
                 const int incomp = 2;
-                const amrex::IntVect& ngrow = mf.nGrowVect();
+                const amrex::IntVect& ng = mf.nGrowVect();
                 
-                w_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                w_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 w_mean[lev]->setVal(1.E34);
-                z_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
+                z_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
             }
             { // CC vars
                 auto& mf = vars_new[lev][Vars::cons];
@@ -205,18 +214,28 @@ public:
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
                 const int ncomp  = 1;
                 const int incomp = 2;
-                const amrex::IntVect& ngrow = mf.nGrowVect();
+                const amrex::IntVect& ng = mf.nGrowVect();
                 
-                t_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                t_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 t_mean[lev]->setVal(1.E34);
 
-                u_mag_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                u_mag_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
                 u_mag_mean[lev]->setVal(1.E34);
 
-                u_tau[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
-                u_tau[lev]->setVal(1.E34);
+                u_star[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
+                u_star[lev]->setVal(1.E34);
 
-                cc_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
+                t_star[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
+                t_star[lev]->setVal(1.E34);
+
+                t_surf[lev] = new amrex::MultiFab(ba2d,dm,ncomp,{ng[0], ng[1], 0});
+                if (erf_st) {
+                   t_surf[lev]->setVal(surf_temp);
+                } else {
+                    t_surf[lev]->setVal(0.0);
+                }
+                
+                cc_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,{ng[0], ng[1], 0});
             }
 
         }
@@ -232,7 +251,9 @@ public:
             delete w_mean[lev];
             delete t_mean[lev];
             delete u_mag_mean[lev];
-            delete u_tau[lev];
+            delete u_star[lev];
+            delete t_star[lev];
+            delete t_surf[lev];
 
             delete x_nd_k[lev];
             delete y_nd_k[lev];
@@ -263,7 +284,7 @@ public:
         SURFACE_TEMPERATURE ///< Surface temperature specified
     };
 
-    ThetaCalcType alg_type{HEAT_FLUX};
+    ThetaCalcType alg_type; //{HEAT_FLUX};
 
     void print() const
     {
@@ -280,7 +301,6 @@ public:
         amrex::Print() << " theta_mean: "     << theta_mean     << "\n";
         amrex::Print() << " surf_temp_flux: " << surf_temp_flux << "\n";
         amrex::Print() << " surf_temp: "      << surf_temp      << "\n";
-        amrex::Print() << " ref_temp: "       << ref_temp       << "\n";
         amrex::Print() << " beta_m: "         << beta_m         << "\n";
         amrex::Print() << " beta_h: "         << beta_h         << "\n";
         amrex::Print() << " gamma_m: "        << gamma_m        << "\n";
@@ -291,12 +311,15 @@ public:
 
         amrex::Vector<amrex::Geometry> m_geom;
         amrex::Vector<amrex::FArrayBox> z_0;
+    
         amrex::Vector<amrex::MultiFab*> u_mean;
         amrex::Vector<amrex::MultiFab*> v_mean;
         amrex::Vector<amrex::MultiFab*> w_mean;
         amrex::Vector<amrex::MultiFab*> t_mean;
         amrex::Vector<amrex::MultiFab*> u_mag_mean;
-        amrex::Vector<amrex::MultiFab*> u_tau;
+        amrex::Vector<amrex::MultiFab*> u_star;
+        amrex::Vector<amrex::MultiFab*> t_star;
+        amrex::Vector<amrex::MultiFab*> t_surf;
 
         amrex::Vector<amrex::iMultiFab*> x_nd_k;
         amrex::Vector<amrex::iMultiFab*> y_nd_k;

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -5,6 +5,7 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_iMultiFab.H>
 
 #include <IndexDefines.H>
 #include <ERF_Constants.H>
@@ -27,12 +28,12 @@ public:
 
     amrex::Real zref{0.2};           ///< Reference height (m)
     amrex::Real z0_const{0.1};       ///< Roughness height -- default constant value(m)
-    amrex::Real utau;                ///< Friction velocity (m/s)
     amrex::Real kappa{KAPPA};        ///< von Karman constant
     amrex::Real gravity{CONST_GRAV}; ///< Acceleration due to gravity (m/s^2)
     amrex::Real obukhov_len{1.0e16}; ///< Non-dimensional Obukhov length
 
     // THIS BECOMES REDUNDANT WITH THE NEW 2D MFs
+    amrex::Real utau;                     ///< Friction velocity (m/s)
     amrex::Real vel_mean[AMREX_SPACEDIM]; ///< Mean velocity (at zref)
     amrex::Real vmag_mean;                ///< Mean wind speed (at zref)
     amrex::Real theta_mean;               ///< Mean potential temperature
@@ -112,11 +113,18 @@ public:
         int nlevs = m_geom.size();
 
         z_0.resize(nlevs);
+        
         u_mean.resize(nlevs);
         v_mean.resize(nlevs);
         w_mean.resize(nlevs);
         t_mean.resize(nlevs);
         u_mag_mean.resize(nlevs);
+        u_tau.resize(nlevs);
+
+        x_nd_k.resize(nlevs);
+        y_nd_k.resize(nlevs);
+        z_nd_k.resize(nlevs);
+        cc_k.resize(nlevs);
 
         for (int lev = 0; lev < nlevs; lev++)
         {
@@ -131,90 +139,84 @@ public:
 
             // 2D MFs for averages
             //--------------------------------------------------------
-            {
+            { // Nodal in x
                 auto& mf = vars_new[lev][Vars::xvel];
-                // Create a 2D ba
+                // Create a 2D ba, dm, & ghost cells
                 amrex::BoxArray ba  = mf.boxArray();
                 amrex::BoxList bl2d = ba.boxList();
                 for (auto& b : bl2d) {
                     b.setRange(2,0);
                 }
                 amrex::BoxArray ba2d(std::move(bl2d));
-                // Distribution map
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
-                // Components and ghost cells
-                const int ncomp = mf.nComp();
+                const int ncomp  = 1;
+                const int incomp = 2;
                 const amrex::IntVect& ngrow = mf.nGrowVect();
+                
                 u_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
                 u_mean[lev]->setVal(1.E34);
+                x_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
             }
-            {
+            { // Nodal in y
                 auto& mf = vars_new[lev][Vars::yvel];
-                // Create a 2D ba
+                // Create a 2D ba, dm, & ghost cells
                 amrex::BoxArray ba  = mf.boxArray();
                 amrex::BoxList bl2d = ba.boxList();
                 for (auto& b : bl2d) {
                     b.setRange(2,0);
                 }
                 amrex::BoxArray ba2d(std::move(bl2d));
-                // Distribution map
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
-                // Components and ghost cells
-                const int ncomp = mf.nComp();
+                const int ncomp  = 1;
+                const int incomp = 2;
                 const amrex::IntVect& ngrow = mf.nGrowVect();
+                
                 v_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
                 v_mean[lev]->setVal(1.E34);
+                y_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
             }
-            {
+            { // Nodal in z
                 auto& mf = vars_new[lev][Vars::zvel];
-                // Create a 2D ba
+                // Create a 2D ba, dm, & ghost cells
                 amrex::BoxArray ba  = mf.boxArray();
                 amrex::BoxList bl2d = ba.boxList();
                 for (auto& b : bl2d) {
                     b.setRange(2,0);
                 }
                 amrex::BoxArray ba2d(std::move(bl2d));
-                // Distribution map
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
-                // Components and ghost cells
-                const int ncomp = mf.nComp();
+                const int ncomp  = 1;
+                const int incomp = 2;
                 const amrex::IntVect& ngrow = mf.nGrowVect();
+                
                 w_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
                 w_mean[lev]->setVal(1.E34);
+                z_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
             }
-            {
+            { // CC vars
                 auto& mf = vars_new[lev][Vars::cons];
-                // Create a 2D ba
+                // Create a 2D ba, dm, & ghost cells
                 amrex::BoxArray ba  = mf.boxArray();
                 amrex::BoxList bl2d = ba.boxList();
                 for (auto& b : bl2d) {
                     b.setRange(2,0);
                 }
                 amrex::BoxArray ba2d(std::move(bl2d));
-                // Distribution map
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
-                // Components and ghost cells
-                const int ncomp = 1;
+                const int ncomp  = 1;
+                const int incomp = 2;
                 const amrex::IntVect& ngrow = mf.nGrowVect();
+                
                 t_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
                 t_mean[lev]->setVal(1.E34);
-            }
-            {
-                auto& mf = vars_new[lev][Vars::cons];
-                // Create a 2D ba
-                amrex::BoxArray ba  = mf.boxArray();
-                amrex::BoxList bl2d = ba.boxList();
-                for (auto& b : bl2d) {
-                    b.setRange(2,0);
-                }
-                amrex::BoxArray ba2d(std::move(bl2d));
-                // Distribution map
-                const amrex::DistributionMapping& dm = mf.DistributionMap();
-                // Components and ghost cells
-                const int ncomp = 1;
-                const amrex::IntVect& ngrow = mf.nGrowVect();
+
                 u_mag_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
                 u_mag_mean[lev]->setVal(1.E34);
+
+                u_tau[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ngrow);
+                u_tau[lev]->setVal(1.E34);
+
+                cc_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ngrow);
             }
 
         }
@@ -230,6 +232,12 @@ public:
             delete w_mean[lev];
             delete t_mean[lev];
             delete u_mag_mean[lev];
+            delete u_tau[lev];
+
+            delete x_nd_k[lev];
+            delete y_nd_k[lev];
+            delete z_nd_k[lev];
+            delete cc_k[lev];
         }
     };
 
@@ -288,6 +296,12 @@ public:
         amrex::Vector<amrex::MultiFab*> w_mean;
         amrex::Vector<amrex::MultiFab*> t_mean;
         amrex::Vector<amrex::MultiFab*> u_mag_mean;
+        amrex::Vector<amrex::MultiFab*> u_tau;
+
+        amrex::Vector<amrex::iMultiFab*> x_nd_k;
+        amrex::Vector<amrex::iMultiFab*> y_nd_k;
+        amrex::Vector<amrex::iMultiFab*> z_nd_k;
+        amrex::Vector<amrex::iMultiFab*> cc_k;
 };
 
 #endif /* ABLMOST_H */

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -35,26 +35,25 @@ void ABLMost::update_fluxes(int lev,
     // New MOSTAverage class
     MOSTAverage ma({&U_old     , &V_old     , &W_old     , &Theta_old },
                    {u_mean[lev], v_mean[lev], w_mean[lev], t_mean[lev], u_mag_mean[lev]},
-                   nullptr, m_geom[lev], 2);
+                   {x_nd_k[lev], y_nd_k[lev], z_nd_k[lev], cc_k[lev]  , cc_k[lev]      },
+                   {zref       , zref       , zref       , zref       , zref           },
+                   nullptr, m_geom[lev], 0, true);
 
     // Compute plane averages for all vars
-    ma.compute_plane_averages(ZDir());
+    ma.compute_averages();
 
     // Write text file of averages
-    //ma.write_most_averages();
-
-    // Interpolate between planar averages and populate the 2D mf
-    for (int i(0); i<5; ++i) ma.line_average_interpolated(zref,0,i);
-
-    /*
+    //ma.write_k_indices();
+    //ma.write_averages();
+    
     // Verify the mf has the same value as computed via PlaneAverage class
     amrex::Print() << "\n";
     amrex::Print() << "CHECKING MOSTAverage class: \n";
-    const auto umf_ptr = ma.get_policy_average(0);
-    const auto vmf_ptr = ma.get_policy_average(1);
-    const auto wmf_ptr = ma.get_policy_average(2);
-    const auto tmf_ptr = ma.get_policy_average(3);
-    const auto smf_ptr = ma.get_policy_average(4);
+    const auto umf_ptr = ma.get_average(0);
+    const auto vmf_ptr = ma.get_average(1);
+    const auto wmf_ptr = ma.get_average(2);
+    const auto tmf_ptr = ma.get_average(3);
+    const auto smf_ptr = ma.get_average(4);
     for (MFIter mfi(*umf_ptr); mfi.isValid(); ++mfi)
     {
         const auto umf_arr = (*umf_ptr)[mfi].array();
@@ -69,7 +68,7 @@ void ABLMost::update_fluxes(int lev,
         amrex::Print() << "S CHECK: " << vmag_mean   << ' ' << smf_arr(0,0,0)  << "\n";
      }
      amrex::Print() << "\n";
-    */
+     //exit(0);
 
      // TODO: utau is now a 2D MF! Figure out the purpose of this iteration...
 

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -11,6 +11,7 @@ void ABLMost::update_fluxes(int lev,
                             int max_iters)
 {
     // THIS BECOMES REDUNDANT WITH THE NEW 2D MFs
+    {
     PlaneAverage Thave(&Theta_old, m_geom[lev], 2);
     PlaneAverage vxave(&U_old, m_geom[lev], 2);
     PlaneAverage vyave(&V_old, m_geom[lev], 2);
@@ -29,48 +30,6 @@ void ABLMost::update_fluxes(int lev,
     VelPlaneAverage vmagave(m_geom[lev]);
     vmagave.compute_hvelmag_averages(U_old,V_old);
     vmag_mean   = vmagave.line_hvelmag_average_interpolated(zref);
-    // END REDUNDANT CODE
-
-
-    // New MOSTAverage class
-    MOSTAverage ma({&U_old     , &V_old     , &W_old     , &Theta_old },
-                   {u_mean[lev], v_mean[lev], w_mean[lev], t_mean[lev], u_mag_mean[lev]},
-                   {x_nd_k[lev], y_nd_k[lev], z_nd_k[lev], cc_k[lev]  , cc_k[lev]      },
-                   {zref       , zref       , zref       , zref       , zref           },
-                   nullptr, m_geom[lev], 0, true);
-
-    // Compute plane averages for all vars
-    ma.compute_averages();
-
-    // Write text file of averages
-    //ma.write_k_indices();
-    //ma.write_averages();
-    
-    // Verify the mf has the same value as computed via PlaneAverage class
-    amrex::Print() << "\n";
-    amrex::Print() << "CHECKING MOSTAverage class: \n";
-    const auto umf_ptr = ma.get_average(0);
-    const auto vmf_ptr = ma.get_average(1);
-    const auto wmf_ptr = ma.get_average(2);
-    const auto tmf_ptr = ma.get_average(3);
-    const auto smf_ptr = ma.get_average(4);
-    for (MFIter mfi(*umf_ptr); mfi.isValid(); ++mfi)
-    {
-        const auto umf_arr = (*umf_ptr)[mfi].array();
-        const auto vmf_arr = (*vmf_ptr)[mfi].array();
-        const auto wmf_arr = (*wmf_ptr)[mfi].array();
-        const auto tmf_arr = (*tmf_ptr)[mfi].array();
-        const auto smf_arr = (*smf_ptr)[mfi].array();
-        amrex::Print() << "U CHECK: " << vel_mean[0] << ' ' << umf_arr(0,0,0)  << "\n";
-        amrex::Print() << "V CHECK: " << vel_mean[1] << ' ' << vmf_arr(0,0,0)  << "\n";
-        amrex::Print() << "W CHECK: " << vel_mean[2] << ' ' << wmf_arr(0,0,0)  << "\n";
-        amrex::Print() << "T CHECK: " << theta_mean  << ' ' << tmf_arr(0,0,0)  << "\n";
-        amrex::Print() << "S CHECK: " << vmag_mean   << ' ' << smf_arr(0,0,0)  << "\n";
-     }
-     amrex::Print() << "\n";
-     //exit(0);
-
-     // TODO: utau is now a 2D MF! Figure out the purpose of this iteration...
 
     constexpr amrex::Real eps = 1.0e-16;
     amrex::Real zeta = 0.0;
@@ -111,7 +70,7 @@ void ABLMost::update_fluxes(int lev,
         ++iter;
     } while ((std::abs(utau_iter - utau) > 1e-5) && iter <= max_iters);
 
-    if (iter >= max_iters) {
+    if (true) { //iter >= max_iters) {
         amrex::Print()
             << "MOData::update_fluxes: Convergence criteria not met after "
             << max_iters << " iterations"
@@ -120,6 +79,167 @@ void ABLMost::update_fluxes(int lev,
             << "\nutau = " << utau << " Tsurf = " << surf_temp
             << " q = " << surf_temp_flux << std::endl;
     }
+    }
+    // END REDUNDANT CODE
+
+    //====================================================================================
+    // New MOSTAverage class
+    MOSTAverage ma({&U_old     , &V_old     , &W_old     , &Theta_old },
+                   {u_mean[lev], v_mean[lev], w_mean[lev], t_mean[lev], u_mag_mean[lev]},
+                   {x_nd_k[lev], y_nd_k[lev], z_nd_k[lev], cc_k[lev]  , cc_k[lev]      },
+                   {zref       , zref       , zref       , zref       , zref           },
+                   nullptr, m_geom[lev], 0, true);
+
+    // Compute plane averages for all vars
+    ma.compute_averages();
+
+    // Write text file of averages
+    //ma.write_k_indices();
+    //ma.write_averages();
+
+    /*
+    // Verify the mf has the same value as computed via PlaneAverage class
+    amrex::Print() << "\n";
+    amrex::Print() << "CHECKING MOSTAverage class: \n";
+    const auto um_ptr = ma.get_average(0);
+    const auto vm_ptr = ma.get_average(1);
+    const auto wm_ptr = ma.get_average(2);
+    const auto tm_ptr = ma.get_average(3);
+    const auto sm_ptr = ma.get_average(4);
+    for (MFIter mfi(*um_ptr); mfi.isValid(); ++mfi)
+    {
+        const auto um_arr = (*um_ptr)[mfi].array();
+        const auto vm_arr = (*vm_ptr)[mfi].array();
+        const auto wm_arr = (*wm_ptr)[mfi].array();
+        const auto tm_arr = (*tm_ptr)[mfi].array();
+        const auto sm_arr = (*sm_ptr)[mfi].array();
+        amrex::Print() << "U CHECK: " << vel_mean[0] << ' ' << um_arr(0,0,0)  << "\n";
+        amrex::Print() << "V CHECK: " << vel_mean[1] << ' ' << vm_arr(0,0,0)  << "\n";
+        amrex::Print() << "W CHECK: " << vel_mean[2] << ' ' << wm_arr(0,0,0)  << "\n";
+        amrex::Print() << "T CHECK: " << theta_mean  << ' ' << tm_arr(0,0,0)  << "\n";
+        amrex::Print() << "S CHECK: " << vmag_mean   << ' ' << sm_arr(0,0,0)  << "\n";
+     }
+     amrex::Print() << "\n";
+    */
+    
+     
+     // Pointers to the computed averages
+     const auto um_ptr  = ma.get_average(0);
+     const auto vm_ptr  = ma.get_average(1);
+     const auto wm_ptr  = ma.get_average(2);
+     const auto tm_ptr  = ma.get_average(3);
+     const auto umm_ptr = ma.get_average(4);
+
+     // Initialize to the adiabatic q=0 case
+     for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+     {
+         amrex::Box bx = mfi.tilebox();
+
+         amrex::Print() << "BX CHK: " << bx << "\n";
+
+         auto t_star_arr = t_star[lev]->array(mfi);
+         auto u_star_arr = u_star[lev]->array(mfi);
+                
+         const auto tm_arr  = tm_ptr->array(mfi);
+         const auto umm_arr = umm_ptr->array(mfi);
+         const auto z0_arr  = z_0[lev].array();
+
+         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+         {
+             t_star_arr(i,j,k) = 0.0;
+             u_star_arr(i,j,k) = kappa * umm_arr(i,j,k) / std::log(zref / z0_arr(i,j,k));
+         });
+     }
+
+     
+     // Specified finite heat flux
+     if ((alg_type == HEAT_FLUX) && (std::abs(surf_temp_flux) > 1.0e-16)) {
+         for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+         {
+             amrex::Box bx = mfi.tilebox();
+
+             auto t_surf_arr = t_surf[lev]->array(mfi);
+             auto t_star_arr = t_star[lev]->array(mfi);
+             auto u_star_arr = u_star[lev]->array(mfi);
+             
+             const auto tm_arr  = tm_ptr->array(mfi);
+             const auto umm_arr = umm_ptr->array(mfi);
+             const auto z0_arr  = z_0[lev].array();
+             
+             ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+             {
+                 int iter = 0;
+                 amrex::Real ustar = 0.0;
+                 amrex::Real tflux = 0.0;
+                 amrex::Real tsurf = 0.0;
+                 amrex::Real zeta  = 0.0;
+                 amrex::Real psi_m = 0.0;
+                 amrex::Real psi_h = 0.0;
+                 do {
+                     ustar = u_star_arr(i,j,k);
+                     tsurf = surf_temp_flux * (std::log(zref / z0_const) - psi_h) /
+                             (ustar * kappa) + tm_arr(i,j,k);
+                     obukhov_len = -ustar * ustar * ustar * tm_arr(i,j,k) /
+                                   (kappa * gravity * surf_temp_flux);
+                     zeta  = zref / obukhov_len;
+                     psi_m = calc_psi_m(zeta);
+                     psi_h = calc_psi_h(zeta);
+                     u_star_arr(i,j,k) = kappa * umm_arr(i,j,k) / (std::log(zref / z0_const) - psi_m);
+                     ++iter;
+                 } while ((std::abs(u_star_arr(i,j,k) - ustar) > 1e-5) && iter <= max_iters);
+
+                 t_surf_arr(i,j,k) = surf_temp_flux * (std::log(zref / z0_const) - psi_h) /
+                                     (u_star_arr(i,j,k) * kappa) + tm_arr(i,j,k);
+                 t_star_arr(i,j,k) = -surf_temp_flux / u_star_arr(i,j,k);
+             });
+         }
+     // Specified surface temperature
+     } else if (alg_type == SURFACE_TEMPERATURE) {
+         for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+         {
+             amrex::Box bx = mfi.tilebox();
+
+             auto t_surf_arr = t_surf[lev]->array(mfi);
+             auto t_star_arr = t_star[lev]->array(mfi);
+             auto u_star_arr = u_star[lev]->array(mfi);
+             
+             const auto tm_arr  = tm_ptr->array(mfi);
+             const auto umm_arr = umm_ptr->array(mfi);
+             const auto z0_arr  = z_0[lev].array();
+             
+             ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+             {
+                 // Nothing to do unless the flux != 0
+                 if (std::abs(t_surf_arr(i,j,k)-tm_arr(i,j,k)) > 1.0e-16) {
+                 
+                 int iter = 0;
+                 amrex::Real ustar = 0.0;
+                 amrex::Real tflux = 0.0;
+                 amrex::Real tsurf = 0.0;
+                 amrex::Real zeta  = 0.0;
+                 amrex::Real psi_m = 0.0;
+                 amrex::Real psi_h = 0.0;
+                 do {
+                     ustar = u_star_arr(i,j,k);
+                     tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * kappa /
+                              (std::log(zref / z0_const) - psi_h);
+                     obukhov_len = -ustar * ustar * ustar * tm_arr(i,j,k) /
+                                   (kappa * gravity * tflux);
+                     zeta  = zref / obukhov_len;
+                     psi_m = calc_psi_m(zeta);
+                     psi_h = calc_psi_h(zeta);
+                     u_star_arr(i,j,k) = kappa * umm_arr(i,j,k) / (std::log(zref / z0_const) - psi_m);
+                     ++iter;
+                 } while ((std::abs(u_star_arr(i,j,k) - ustar) > 1e-5) && iter <= max_iters);
+
+                 t_star_arr(i,j,k) = kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
+                                     (std::log(zref / z0_const) - psi_h);
+                 }
+             });
+         }
+     }
+     amrex::Print() << "CLEARED!" << "\n";
+     //==================================================================================== 
 }
 
 
@@ -143,11 +263,12 @@ ABLMost::impose_most_bcs(const int lev,
         const auto vm_arr  = v_mean[lev]->array(mfi);
         const auto tm_arr  = t_mean[lev]->array(mfi);
         const auto umm_arr = u_mag_mean[lev]->array(mfi);
+        const auto u_star_arr = u_star[lev]->array(mfi);
+        const auto t_star_arr = t_star[lev]->array(mfi);
+        const auto t_surf_arr = t_surf[lev]->array(mfi);
 
         // Define temporaries so we can access these on GPU
         Real d_kappa = kappa;
-        Real d_utau  = utau;
-        Real d_sfcT  = surf_temp;
         Real d_dz    = m_geom[lev].CellSize(2);
 
         // Get height array
@@ -173,7 +294,6 @@ ABLMost::impose_most_bcs(const int lev,
                 int n = Cons::RhoTheta;
                 ParallelFor(b2d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real d_phi_h = d_most.phi_h(z0_arr(i,j,zlo));
                     Real velx, vely, rho, theta, eta;
                     int ix, jx, iy, jy, ie, je, ic, jc;
 
@@ -202,13 +322,17 @@ ABLMost::impose_most_bcs(const int lev,
                     rho   = cons_arr(ic,jc,zlo,Rho_comp);
                     theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
                     eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v);
-                    Real d_thM =  tm_arr(ic,jc,zlo);
-                    Real d_vmM = umm_arr(ic,jc,zlo);
-
+                    
+                    Real d_thM  =  tm_arr(ic,jc,zlo);
+                    Real d_vmM  = umm_arr(ic,jc,zlo);
+                    Real d_utau = u_star_arr(ic,jc,zlo);
+                    Real d_ttau = t_star_arr(ic,jc,zlo);
+                    Real d_sfcT = t_surf_arr(ic,jc,zlo);
+                    
                     Real vmag    = sqrt(velx*velx+vely*vely);
                     Real num1    = (theta-d_thM)*d_vmM;
                     Real num2    = (d_thM-d_sfcT)*vmag;
-                    Real moflux  = (num1+num2)*d_utau*d_kappa/(d_phi_h*d_vmM);
+                    Real moflux  = d_ttau*d_utau*(num1+num2)/((d_thM-d_sfcT)*d_vmM);
                     Real deltaz  = d_dz * (zlo - k);
 
                     if (!var_is_derived) {
@@ -251,8 +375,12 @@ ABLMost::impose_most_bcs(const int lev,
                                    cons_arr(ic  ,jc,zlo,Rho_comp));
                     eta   = 0.5 *( eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)+
                                    eta_arr(ie  ,je,zlo,EddyDiff::Mom_v));
-                    Real d_vxM = um_arr(i,j,zlo);
-                    Real d_vmM = 0.5 *( umm_arr(ic-1,jc,zlo) + umm_arr(ic,jc,zlo) );
+
+                    
+                    amrex::Print() << "LP: " << amrex::IntVect(ic,jc,zlo) << "\n";
+                    Real d_vxM  = um_arr(i,j,zlo);
+                    Real d_vmM  = 0.5 * ( umm_arr(ic-1,jc,zlo) + umm_arr(ic,jc,zlo) );
+                    Real d_utau = 0.5 * ( u_star_arr(ic-1,jc,zlo) + u_star_arr(ic,jc,zlo) );
 
                     Real vmag    = sqrt(velx*velx+vely*vely);
                     Real stressx = ( (velx-d_vxM)*d_vmM + vmag*d_vxM )/
@@ -299,8 +427,10 @@ ABLMost::impose_most_bcs(const int lev,
                                  cons_arr(ic,jc  ,zlo,Rho_comp));
                     eta   = 0.5*(eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)+
                                  eta_arr(ie,je  ,zlo,EddyDiff::Mom_v));
-                    Real d_vyM = vm_arr(i,j,zlo);
-                    Real d_vmM = 0.5 *( umm_arr(ic,jc-1,zlo) + umm_arr(ic,jc,zlo) );
+                    
+                    Real d_vyM  = vm_arr(i,j,zlo);
+                    Real d_vmM  = 0.5 * ( umm_arr(ic,jc-1,zlo) + umm_arr(ic,jc,zlo) );
+                    Real d_utau = 0.5 * ( u_star_arr(ic,jc-1,zlo) + u_star_arr(ic,jc,zlo) );
 
                     Real vmag    = sqrt(velx*velx+vely*vely);
                     Real stressy = ( (vely-d_vyM)*d_vmM + vmag*d_vyM ) /

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -11,7 +11,7 @@ public:
     explicit MOSTAverage(amrex::Vector<const amrex::MultiFab*> fields,
                          amrex::Vector<amrex::MultiFab*> averages,
                          amrex::Vector<amrex::iMultiFab*> k_indx,
-                         amrex::Vector<amrex::Real> z_ref, 
+                         amrex::Vector<amrex::Real> z_ref,
                          const amrex::MultiFab* z_nd,
                          const amrex::Geometry geom,
                          int policy,
@@ -46,10 +46,10 @@ public:
 
     // Write k indices for each average
     void write_k_indices();
-    
+
     // Write averages on 2D mf
     void write_averages();
-        
+
 protected:
     amrex::Real m_dz;  // Mesh spacing in axis direction
     amrex::Real m_zlo; // Bottom of domain in axis direction

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -4,27 +4,29 @@
 #include <AMReX_Gpu.H>
 #include <AMReX_FArrayBox.H>
 #include <AMReX_MultiFab.H>
-#include <DirectionSelector.H>
+#include <AMReX_iMultiFab.H>
 
 class MOSTAverage {
 public:
     explicit MOSTAverage(amrex::Vector<const amrex::MultiFab*> fields,
                          amrex::Vector<amrex::MultiFab*> averages,
+                         amrex::Vector<amrex::iMultiFab*> k_indx,
+                         amrex::Vector<amrex::Real> z_ref, 
                          const amrex::MultiFab* z_nd,
                          const amrex::Geometry geom,
-                         int axis);
+                         int policy,
+                         bool update_k);
      MOSTAverage() = default;
     ~MOSTAverage() = default;
 
-    // Evaluate line average at specific location for any average component
-    void line_average_interpolated(amrex::Real x, int icomp, int imf) const;
+    // Populate a 2D iMF with the k indices for averaging
+    void compute_plane_k_indices();
 
-    // Set local vector to m_line_average
-    void line_average(int icomp, int imf, amrex::Vector<amrex::Real>& l_vec);
+    // Driver for the different average policies
+    void compute_averages();
 
-    // Fill line storage with averages
-    template <typename IndexSelector>
-    void compute_plane_averages(const IndexSelector& idxOp);
+    // Fill plane storage with averages
+    void compute_plane_averages();
 
     // Get number of components for a mf in m_fields
     int ncomp()      const  { return m_ncomps[0]; }
@@ -35,187 +37,36 @@ public:
     const amrex::MultiFab* get_field(int i) const { return m_fields[i]; }
 
     // Get pointer to the 2D mf of averages
-    const amrex::MultiFab* get_policy_average()      const { return m_averages[0]; };
-    const amrex::MultiFab* get_policy_average(int i) const { return m_averages[i]; };
+    const amrex::MultiFab* get_average()      const { return m_averages[0]; };
+    const amrex::MultiFab* get_average(int i) const { return m_averages[i]; };
 
     // Get plane averages long dir()
-    const amrex::Vector<amrex::Real>& get_line_average()      const { return m_line_average[0]; }
-    const amrex::Vector<amrex::Real>& get_line_average(int i) const { return m_line_average[i]; }
+    const amrex::Vector<amrex::Real>& get_plane_average()      const { return m_plane_average[0]; }
+    const amrex::Vector<amrex::Real>& get_plane_average(int i) const { return m_plane_average[i]; }
 
-    // Set precision of text file output
-    void set_precision(int p) { m_precision = p; }
-
-    // Write text file with m_line_averages
-    void write_most_averages();
-
-    // Get geometry values
-    amrex::Real dx()  const { return m_dx; }
-    amrex::Real xlo() const { return m_xlo; }
-    int axis()        const { return m_axis; }
-    int level()       const { return m_level; }
-    int ncell_plane(int i) const { return m_ncell_plane[i]; }
-    int ncell_line()  const { return m_ncell_line; }
-
+    // Write k indices for each average
+    void write_k_indices();
+    
+    // Write averages on 2D mf
+    void write_averages();
+        
 protected:
+    amrex::Real m_dz;  // Mesh spacing in axis direction
+    amrex::Real m_zlo; // Bottom of domain in axis direction
 
-    int m_ncell_line;  // Number of cells along line
+    amrex::Vector<int> m_ncomps;      // Number of components (mf)
+    amrex::Vector<int> m_ncell_plane; // Number of cells in plane (mf)
 
-    amrex::Real m_dx;  // Mesh spacing in axis direction
-    amrex::Real m_xlo; // Bottom of domain in axis direction
-
-    int m_precision   = 4; // Precision for line plot text file
-    const int m_level = 0; // Level for plane averaging for now fixed at level=0
-
-    amrex::Vector<int> m_ncell_plane; // Number of cells in plane
-
-    amrex::Vector<int> m_ncomps; // Number of components
-
-    amrex::Vector<amrex::Vector<amrex::Real>> m_line_average; // Planar average along dir()
+    amrex::Vector<amrex::Vector<amrex::Real>> m_plane_average; // Plane avgs (mf,2)
 
     amrex::Vector<const amrex::MultiFab*> m_fields;  // Ptr to fields to be averaged
     amrex::Vector<amrex::MultiFab*> m_averages;      // Ptr to 2D mf to hold averages
+    amrex::Vector<amrex::iMultiFab*> m_k_indx;       // Ptr to 2D imf to hold k indices
+    amrex::Vector<amrex::Real> m_z_ref;              // Vector of reals for height above MOST BC
+    amrex::Vector<amrex::Real> c_interp;             // Interpolation factors
     const amrex::MultiFab* m_z_nd;                   // Ptr to terrain heigh coords
     amrex::Geometry m_geom;                          // Geometry
-    const int m_axis;                                // Averaging axis
+    const int m_policy;                              // Policy for averaging
+    bool m_update_k;                                 // Flag to update 2D imf with k indices
 };
-
-// Evaluate line average at specific location for any average component
-AMREX_FORCE_INLINE
-void
-MOSTAverage::line_average_interpolated(amrex::Real x, int icomp, int imf) const
-{
-    int ncomp = m_ncomps[imf];
-    AMREX_ALWAYS_ASSERT(icomp >= 0 && icomp < ncomp);
-
-    amrex::Real c = 0.0;
-    int ind = 0;
-
-    if (x > m_xlo + 0.5 * m_dx) {
-        ind = static_cast<int>(floor((x - m_xlo) / m_dx - 0.5));
-        const amrex::Real x1 = m_xlo + (ind + 0.5) * m_dx;
-        c = (x - x1) / m_dx;
-    }
-
-    if (ind + 1 >= m_ncell_line) {
-        ind = m_ncell_line - 2;
-        c = 1.0;
-    }
-
-    AMREX_ALWAYS_ASSERT(ind >= 0 && ind + 1 < m_ncell_line);
-
-    // Interpolated value between planar averages
-    amrex::Real avg = m_line_average[imf][ncomp * ind       + icomp] * (1.0 - c) +
-                      m_line_average[imf][ncomp * (ind + 1) + icomp] * c;
-
-    // Set the 2D multifab to a constant value
-    m_averages[imf]->setVal(avg);
-}
-
-// Set local vector to m_line_average
-AMREX_FORCE_INLINE
-void
-MOSTAverage::line_average(int icomp, int imf, amrex::Vector<amrex::Real>& l_vec)
-{
-    int ncomp = m_ncomps[imf];
-    AMREX_ALWAYS_ASSERT(icomp >= 0 && icomp < ncomp);
-
-    for (int i = 0; i < m_ncell_line; i++)
-        l_vec[i] = m_line_average[imf][ncomp * i + icomp];
-}
-
-// Fill line storage with averages
-template <typename IndexSelector>
-void
-MOSTAverage::compute_plane_averages(const IndexSelector& idxOp)
-{
-    // Averages over all the fields
-    //----------------------------------------------------------
-    for (int imf(0); imf<m_fields.size(); ++imf) {
-        const int ncomp = m_ncomps[imf];
-        const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[imf];
-
-        amrex::AsyncArray<amrex::Real> lavg(m_line_average[imf].data(), m_line_average[imf].size());
-        amrex::Real* line_avg = lavg.data();
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box bx  = mfi.tilebox();
-            amrex::Box pbx = PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
-
-            auto mf_arr = m_fields[imf]->const_array(mfi);
-
-            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
-            AMREX_GPU_DEVICE(int p_i, int p_j, int p_k, amrex::Gpu::Handler const& handler) noexcept
-            {
-                // Loop over the direction perpendicular to the plane.
-                // This reduces the atomic pressure on the destination arrays.
-                amrex::Box lbx = ParallelBox<IndexSelector>(bx, amrex::IntVect{p_i, p_j, p_k});
-
-                for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
-                    for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
-                        for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i) {
-                            int ind = idxOp.getIndx(i, j, k);
-                            for (int n = 0; n < ncomp; ++n) {
-                                amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],
-                                                            mf_arr(i, j, k, n) * denom, handler);
-                            }
-                        }
-                    }
-                }
-            });
-        }
-
-        lavg.copyToHost(m_line_average[imf].data(), m_line_average[imf].size());
-        amrex::ParallelDescriptor::ReduceRealSum(m_line_average[imf].data(), m_line_average[imf].size());
-    }
-
-    // Averages for the tangential velocity magnitude
-    //----------------------------------------------------------
-    int imf  = 0;
-    int iavg = m_fields.size();
-    const int ncomp = m_ncomps[iavg];
-    const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[iavg];
-
-    amrex::AsyncArray<amrex::Real> lavg(m_line_average[iavg].data(), m_line_average[iavg].size());
-    amrex::Real* line_avg = lavg.data();
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-    for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        amrex::Box bx  = amrex::enclosedCells(mfi.tilebox());
-        amrex::Box pbx = PerpendicularBox<IndexSelector>(bx, amrex::IntVect{0, 0, 0});
-
-        auto u_mf_arr = m_fields[imf]->const_array(mfi);
-        auto v_mf_arr = m_fields[imf+1]->const_array(mfi);
-
-        ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
-        AMREX_GPU_DEVICE(int p_i, int p_j, int p_k, amrex::Gpu::Handler const& handler) noexcept
-        {
-            // Loop over the direction perpendicular to the plane.
-            // This reduces the atomic pressure on the destination arrays.
-            amrex::Box lbx = ParallelBox<IndexSelector>(bx, amrex::IntVect{p_i, p_j, p_k});
-
-            for (int k = lbx.smallEnd(2); k <= lbx.bigEnd(2); ++k) {
-                for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
-                    for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i) {
-                        int ind = idxOp.getIndx(i, j, k);
-                        for (int n = 0; n < ncomp; ++n) {
-                            const amrex::Real u_val = 0.5 * (u_mf_arr(i,j,k) + u_mf_arr(i+1,j  ,k));
-                            const amrex::Real v_val = 0.5 * (v_mf_arr(i,j,k) + v_mf_arr(i  ,j+1,k));
-                            const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
-                            amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],
-                                                        mag * denom, handler);
-                        }
-                    }
-                }
-            }
-        });
-    }
-
-    lavg.copyToHost(m_line_average[iavg].data(), m_line_average[iavg].size());
-    amrex::ParallelDescriptor::ReduceRealSum(m_line_average[iavg].data(), m_line_average[iavg].size());
-}
 #endif

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -74,20 +74,20 @@ MOSTAverage::MOSTAverage (amrex::Vector<const amrex::MultiFab*> fields,
 void
 MOSTAverage::compute_plane_k_indices()
 {
-    for (int i(0); i<m_averages.size(); ++i) {
-        int z = m_z_ref[i];
+    for (int iavg(0); iavg<m_averages.size(); ++iavg) {
+        int z = m_z_ref[iavg];
         AMREX_ALWAYS_ASSERT(z >= m_zlo + 0.5 * m_dz);
         
         int k_lo = static_cast<int>(floor((z - m_zlo) / m_dz - 0.5));
         int k_hi = k_lo + 1;        
         const amrex::Real z_lo = m_zlo + (k_lo + 0.5) * m_dz;
-        c_interp[i] = (z - z_lo) / m_dz;
+        c_interp[iavg] = (z - z_lo) / m_dz;
 
-        const amrex::IntVect& ng = m_k_indx[i]->nGrowVect();
+        const amrex::IntVect& ng = m_k_indx[iavg]->nGrowVect();
         
-        for (amrex::MFIter mfi(*m_k_indx[i], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        for (amrex::MFIter mfi(*m_k_indx[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             amrex::Box gbx = mfi.growntilebox({ng[0], ng[1], 0});
-            auto k_arr     = m_k_indx[i]->array(mfi);
+            auto k_arr     = m_k_indx[iavg]->array(mfi);
 
             ParallelFor(gbx,gbx,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -3,37 +3,38 @@
 // Constructor
 MOSTAverage::MOSTAverage (amrex::Vector<const amrex::MultiFab*> fields,
                           amrex::Vector<amrex::MultiFab*> averages,
+                          amrex::Vector<amrex::iMultiFab*> k_indx,
+                          amrex::Vector<amrex::Real> z_ref,
                           const amrex::MultiFab* z_nd,
                           amrex::Geometry geom,
-                          int axis)
-    : m_fields(fields), m_averages(averages), m_z_nd(z_nd), m_geom(geom), m_axis(axis)
+                          int policy,
+                          bool update_k)
+    : m_fields(fields), m_averages(averages), m_k_indx(k_indx), m_z_ref(z_ref)  ,
+      m_z_nd(z_nd)    , m_geom(geom)        , m_policy(policy), m_update_k(update_k)
 {
-    AMREX_ALWAYS_ASSERT(m_axis >= 0 && m_axis < AMREX_SPACEDIM);
     AMREX_ALWAYS_ASSERT(fields.size() >= 2);
 
     // Domain bottom and cell-size
-    m_xlo   = m_geom.ProbLo  (m_axis);
-    m_dx    = m_geom.CellSize(m_axis);
+    m_zlo = m_geom.ProbLo  (2);
+    m_dz  = m_geom.CellSize(2);
 
-    // Cells per line
+    // Num components, line avg, cells per plane
     amrex::Box domain = m_geom.Domain();
     amrex::IntVect dom_lo(domain.loVect());
     amrex::IntVect dom_hi(domain.hiVect());
-    m_ncell_line = dom_hi[m_axis] - dom_lo[m_axis] + 1;
-
-    // Num components, line avg, cells per plane
     int asize = m_averages.size();
     m_ncomps.resize( asize );
-    m_line_average.resize( asize );
+    m_plane_average.resize( asize );
     m_ncell_plane.resize( asize );
+    c_interp.resize( asize );
     for (int i(0); i<asize; ++i) {
         m_ncomps[i] = m_averages[i]->nComp();
-        m_line_average[i].resize(static_cast<size_t>(m_ncell_line) * m_ncomps[i], 0.0);
+        m_plane_average[i].resize(2,0.0);
 
         m_ncell_plane[i] = 1;
         amrex::IndexType ixt = m_averages[i]->boxArray().ixType();
         for (int j = 0; j < AMREX_SPACEDIM; ++j) {
-            if (j != m_axis) {
+            if (j != 2) {
                 if (ixt.nodeCentered(j)) {
                     m_ncell_plane[i] *= (dom_hi[j] - dom_lo[j] + 2);
                 } else {
@@ -42,25 +43,232 @@ MOSTAverage::MOSTAverage (amrex::Vector<const amrex::MultiFab*> fields,
             }
         }
     }
-}
 
-// Write data
-void
-MOSTAverage::write_most_averages()
-{
-    int nmf = m_fields.size();
-    std::ofstream ofile;
-    ofile.open ("MOSTAverages.txt");
-    ofile << "Averages compute via the MOSTAverages class:\n";
-    for (int k(0); k<m_ncell_line; ++k) {
-        ofile << "Index: " << k << ' ';
-        for (int imf(0); imf<=nmf; ++imf) {
-            int ncomp = m_ncomps[imf];
-            for (int n(0); n<ncomp; ++n) {
-                ofile << m_line_average[imf][ncomp * k + n] << ' ';
+    // Compute the k values for averaging (better policy implementation)
+    switch(m_policy) {
+    case 0: // Standard plane average
+        if (m_update_k) {
+            compute_plane_k_indices();
+        } else {
+            for (int i(0); i<m_averages.size(); ++i) {
+                int z = m_z_ref[i];
+                int k_lo = static_cast<int>(floor((z - m_zlo) / m_dz - 0.5));        
+                const amrex::Real z_lo = m_zlo + (k_lo + 0.5) * m_dz;
+                c_interp[i] = (z - z_lo) / m_dz;
             }
         }
-        ofile << "\n";
+        break;
+        
+    case 1: // Fixed height above the terrain surface
+        break;
+        
+    case 2: // Along a normal vector
+        break;
+        
+    default:
+        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+    }
+}
+
+// Populate a 2D iMF with the k indices for averaging
+void
+MOSTAverage::compute_plane_k_indices()
+{
+    for (int i(0); i<m_averages.size(); ++i) {
+        int z = m_z_ref[i];
+        AMREX_ALWAYS_ASSERT(z >= m_zlo + 0.5 * m_dz);
+        
+        int k_lo = static_cast<int>(floor((z - m_zlo) / m_dz - 0.5));
+        int k_hi = k_lo + 1;        
+        const amrex::Real z_lo = m_zlo + (k_lo + 0.5) * m_dz;
+        c_interp[i] = (z - z_lo) / m_dz;
+
+        const amrex::IntVect& ng = m_k_indx[i]->nGrowVect();
+        
+        for (amrex::MFIter mfi(*m_k_indx[i], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box gbx = mfi.growntilebox({ng[0], ng[1], 0});
+            auto k_arr     = m_k_indx[i]->array(mfi);
+
+            ParallelFor(gbx,gbx,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                k_arr(i,j,k,0) = k_lo;
+            },
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {           
+                k_arr(i,j,k,1) = k_hi;
+            });
+       }
+    }
+}
+
+// Driver to call appropriate average member function
+void
+MOSTAverage::compute_averages()
+{
+    switch(m_policy) {
+    case 0: // Standard plane average
+        compute_plane_averages();
+        break;
+        
+    case 1: // Fixed height above the terrain surface
+        break;
+        
+    case 2: // Along a normal vector
+        break;
+        
+    default:
+        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+    }
+}
+
+// Fill plane storage with averages
+void
+MOSTAverage::compute_plane_averages()
+{
+    // Averages over all the fields
+    //----------------------------------------------------------
+    for (int imf(0); imf<m_fields.size(); ++imf) {
+        const int ncomp = m_ncomps[imf];
+        const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[imf];
+
+        amrex::AsyncArray<amrex::Real> pavg(m_plane_average[imf].data(), m_plane_average[imf].size());
+        amrex::Real* plane_avg = pavg.data();
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box bx  = mfi.tilebox();
+            amrex::Box pbx = bx; pbx.setSmall(2,0); pbx.setBig(2,1);
+
+            auto mf_arr = m_fields[imf]->const_array(mfi);
+            auto k_arr  = m_k_indx[imf]->const_array(mfi);
+            
+            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
+            AMREX_GPU_DEVICE(int i, int j, int n, amrex::Gpu::Handler const& handler) noexcept
+            {
+                int k = k_arr(i,j,0,n);
+                amrex::Gpu::deviceReduceSum(&plane_avg[n],mf_arr(i, j, k) * denom, handler);
+            });
+        }
+
+        pavg.copyToHost(m_plane_average[imf].data(), m_plane_average[imf].size());
+        amrex::ParallelDescriptor::ReduceRealSum(m_plane_average[imf].data(), m_plane_average[imf].size());
+
+        // No spatial variation with plane averages
+        amrex::Real c_val = c_interp[imf];
+        amrex::Real a_val = m_plane_average[imf][0]*(1.0 - c_val) + m_plane_average[imf][1]*c_val; 
+        m_averages[imf]->setVal(a_val);
+    }
+
+    // Averages for the tangential velocity magnitude
+    //----------------------------------------------------------
+    int imf  = 0;
+    int iavg = m_fields.size();
+    const int ncomp = m_ncomps[iavg];
+    const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[iavg];
+
+    amrex::AsyncArray<amrex::Real> pavg(m_plane_average[iavg].data(), m_plane_average[iavg].size());
+    amrex::Real* plane_avg = pavg.data();
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        amrex::Box bx  = amrex::enclosedCells(mfi.tilebox());
+        amrex::Box pbx = bx; pbx.setSmall(2,0); pbx.setBig(2,1);
+
+        auto u_mf_arr = m_fields[imf]->const_array(mfi);
+        auto v_mf_arr = m_fields[imf+1]->const_array(mfi);
+
+        auto k_u_arr  = m_k_indx[imf]->const_array(mfi);
+        auto k_v_arr  = m_k_indx[imf+1]->const_array(mfi);
+        
+        ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
+        AMREX_GPU_DEVICE(int i, int j, int n, amrex::Gpu::Handler const& handler) noexcept
+        {
+            int k_u = k_u_arr(i,j,0,n);
+            int k_v = k_v_arr(i,j,0,n);
+            
+            const amrex::Real u_val = 0.5 * (u_mf_arr(i,j,k_u) + u_mf_arr(i+1,j  ,k_u));
+            const amrex::Real v_val = 0.5 * (v_mf_arr(i,j,k_v) + v_mf_arr(i  ,j+1,k_v));
+            const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
+            amrex::Gpu::deviceReduceSum(&plane_avg[n],mag * denom, handler);
+        });
+    }
+
+    pavg.copyToHost(m_plane_average[iavg].data(), m_plane_average[iavg].size());
+    amrex::ParallelDescriptor::ReduceRealSum(m_plane_average[iavg].data(), m_plane_average[iavg].size());
+
+    // No spatial variation with plane averages
+    amrex::Real c_val = c_interp[iavg];
+    amrex::Real a_val = m_plane_average[iavg][0]*(1.0 - c_val) + m_plane_average[iavg][1]*c_val; 
+    m_averages[iavg]->setVal(a_val);
+}
+
+// Write k indices
+void
+MOSTAverage::write_k_indices()
+{
+    // Last component u_mag_mean is cc
+    int navg = m_averages.size() - 1;
+    
+    std::ofstream ofile;
+    ofile.open ("MOST_K_indices.txt");
+    ofile << "K indices used to compute averages via MOSTAverages class:\n";
+
+    for (amrex::MFIter mfi(*m_averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
+        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
+        
+        for (int j(jl); j<=ju; ++j) {
+            for (int i(il); i<=iu; ++i) {
+                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
+                int k = 0;
+                for (int iavg(0); iavg<=navg; ++iavg) {
+                    auto k_arr = m_k_indx[iavg]->array(mfi);
+                    ofile << "iavg K_lo K_hi c_interp: "
+                          << iavg << ' '
+                          << k_arr(i,j,k,0) << ' ' 
+                          << k_arr(i,j,k,1) << ' '
+                          << c_interp[iavg] << "\n";
+                }
+                ofile << "\n";
+            }
+        }
+    }
+    ofile.close();
+}
+
+// Write averages
+void
+MOSTAverage::write_averages()
+{
+    // Last component u_mag_mean is cc
+    int navg = m_averages.size() - 1;
+    
+    std::ofstream ofile;
+    ofile.open ("MOST_averages.txt");
+    ofile << "Averages computed via MOSTAverages class:\n";
+
+    for (amrex::MFIter mfi(*m_averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
+        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
+        
+        for (int j(jl); j<=ju; ++j) {
+            for (int i(il); i<=iu; ++i) {
+                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
+                int k = 0;
+                for (int iavg(0); iavg<=navg; ++iavg) {
+                    auto mf_arr = m_averages[iavg]->array(mfi);
+                    ofile << "iavg val: "
+                          << iavg << ' '
+                          << mf_arr(i,j,k) << "\n";
+                }
+                ofile << "\n";
+            }
+        }
     }
     ofile.close();
 }

--- a/Source/ERF_Constants.H
+++ b/Source/ERF_Constants.H
@@ -4,6 +4,7 @@
 #include <AMReX_REAL.H>
 
 constexpr amrex::Real PI = 3.14159265358979323846264338327950288;
+constexpr amrex::Real PIoTwo = PI/2.0;
 
 //TODO: Change these types of macros to 'const'
 #define R_d      287.0   // gas constant for dry air [J/(kg-K)]


### PR DESCRIPTION
1. This fixes the defaulting of MOST to adiabatic with zero flux.

2. If users specify a surface temperature, MOST BC uses that T_surf. If users specify a surface flux, MOST BC imposes that flux. If nothing is specified, MOST BC defaults to adiabatic.

3. This passed a verification test for U & Theta.

4. This runs with just the new data structures and MOSTAverage class. Interface with MA class needs work though.