### PR TITLE
Port MA class

### DIFF
--- a/Exec/ABL/inputs_most_test
+++ b/Exec/ABL/inputs_most_test
@@ -1,0 +1,74 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 200
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_extent =  256   256   256
+amr.n_cell           =   16    16    16
+
+geometry.is_periodic = 1 1 0
+
+zhi.type = "SlipWall"
+
+# MOST BOUNDARY (DEFAULT IS ADIABATIC FOR THETA)
+zlo.type                 = "Most"
+erf.most.average_policy  = 0       # POLICY FOR AVERAGING
+erf.most.z0              = 4.0
+erf.most.zref            = 8.0
+#erf.most.surf_temp       = 301.0   # SPECIFIED SURFACE TEMP
+#erf.most.surf_temp_flux  = 8.14165 # SPECIFIED SURFACE FLUX
+#erf.most.k_indx          = 0       # SPECIFIED K INDEX
+#erf.most.radius          = 0       # SPECIFIED REGION RADIUS
+#erf.most.time_average    = true    # USE TIME AVERAGING
+#erf.most.time_window     = 50.0    # WINDOW FOR TIME AVG
+
+
+
+# TIME STEP CONTROL
+erf.fixed_dt           = 0.2  # fixed time step depending on grid resolution
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt       # prefix of plotfile name
+erf.plot_int_1      = 10        # number of timesteps between plotfiles
+erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta
+
+# SOLVER CHOICE
+erf.alpha_T = 0.0
+erf.alpha_C = 1.0
+erf.use_gravity = false
+
+erf.les_type = "Smagorinsky"
+#erf.pbl_type = "MYNN2.5"
+erf.Cs       = 0.1
+
+erf.spatial_order = 2
+
+# PROBLEM PARAMETERS
+prob.rho_0 = 1.0
+prob.A_0   = 1.0
+prob.T_0   = 300.0
+
+prob.U_0 = 10.0
+prob.V_0 = 0.0
+prob.W_0 = 0.0
+
+# Higher values of perturbations lead to instability
+# Instability seems to be coming from BC
+prob.U_0_Pert_Mag = 0.0
+prob.V_0_Pert_Mag = 0.0
+prob.W_0_Pert_Mag = 0.0

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -9,6 +9,7 @@
 
 #include <IndexDefines.H>
 #include <ERF_Constants.H>
+#include <MOSTAverage.H>
 
 /** Monin-Obukhov surface layer profile
  *
@@ -79,7 +80,10 @@ public:
 
     // Constructor
     explicit ABLMost(const amrex::Vector<amrex::Geometry>& geom,
-                     const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_new) : m_geom(geom)
+                     const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
+      : m_geom(geom), m_ma(zref,geom,vars_old,Theta_prim,z_phys_nd)
     {
         amrex::ParmParse pp("erf");
         pp.query("most.zref"     , zref);
@@ -95,22 +99,10 @@ public:
         }
 
         int nlevs = m_geom.size();
-
         z_0.resize(nlevs);
-
-        u_mean.resize(nlevs);
-        v_mean.resize(nlevs);
-        w_mean.resize(nlevs);
-        t_mean.resize(nlevs);
-        u_mag_mean.resize(nlevs);
         u_star.resize(nlevs);
         t_star.resize(nlevs);
         t_surf.resize(nlevs);
-
-        x_nd_k.resize(nlevs);
-        y_nd_k.resize(nlevs);
-        z_nd_k.resize(nlevs);
-        cc_k.resize(nlevs);
 
         for (int lev = 0; lev < nlevs; lev++)
         {
@@ -123,64 +115,10 @@ public:
             z_0[lev].resize(bx,1);
             z_0[lev].setVal<amrex::RunOn::Device>(z0_const);
 
-            // 2D MFs for averages
+            // 2D MFs for U*, T*, T_surf
             //--------------------------------------------------------
-            { // Nodal in x
-                auto& mf = vars_new[lev][Vars::xvel];
-                // Create a 2D ba, dm, & ghost cells
-                amrex::BoxArray ba  = mf.boxArray();
-                amrex::BoxList bl2d = ba.boxList();
-                for (auto& b : bl2d) {
-                    b.setRange(2,0);
-                }
-                amrex::BoxArray ba2d(std::move(bl2d));
-                const amrex::DistributionMapping& dm = mf.DistributionMap();
-                const int ncomp   = 1;
-                const int incomp  = 1;
-                amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
-
-                u_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
-                u_mean[lev]->setVal(1.E34);
-                x_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
-            }
-            { // Nodal in y
-                auto& mf = vars_new[lev][Vars::yvel];
-                // Create a 2D ba, dm, & ghost cells
-                amrex::BoxArray ba  = mf.boxArray();
-                amrex::BoxList bl2d = ba.boxList();
-                for (auto& b : bl2d) {
-                    b.setRange(2,0);
-                }
-                amrex::BoxArray ba2d(std::move(bl2d));
-                const amrex::DistributionMapping& dm = mf.DistributionMap();
-                const int ncomp   = 1;
-                const int incomp  = 1;
-                amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
-
-                v_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
-                v_mean[lev]->setVal(1.E34);
-                y_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
-            }
-            { // Nodal in z
-                auto& mf = vars_new[lev][Vars::zvel];
-                // Create a 2D ba, dm, & ghost cells
-                amrex::BoxArray ba  = mf.boxArray();
-                amrex::BoxList bl2d = ba.boxList();
-                for (auto& b : bl2d) {
-                    b.setRange(2,0);
-                }
-                amrex::BoxArray ba2d(std::move(bl2d));
-                const amrex::DistributionMapping& dm = mf.DistributionMap();
-                const int ncomp   = 1;
-                const int incomp  = 1;
-                amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
-
-                w_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
-                w_mean[lev]->setVal(1.E34);
-                z_nd_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
-            }
             { // CC vars
-                auto& mf = vars_new[lev][Vars::cons];
+                auto& mf = vars_old[lev][Vars::cons];
                 // Create a 2D ba, dm, & ghost cells
                 amrex::BoxArray ba  = mf.boxArray();
                 amrex::BoxList bl2d = ba.boxList();
@@ -190,14 +128,7 @@ public:
                 amrex::BoxArray ba2d(std::move(bl2d));
                 const amrex::DistributionMapping& dm = mf.DistributionMap();
                 const int ncomp   = 1;
-                const int incomp  = 1;
                 amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
-
-                t_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
-                t_mean[lev]->setVal(1.E34);
-
-                u_mag_mean[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
-                u_mag_mean[lev]->setVal(1.E34);
 
                 u_star[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
                 u_star[lev]->setVal(1.E34);
@@ -211,11 +142,8 @@ public:
                 } else {
                     t_surf[lev]->setVal(0.0);
                 }
-
-                cc_k[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
             }
-
-        }
+        }// lev
     }
 
     // Destructor
@@ -223,19 +151,9 @@ public:
     {
         for (int lev(0); lev<m_geom.size(); ++lev)
         {
-            delete u_mean[lev];
-            delete v_mean[lev];
-            delete w_mean[lev];
-            delete t_mean[lev];
-            delete u_mag_mean[lev];
-            delete u_star[lev];
-            delete t_star[lev];
-            delete t_surf[lev];
-
-            delete x_nd_k[lev];
-            delete y_nd_k[lev];
-            delete z_nd_k[lev];
-            delete cc_k[lev];
+          delete u_star[lev];
+          delete t_star[lev];
+          delete t_surf[lev];
         }
     };
 
@@ -251,10 +169,7 @@ public:
                     amrex::MultiFab* eddyDiffs);
 
     void
-    update_fluxes(int lev,
-                  amrex::MultiFab& S_new, amrex::MultiFab& U_new,
-                  amrex::MultiFab& V_new, amrex::MultiFab& W_new,
-                  int max_iters = 25);
+    update_fluxes(int lev, int max_iters = 25);
 
     enum ThetaCalcType {
         HEAT_FLUX = 0,      ///< Heat-flux specified
@@ -279,22 +194,14 @@ public:
 
     private:
 
-        amrex::Vector<amrex::Geometry> m_geom;
+
+        amrex::Vector<amrex::Geometry>  m_geom;
         amrex::Vector<amrex::FArrayBox> z_0;
 
-        amrex::Vector<amrex::MultiFab*> u_mean;
-        amrex::Vector<amrex::MultiFab*> v_mean;
-        amrex::Vector<amrex::MultiFab*> w_mean;
-        amrex::Vector<amrex::MultiFab*> t_mean;
-        amrex::Vector<amrex::MultiFab*> u_mag_mean;
+        MOSTAverage m_ma;
         amrex::Vector<amrex::MultiFab*> u_star;
         amrex::Vector<amrex::MultiFab*> t_star;
         amrex::Vector<amrex::MultiFab*> t_surf;
-
-        amrex::Vector<amrex::iMultiFab*> x_nd_k;
-        amrex::Vector<amrex::iMultiFab*> y_nd_k;
-        amrex::Vector<amrex::iMultiFab*> z_nd_k;
-        amrex::Vector<amrex::iMultiFab*> cc_k;
 };
 
 #endif /* ABLMOST_H */

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -33,19 +33,8 @@ public:
     amrex::Real gravity{CONST_GRAV}; ///< Acceleration due to gravity (m/s^2)
     amrex::Real surf_temp_flux{0.0}; ///< Heat flux
     amrex::Real surf_temp;           ///< Surface temperature
