### PR TITLE
MAC interpolation w/ terrain

### DIFF
--- a/Exec/WitchOfAgnesi/inputs_most_test
+++ b/Exec/WitchOfAgnesi/inputs_most_test
@@ -26,11 +26,12 @@ zhi.type = "SlipWall"
 #=================================================================
 zlo.type                   = "Most"
 erf.most.average_policy    = 0       # POLICY FOR AVERAGING
-erf.most.use_normal_vector = true    # USE NORMAL VECTOR W/ TERRAIN   
+erf.most.use_normal_vector = true    # USE NORMAL VECTOR W/ TERRAIN
+erf.most.use_interpolation = true    # USE INTERPOLATION ON DESTINATION   
 #erf.most.time_average      = true    # USE TIME AVERAGING
 #-----------------------------------------------------------------        
 erf.most.z0                = 0.01    # SURFACE ROUGHNESS
-erf.most.zref              = 0.20    # QUERY DISTANCE (HEIGHT OR NORM LENGTH)
+erf.most.zref              = 0.05    # QUERY DISTANCE (HEIGHT OR NORM LENGTH)
 #----------------------------------------------------------------- 
 #erf.most.surf_temp         = 301.0   # SPECIFIED SURFACE TEMP
 #erf.most.surf_temp_flux    = 8.14165 # SPECIFIED SURFACE FLUX

--- a/Exec/WitchOfAgnesi/inputs_most_test
+++ b/Exec/WitchOfAgnesi/inputs_most_test
@@ -25,26 +25,26 @@ zhi.type = "SlipWall"
 # MOST BOUNDARY
 #=================================================================
 zlo.type                   = "Most"
-erf.most.average_policy    = 0       # POLICY FOR AVERAGING
-erf.most.use_normal_vector = true    # USE NORMAL VECTOR W/ TERRAIN
+erf.most.average_policy    = 1       # POLICY FOR AVERAGING
+erf.most.use_normal_vector = false   # USE NORMAL VECTOR W/ TERRAIN
 erf.most.use_interpolation = true    # USE INTERPOLATION ON DESTINATION   
 #erf.most.time_average      = true    # USE TIME AVERAGING
 #-----------------------------------------------------------------        
 erf.most.z0                = 0.01    # SURFACE ROUGHNESS
-erf.most.zref              = 0.05    # QUERY DISTANCE (HEIGHT OR NORM LENGTH)
+erf.most.zref              = 0.075    # QUERY DISTANCE (HEIGHT OR NORM LENGTH)
 #----------------------------------------------------------------- 
 #erf.most.surf_temp         = 301.0   # SPECIFIED SURFACE TEMP
 #erf.most.surf_temp_flux    = 8.14165 # SPECIFIED SURFACE FLUX
 #----------------------------------------------------------------- 
 #erf.most.k_arr_in          = 0       # SPECIFIED K INDEX ARRAY (MAXLEV)
-#erf.most.radius            = 0       # SPECIFIED REGION RADIUS
+erf.most.radius            = 1       # SPECIFIED REGION RADIUS
 #-----------------------------------------------------------------
 #erf.most.time_window       = 50.0    # WINDOW FOR TIME AVG
     
     
 # TIME STEP CONTROL
-erf.no_substepping     = 1
-erf.fixed_dt           = 1E-5     
+erf.no_substepping = 1
+erf.fixed_dt       = 1E-5     
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1        # timesteps between computing mass
@@ -64,27 +64,19 @@ erf.plot_int_1      = 1       # number of timesteps between plotfiles
 erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta pres_hse dens_hse pert_pres pert_dens z_phys detJ dpdx dpdy pres_hse_x pres_hse_y
 
 # SOLVER CHOICE
-erf.use_gravity = true
-erf.use_coriolis = false
+erf.use_gravity          = true
+erf.use_coriolis         = false
 erf.use_rayleigh_damping = false
-erf.spatial_order = 2
-erf.les_type = "None"
-
-# MULTILEVEL
-amr.max_level = 0
-amr.ref_ratio_vect = 2 2 1
-
-erf.refinement_indicators = box1
-erf.box1.max_level = 1
-erf.box1.in_box_lo =  2. 0.25
-erf.box1.in_box_hi =  8. 0.75
+erf.spatial_order        = 2
+erf.les_type             = "Smagorinsky"
+erf.Cs                   = 0.1
 
 # TERRRAIN GRID TYPE
 erf.use_terrain = true
 erf.terrain_smoothing = 0
 
 # Diffusion coefficient from Straka, K = 75 m^2/s
-erf.molec_diff_type = "ConstantAlpha"
+erf.molec_diff_type = "Constant"
 erf.rho0_trans = 1.0 # [kg/m^3], used to convert input diffusivities
 erf.dynamicViscosity = 0.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
 erf.alpha_T = 0.0 # [m^2/s]
@@ -94,5 +86,5 @@ erf.alpha_T = 0.0 # [m^2/s]
 
 # PROBLEM PARAMETERS (optional)
 prob.T_0   = 300.0
-prob.U_0   = 0.0
+prob.U_0   = 1.0
 prob.rho_0 = 1.16

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -20,9 +20,15 @@ public:
     {
         for (int lev(0); lev<m_maxlev; ++lev){
             for (int iavg(0); iavg<m_navg; ++iavg) delete m_averages[lev][iavg];
-            delete m_k_indx[lev];
-            delete m_j_indx[lev];
+            
             delete m_i_indx[lev];
+            delete m_j_indx[lev];
+            delete m_k_indx[lev];
+            
+            delete m_x_pos[lev];
+            delete m_y_pos[lev];
+            delete m_z_pos[lev];
+            
         }
     };
 
