### PR TITLE
Fix failure of ABL-MOST RegTest.

### DIFF
--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -69,9 +69,9 @@ public:
 
     // Constructor
     explicit ABLMost(const amrex::Vector<amrex::Geometry>& geom,
-                     const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
-                     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
-                     const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
+                     amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                     amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                     amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd)
       : m_geom(geom), m_ma(geom,vars_old,Theta_prim,z_phys_nd)
     {
         amrex::ParmParse pp("erf");
@@ -159,6 +159,12 @@ public:
 
     void
     update_fluxes(int lev, int max_iters = 25);
+
+    void
+    update_mac_ptrs(int lev,
+                    amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim)
+    { m_ma.update_field_ptrs(lev,vars_old,Theta_prim); };
 
     const amrex::MultiFab*
     get_u_star(int lev) { return u_star[lev]; };

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -11,9 +11,9 @@
 class MOSTAverage {
 public:
     explicit MOSTAverage(const amrex::Vector<amrex::Geometry>& geom,
-                         const amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
-                         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
-                         const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd);
+                         amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                         amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                         amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd);
     MOSTAverage() = default;
     ~MOSTAverage()
     {
@@ -22,6 +22,11 @@ public:
             delete m_k_indx[lev];
         }
     };
+
+    // Reset the pointers to field MFs
+    void update_field_ptrs(int lev,
+                           amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                           amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim);
 
     // Compute ncells per plane
     void set_plane_normalization();
@@ -52,7 +57,7 @@ protected:
     // Passed through constructor
     //--------------------------------------------
     const amrex::Vector<amrex::Geometry> m_geom;                     // Geometry at each level
-    amrex::Vector<amrex::Vector<const amrex::MultiFab*>>  m_fields;  // Ptr to fields to be averaged
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_fields;        // Ptr to fields to be averaged
     amrex::Vector<amrex::MultiFab*> m_z_phys_nd;                     // Ptr to terrain heigh coords
 
     // General vars for multiple or all policies

--- a/Source/TimeIntegration/ERF_TimeStepping.cpp
+++ b/Source/TimeIntegration/ERF_TimeStepping.cpp
@@ -99,6 +99,9 @@ ERF::Advance (int lev, Real time, Real dt_lev, int /*iteration*/, int /*ncycle*/
         amrex::IntVect ng = S_old.nGrowVect(); ng[2]=0;
         MultiFab::Copy(  *Theta_prim[lev], S_old, Cons::RhoTheta, 0, 1, ng);
         MultiFab::Divide(*Theta_prim[lev], S_old, Cons::Rho     , 0, 1, ng);
+        // NOTE: std::swap above causes the field ptrs to be out of date.
+        //       Reassign the field ptrs for MAC avg computation.
+        m_most->update_mac_ptrs(lev, vars_old, Theta_prim);
         m_most->update_fluxes(lev);
       }
     }


### PR DESCRIPTION
1. The pointers to vars_new and vars_old are swapped each time step in advance. This broke the new paradigm where MAC is initialized only once and it grabs pointers to vars_old for use in averaging. New member function to update the field pointers fixes this.