-
-    // Linked to the PBL scheme & Redundant
-    //========================================================
-    amrex::Real obukhov_len{1.0e16}; ///< Non-dimensional Obukhov length
-    amrex::Real theta_mean;          ///< Mean potential temperature
-
-    amrex::Real vel_mean[AMREX_SPACEDIM]; ///< Mean velocity (at zref)
-    amrex::Real vmag_mean;                ///< Mean wind speed (at zref)
-    amrex::Real utau;                     ///< Friction velocity (m/s)
-    //========================================================
-
-    amrex::Real beta_m{5.0}; // Constants from Dyer, BLM, 1974
-    amrex::Real beta_h{5.0}; // https://doi.org/10.1007/BF00240838
+    amrex::Real beta_m{5.0};         ///< Constants from Dyer, BLM, 1974
+    amrex::Real beta_h{5.0};         ///< https://doi.org/10.1007/BF00240838
     amrex::Real gamma_m{16.0};
     amrex::Real gamma_h{16.0};
 

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -83,7 +83,7 @@ public:
                      const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
                      const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
                      const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
-      : m_geom(geom), m_ma(zref,geom,vars_old,Theta_prim,z_phys_nd)
+      : m_geom(geom), m_ma(geom,vars_old,Theta_prim,z_phys_nd)
     {
         amrex::ParmParse pp("erf");
         pp.query("most.zref"     , zref);
@@ -171,6 +171,15 @@ public:
     void
     update_fluxes(int lev, int max_iters = 25);
 
+    const amrex::MultiFab*
+    get_u_star(int lev) { return u_star[lev]; };
+
+    const amrex::MultiFab*
+    get_t_star(int lev) { return t_star[lev]; };
+
+    const amrex::MultiFab*
+    get_mac_avg(int lev, int comp) { return m_ma.get_average(lev,comp); };
+
     enum ThetaCalcType {
         HEAT_FLUX = 0,      ///< Heat-flux specified
         SURFACE_TEMPERATURE ///< Surface temperature specified
@@ -193,8 +202,6 @@ public:
     }
 
     private:
-
-
         amrex::Vector<amrex::Geometry>  m_geom;
         amrex::Vector<amrex::FArrayBox> z_0;
 

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -5,97 +5,17 @@
 
 using namespace amrex;
 
-void ABLMost::update_fluxes(int lev,
-                            amrex::MultiFab& Theta_old, amrex::MultiFab& U_old,
-                            amrex::MultiFab& V_old    , amrex::MultiFab& W_old,
-                            int max_iters)
+void ABLMost::update_fluxes(int lev, int max_iters)
 {
-    // TODO: REMOVE ALL OF THIS AFTER PBL STUFF ADDRESSED
-    // THIS BECOMES REDUNDANT WITH THE NEW 2D MFs
-    {
-    PlaneAverage Thave(&Theta_old, m_geom[lev], 2);
-    PlaneAverage vxave(&U_old, m_geom[lev], 2);
-    PlaneAverage vyave(&V_old, m_geom[lev], 2);
-    PlaneAverage vzave(&W_old, m_geom[lev], 2);
-    Thave.compute_averages(ZDir(), Thave.field());
-    vxave.compute_averages(ZDir(), vxave.field());
-    vyave.compute_averages(ZDir(), vyave.field());
-    vzave.compute_averages(ZDir(), vzave.field());
-    vel_mean[0] = vxave.line_average_interpolated(zref, 0);
-    vel_mean[1] = vyave.line_average_interpolated(zref, 0);
-    vel_mean[2] = vzave.line_average_interpolated(zref, 0);
-    theta_mean  = Thave.line_average_interpolated(zref, 0);
-    VelPlaneAverage vmagave(m_geom[lev]);
-    vmagave.compute_hvelmag_averages(U_old,V_old);
-    vmag_mean   = vmagave.line_hvelmag_average_interpolated(zref);
-
-    constexpr amrex::Real eps = 1.0e-16;
-    amrex::Real zeta = 0.0;
-    amrex::Real utau_iter = 0.0;
-    // Initialize variables
-    amrex::Real psi_m = 0.0;
-    amrex::Real psi_h = 0.0;
-    utau = kappa * vmag_mean / (std::log(zref / z0_const));
-    int iter = 0;
-    do {
-        utau_iter = utau;
-        switch (alg_type) {
-        case HEAT_FLUX:
-            surf_temp = surf_temp_flux * (std::log(zref / z0_const) - psi_h) /
-                        (utau * kappa) + theta_mean;
-            break;
-        case SURFACE_TEMPERATURE:
-            surf_temp_flux = -(theta_mean - surf_temp) * utau * kappa /
-                              (std::log(zref / z0_const) - psi_h);
-            break;
-        }
-        if (std::abs(surf_temp_flux) > eps) {
-            // Stable and unstable ABL conditions
-            obukhov_len = -utau * utau * utau * theta_mean /
-                           (kappa * gravity * surf_temp_flux);
-            zeta = zref / obukhov_len;
-        } else {
-            // Neutral conditions
-            obukhov_len = std::numeric_limits<amrex::Real>::max();
-            zeta = 0.0;
-        }
-        psi_m = calc_psi_m(zeta);
-        psi_h = calc_psi_h(zeta);
-        utau = kappa * vmag_mean / (std::log(zref / z0_const) - psi_m);
-        ++iter;
-    } while ((std::abs(utau_iter - utau) > 1e-5) && iter <= max_iters);
-    if (iter >= max_iters) {
-        amrex::Print()
-            << "MOData::update_fluxes: Convergence criteria not met after "
-            << max_iters << " iterations"
-            << "\nObuhov length = " << obukhov_len << " zeta = " << zeta
-            << "\npsi_m = " << psi_m << " psi_h = " << psi_h
-            << "\nutau = " << utau << " Tsurf = " << surf_temp
-            << " q = " << surf_temp_flux << std::endl;
-    }
-    }
-    // END REDUNDANT CODE
-
-    // New MOSTAverage class
-    MOSTAverage ma({&U_old     , &V_old     , &W_old     , &Theta_old },
-                   {u_mean[lev], v_mean[lev], w_mean[lev], t_mean[lev], u_mag_mean[lev]},
-                   {x_nd_k[lev], y_nd_k[lev], z_nd_k[lev], cc_k[lev]  , cc_k[lev]      },
-                   {zref       , zref       , zref       , zref       , zref           },
-                   nullptr, m_geom[lev], 0, true);
-
     // Compute plane averages for all vars
-    ma.compute_averages();
-
-    /*
-    // Write text file of averages
-    ma.write_k_indices();
-    ma.write_averages();
-    exit(0);
-    */
+    m_ma.compute_averages();
 
     // Pointers to the computed averages
-    const auto tm_ptr  = ma.get_average(3);
-    const auto umm_ptr = ma.get_average(4);
+    const auto tm_ptr  = m_ma.get_average(lev,2);
+    const auto umm_ptr = m_ma.get_average(lev,3);
+
+    amrex::Print() << "CLEARED!!\n";
+    exit(0);
 
     // GPU device captures
     amrex::Real d_kappa = kappa;
@@ -223,17 +143,24 @@ ABLMost::impose_most_bcs(const int lev,
     const int icomp = 0;
     for (MFIter mfi(*mfs[0]); mfi.isValid(); ++mfi)
     {
-        // Get data arrays
+        // Get field arrays
         const auto cons_arr = mfs[Vars::cons]->array(mfi);
         const auto velx_arr = mfs[Vars::xvel]->array(mfi);
         const auto vely_arr = mfs[Vars::yvel]->array(mfi);
         const auto  eta_arr = eddyDiffs->array(mfi);
 
         // Get average arrays
-        const auto um_arr  = u_mean[lev]->array(mfi);
-        const auto vm_arr  = v_mean[lev]->array(mfi);
-        const auto tm_arr  = t_mean[lev]->array(mfi);
-        const auto umm_arr = u_mag_mean[lev]->array(mfi);
+        const auto u_mean     = m_ma.get_average(lev,0);
+        const auto v_mean     = m_ma.get_average(lev,1);
+        const auto t_mean     = m_ma.get_average(lev,2);
+        const auto u_mag_mean = m_ma.get_average(lev,3);
+
+        const auto um_arr  = u_mean->array(mfi);
+        const auto vm_arr  = v_mean->array(mfi);
+        const auto tm_arr  = t_mean->array(mfi);
+        const auto umm_arr = u_mag_mean->array(mfi);
+
+        // Get derived arrays
         const auto u_star_arr = u_star[lev]->array(mfi);
         const auto t_star_arr = t_star[lev]->array(mfi);
         const auto t_surf_arr = t_surf[lev]->array(mfi);

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -8,14 +8,11 @@ using namespace amrex;
 void ABLMost::update_fluxes(int lev, int max_iters)
 {
     // Compute plane averages for all vars
-    m_ma.compute_averages();
+    m_ma.compute_averages(lev);
 
     // Pointers to the computed averages
     const auto tm_ptr  = m_ma.get_average(lev,2);
     const auto umm_ptr = m_ma.get_average(lev,3);
-
-    amrex::Print() << "CLEARED!!\n";
-    exit(0);
 
     // GPU device captures
     amrex::Real d_kappa = kappa;

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -10,37 +10,77 @@
 
 class MOSTAverage {
 public:
-    explicit MOSTAverage(amrex::Real& zref,
-                         const amrex::Vector<amrex::Geometry>& geom,
+    explicit MOSTAverage(const amrex::Vector<amrex::Geometry>& geom,
                          const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
                          const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd);
-     MOSTAverage() = default;
+    MOSTAverage() = default;
     ~MOSTAverage()
-     {
-       for (int lev(0); lev<m_geom.size(); ++lev)
-       {
-         for (int iavg(0); iavg<navg; ++iavg) delete m_averages[lev][iavg];
-         delete m_k_indx[lev];
-       }
-     };
+    {
+        for (int lev(0); lev<m_maxlev; ++lev){
+            for (int iavg(0); iavg<m_navg; ++iavg) delete m_averages[lev][iavg];
+            delete m_k_indx[lev];
+        }
+    };
 
-     // Driver for the different average policies
-     void compute_averages();
+    // Compute ncells per plane
+    void set_plane_normalization();
 
-     // Get pointer to the 2D mf of averages
-     const amrex::MultiFab* get_average(int lev, int comp) const { return m_averages[lev][comp]; };
+    // Populate a 2D iMF with a uniform k value
+    void set_uniform_k_indices();
+
+    // Driver for the different average policies
+    void compute_averages(int lev);
+
+    // Fill averages for policy::plane
+    void compute_plane_averages(int lev);
+
+    // Fill averages for policy::point
+    void compute_point_averages(int lev);
+
+    // Write k indices for each average
+    void write_k_indices(int lev);
+
+    // Write averages on 2D mf
+    void write_averages(int lev);
+
+    // Get pointer to the 2D mf of averages
+    const amrex::MultiFab* get_average(int lev, int comp) const { return m_averages[lev][comp]; };
 
 protected:
 
-    int nvar{3};                                                // 3 field for U/V/T
-    int navg{4};                                                // 4 averages for U/V/T/Umag
-    amrex::Real m_zref;                                         // Vector of reals for height above MOST BC
-    const amrex::Vector<amrex::Geometry> m_geom;                      // Geometry at each level
-    amrex::Vector<amrex::Vector<const amrex::MultiFab*>>  m_fields;   // Ptr to fields to be averaged
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_averages; // Ptr to 2D mf to hold averages
-    amrex::Vector<amrex::MultiFab*> m_z_phys_nd;// Ptr to terrain heigh coords
-    amrex::Vector<amrex::iMultiFab*> m_k_indx;                  // Ptr to 2D imf to hold k indices
+    // Passed through constructor
+    //--------------------------------------------
+    const amrex::Vector<amrex::Geometry> m_geom;                     // Geometry at each level
+    amrex::Vector<amrex::Vector<const amrex::MultiFab*>>  m_fields;  // Ptr to fields to be averaged
+    amrex::Vector<amrex::MultiFab*> m_z_phys_nd;                     // Ptr to terrain heigh coords
 
+    // General vars for multiple or all policies
+    //--------------------------------------------
+    int m_nvar{3};                                                   // 3 field for U/V/T
+    int m_navg{4};                                                   // 4 averages for U/V/T/Umag
+    int m_maxlev{0};                                                 // Total number of levels
+    int m_policy{0};                                                 // Policy for type of averaging
+    amrex::Real m_zref;                                              // Height for MOST BC
+    std::string m_pp_prefix {"erf"};                                 // ParmParse prefix
+    amrex::Vector<amrex::iMultiFab*> m_k_indx;                       // Ptr to 2D imf to hold k indices (maxlev)
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_averages;      // Ptr to 2D mf to hold averages (maxlev,navg)
+
+    // Vars for planar average policy
+    //--------------------------------------------
+    amrex::Vector<amrex::Vector<int>> m_ncell_plane;                 // Number of cells in plane (maxlev,navg)
+    amrex::Vector<amrex::Vector<amrex::Real>> m_plane_average;       // Plane avgs (maxlev,navg)
+
+    // Vars for point/region average policy
+    //--------------------------------------------
+    int m_k_ind{-1};                                                 // k_index for point/region average
+    int m_radius{0};                                                 // Radius around k_index
+
+    // Time average w/ exponential filter fun
+    //--------------------------------------------
+    bool m_t_avg{false};                                             // Flag to do moving average in time
+    amrex::Vector<int> m_t_init;                                     // Flag to specify if averages are initialized
+    amrex::Real m_time_window{1.0e-16};                              // Width of the exp filter function
+    amrex::Real m_fact_new, m_fact_old;                              // Time average factors for new and old means
 };
 #endif

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -6,72 +6,41 @@
 #include <AMReX_MultiFab.H>
 #include <AMReX_iMultiFab.H>
 #include <AMReX_ParmParse.H>
+#include <IndexDefines.H>
 
 class MOSTAverage {
 public:
-    explicit MOSTAverage(amrex::Vector<const amrex::MultiFab*> fields,
-                         amrex::Vector<amrex::MultiFab*> averages,
-                         amrex::Vector<amrex::iMultiFab*> k_indx,
-                         amrex::Vector<amrex::Real> z_ref,
-                         const amrex::MultiFab* z_nd,
-                         const amrex::Geometry geom,
-                         int policy,
-                         bool update_k);
+    explicit MOSTAverage(amrex::Real& zref,
+                         const amrex::Vector<amrex::Geometry>& geom,
+                         const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd);
      MOSTAverage() = default;
-    ~MOSTAverage() = default;
+    ~MOSTAverage()
+     {
+       for (int lev(0); lev<m_geom.size(); ++lev)
+       {
+         for (int iavg(0); iavg<navg; ++iavg) delete m_averages[lev][iavg];
+         delete m_k_indx[lev];
+       }
+     };
 
-    // Populate a 2D iMF with a uniform k value
-    void set_uniform_k_indices();
+     // Driver for the different average policies
+     void compute_averages();
 
-    // Driver for the different average policies
-    void compute_averages();
-
-    // Fill averages for policy::plane
-    void compute_plane_averages();
-
-    // Fill averages for policy::point
-    void compute_point_averages();
-
-    // Get number of components for a mf in m_fields
-    int ncomp()      const  { return m_ncomps[0]; }
-    int ncomp(int i) const  { return m_ncomps[i]; }
-
-    // Get pointer to mf in m_fields
-    const amrex::MultiFab* get_field()      const { return m_fields[0]; }
-    const amrex::MultiFab* get_field(int i) const { return m_fields[i]; }
-
-    // Get pointer to the 2D mf of averages
-    const amrex::MultiFab* get_average()      const { return m_averages[0]; };
-    const amrex::MultiFab* get_average(int i) const { return m_averages[i]; };
-
-    // Get plane averages long dir()
-    const amrex::Real& get_plane_average()      const { return m_plane_average[0]; }
-    const amrex::Real& get_plane_average(int i) const { return m_plane_average[i]; }
-
-    // Write k indices for each average
-    void write_k_indices();
-
-    // Write averages on 2D mf
-    void write_averages();
+     // Get pointer to the 2D mf of averages
+     const amrex::MultiFab* get_average(int lev, int comp) const { return m_averages[lev][comp]; };
 
 protected:
-    amrex::Real m_dz;  // Mesh spacing in axis direction
-    amrex::Real m_zlo; // Bottom of domain in axis direction
 
-    int m_k_ind  = -1; // Specified k_index for local-point/region average
-    int m_radius =  0; // Specified radius around k_index
+    int nvar{3};                                                // 3 field for U/V/T
+    int navg{4};                                                // 4 averages for U/V/T/Umag
+    amrex::Real m_zref;                                         // Vector of reals for height above MOST BC
+    const amrex::Vector<amrex::Geometry> m_geom;                      // Geometry at each level
+    amrex::Vector<amrex::Vector<const amrex::MultiFab*>>  m_fields;   // Ptr to fields to be averaged
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_averages; // Ptr to 2D mf to hold averages
+    amrex::Vector<amrex::MultiFab*> m_z_phys_nd;// Ptr to terrain heigh coords
+    amrex::Vector<amrex::iMultiFab*> m_k_indx;                  // Ptr to 2D imf to hold k indices
 
-    amrex::Vector<int> m_ncomps;      // Number of components (mf)
-    amrex::Vector<int> m_ncell_plane; // Number of cells in plane (mf)
-
-    amrex::Vector<const amrex::MultiFab*> m_fields;  // Ptr to fields to be averaged
-    amrex::Vector<amrex::MultiFab*> m_averages;      // Ptr to 2D mf to hold averages
-    amrex::Vector<amrex::iMultiFab*> m_k_indx;       // Ptr to 2D imf to hold k indices
-    amrex::Vector<amrex::Real> m_plane_average;      // Plane avgs (mf,1)
-    amrex::Vector<amrex::Real> m_z_ref;              // Vector of reals for height above MOST BC
-    const amrex::MultiFab* m_z_nd;                   // Ptr to terrain heigh coords
-    amrex::Geometry m_geom;                          // Geometry
-    const int m_policy;                              // Policy for averaging
-    bool m_update_k;                                 // Flag to update 2D imf with k indices
 };
 #endif

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -1,33 +1,35 @@
 #include <MOSTAverage.H>
 
 // Constructor
-MOSTAverage::MOSTAverage (amrex::Real& zref,
-                          const amrex::Vector<amrex::Geometry>& geom,
+MOSTAverage::MOSTAverage (const amrex::Vector<amrex::Geometry>& geom,
                           const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
                           const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
                           const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
-  : m_zref(zref), m_geom(geom)
+  : m_geom(geom)
 {
-    // Get PTR to fields and create 2D MFs for averages
+    // Get the policy (defaults to planar avg)
     //--------------------------------------------------------
-    int nlevs = m_geom.size();
-    m_fields.resize(nlevs);
-    m_k_indx.resize(nlevs);
-    m_averages.resize(nlevs);
-    m_z_phys_nd.resize(nlevs);
-    for (int lev = 0; lev < nlevs; lev++)
-    {
-      m_fields[lev].resize(nvar);
-      m_averages[lev].resize(navg);
+    amrex::ParmParse pp(m_pp_prefix);
+    pp.query("most.average_policy",m_policy);
+    pp.query("most.zref",m_zref);
+
+    // Set up fields and 2D MF/iMFs for averages
+    //--------------------------------------------------------
+    m_maxlev = m_geom.size();
+    m_fields.resize(m_maxlev);
+    m_k_indx.resize(m_maxlev);
+    m_averages.resize(m_maxlev);
+    m_z_phys_nd.resize(m_maxlev);
+    for (int lev = 0; lev < m_maxlev; lev++) {
+      m_fields[lev].resize(m_nvar);
+      m_averages[lev].resize(m_navg);
       m_z_phys_nd[lev] = z_phys_nd[lev].get();
       { // Nodal in x
         auto& mf = vars_old[lev][Vars::xvel];
         // Create a 2D ba, dm, & ghost cells
         amrex::BoxArray ba  = mf.boxArray();
         amrex::BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-          b.setRange(2,0);
-        }
+        for (auto& b : bl2d) b.setRange(2,0);
         amrex::BoxArray ba2d(std::move(bl2d));
         const amrex::DistributionMapping& dm = mf.DistributionMap();
         const int ncomp   = 1;
@@ -42,9 +44,7 @@ MOSTAverage::MOSTAverage (amrex::Real& zref,
         // Create a 2D ba, dm, & ghost cells
         amrex::BoxArray ba  = mf.boxArray();
         amrex::BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-          b.setRange(2,0);
-        }
+        for (auto& b : bl2d) b.setRange(2,0);
         amrex::BoxArray ba2d(std::move(bl2d));
         const amrex::DistributionMapping& dm = mf.DistributionMap();
         const int ncomp   = 1;
@@ -59,9 +59,7 @@ MOSTAverage::MOSTAverage (amrex::Real& zref,
         // Create a 2D ba, dm, & ghost cells
         amrex::BoxArray ba  = mf.boxArray();
         amrex::BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-          b.setRange(2,0);
-        }
+        for (auto& b : bl2d) b.setRange(2,0);
         amrex::BoxArray ba2d(std::move(bl2d));
         const amrex::DistributionMapping& dm = mf.DistributionMap();
         const int ncomp   = 1;
@@ -78,13 +76,445 @@ MOSTAverage::MOSTAverage (amrex::Real& zref,
         m_k_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
       }
     } // lev
+
+    // Setup auxiliary data for the chosen policy
+    //--------------------------------------------------------
+    switch(m_policy) {
+    case 0: // Standard plane average
+        set_plane_normalization();
+        set_uniform_k_indices();
+        break;
+
+    case 1: // Local region/point
+        set_uniform_k_indices();
+        break;
+
+    case 2: // Fixed height above the terrain surface
+        break;
+
+    case 3: // Along a normal vector
+        break;
+
+    default:
+        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+    }
+
+    // Set up the exponential time filtering
+    //--------------------------------------------------------
+    pp.query("most.time_average", m_t_avg);
+    if (m_t_avg) {
+        // m_time_window is normalized by the time-step "dt"
+        pp.query("most.time_window", m_time_window);
+
+        // Exponential filter function
+        m_fact_old = std::exp(-1.0 / m_time_window);
+
+        // Enforce discrete normalization: (mfn*val_new + mfo*val_old)
+        m_fact_new = 1.0 - m_fact_old;
+
+        // None of the averages are initialized
+        m_t_init.resize(m_maxlev,0);
+    }
 }
 
+
+// Compute ncells per plane
+void
+MOSTAverage::set_plane_normalization()
+{
+    // Cells per plane and temp avg storage
+    m_ncell_plane.resize(m_maxlev);
+    m_plane_average.resize(m_maxlev);
+
+    for (int lev = 0; lev < m_maxlev; lev++) {
+        // Num components, plane avg, cells per plane
+        amrex::Box domain = m_geom[lev].Domain();
+        amrex::IntVect dom_lo(domain.loVect());
+        amrex::IntVect dom_hi(domain.hiVect());
+        m_ncell_plane[lev].resize(m_navg);
+        m_plane_average[lev].resize(m_navg);
+        for (int iavg(0); iavg<m_navg; ++iavg) {
+            m_plane_average[lev][iavg] = 0.0;
+
+            m_ncell_plane[lev][iavg] = 1;
+            amrex::IndexType ixt = m_averages[lev][iavg]->boxArray().ixType();
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                if (idim != 2) {
+                    if (ixt.nodeCentered(idim)) {
+                        m_ncell_plane[lev][iavg] *= (dom_hi[idim] - dom_lo[idim] + 2);
+                    } else {
+                        m_ncell_plane[lev][iavg] *= (dom_hi[idim] - dom_lo[idim] + 1);
+                    }
+                }
+            } // idim
+        } // iavg
+    } // lev
+}
+
+
+// Populate a 2D iMF with the k indices for averaging
+void
+MOSTAverage::set_uniform_k_indices()
+{
+    amrex::ParmParse pp(m_pp_prefix);
+    auto read_k = pp.query("most.k_indx", m_k_ind);
+    pp.query("most.radius", m_radius);
+
+    // Specified k index
+    if (read_k) {
+        m_k_ind = std::max(m_radius,m_k_ind);
+        for (int lev = 0; lev < m_maxlev; lev++) m_k_indx[lev]->setVal(m_k_ind);
+    // Set k from zref
+    } else {
+        for (int lev = 0; lev < m_maxlev; lev++) {
+            amrex::Real m_zlo = m_geom[lev].ProbLo(2);
+            amrex::Real m_dz  = m_geom[lev].CellSize(2);
+
+            AMREX_ALWAYS_ASSERT(m_zref >= m_zlo + 0.5 * m_dz);
+
+            int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));
+            lk = std::max(m_radius,lk);
+            amrex::IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
+
+            for (amrex::MFIter mfi(*m_k_indx[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                amrex::Box gpbx = mfi.growntilebox(ng);
+                auto k_arr      = m_k_indx[lev]->array(mfi);
+                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    k_arr(i,j,k) = lk;
+                });
+            } // MFiter
+        } // lev
+    } // read_k
+}
 
 
 // Driver to call appropriate average member function
 void
-MOSTAverage::compute_averages()
+MOSTAverage::compute_averages(int lev)
 {
-  amrex::Print() << "INSIDE MAC->CA\n";
+    switch(m_policy) {
+    case 0: // Standard plane average
+        compute_plane_averages(lev);
+        break;
+
+    case 1: // Local region/point
+        compute_point_averages(lev);
+        break;
+
+    case 2: // Fixed height above the terrain surface
+        break;
+
+    case 3: // Along a normal vector
+        break;
+
+    default:
+        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+    }
+
+    // We have initialized the averages
+    if (m_t_avg) m_t_init[lev] = 1;
+}
+
+
+// Fill plane storage with averages
+void
+MOSTAverage::compute_plane_averages(int lev)
+{
+    // Peel back the level
+    auto& fields        = m_fields[lev];
+    auto& averages      = m_averages[lev];
+    auto& k_indx        = m_k_indx[lev];
+    auto& ncell_plane   = m_ncell_plane[lev];
+    auto& plane_average = m_plane_average[lev];
+
+    // Set factors for time averaging
+    amrex::Real d_fact_new, d_fact_old;
+    if (m_t_avg && m_t_init[lev]) {
+        d_fact_new = m_fact_new;
+        d_fact_old = m_fact_old;
+    } else {
+        d_fact_new = 1.0;
+        d_fact_old = 0.0;
+    }
+
+    // GPU array to accumulate averages into
+    amrex::Gpu::DeviceVector<amrex::Real> pavg(plane_average.size(), 0.0);
+    amrex::Real* plane_avg = pavg.data();
+
+    // Averages over all the fields
+    //----------------------------------------------------------
+    for (int imf(0); imf<m_nvar; ++imf) {
+        const amrex::Real denom = 1.0 / (amrex::Real)ncell_plane[imf];
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            auto mf_arr = fields[imf]->const_array(mfi);
+            auto k_arr  = k_indx->const_array(mfi);
+
+            amrex::Real d_val_old = plane_average[imf]*d_fact_old;
+
+            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
+            AMREX_GPU_DEVICE(int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
+            {
+                int mk = k_arr(i,j,k);
+                amrex::Real val = denom * ( mf_arr(i,j,mk)*d_fact_new + d_val_old );
+                amrex::Gpu::deviceReduceSum(&plane_avg[imf], val, handler);
+            });
+        }
+    }
+
+    // Averages for the tangential velocity magnitude
+    //----------------------------------------------------------
+    {
+        int imf  = 0;
+        int iavg = m_navg - 1;
+        const amrex::Real denom = 1.0 / (amrex::Real)ncell_plane[iavg];
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            auto u_mf_arr = fields[imf  ]->const_array(mfi);
+            auto v_mf_arr = fields[imf+1]->const_array(mfi);
+            auto k_arr    = k_indx->const_array(mfi);
+
+            amrex::Real d_val_old = plane_average[iavg]*d_fact_old;
+
+            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
+            AMREX_GPU_DEVICE(int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
+            {
+                int mk = k_arr(i,j,k);
+
+                const amrex::Real u_val = 0.5 * (u_mf_arr(i,j,mk) + u_mf_arr(i+1,j  ,mk));
+                const amrex::Real v_val = 0.5 * (v_mf_arr(i,j,mk) + v_mf_arr(i  ,j+1,mk));
+                const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
+                amrex::Real val = denom * ( mag*d_fact_new + d_val_old);
+                amrex::Gpu::deviceReduceSum(&plane_avg[iavg], val, handler);
+            });
+        }
+    }
+
+    // Copy to host and sum across procs
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, pavg.begin(), pavg.end(), plane_average.begin());
+    amrex::ParallelDescriptor::ReduceRealSum(plane_average.data(), plane_average.size());
+
+    // No spatial variation with plane averages
+    for (int iavg(0); iavg<m_navg; ++iavg) averages[iavg]->setVal(plane_average[iavg]);
+}
+
+
+// Fill 2D MF with local averages
+void
+MOSTAverage::compute_point_averages(int lev)
+{
+    // Peel back the level
+    auto& fields   = m_fields[lev];
+    auto& averages = m_averages[lev];
+    auto& k_indx   = m_k_indx[lev];
+    auto& geom     = m_geom[lev];
+
+    // Set factors for time averaging
+    amrex::Real d_fact_new, d_fact_old;
+    if (m_t_avg && m_t_init[lev]) {
+        d_fact_new = m_fact_new;
+        d_fact_old = m_fact_old;
+    } else {
+        d_fact_new = 1.0;
+        d_fact_old = 0.0;
+    }
+
+    // Number of cells contained in the local average
+    int ncell_avg = (2 * m_radius + 1) * (2 * m_radius + 1) * (2 * m_radius + 1);
+    const amrex::Real denom = 1.0 / (amrex::Real) ncell_avg;
+
+    // Capture radius for device
+    int d_radius = m_radius;
+
+    // Averages over all the fields
+    //----------------------------------------------------------
+    for (int imf(0); imf<m_nvar; ++imf) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            auto mf_arr = fields[imf]->const_array(mfi);
+            auto ma_arr = averages[imf]->array(mfi);
+            auto k_arr  = k_indx->const_array(mfi);
+
+            ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            {
+                ma_arr(i,j,k) *= d_fact_old;
+
+                int mk = k_arr(i,j,k);
+                for (int lk(mk-d_radius); lk<=(mk+d_radius); ++lk) {
+                    for (int lj(j-d_radius); lj<=(j+d_radius); ++lj) {
+                        for (int li(i-d_radius); li<=(i+d_radius); ++li) {
+                            amrex::Real val = denom * mf_arr(li, lj, lk) * d_fact_new;
+                            ma_arr(i,j,k) += val;
+                        }
+                    }
+                }
+            });
+        }
+
+        // Fill interior ghost cells and any ghost cells outside a periodic domain
+        //***********************************************************************************
+        averages[imf]->FillBoundary(geom.periodicity());
+    }
+
+    // Averages for the tangential velocity magnitude
+    //----------------------------------------------------------
+    {
+        int imf  = 0;
+        int iavg = m_navg - 1;
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+        for (amrex::MFIter mfi(*averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            auto u_mf_arr = fields[imf]->const_array(mfi);
+            auto v_mf_arr = fields[imf+1]->const_array(mfi);
+            auto ma_arr   = averages[iavg]->array(mfi);
+            auto k_arr    = k_indx->const_array(mfi);
+
+            ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            {
+                ma_arr(i,j,k) *= d_fact_old;
+
+                int mk = k_arr(i,j,k);
+                for (int lk(mk-d_radius); lk<=(mk+d_radius); ++lk) {
+                    for (int lj(j-d_radius); lj<=(j+d_radius); ++lj) {
+                        for (int li(i-d_radius); li<=(i+d_radius); ++li) {
+                            const amrex::Real u_val = 0.5 * (u_mf_arr(li,lj,lk) + u_mf_arr(li+1,lj  ,lk));
+                            const amrex::Real v_val = 0.5 * (v_mf_arr(li,lj,lk) + v_mf_arr(li  ,lj+1,lk));
+                            const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
+                            amrex::Real val = denom * mag * d_fact_new;
+                            ma_arr(i,j,k) += val;
+                        }
+                    }
+                }
+            });
+
+            // Fill interior ghost cells and any ghost cells outside a periodic domain
+            //***********************************************************************************
+            averages[iavg]->FillBoundary(geom.periodicity());
+        }
+    }
+
+
+    // Need to fill ghost cells outside the domain if not periodic
+    bool not_per_x = !(geom.periodicity().isPeriodic(0));
+    bool not_per_y = !(geom.periodicity().isPeriodic(1));
+    if (not_per_x || not_per_y) {
+        amrex::Box domain = geom.Domain();
+        for (int iavg(0); iavg<m_navg; ++iavg) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            amrex::IndexType ixt = averages[iavg]->boxArray().ixType();
+            amrex::Box ldomain   = domain; ldomain.convert(ixt);
+            amrex::IntVect ng    = averages[iavg]->nGrowVect(); ng[2]=0;
+            for (amrex::MFIter mfi(*averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+                amrex::Box gpbx = mfi.growntilebox(ng); gpbx.setSmall(2,0); gpbx.setBig(2,0);
+
+                if (ldomain.contains(gpbx)) continue;
+
+                auto ma_arr = averages[iavg]->array(mfi);
+
+                int i_lo = ldomain.smallEnd(0); int i_hi = ldomain.bigEnd(0);
+                int j_lo = ldomain.smallEnd(1); int j_hi = ldomain.bigEnd(1);
+                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                {
+                    int li, lj;
+                    li = i  < i_lo ? i_lo : i;
+                    li = li > i_hi ? i_hi : li;
+                    lj = j  < j_lo ? j_lo : j;
+                    lj = lj > j_hi ? j_hi : lj;
+
+                    ma_arr(i,j,k) = ma_arr(li,lj,k);
+                });
+            } // MFiter
+        } // iavg
+    } // Not periodic
+}
+
+
+// Write k indices
+void
+MOSTAverage::write_k_indices(int lev)
+{
+    // Peel back the level
+    auto& averages = m_averages[lev];
+    auto& k_indx   = m_k_indx[lev];
+
+    int navg = m_navg - 1;
+
+    std::ofstream ofile;
+    ofile.open ("MOST_k_indices.txt");
+    ofile << "K indices used to compute averages via MOSTAverages class:\n";
+
+    for (amrex::MFIter mfi(*averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
+        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
+
+        auto k_arr = k_indx->array(mfi);
+
+        for (int j(jl); j<=ju; ++j) {
+            for (int i(il); i<=iu; ++i) {
+                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
+                int k = 0;
+                ofile << "K_ind: "
+                      << k_arr(i,j,k) << "\n";
+                ofile << "\n";
+            }
+        }
+    }
+    ofile.close();
+}
+
+// Write averages
+void
+MOSTAverage::write_averages(int lev)
+{
+    // Peel back the level
+    auto& averages = m_averages[lev];
+
+    int navg = m_navg - 1;
+
+    std::ofstream ofile;
+    ofile.open ("MOST_averages.txt");
+    ofile << "Averages computed via MOSTAverages class:\n";
+
+    for (amrex::MFIter mfi(*averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
+        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
+
+        for (int j(jl); j<=ju; ++j) {
+            for (int i(il); i<=iu; ++i) {
+                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
+                int k = 0;
+                for (int iavg(0); iavg<=navg; ++iavg) {
+                    auto mf_arr = averages[iavg]->array(mfi);
+                    ofile << "iavg val: "
+                          << iavg << ' '
+                          << mf_arr(i,j,k) << "\n";
+                }
+                ofile << "\n";
+            }
+        }
+    }
+    ofile.close();
 }

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -1,386 +1,90 @@
 #include <MOSTAverage.H>
 
 // Constructor
-MOSTAverage::MOSTAverage (amrex::Vector<const amrex::MultiFab*> fields,
-                          amrex::Vector<amrex::MultiFab*> averages,
-                          amrex::Vector<amrex::iMultiFab*> k_indx,
-                          amrex::Vector<amrex::Real> z_ref,
-                          const amrex::MultiFab* z_nd,
-                          amrex::Geometry geom,
-                          int policy,
-                          bool update_k)
-    : m_fields(fields), m_averages(averages), m_k_indx(k_indx), m_z_ref(z_ref)      ,
-      m_z_nd(z_nd)    , m_geom(geom)        , m_policy(policy), m_update_k(update_k)
+MOSTAverage::MOSTAverage (amrex::Real& zref,
+                          const amrex::Vector<amrex::Geometry>& geom,
+                          const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                          const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                          const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
+  : m_zref(zref), m_geom(geom)
 {
-    AMREX_ALWAYS_ASSERT(fields.size() >= 2);
-
-    // Domain bottom and cell-size
-    m_zlo = m_geom.ProbLo  (2);
-    m_dz  = m_geom.CellSize(2);
-
-    // Num components, plane avg, cells per plane
-    amrex::Box domain = m_geom.Domain();
-    amrex::IntVect dom_lo(domain.loVect());
-    amrex::IntVect dom_hi(domain.hiVect());
-    int asize = m_averages.size();
-    m_ncomps.resize( asize );
-    m_plane_average.resize( asize );
-    m_ncell_plane.resize( asize );
-    for (int iavg(0); iavg<asize; ++iavg) {
-        m_ncomps[iavg]        = m_averages[iavg]->nComp();
-        m_plane_average[iavg] = 0.0;
-
-        m_ncell_plane[iavg] = 1;
-        amrex::IndexType ixt = m_averages[iavg]->boxArray().ixType();
-        for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-            if (idim != 2) {
-                if (ixt.nodeCentered(idim)) {
-                    m_ncell_plane[iavg] *= (dom_hi[idim] - dom_lo[idim] + 2);
-                } else {
-                    m_ncell_plane[iavg] *= (dom_hi[idim] - dom_lo[idim] + 1);
-                }
-            }
+    // Get PTR to fields and create 2D MFs for averages
+    //--------------------------------------------------------
+    int nlevs = m_geom.size();
+    m_fields.resize(nlevs);
+    m_k_indx.resize(nlevs);
+    m_averages.resize(nlevs);
+    m_z_phys_nd.resize(nlevs);
+    for (int lev = 0; lev < nlevs; lev++)
+    {
+      m_fields[lev].resize(nvar);
+      m_averages[lev].resize(navg);
+      m_z_phys_nd[lev] = z_phys_nd[lev].get();
+      { // Nodal in x
+        auto& mf = vars_old[lev][Vars::xvel];
+        // Create a 2D ba, dm, & ghost cells
+        amrex::BoxArray ba  = mf.boxArray();
+        amrex::BoxList bl2d = ba.boxList();
+        for (auto& b : bl2d) {
+          b.setRange(2,0);
         }
-    }
+        amrex::BoxArray ba2d(std::move(bl2d));
+        const amrex::DistributionMapping& dm = mf.DistributionMap();
+        const int ncomp   = 1;
+        amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
 
-    // Select a policy for k-index
-    if (m_update_k) {
-        switch(m_policy) {
-        case 0: // Standard plane average
-            set_uniform_k_indices();
-            break;
-
-        case 1: // Local region/point
-            set_uniform_k_indices();
-            break;
-
-        case 2: // Fixed height above the terrain surface
-            break;
-
-        case 3: // Along a normal vector
-            break;
-
-        default:
-            AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+          m_fields[lev][0] = &mf;
+        m_averages[lev][0] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        m_averages[lev][0]->setVal(1.E34);
+      }
+      { // Nodal in y
+        auto& mf = vars_old[lev][Vars::yvel];
+        // Create a 2D ba, dm, & ghost cells
+        amrex::BoxArray ba  = mf.boxArray();
+        amrex::BoxList bl2d = ba.boxList();
+        for (auto& b : bl2d) {
+          b.setRange(2,0);
         }
-    }
+        amrex::BoxArray ba2d(std::move(bl2d));
+        const amrex::DistributionMapping& dm = mf.DistributionMap();
+        const int ncomp   = 1;
+        amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
+
+          m_fields[lev][1] = &mf;
+        m_averages[lev][1] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        m_averages[lev][1]->setVal(1.E34);
+      }
+      { // CC vars
+        auto& mf = *Theta_prim[lev];
+        // Create a 2D ba, dm, & ghost cells
+        amrex::BoxArray ba  = mf.boxArray();
+        amrex::BoxList bl2d = ba.boxList();
+        for (auto& b : bl2d) {
+          b.setRange(2,0);
+        }
+        amrex::BoxArray ba2d(std::move(bl2d));
+        const amrex::DistributionMapping& dm = mf.DistributionMap();
+        const int ncomp   = 1;
+        const int incomp  = 1;
+        amrex::IntVect ng = mf.nGrowVect(); ng[2]=0;
+
+          m_fields[lev][2] = &mf;
+        m_averages[lev][2] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        m_averages[lev][2]->setVal(1.E34);
+
+        m_averages[lev][3] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        m_averages[lev][3]->setVal(1.E34);
+
+        m_k_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
+      }
+    } // lev
 }
 
-// Populate a 2D iMF with the k indices for averaging
-void
-MOSTAverage::set_uniform_k_indices()
-{
-    amrex::ParmParse pp("erf");
-    auto read_k = pp.query("most.k_indx", m_k_ind);
-    pp.query("most.radius", m_radius);
-
-    // Specified k index
-    if (read_k) {
-        m_k_ind = std::max(m_radius,m_k_ind);
-        for (int iavg(0); iavg<m_averages.size(); ++iavg) m_k_indx[iavg]->setVal(m_k_ind);
-    // Set k from zref
-    } else {
-        for (int iavg(0); iavg<m_averages.size(); ++iavg) {
-            amrex::Real z = m_z_ref[iavg];
-
-            AMREX_ALWAYS_ASSERT(z >= m_zlo + 0.5 * m_dz);
-
-            int lk = static_cast<int>(floor((z - m_zlo) / m_dz - 0.5));
-            lk = std::max(m_radius,lk);
-            amrex::IntVect ng = m_k_indx[iavg]->nGrowVect(); ng[2]=0;
-
-            for (amrex::MFIter mfi(*m_k_indx[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                amrex::Box gpbx = mfi.growntilebox(ng);
-                auto k_arr      = m_k_indx[iavg]->array(mfi);
-                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    k_arr(i,j,k) = lk;
-                });
-            } // MFiter
-        } // iavg
-    } // read_k
-}
 
 
 // Driver to call appropriate average member function
 void
 MOSTAverage::compute_averages()
 {
-    switch(m_policy) {
-    case 0: // Standard plane average
-        compute_plane_averages();
-        break;
-
-    case 1: // Local region/point
-        compute_point_averages();
-        break;
-
-    case 2: // Fixed height above the terrain surface
-        break;
-
-    case 3: // Along a normal vector
-        break;
-
-    default:
-        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
-    }
-}
-
-// Fill plane storage with averages
-void
-MOSTAverage::compute_plane_averages()
-{
-    // GPU array to accumulate averages into
-    amrex::AsyncArray<amrex::Real> pavg(m_plane_average.data(), m_plane_average.size());
-    amrex::Real* plane_avg = pavg.data();
-
-    // Averages over all the fields
-    //----------------------------------------------------------
-    for (int imf(0); imf<m_fields.size(); ++imf) {
-        const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[imf];
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
-
-            auto mf_arr = m_fields[imf]->const_array(mfi);
-            auto k_arr  = m_k_indx[imf]->const_array(mfi);
-
-            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
-            AMREX_GPU_DEVICE(int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
-            {
-                int mk = k_arr(i,j,k);
-                amrex::Gpu::deviceReduceSum(&plane_avg[imf],mf_arr(i, j, mk) * denom, handler);
-            });
-        }
-    }
-
-    // Averages for the tangential velocity magnitude
-    //----------------------------------------------------------
-    {
-        int imf  = 0;
-        int iavg = m_fields.size();
-        const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane[iavg];
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(*m_averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
-
-            auto u_mf_arr = m_fields[imf]->const_array(mfi);
-            auto v_mf_arr = m_fields[imf+1]->const_array(mfi);
-
-            auto k_u_arr  = m_k_indx[imf]->const_array(mfi);
-            auto k_v_arr  = m_k_indx[imf+1]->const_array(mfi);
-
-            ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
-            AMREX_GPU_DEVICE(int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
-            {
-                int mk_u = k_u_arr(i,j,k);
-                int mk_v = k_v_arr(i,j,k);
-
-                const amrex::Real u_val = 0.5 * (u_mf_arr(i,j,mk_u) + u_mf_arr(i+1,j  ,mk_u));
-                const amrex::Real v_val = 0.5 * (v_mf_arr(i,j,mk_v) + v_mf_arr(i  ,j+1,mk_v));
-                const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
-                amrex::Gpu::deviceReduceSum(&plane_avg[iavg],mag * denom, handler);
-            });
-        }
-    }
-
-    // Copy to host and sum across procs
-    pavg.copyToHost(m_plane_average.data(), m_plane_average.size());
-    amrex::ParallelDescriptor::ReduceRealSum(m_plane_average.data(), m_plane_average.size());
-
-    // No spatial variation with plane averages
-    for (int iavg(0); iavg<m_averages.size(); ++iavg) m_averages[iavg]->setVal(m_plane_average[iavg]);
-}
-
-// Fill 2D MF with local averages
-void
-MOSTAverage::compute_point_averages()
-{
-    // Number of cells contained in the local average
-    int ncell_avg = (2 * m_radius + 1) * (2 * m_radius + 1) * (2 * m_radius + 1);
-    const amrex::Real denom = 1.0 / (amrex::Real) ncell_avg;
-
-    // Capture radius for device
-    int d_radius = m_radius;
-
-    // Averages over all the fields
-    //----------------------------------------------------------
-    for (int imf(0); imf<m_fields.size(); ++imf) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(*m_fields[imf], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
-
-            auto mf_arr = m_fields[imf]->const_array(mfi);
-            auto k_arr  = m_k_indx[imf]->const_array(mfi);
-            auto ma_arr = m_averages[imf]->array(mfi);
-
-            ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                ma_arr(i,j,k) = 0.0;
-
-                int mk = k_arr(i,j,k);
-                for (int lk(mk-d_radius); lk<=(mk+d_radius); ++lk) {
-                    for (int lj(j-d_radius); lj<=(j+d_radius); ++lj) {
-                        for (int li(i-d_radius); li<=(i+d_radius); ++li) {
-                            ma_arr(i,j,k) += mf_arr(li, lj, lk) * denom;
-                        }
-                    }
-                }
-            });
-        }
-
-        // Fill interior ghost cells and any ghost cells outside a periodic domain
-        //***********************************************************************************
-        m_averages[imf]->FillBoundary(m_geom.periodicity());
-    }
-
-    // Averages for the tangential velocity magnitude
-    //----------------------------------------------------------
-    {
-        int imf  = 0;
-        int iavg = m_fields.size();
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-        for (amrex::MFIter mfi(*m_averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
-
-            auto u_mf_arr = m_fields[imf]->const_array(mfi);
-            auto v_mf_arr = m_fields[imf+1]->const_array(mfi);
-            auto k_arr    = m_k_indx[imf]->const_array(mfi);
-            auto ma_arr   = m_averages[iavg]->array(mfi);
-
-            ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                ma_arr(i,j,k) = 0.0;
-
-                int mk = k_arr(i,j,k);
-                for (int lk(mk-d_radius); lk<=(mk+d_radius); ++lk) {
-                    for (int lj(j-d_radius); lj<=(j+d_radius); ++lj) {
-                        for (int li(i-d_radius); li<=(i+d_radius); ++li) {
-                            const amrex::Real u_val = 0.5 * (u_mf_arr(li,lj,lk) + u_mf_arr(li+1,lj  ,lk));
-                            const amrex::Real v_val = 0.5 * (v_mf_arr(li,lj,lk) + v_mf_arr(li  ,lj+1,lk));
-                            const amrex::Real mag   = std::sqrt(u_val*u_val + v_val*v_val);
-                            ma_arr(i,j,k) += mag * denom;
-                        }
-                    }
-                }
-            });
-
-            // Fill interior ghost cells and any ghost cells outside a periodic domain
-            //***********************************************************************************
-            m_averages[iavg]->FillBoundary(m_geom.periodicity());
-        }
-    }
-
-
-    // Need to fill ghost cells outside the domain if not periodic
-    bool not_per_x = !(m_geom.periodicity().isPeriodic(0));
-    bool not_per_y = !(m_geom.periodicity().isPeriodic(1));
-    if (not_per_x || not_per_y) {
-        amrex::Box domain = m_geom.Domain();
-        for (int iavg(0); iavg<m_averages.size(); ++iavg) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            amrex::IndexType ixt = m_averages[iavg]->boxArray().ixType();
-            amrex::Box ldomain   = domain; ldomain.convert(ixt);
-            amrex::IntVect ng    = m_averages[iavg]->nGrowVect(); ng[2]=0;
-            for (amrex::MFIter mfi(*m_averages[iavg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                amrex::Box gpbx = mfi.growntilebox(ng); gpbx.setSmall(2,0); gpbx.setBig(2,0);
-
-                if (ldomain.contains(gpbx)) continue;
-
-                auto ma_arr = m_averages[iavg]->array(mfi);
-
-                int i_lo = ldomain.smallEnd(0); int i_hi = ldomain.bigEnd(0);
-                int j_lo = ldomain.smallEnd(1); int j_hi = ldomain.bigEnd(1);
-                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-                {
-                    int li, lj;
-                    li = i  < i_lo ? i_lo : i;
-                    li = li > i_hi ? i_hi : li;
-                    lj = j  < j_lo ? j_lo : j;
-                    lj = lj > j_hi ? j_hi : lj;
-
-                    ma_arr(i,j,k) = ma_arr(li,lj,k);
-                });
-            } // MFiter
-        } // ima
-    } // Not periodic
-}
-
-// Write k indices
-void
-MOSTAverage::write_k_indices()
-{
-    // Last component u_mag_mean is cc
-    int navg = m_averages.size() - 1;
-
-    std::ofstream ofile;
-    ofile.open ("MOST_k_indices.txt");
-    ofile << "K indices used to compute averages via MOSTAverages class:\n";
-
-    for (amrex::MFIter mfi(*m_averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
-        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
-        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
-
-        for (int j(jl); j<=ju; ++j) {
-            for (int i(il); i<=iu; ++i) {
-                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
-                int k = 0;
-                for (int iavg(0); iavg<=navg; ++iavg) {
-                    auto k_arr = m_k_indx[iavg]->array(mfi);
-                    ofile << "iavg K_ind: "
-                          << iavg << ' '
-                          << k_arr(i,j,k) << "\n";
-                }
-                ofile << "\n";
-            }
-        }
-    }
-    ofile.close();
-}
-
-// Write averages
-void
-MOSTAverage::write_averages()
-{
-    // Last component u_mag_mean is cc
-    int navg = m_averages.size() - 1;
-
-    std::ofstream ofile;
-    ofile.open ("MOST_averages.txt");
-    ofile << "Averages computed via MOSTAverages class:\n";
-
-    for (amrex::MFIter mfi(*m_averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
-        int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
-        int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
-
-        for (int j(jl); j<=ju; ++j) {
-            for (int i(il); i<=iu; ++i) {
-                ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
-                int k = 0;
-                for (int iavg(0); iavg<=navg; ++iavg) {
-                    auto mf_arr = m_averages[iavg]->array(mfi);
-                    ofile << "iavg val: "
-                          << iavg << ' '
-                          << mf_arr(i,j,k) << "\n";
-                }
-                ofile << "\n";
-            }
-        }
-    }
-    ofile.close();
+  amrex::Print() << "INSIDE MAC->CA\n";
 }

--- a/Source/Diffusion/Diffusion.H
+++ b/Source/Diffusion/Diffusion.H
@@ -61,7 +61,7 @@ void DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int
                              const amrex::Array4<const amrex::Real>& mf_v ,
                              const amrex::Array4<const amrex::Real>& mu_turb,
                              const SolverChoice &solverChoice,
-                             const amrex::Real& theta_mean,
+                             const amrex::Array4<const amrex::Real>& tm_arr,
                              const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                              const amrex::BCRec* bc_ptr);
 
@@ -84,7 +84,7 @@ void DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int
                              const amrex::Array4<const amrex::Real>& mf_v ,
                              const amrex::Array4<const amrex::Real>& mu_turb,
                              const SolverChoice &solverChoice,
-                             const amrex::Real& theta_mean,
+                             const amrex::Array4<const amrex::Real>& tm_arr,
                              const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                              const amrex::BCRec* bc_ptr);
 

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -22,7 +22,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
                         const Array4<const Real>& mf_v,
                         const Array4<const Real>& mu_turb,
                         const SolverChoice &solverChoice,