@@ -45,7 +51,13 @@ public:
     void set_k_indices_T();
 
     // Populate all 2D iMFs with terrain (ijk_indx)
-    void set_ijk_indices_T();
+    void set_norm_indices_T();
+
+    // Populate positions (w/ terrain & norm vector & interpolation)
+    void set_z_positions_T();
+    
+    // Populate positions (w/ terrain & norm vector & interpolation)
+    void set_norm_positions_T();
 
     // Driver for the different average policies
     void compute_averages(int lev);
@@ -60,10 +72,10 @@ public:
     void write_k_indices(int lev);
 
     // Write ijk indices
-    void write_ijk_indices(int lev);
+    void write_norm_indices(int lev);
 
     // Write XZ planar positions
-    void write_XZ_planar_positions(int lev, int lj);
+    void write_xz_positions(int lev, int j);
 
     // Write averages on 2D mf
     void write_averages(int lev);
@@ -73,6 +85,87 @@ public:
 
     // Get z_ref (may be computed from specified k_indx)
     amrex::Real get_zref() { return m_zref; };
+
+    // Interpolate fields to a specified position
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void trilinear_interp_N (const amrex::RealVect& pos,
+                             amrex::Real* interp_vals,
+                             amrex::Array4<amrex::Real const> const& interp_array,
+                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& plo,
+                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& dxi,
+                             const int interp_comp)
+    {
+        const amrex::RealVect lx((pos[0] - plo[0])*dxi[0] + 0.5,
+                                 (pos[1] - plo[1])*dxi[1] + 0.5,
+                                 (pos[2] - plo[2])*dxi[2] + 0.5);
+
+        const amrex::IntVect ijk = lx.floor();
+        
+        int i = ijk[0]; int j = ijk[1]; int k = ijk[2];
+        
+        // Weights
+        const amrex::RealVect sx_hi = lx - ijk;
+        const amrex::RealVect sx_lo = 1 - sx_hi;
+        
+        for (int n = 0; n < interp_comp; n++)
+            interp_vals[n] = sx_lo[0]*sx_lo[1]*sx_lo[2]*interp_array(i-1, j-1, k-1,n) +
+                             sx_lo[0]*sx_lo[1]*sx_hi[2]*interp_array(i-1, j-1, k  ,n) +
+                             sx_lo[0]*sx_hi[1]*sx_lo[2]*interp_array(i-1, j  , k-1,n) +
+                             sx_lo[0]*sx_hi[1]*sx_hi[2]*interp_array(i-1, j  , k  ,n) +
+                             sx_hi[0]*sx_lo[1]*sx_lo[2]*interp_array(i  , j-1, k-1,n) +
+                             sx_hi[0]*sx_lo[1]*sx_hi[2]*interp_array(i  , j-1, k  ,n) +
+                             sx_hi[0]*sx_hi[1]*sx_lo[2]*interp_array(i  , j  , k-1,n) +
+                             sx_hi[0]*sx_hi[1]*sx_hi[2]*interp_array(i  , j  , k  ,n);
+    }
+
+    // Interpolate fields to a specified position
+    AMREX_GPU_HOST_DEVICE AMREX_INLINE
+    void trilinear_interp_T (int& li, int& lj,
+                             const amrex::RealVect& pos,
+                             amrex::Real* interp_vals,
+                             amrex::Array4<amrex::Real const> const& interp_array,
+                             amrex::Array4<amrex::Real const> const& z_arr,
+                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& plo,
+                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& dxi,
+                             const int interp_comp)
+    {
+        // Z must be found from bisection
+        amrex::Real zval;
+        int kmax = ubound(z_arr).z;
+        amrex::Real z_target = pos[2] + z_arr(li,lj,0);
+        for (int lk(0); lk<=kmax; ++lk) {
+            amrex::Real z_lo = 0.25 * ( z_arr(li,lj  ,lk  ) + z_arr(li+1,lj  ,lk  )
+                                      + z_arr(li,lj+1,lk  ) + z_arr(li+1,lj+1,lk  ) );
+            amrex::Real z_hi = 0.25 * ( z_arr(li,lj  ,lk+1) + z_arr(li+1,lj  ,lk+1)
+                                      + z_arr(li,lj+1,lk+1) + z_arr(li+1,lj+1,lk+1) );
+            if (z_target > z_lo && z_target < z_hi){
+                zval = (amrex::Real) lk + ((z_target - z_lo) / (z_hi - z_lo)) + 0.5;
+                break;
+            }
+        }
+        
+        const amrex::RealVect lx((pos[0] - plo[0])*dxi[0] + 0.5,
+                                 (pos[1] - plo[1])*dxi[1] + 0.5,
+                                  zval);
+        
+        const amrex::IntVect ijk = lx.floor();
+        
+        int i = ijk[0]; int j = ijk[1]; int k = ijk[2];
+        
+        // Weights
+        const amrex::RealVect sx_hi = lx - ijk;
+        const amrex::RealVect sx_lo = 1 - sx_hi;
+        
+        for (int n = 0; n < interp_comp; n++)
+            interp_vals[n] = sx_lo[0]*sx_lo[1]*sx_lo[2]*interp_array(i-1, j-1, k-1,n) +
+                             sx_lo[0]*sx_lo[1]*sx_hi[2]*interp_array(i-1, j-1, k  ,n) +
+                             sx_lo[0]*sx_hi[1]*sx_lo[2]*interp_array(i-1, j  , k-1,n) +
+                             sx_lo[0]*sx_hi[1]*sx_hi[2]*interp_array(i-1, j  , k  ,n) +
+                             sx_hi[0]*sx_lo[1]*sx_lo[2]*interp_array(i  , j-1, k-1,n) +
+                             sx_hi[0]*sx_lo[1]*sx_hi[2]*interp_array(i  , j-1, k  ,n) +
+                             sx_hi[0]*sx_hi[1]*sx_lo[2]*interp_array(i  , j  , k-1,n) +
+                             sx_hi[0]*sx_hi[1]*sx_hi[2]*interp_array(i  , j  , k  ,n);
+    }
 
 protected:
 