-                        const Real& theta_mean,
+                        const Array4<const Real>& tm_arr,
                         const amrex::GpuArray<Real,AMREX_SPACEDIM> grav_gpu,
                         const amrex::BCRec* bc_ptr)
 {
@@ -265,7 +265,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cell_rhs(i, j, k, qty_index) += ComputeQKESourceTerms(i,j,k,u,v,cell_data,cell_prim,
-                                                                  mu_turb,cellSizeInv,domain,solverChoice,theta_mean);
+                                                                  mu_turb,cellSizeInv,domain,solverChoice,tm_arr(i,j,0));
         });
     }
 

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -25,7 +25,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
                         const Array4<const Real>& mf_v,
                         const Array4<const Real>& mu_turb,
                         const SolverChoice &solverChoice,
-                        const Real& theta_mean,
+                        const Array4<const Real>& tm_arr,
                         const amrex::GpuArray<Real,AMREX_SPACEDIM> grav_gpu,
                         const amrex::BCRec* bc_ptr)
 {
@@ -438,7 +438,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cell_rhs(i, j, k, qty_index) += ComputeQKESourceTerms(i,j,k,u,v,cell_data,cell_prim,
-                                                                  mu_turb,dxInv,domain,solverChoice,theta_mean);
+                                                                  mu_turb,dxInv,domain,solverChoice,tm_arr(i,j,0));
         });
     }
 }

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -432,8 +432,6 @@ private:
     void post_update (amrex::MultiFab& state_mf, const amrex::Real time, const amrex::Geometry& geom);
     void fill_rhs (amrex::MultiFab& rhs_mf, const amrex::MultiFab& state_mf, const amrex::Real time, const amrex::Geometry& geom);
 