@@ -90,9 +183,12 @@ protected:
     int m_policy{0};                                                 // Policy for type of averaging
     amrex::Real m_zref{-1.0};                                        // Height above surface for MOST BC
     std::string m_pp_prefix {"erf"};                                 // ParmParse prefix
-    amrex::Vector<amrex::iMultiFab*> m_k_indx;                       // Ptr to 2D imf to hold k indices (maxlev)
-    amrex::Vector<amrex::iMultiFab*> m_j_indx;                       // Ptr to 2D imf to hold j indices (maxlev)
+    amrex::Vector<amrex::MultiFab*> m_x_pos;                         // Ptr to 2D mf to hold x position (maxlev)
+    amrex::Vector<amrex::MultiFab*> m_y_pos;                         // Ptr to 2D mf to hold y position (maxlev)
+    amrex::Vector<amrex::MultiFab*> m_z_pos;                         // Ptr to 2D mf to hold z position (maxlev)
     amrex::Vector<amrex::iMultiFab*> m_i_indx;                       // Ptr to 2D imf to hold i indices (maxlev)
+    amrex::Vector<amrex::iMultiFab*> m_j_indx;                       // Ptr to 2D imf to hold j indices (maxlev)
+    amrex::Vector<amrex::iMultiFab*> m_k_indx;                       // Ptr to 2D imf to hold k indices (maxlev)   
     amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_averages;       // Ptr to 2D mf to hold averages (maxlev,navg)
 
     // Vars for planar average policy
@@ -108,6 +204,7 @@ protected:
 
     // Vars for normal vector policy
     //--------------------------------------------
+    bool m_interp{false};                                            // Do interpolation on destination?
     bool m_norm_vec{false};                                          // Use normal vector to find IJK?
 
     // Time average w/ exponential filter fun

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -87,7 +87,7 @@ public:
 
     // Interpolate fields to a specified position (w/ terrain)
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    void trilinear_interp_T (const amrex::Real& xp,
+    static void trilinear_interp_T (const amrex::Real& xp,
                              const amrex::Real& yp,
                              const amrex::Real& zp,
                              amrex::Real* interp_vals,

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -20,15 +20,14 @@ public:
     {
         for (int lev(0); lev<m_maxlev; ++lev){
             for (int iavg(0); iavg<m_navg; ++iavg) delete m_averages[lev][iavg];
-            
-            delete m_i_indx[lev];
-            delete m_j_indx[lev];
-            delete m_k_indx[lev];
-            
+
             delete m_x_pos[lev];
             delete m_y_pos[lev];
             delete m_z_pos[lev];
-            
+
+            delete m_i_indx[lev];
+            delete m_j_indx[lev];
+            delete m_k_indx[lev];
         }
     };
 
@@ -44,18 +43,18 @@ public:
     void set_region_normalization()
     {m_ncell_region = (2 * m_radius + 1) * (2 * m_radius + 1) * (2 * m_radius + 1);};
 
-    // Populate a 2D iMF w/o terrain (k_indx)
+    // Populate a 2D iMF k_indx (w/o terrain)
     void set_k_indices_N();
 
-    // Populate a 2D iMF with terrain (k_indx)
+    // Populate a 2D iMF k_indx (w/ terrain)
     void set_k_indices_T();
 
-    // Populate all 2D iMFs with terrain (ijk_indx)
+    // Populate all 2D iMFs ijk_indx (w/ terrain)
     void set_norm_indices_T();
 
     // Populate positions (w/ terrain & norm vector & interpolation)
     void set_z_positions_T();
-    
+
     // Populate positions (w/ terrain & norm vector & interpolation)
     void set_norm_positions_T();
 
@@ -86,42 +85,11 @@ public:
     // Get z_ref (may be computed from specified k_indx)
     amrex::Real get_zref() { return m_zref; };
 
-    // Interpolate fields to a specified position
+    // Interpolate fields to a specified position (w/ terrain)
     AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    void trilinear_interp_N (const amrex::RealVect& pos,
-                             amrex::Real* interp_vals,
-                             amrex::Array4<amrex::Real const> const& interp_array,
-                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& plo,
-                             const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& dxi,
-                             const int interp_comp)
-    {
-        const amrex::RealVect lx((pos[0] - plo[0])*dxi[0] + 0.5,
-                                 (pos[1] - plo[1])*dxi[1] + 0.5,
-                                 (pos[2] - plo[2])*dxi[2] + 0.5);
-
-        const amrex::IntVect ijk = lx.floor();
-        
-        int i = ijk[0]; int j = ijk[1]; int k = ijk[2];
-        
-        // Weights
-        const amrex::RealVect sx_hi = lx - ijk;
-        const amrex::RealVect sx_lo = 1 - sx_hi;
-        
-        for (int n = 0; n < interp_comp; n++)
-            interp_vals[n] = sx_lo[0]*sx_lo[1]*sx_lo[2]*interp_array(i-1, j-1, k-1,n) +
-                             sx_lo[0]*sx_lo[1]*sx_hi[2]*interp_array(i-1, j-1, k  ,n) +
-                             sx_lo[0]*sx_hi[1]*sx_lo[2]*interp_array(i-1, j  , k-1,n) +
-                             sx_lo[0]*sx_hi[1]*sx_hi[2]*interp_array(i-1, j  , k  ,n) +
-                             sx_hi[0]*sx_lo[1]*sx_lo[2]*interp_array(i  , j-1, k-1,n) +
-                             sx_hi[0]*sx_lo[1]*sx_hi[2]*interp_array(i  , j-1, k  ,n) +
-                             sx_hi[0]*sx_hi[1]*sx_lo[2]*interp_array(i  , j  , k-1,n) +
-                             sx_hi[0]*sx_hi[1]*sx_hi[2]*interp_array(i  , j  , k  ,n);
-    }
-
-    // Interpolate fields to a specified position
-    AMREX_GPU_HOST_DEVICE AMREX_INLINE
-    void trilinear_interp_T (int& li, int& lj,
-                             const amrex::RealVect& pos,
+    void trilinear_interp_T (const amrex::Real& xp,
+                             const amrex::Real& yp,
+                             const amrex::Real& zp,
                              amrex::Real* interp_vals,
                              amrex::Array4<amrex::Real const> const& interp_array,
                              amrex::Array4<amrex::Real const> const& z_arr,
@@ -129,33 +97,35 @@ public:
                              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& dxi,
                              const int interp_comp)
     {
-        // Z must be found from bisection
+        // Search to get z/k
         amrex::Real zval;
         int kmax = ubound(z_arr).z;
-        amrex::Real z_target = pos[2] + z_arr(li,lj,0);
-        for (int lk(0); lk<=kmax; ++lk) {
-            amrex::Real z_lo = 0.25 * ( z_arr(li,lj  ,lk  ) + z_arr(li+1,lj  ,lk  )
-                                      + z_arr(li,lj+1,lk  ) + z_arr(li+1,lj+1,lk  ) );
-            amrex::Real z_hi = 0.25 * ( z_arr(li,lj  ,lk+1) + z_arr(li+1,lj  ,lk+1)
-                                      + z_arr(li,lj+1,lk+1) + z_arr(li+1,lj+1,lk+1) );
+        int i_new = (int) (xp * dxi[0] - 0.5);
+        int j_new = (int) (yp * dxi[1] - 0.5);
+        amrex::Real z_target = zp;
+        for (int lk(0); lk<kmax; ++lk) {
+            amrex::Real z_lo = 0.25 * ( z_arr(i_new,j_new  ,lk  ) + z_arr(i_new+1,j_new  ,lk  )
+                                      + z_arr(i_new,j_new+1,lk  ) + z_arr(i_new+1,j_new+1,lk  ) );
+            amrex::Real z_hi = 0.25 * ( z_arr(i_new,j_new  ,lk+1) + z_arr(i_new+1,j_new  ,lk+1)
+                                      + z_arr(i_new,j_new+1,lk+1) + z_arr(i_new+1,j_new+1,lk+1) );
             if (z_target > z_lo && z_target < z_hi){
                 zval = (amrex::Real) lk + ((z_target - z_lo) / (z_hi - z_lo)) + 0.5;
                 break;
             }
         }
-        
-        const amrex::RealVect lx((pos[0] - plo[0])*dxi[0] + 0.5,
-                                 (pos[1] - plo[1])*dxi[1] + 0.5,
+
+        const amrex::RealVect lx((xp - plo[0])*dxi[0] + 0.5,
+                                 (yp - plo[1])*dxi[1] + 0.5,
                                   zval);
-        
+
         const amrex::IntVect ijk = lx.floor();
-        
+
         int i = ijk[0]; int j = ijk[1]; int k = ijk[2];
-        
+
         // Weights
         const amrex::RealVect sx_hi = lx - ijk;
         const amrex::RealVect sx_lo = 1 - sx_hi;
-        
+
         for (int n = 0; n < interp_comp; n++)
             interp_vals[n] = sx_lo[0]*sx_lo[1]*sx_lo[2]*interp_array(i-1, j-1, k-1,n) +
                              sx_lo[0]*sx_lo[1]*sx_hi[2]*interp_array(i-1, j-1, k  ,n) +
@@ -188,7 +158,7 @@ protected:
     amrex::Vector<amrex::MultiFab*> m_z_pos;                         // Ptr to 2D mf to hold z position (maxlev)
     amrex::Vector<amrex::iMultiFab*> m_i_indx;                       // Ptr to 2D imf to hold i indices (maxlev)
     amrex::Vector<amrex::iMultiFab*> m_j_indx;                       // Ptr to 2D imf to hold j indices (maxlev)
-    amrex::Vector<amrex::iMultiFab*> m_k_indx;                       // Ptr to 2D imf to hold k indices (maxlev)   
+    amrex::Vector<amrex::iMultiFab*> m_k_indx;                       // Ptr to 2D imf to hold k indices (maxlev)
     amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_averages;       // Ptr to 2D mf to hold averages (maxlev,navg)
 
     // Vars for planar average policy

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -519,7 +519,6 @@ MOSTAverage::compute_plane_averages(int lev)
             amrex::Real d_val_old = plane_average[imf]*d_fact_old;
 
             if (m_interp) {
-                const auto mac   = this;
                 const auto plo   = geom.ProbLoArray();
                 const auto dxInv = geom.InvCellSizeArray();
                 const auto z_phys_arr = z_phys->const_array(mfi);
@@ -530,7 +529,7 @@ MOSTAverage::compute_plane_averages(int lev)
                 AMREX_GPU_DEVICE(int i, int j, int k, amrex::Gpu::Handler const& handler) noexcept
                 {
                     amrex::Real interp{0};
-                    mac->trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
+                    trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
                                             &interp, mf_arr, z_phys_arr, plo, dxInv, 1);
                     amrex::Real val = denom * ( interp*d_fact_new + d_val_old );
                     amrex::Gpu::deviceReduceSum(&plane_avg[imf], val, handler);
@@ -571,7 +570,6 @@ MOSTAverage::compute_plane_averages(int lev)
             amrex::Real d_val_old = plane_average[iavg]*d_fact_old;
 
             if (m_interp) {
-                const auto mac   = this;
                 const auto plo   = m_geom[lev].ProbLoArray();
                 const auto dxInv = m_geom[lev].InvCellSizeArray();
                 const auto z_phys_arr = z_phys->const_array(mfi);
@@ -583,9 +581,9 @@ MOSTAverage::compute_plane_averages(int lev)
                 {
                     amrex::Real u_interp{0};
                     amrex::Real v_interp{0};
-                    mac->trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
+                    trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
                                             &u_interp, u_mf_arr, z_phys_arr, plo, dxInv, 1);
-                    mac->trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
+                    trilinear_interp_T(x_pos_arr(i,j,k), y_pos_arr(i,j,k), z_pos_arr(i,j,k),
                                             &v_interp, v_mf_arr, z_phys_arr, plo, dxInv, 1);
                     const amrex::Real mag   = std::sqrt(u_interp*u_interp + v_interp*v_interp);
                     amrex::Real val = denom * ( mag*d_fact_new + d_val_old);
@@ -667,7 +665,6 @@ MOSTAverage::compute_region_averages(int lev)
             auto ma_arr = averages[imf]->array(mfi);
 
             if (m_interp) {
-                const auto mac   = this;
                 const auto plo   = geom.ProbLoArray();
                 const auto dx    = geom.CellSizeArray();
                 const auto dxInv = geom.InvCellSizeArray();
@@ -687,7 +684,7 @@ MOSTAverage::compute_region_averages(int lev)
                             amrex::Real xp = x_pos_arr(i,j,k) + li*dx[0];
                             amrex::Real yp = y_pos_arr(i,j,k) + lj*dx[1];
                             amrex::Real zp = z_pos_arr(i,j,k) + met_h_zeta*lk*dx[2];
-                            mac->trilinear_interp_T(xp, yp, zp, &interp, mf_arr, z_phys_arr, plo, dxInv, 1);
+                            trilinear_interp_T(xp, yp, zp, &interp, mf_arr, z_phys_arr, plo, dxInv, 1);
                             amrex::Real val = denom * interp * d_fact_new;
                             ma_arr(i,j,k) += val;
                         }
@@ -739,7 +736,6 @@ MOSTAverage::compute_region_averages(int lev)
             auto ma_arr   = averages[iavg]->array(mfi);
 
             if (m_interp) {
-                const auto mac   = this;
                 const auto plo   = geom.ProbLoArray();
                 const auto dx    = geom.CellSizeArray();
                 const auto dxInv = geom.InvCellSizeArray();
@@ -760,8 +756,8 @@ MOSTAverage::compute_region_averages(int lev)
                             amrex::Real xp = x_pos_arr(i,j,k) + li*dx[0];
                             amrex::Real yp = y_pos_arr(i,j,k) + lj*dx[1];
                             amrex::Real zp = z_pos_arr(i,j,k) + met_h_zeta*lk*dx[2];
-                            mac->trilinear_interp_T(xp, yp, zp, &u_interp, u_mf_arr, z_phys_arr, plo, dxInv, 1);
-                            mac->trilinear_interp_T(xp, yp, zp, &v_interp, v_mf_arr, z_phys_arr, plo, dxInv, 1);
+                            trilinear_interp_T(xp, yp, zp, &u_interp, u_mf_arr, z_phys_arr, plo, dxInv, 1);
+                            trilinear_interp_T(xp, yp, zp, &v_interp, v_mf_arr, z_phys_arr, plo, dxInv, 1);
                             amrex::Real mag = std::sqrt(u_interp*u_interp + v_interp*v_interp);
                             amrex::Real val = denom * mag * d_fact_new;
                             ma_arr(i,j,k) += val;

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -13,7 +13,10 @@ MOSTAverage::MOSTAverage (const amrex::Vector<amrex::Geometry>& geom,
     pp.query("most.radius",m_radius);
     pp.query("most.time_average",m_t_avg);
     pp.query("most.average_policy",m_policy);
+    pp.query("most.use_interpolation",m_interp);
     pp.query("most.use_normal_vector",m_norm_vec);
+
+    AMREX_ASSERT_WITH_MESSAGE(m_radius<=2, "Radius must be less than nGhost=3!");
 
     // Set up fields and 2D MF/iMFs for averages
     //--------------------------------------------------------
@@ -22,9 +25,13 @@ MOSTAverage::MOSTAverage (const amrex::Vector<amrex::Geometry>& geom,
 
     m_k_in.resize(m_maxlev);
 
-    m_k_indx.resize(m_maxlev);
-    m_j_indx.resize(m_maxlev);
+    m_x_pos.resize(m_maxlev);
+    m_y_pos.resize(m_maxlev);
+    m_z_pos.resize(m_maxlev);
+
     m_i_indx.resize(m_maxlev);
+    m_j_indx.resize(m_maxlev);
+    m_k_indx.resize(m_maxlev);
 
     m_averages.resize(m_maxlev);
 
@@ -85,29 +92,39 @@ MOSTAverage::MOSTAverage (const amrex::Vector<amrex::Geometry>& geom,
         m_averages[lev][3] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
         m_averages[lev][3]->setVal(1.E34);
 
-        m_k_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
-
-        if (m_norm_vec) {
-            m_j_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
+        if (m_z_phys_nd[0] && m_norm_vec && m_interp) {
+            m_x_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+            m_y_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+            m_z_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        } else if (m_z_phys_nd[0] && m_interp) {
+            m_x_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+            m_y_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+            m_z_pos[lev] = new amrex::MultiFab(ba2d,dm,ncomp,ng);
+        } else if (m_z_phys_nd[0] && m_norm_vec) {
             m_i_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
+            m_j_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
+            m_k_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
         } else {
-            m_j_indx[lev] = nullptr;
-            m_i_indx[lev] = nullptr;
+            m_k_indx[lev] = new amrex::iMultiFab(ba2d,dm,incomp,ng);
         }
       }
     } // lev
 
-    // Setup 2d iMF(s) for spatial configuration
+    // Setup auxiliary data for spatial configuration & policy
     //--------------------------------------------------------
-    if (m_norm_vec && m_z_phys_nd[0]) { // Use norm vector with terrain
-        set_ijk_indices_T();
-    } else if (m_z_phys_nd[0]) {        // No norm vector with terrain
+    if (m_z_phys_nd[0] && m_norm_vec && m_interp) { // Terrain w/ norm & w/ interpolation
+        set_norm_positions_T();
+    } else if (m_z_phys_nd[0] && m_interp) {        // Terrain w/ interpolation
+        set_z_positions_T();
+    } else if (m_z_phys_nd[0] && m_norm_vec) {      // Terrain w/ norm & w/o interpolation
+        set_norm_indices_T();
+    } else if (m_z_phys_nd[0]) {                    // Terrain
         set_k_indices_T();
-    } else {                            // No norm vector and no terrain
+    } else {                                        // No Terrain
         set_k_indices_N();
     }
 
-    // Setup auxiliary data for the chosen policy
+    // Setup normalization data for the chosen policy
     //--------------------------------------------------------
     switch(m_policy) {
     case 0: // Plane average
@@ -136,13 +153,13 @@ MOSTAverage::MOSTAverage (const amrex::Vector<amrex::Geometry>& geom,
         m_t_init.resize(m_maxlev,0);
     }
 
-    /*
+    
     // DEBUG: DELETE WHEN FINISHED
     //=============================
-    write_ijk_indices(0);
-    write_XZ_planar_positions(0,0);
+    //write_norm_indices(0);
+    write_xz_positions(0,0);
     exit(0);
-    */
+    
 }
 
 
@@ -206,25 +223,20 @@ MOSTAverage::set_k_indices_N()
             amrex::Real m_zlo = m_geom[lev].ProbLo(2);
             amrex::Real m_dz  = m_geom[lev].CellSize(2);
 
-            AMREX_ALWAYS_ASSERT(m_zref >= m_zlo + 0.5 * m_dz);
+            AMREX_ASSERT_WITH_MESSAGE(m_zref >= m_zlo + 0.5 * m_dz,
+                                      "Query point must be past first z-cell!");
 
             int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));
-            lk = std::max(m_radius,lk);
-            amrex::IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
 
-            for (amrex::MFIter mfi(*m_k_indx[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                amrex::Box gpbx = mfi.growntilebox(ng);
-                auto k_arr      = m_k_indx[lev]->array(mfi);
-                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-                {
-                    k_arr(i,j,k) = lk;
-                });
-            }
+            AMREX_ALWAYS_ASSERT(lk >= m_radius);
+            
+            m_k_indx[lev]->setVal(lk);
         }
     // Specified k_indx & compute z_ref
     } else if (read_k) {
         for (int lev(0); lev < m_maxlev; lev++){
-            m_k_in[lev] = std::max(m_radius,m_k_in[lev]);
+            AMREX_ASSERT_WITH_MESSAGE(m_k_in[lev] >= m_radius,
+                                      "K index must be larger than averaging radius!");
             m_k_indx[lev]->setVal(m_k_in[lev]);
         }
 
@@ -245,18 +257,18 @@ MOSTAverage::set_k_indices_T()
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
     // Capture for device
-    amrex::Real d_zref = m_zref;
-
+    amrex::Real d_zref   = m_zref;
+    amrex::Real d_radius = m_radius;
+    
     // Specify z_ref & compute k_indx (z_ref takes precedence)
     if (read_z) {
         for (int lev(0); lev < m_maxlev; lev++) {
             int kmax = m_geom[lev].Domain().bigEnd(2);
-            amrex::IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
             for (amrex::MFIter mfi(*m_k_indx[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-                amrex::Box gpbx  = mfi.growntilebox(ng);
+                amrex::Box npbx  = mfi.tilebox(); npbx.convert({1,1,0});
                 const auto z_arr = m_z_phys_nd[lev]->const_array(mfi);
                 auto k_arr       = m_k_indx[lev]->array(mfi);
-                ParallelFor(gpbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     amrex::Real z_target = d_zref + z_arr(i,j,k);
                     for (int lk(0); lk<=kmax; ++lk) {
@@ -265,6 +277,8 @@ MOSTAverage::set_k_indices_T()
                         amrex::Real z_hi = 0.25 * ( z_arr(i,j  ,lk+1) + z_arr(i+1,j  ,lk+1)
                                                   + z_arr(i,j+1,lk+1) + z_arr(i+1,j+1,lk+1) );
                         if (z_target > z_lo && z_target < z_hi){
+                            AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
+                                                      "K index must be larger than averaging radius!");
                             k_arr(i,j,k) = lk;
                             break;
                         }
@@ -281,25 +295,27 @@ MOSTAverage::set_k_indices_T()
 
 // Populate all 2D iMFs for averaging (w/ terrain & norm vector)
 void
-MOSTAverage::set_ijk_indices_T()
+MOSTAverage::set_norm_indices_T()
 {
     amrex::ParmParse pp(m_pp_prefix);
     pp.query("most.zref",m_zref);
 
     // Capture for device
-    amrex::Real d_zref = m_zref;
+    amrex::Real d_zref   = m_zref;
+    amrex::Real d_radius = m_radius;
 
     for (int lev(0); lev < m_maxlev; lev++) {
         int kmax = m_geom[lev].Domain().bigEnd(2);
-        amrex::IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
         const auto dxInv  = m_geom[lev].InvCellSizeArray();
+        amrex::IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
         for (amrex::MFIter mfi(*m_k_indx[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            amrex::Box gpbx = mfi.growntilebox(ng);
+            amrex::Box npbx  = mfi.tilebox(); npbx.convert({1,1,0});
+            amrex::Box gpbx  = mfi.growntilebox(ng);
             const auto z_arr = m_z_phys_nd[lev]->const_array(mfi);
-            auto k_arr       = m_k_indx[lev]->array(mfi);
-            auto j_arr       = m_j_indx[lev]->array(mfi);
             auto i_arr       = m_i_indx[lev]->array(mfi);
-            ParallelFor(gpbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            auto j_arr       = m_j_indx[lev]->array(mfi);
+            auto k_arr       = m_k_indx[lev]->array(mfi);           
+            ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // Elements of normal vector
                 amrex::Real met_h_xi  = Compute_h_xi_AtCellCenter (i,j,k,dxInv,z_arr);
@@ -327,10 +343,110 @@ MOSTAverage::set_ijk_indices_T()
                     amrex::Real z_hi = 0.25 * ( z_arr(i_new,j_new  ,lk+1) + z_arr(i_new+1,j_new  ,lk+1)
                                               + z_arr(i_new,j_new+1,lk+1) + z_arr(i_new+1,j_new+1,lk+1) );
                     if (z_target > z_lo && z_target < z_hi){
+                        AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
+                                                  "K index must be larger than averaging radius!");
                         k_arr(i,j,k) = lk;
                         break;
                     }
                 }
+
+                // Destination cell must be contained on the current process!
+                AMREX_ASSERT_WITH_MESSAGE(gpbx.contains(i_arr(i,j,k),j_arr(i,j,k),k_arr(i,j,k)),
+                                          "Query index outside of proc domain!");
+            });
+        }
+    }
+}
+
+
+// Populate positions (w/ terrain & interpolation)
+void
+MOSTAverage::set_z_positions_T()
+{
+    amrex::ParmParse pp(m_pp_prefix);
+    pp.query("most.zref",m_zref);
+
+    // Capture for device
+    amrex::Real d_zref   = m_zref;
+
+    for (int lev(0); lev < m_maxlev; lev++) {
+        amrex::RealVect base;
+        const auto dx = m_geom[lev].CellSizeArray();
+        amrex::IntVect ng = m_x_pos[lev]->nGrowVect(); ng[2]=0;
+        for (amrex::MFIter mfi(*m_x_pos[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box npbx  = mfi.tilebox(); npbx.convert({1,1,0});
+            amrex::Box gpbx  = mfi.growntilebox(ng);
+            amrex::RealBox grb{gpbx,dx.data(),base.dataPtr()};
+            
+            auto x_pos_arr   = m_x_pos[lev]->array(mfi);
+            auto y_pos_arr   = m_y_pos[lev]->array(mfi);
+            auto z_pos_arr   = m_z_pos[lev]->array(mfi);
+            ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                // Final position at end of vector
+                x_pos_arr(i,j,k) = ((amrex::Real) i + 0.5) * dx[0];
+                y_pos_arr(i,j,k) = ((amrex::Real) j + 0.5) * dx[1];
+                z_pos_arr(i,j,k) = d_zref;
+
+                // Destination position must be contained on the current process!
+                amrex::Real pos[] = {x_pos_arr(i,j,k),y_pos_arr(i,j,k),0.5*dx[2]};
+                AMREX_ASSERT_WITH_MESSAGE( grb.contains(&pos[0]),
+                                           "Query point outside of proc domain!");
+            });
+        }
+    }
+}
+
+
+// Populate positions (w/ terrain & norm vector & interpolation)
+void
+MOSTAverage::set_norm_positions_T()
+{
+    amrex::ParmParse pp(m_pp_prefix);
+    pp.query("most.zref",m_zref);
+
+    // Capture for device
+    amrex::Real d_zref = m_zref;
+
+    for (int lev(0); lev < m_maxlev; lev++) {
+        amrex::RealVect base;
+        const auto dx = m_geom[lev].CellSizeArray();
+        const auto dxInv  = m_geom[lev].InvCellSizeArray();
+        amrex::IntVect ng = m_x_pos[lev]->nGrowVect(); ng[2]=0;
+        for (amrex::MFIter mfi(*m_x_pos[lev], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+            amrex::Box npbx  = mfi.tilebox(); npbx.convert({1,1,0});
+            amrex::Box gpbx  = mfi.growntilebox(ng);
+            amrex::RealBox grb{gpbx,dx.data(),base.dataPtr()};
+            
+            const auto z_arr = m_z_phys_nd[lev]->const_array(mfi);
+            auto x_pos_arr   = m_x_pos[lev]->array(mfi);
+            auto y_pos_arr   = m_y_pos[lev]->array(mfi);
+            auto z_pos_arr   = m_z_pos[lev]->array(mfi);
+            ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            {
+                // Elements of normal vector
+                amrex::Real met_h_xi  = Compute_h_xi_AtCellCenter (i,j,k,dxInv,z_arr);
+                amrex::Real met_h_eta = Compute_h_eta_AtCellCenter(i,j,k,dxInv,z_arr);
+                amrex::Real mag = std::sqrt(met_h_xi*met_h_xi + met_h_eta*met_h_eta + 1.0);
+
+                // Unit-normal vector scaled by z_ref
+                amrex::Real delta_x = -met_h_xi/mag  * d_zref;
+                amrex::Real delta_y = -met_h_eta/mag * d_zref;
+                amrex::Real delta_z = 1.0/mag * d_zref;
+
+                // Position of the current node (indx:0,0,1)
+                amrex::Real x0 = ((amrex::Real) i + 0.5) * dx[0];
+                amrex::Real y0 = ((amrex::Real) j + 0.5) * dx[1];
+
+                // Final position at end of vector
+                x_pos_arr(i,j,k) = x0 + delta_x;
+                y_pos_arr(i,j,k) = y0 + delta_y;
+                z_pos_arr(i,j,k) = delta_z;
+
+                // Destination position must be contained on the current process!
+                amrex::Real pos[] = {x_pos_arr(i,j,k),y_pos_arr(i,j,k),0.5*dx[2]};
+                AMREX_ASSERT_WITH_MESSAGE( grb.contains(&pos[0]),
+                                           "Query point outside of proc domain!");
             });
         }
     }
@@ -646,7 +762,7 @@ MOSTAverage::write_k_indices(int lev)
 
 // Write ijk indices
 void
-MOSTAverage::write_ijk_indices(int lev)
+MOSTAverage::write_norm_indices(int lev)
 {
     // Peel back the level
     auto& averages = m_averages[lev];
@@ -690,47 +806,29 @@ MOSTAverage::write_ijk_indices(int lev)
 
 // Write position of XZ plane
 void
-MOSTAverage::write_XZ_planar_positions(int lev, int lj)
+MOSTAverage::write_xz_positions(int lev, int j)
 {
     // Peel back the level
-    auto& averages = m_averages[lev];
-    auto& z_mf     = m_z_phys_nd[lev];
-    auto& k_indx   = m_k_indx[lev];
-    auto& j_indx   = m_j_indx[lev];
-    auto& i_indx   = m_i_indx[lev];
+    auto& z_phys_mf = m_z_phys_nd[lev];
+    auto& x_pos_mf  = m_x_pos[lev];
+    auto& z_pos_mf  = m_z_pos[lev];
 
     int navg = m_navg - 1;
-
-    amrex::Real m_xlo = m_geom[lev].ProbLo(0);
-    amrex::Real m_dx  = m_geom[lev].CellSize(0);
 
     std::ofstream ofile;
     ofile.open ("MOST_XZ_positions.txt");
 
-    for (amrex::MFIter mfi(*averages[navg], amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+    for (amrex::MFIter mfi(*x_pos_mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         amrex::Box bx  = mfi.tilebox(); bx.setBig(2,0);
         int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
 
-        const auto z_arr = z_mf->const_array(mfi);
-        auto k_arr = k_indx->array(mfi);
-        auto j_arr = j_indx ? j_indx->array(mfi) : amrex::Array4<int> {};
-        auto i_arr = i_indx ? i_indx->array(mfi) : amrex::Array4<int> {};
+        auto z_phys_arr = z_phys_mf->array(mfi);
+        auto x_pos_arr  = x_pos_mf->array(mfi);
+        auto z_pos_arr  = z_pos_mf->array(mfi);
 
-        for (int i(il); i <= iu; ++i) {
-
-            int k  = 0;
-            int km = k_arr(i,lj,k);
-            int jm = j_arr ? j_arr(i,lj,k) : lj;
-            int im = i_arr ? i_arr(i,lj,k) :  i;
-
-            amrex::Real xpos = ((amrex::Real)im + 0.5) * m_dx + m_xlo;
-            amrex::Real zpos = 0.125 * ( z_arr(im,jm  ,km  ) + z_arr(im+1,jm  ,km  )
-                                       + z_arr(im,jm+1,km  ) + z_arr(im+1,jm+1,km  )
-                                       + z_arr(im,jm  ,km+1) + z_arr(im+1,jm  ,km+1)
-                                       + z_arr(im,jm+1,km+1) + z_arr(im+1,jm+1,km+1) );
-
-            ofile << xpos << ' ' << zpos << "\n";
-        }
+        int k  = 0;
+        for (int i(il); i <= iu; ++i)
+            ofile << x_pos_arr(i,j,k) << ' ' << z_pos_arr(i,j,k) + z_phys_arr(i,j,k) << "\n";
     }
     ofile.close();
 }

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -337,8 +337,8 @@ void erf_slow_rhs_pre (int level, int nrk,
             if (l_use_terrain) {
                 amrex::ParallelFor(tbxxz,tbxyz,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                    Real GradWz = 0.25 * dxInv[2] * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
-                                                    - w(i  ,j  ,k-1) - w(i-1,j  ,k-1) );
+                    Real GradWz = 0.5 * dxInv[2] * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
+                                                   - w(i  ,j  ,k  ) - w(i-1,j  ,k  ) );
 
                     Real met_h_xi,met_h_zeta;
                     met_h_xi   = Compute_h_xi_AtEdgeCenterJ  (i,j,k,dxInv,z_nd);
@@ -350,8 +350,8 @@ void erf_slow_rhs_pre (int level, int nrk,
                     tau31(i,j,k) = tau13(i,j,k);
                 },
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                    Real GradWz = 0.25 * dxInv[2] * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
-                                                    - w(i  ,j  ,k-1) - w(i  ,j-1,k-1) );
+                    Real GradWz = 0.5 * dxInv[2] * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+                                                   - w(i  ,j  ,k  ) - w(i  ,j-1,k  ) );
 
                     Real met_h_eta,met_h_zeta;
                     met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);


### PR DESCRIPTION
1. Add option to complete bi-linear interpolation with terrain and query points found from a specified vertical distance and specified normal vector length.

2. This ran with debug and cuda for WOA.