-    void setupABLMost(int lev);
-
     ////////////////
     // private data members
 
@@ -461,6 +459,9 @@ private:
 
     // BoxArray at each level to define where we actually evolve the solution
     amrex::Vector<amrex::BoxArray> grids_to_evolve;
+
+    // Store Theta variable for MOST BC
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> Theta_prim;
 
     // Scratch space for time integrator
     amrex::Vector<amrex::MultiFab> rU_old;

--- a/Source/TimeIntegration/ERF_TimeStepping.cpp
+++ b/Source/TimeIntegration/ERF_TimeStepping.cpp
@@ -95,7 +95,12 @@ ERF::Advance (int lev, Real time, Real dt_lev, int /*iteration*/, int /*ncycle*/
 
     // configure ABLMost params if used MostWall boundary condition
     if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::MOST) {
-        if (m_most) setupABLMost(lev);
+      if (m_most) {
+        amrex::IntVect ng = S_old.nGrowVect(); ng[2]=0;
+        MultiFab::Copy(  *Theta_prim[lev], S_old, Cons::RhoTheta, 0, 1, ng);
+        MultiFab::Divide(*Theta_prim[lev], S_old, Cons::Rho     , 0, 1, ng);
+        m_most->update_fluxes(lev);
+      }
     }
 
     // We need to set these because otherwise in the first call to erf_advance we may

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -185,7 +185,7 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
             Array4<Real> diffflux_y = dflux_y->array(mfi);
             Array4<Real> diffflux_z = dflux_z->array(mfi);
 
-            const Array4<const Real> tm_arr = t_mean_mf->const_array(mfi);
+            const Array4<const Real> tm_arr = t_mean_mf ? t_mean_mf->const_array(mfi) : Array4<const Real>{};
 
             // NOTE: No diffusion for continuity, so n starts at 1.
             //       KE calls moved inside DiffSrcForState.

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -39,8 +39,8 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
 {
     BL_PROFILE_REGION("erf_slow_rhs_post()");
 
-    amrex::Real theta_mean;
-    if (most) theta_mean = most->theta_mean;
+    const MultiFab* t_mean_mf = nullptr;
+    if (most) t_mean_mf = most->get_mac_avg(0,2);
 
     const int l_spatial_order   = solverChoice.spatial_order;
     const bool l_use_terrain    = solverChoice.use_terrain;
@@ -185,6 +185,8 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
             Array4<Real> diffflux_y = dflux_y->array(mfi);
             Array4<Real> diffflux_z = dflux_z->array(mfi);
 
+            const Array4<const Real> tm_arr = t_mean_mf->const_array(mfi);
+
             // NOTE: No diffusion for continuity, so n starts at 1.
             //       KE calls moved inside DiffSrcForState.
             int n_start = amrex::max(start_comp,RhoTheta_comp);
@@ -193,7 +195,7 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
                                    cur_cons, cur_prim, source_fab, cell_rhs,
                                    diffflux_x, diffflux_y, diffflux_z,
                                    dxInv, mf_m, mf_u, mf_v,
-                                   mu_turb, solverChoice, theta_mean, grav_gpu, bc_ptr);
+                                   mu_turb, solverChoice, tm_arr, grav_gpu, bc_ptr);
         }
 
         // This updates just the "slow" conserved variables

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -426,9 +426,9 @@ void erf_slow_rhs_pre (int level, int nrk,
         if (l_use_diff) {
             Array4<Real> diffflux_x = dflux_x->array(mfi);
             Array4<Real> diffflux_y = dflux_y->array(mfi);
-            Array4<Real> diffflux_z = dflux_z->array(mfi);
+            Array4<Real> diffflux_z = dflux_z->array(mfi);;
 
-            const Array4<const Real> tm_arr = t_mean_mf->const_array(mfi);
+            const Array4<const Real> tm_arr = t_mean_mf ? t_mean_mf->const_array(mfi) : Array4<const Real>{};
 
             // NOTE: No diffusion for continuity, so n starts at 1.
             //       KE calls moved inside DiffSrcForState.

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -44,8 +44,8 @@ void erf_slow_rhs_pre (int level, int nrk,
 {
     BL_PROFILE_REGION("erf_slow_rhs_pre()");
 
-    amrex::Real theta_mean;
-    if (most) theta_mean = most->theta_mean;
+    const MultiFab* t_mean_mf = nullptr;
+    if (most) t_mean_mf = most->get_mac_avg(0,2);
 
     int start_comp = 0;
     int   num_comp = 2;
@@ -428,6 +428,8 @@ void erf_slow_rhs_pre (int level, int nrk,
             Array4<Real> diffflux_y = dflux_y->array(mfi);
             Array4<Real> diffflux_z = dflux_z->array(mfi);
 
+            const Array4<const Real> tm_arr = t_mean_mf->const_array(mfi);
+
             // NOTE: No diffusion for continuity, so n starts at 1.
             //       KE calls moved inside DiffSrcForState.
             int n_start = amrex::max(start_comp,RhoTheta_comp);
@@ -438,13 +440,13 @@ void erf_slow_rhs_pre (int level, int nrk,
                                        cell_data, cell_prim, source_fab, cell_rhs,
                                        diffflux_x, diffflux_y, diffflux_z, z_nd, detJ,
                                        dxInv, mf_m, mf_u, mf_v,
-                                       mu_turb, solverChoice, theta_mean, grav_gpu, bc_ptr);
+                                       mu_turb, solverChoice, tm_arr, grav_gpu, bc_ptr);
             } else {
                 DiffusionSrcForState_N(bx, domain, n_start, n_end, u, v, w,
                                        cell_data, cell_prim, source_fab, cell_rhs,
                                        diffflux_x, diffflux_y, diffflux_z,
                                        dxInv, mf_m, mf_u, mf_v,
-                                       mu_turb, solverChoice, theta_mean, grav_gpu, bc_ptr);
+                                       mu_turb, solverChoice, tm_arr, grav_gpu, bc_ptr);
             }
         }
 


### PR DESCRIPTION
1. Only instantiate the MOSTAverage class one time (rather than each time step).

2. Move data structures for averages from ABLMost to MOSTAverage.

3. Implement time averaging with an exponential filter function.

4. Use the averages (2D MFs now) within the PBL model.

5. New Theta_prim MF for use by MOSTAverage.

6. Fill Theta_prim in erf_advance before we take a step.