### PR TITLE
Updates to Bubble for 2D squall problem

### DIFF
--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -68,8 +68,16 @@ perturb_rho_theta (const amrex::Real x,
     amrex::Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0/p_hse, rdOcp);
 
     // Update state -- this version perturbs rho but not p
-    rhotheta = getRhoThetagivenP(p_hse);
-    rho = rhotheta / theta_perturbed;
+    if (parms.T_0 > 0)
+    {
+        rhotheta = getRhoThetagivenP(p_hse);
+        rho = rhotheta / theta_perturbed;
+    } else {
+        // already have a background field initialized, need to return
+        // perturbations
+        rhotheta = 0.0;
+        rho = getRhoThetagivenP(p_hse) / theta_perturbed - r_hse;
+    }
 }
 
 #endif

--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -26,6 +26,9 @@ struct ProbParm {
   bool T_pert_is_airtemp = true; // T_pert input is air temperature
   bool perturb_rho = true; // not rho*theta (i.e., p is constant); otherwise perturb rho*theta
 
+  // rayleigh damping
+  amrex::Real dampcoef = 0.0; // inverse time scale [1/s]
+  amrex::Real zdamp = 5000.0; // damping depth [m] from model top
 }; // namespace ProbParm
 
 extern ProbParm parms;

--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -23,6 +23,8 @@ struct ProbParm {
 
   // perturbation temperature
   amrex::Real T_pert = -15.0;
+  bool T_pert_potential = false; // input is potential temperature
+  bool perturb_rho = true; // not rho*theta (i.e., p is constant); otherwise perturb rho*theta
 
 }; // namespace ProbParm
 
@@ -44,9 +46,6 @@ perturb_rho_theta (const amrex::Real x,
                    amrex::Real& rho,
                    amrex::Real& rhotheta)
 {
-    // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
-    const amrex::Real Tbar_hse = p_hse / (R_d * r_hse);
-
     // Perturbation air temperature
     // - The bubble is either cylindrical (for 2-D problems, if two
     //   radial extents are specified) or an ellipsoid (if all three
@@ -64,19 +63,46 @@ perturb_rho_theta (const amrex::Real x,
         dT = pp.T_pert * (std::cos(PI*L) + 1.0)/2.0;
     }
 
-    // Note: theta_perturbed is theta PLUS perturbation in theta
-    amrex::Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0/p_hse, rdOcp);
+    // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
+    const amrex::Real Tbar_hse = p_hse / (R_d * r_hse);
 
-    // Update state -- this version perturbs rho but not p
-    if (pp.T_0 > 0)
-    {
-        rhotheta = getRhoThetagivenP(p_hse);
-        rho = rhotheta / theta_perturbed;
+    // Note: theta_perturbed is theta PLUS perturbation in theta
+    amrex::Real theta_perturbed;
+    if (pp.T_pert_potential) {
+        // dT is potential temperature
+        theta_perturbed = Tbar_hse*std::pow(p_0/p_hse, rdOcp) + dT;
     } else {
-        // already have a background field initialized, need to return
-        // perturbations
-        rhotheta = 0.0;
-        rho = getRhoThetagivenP(p_hse) / theta_perturbed - r_hse;
+        // dT is air temperature
+        theta_perturbed = (Tbar_hse + dT)*std::pow(p_0/p_hse, rdOcp);
+    }
+
+    if (pp.perturb_rho) // - this version perturbs rho but not p (like density current problem)
+    {
+        if (pp.T_0 > 0)
+        {
+            // update full state, calculate HSE base state later
+            rhotheta = getRhoThetagivenP(p_hse);
+            rho = rhotheta / theta_perturbed;
+        } else {
+            // already have a background field initialized, need to return
+            // rho and rhotheta as _perturbations_
+            rhotheta = 0.0; // i.e., hydrostatically balanced pressure stays const
+            rho = getRhoThetagivenP(p_hse) / theta_perturbed - r_hse;
+        }
+    }
+    else // - this version perturbs p but not rho
+    {
+        if (pp.T_0 > 0)
+        {
+            // update full state, calculate HSE base state later
+            rho = r_hse;
+            rhotheta = r_hse * theta_perturbed;
+        } else {
+            // already have a base field initialized, need to return
+            // rho and rhotheta as _perturbations_
+            rho = 0.0; // i.e., hydrostatically balanced density stays const
+            rhotheta = r_hse * theta_perturbed - getRhoThetagivenP(p_hse);
+        }
     }
 }
 

--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -23,7 +23,7 @@ struct ProbParm {
 
   // perturbation temperature
   amrex::Real T_pert = -15.0;
-  bool T_pert_potential = false; // input is potential temperature
+  bool T_pert_is_airtemp = true; // T_pert input is air temperature
   bool perturb_rho = true; // not rho*theta (i.e., p is constant); otherwise perturb rho*theta
 
 }; // namespace ProbParm
@@ -68,38 +68,46 @@ perturb_rho_theta (const amrex::Real x,
 
     // Note: theta_perturbed is theta PLUS perturbation in theta
     amrex::Real theta_perturbed;
-    if (pp.T_pert_potential) {
-        // dT is potential temperature
-        theta_perturbed = Tbar_hse*std::pow(p_0/p_hse, rdOcp) + dT;
-    } else {
+    if (pp.T_pert_is_airtemp) {
         // dT is air temperature
         theta_perturbed = (Tbar_hse + dT)*std::pow(p_0/p_hse, rdOcp);
+    } else {
+        // dT is potential temperature
+        theta_perturbed = Tbar_hse*std::pow(p_0/p_hse, rdOcp) + dT;
     }
 
-    if (pp.perturb_rho) // - this version perturbs rho but not p (like density current problem)
+    if (pp.perturb_rho)
     {
+        // this version perturbs rho but not p (i.e., rho*theta)
+        // - hydrostatic rebalance is needed
+        // - this is the approach taken in the density current problem
+
         if (pp.T_0 > 0)
         {
-            // update full state, calculate HSE base state later
+            // background field has not been initialized, update full state,
+            // need to calculate HSE later
             rhotheta = getRhoThetagivenP(p_hse);
             rho = rhotheta / theta_perturbed;
         } else {
-            // already have a background field initialized, need to return
-            // rho and rhotheta as _perturbations_
+            // already have a background field initialized, need to
+            // return rho and rhotheta as deviations from the base state
             rhotheta = 0.0; // i.e., hydrostatically balanced pressure stays const
             rho = getRhoThetagivenP(p_hse) / theta_perturbed - r_hse;
         }
     }
-    else // - this version perturbs p but not rho
+    else
     {
+        // this version perturbs rho*theta (i.e., p) but not rho
+
         if (pp.T_0 > 0)
         {
-            // update full state, calculate HSE base state later
+            // background field has not been initialized, update full state,
+            // need to calculate HSE later
             rho = r_hse;
             rhotheta = r_hse * theta_perturbed;
         } else {
-            // already have a base field initialized, need to return
-            // rho and rhotheta as _perturbations_
+            // already have a background field initialized, need to
+            // return rho and rhotheta as deviations from the base state
             rho = 0.0; // i.e., hydrostatically balanced density stays const
             rhotheta = r_hse * theta_perturbed - getRhoThetagivenP(p_hse);
         }

--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -6,8 +6,8 @@
 
 struct ProbParm {
   // background conditions
-  // if init_type != "" then these are perturbations
-  amrex::Real T_0 = 0.0;
+  // if init_type != "" then these are perturbations and should be 0
+  amrex::Real T_0 = 300.0;
   amrex::Real U_0 = 0.0;
   amrex::Real V_0 = 0.0;
 

--- a/Exec/Bubble/prob.H
+++ b/Exec/Bubble/prob.H
@@ -68,7 +68,7 @@ perturb_rho_theta (const amrex::Real x,
     amrex::Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0/p_hse, rdOcp);
 
     // Update state -- this version perturbs rho but not p
-    if (parms.T_0 > 0)
+    if (pp.T_0 > 0)
     {
         rhotheta = getRhoThetagivenP(p_hse);
         rho = rhotheta / theta_perturbed;

--- a/Exec/Bubble/prob.cpp
+++ b/Exec/Bubble/prob.cpp
@@ -504,7 +504,6 @@ erf_init_rayleigh(Vector<Real>& tau,
           ubar[k]     = parms.U_0;
           vbar[k]     = parms.V_0;
           thetabar[k] = parms.T_0;
-          amrex::Print() << z << " " << zfrac << " " << tau[k] << std::endl;
       }
       else
       {

--- a/Exec/Bubble/prob.cpp
+++ b/Exec/Bubble/prob.cpp
@@ -503,4 +503,6 @@ amrex_probinit(
   pp.query("y_r", parms.y_r);
   pp.query("z_r", parms.z_r);
   pp.query("T_pert", parms.T_pert);
+  pp.query("T_pert_potential", parms.T_pert_potential);
+  pp.query("perturb_rho", parms.perturb_rho);
 }

--- a/Exec/Bubble/prob.cpp
+++ b/Exec/Bubble/prob.cpp
@@ -16,8 +16,6 @@ init_isentropic_hse_no_terrain(const Real& r_sfc, const Real& theta,
                                const Real& dz,    const Real&  /*prob_lo_z*/,
                                const int& khi)
 {
-  AMREX_ALWAYS_ASSERT(parms.T_0 > 0);
-
   // r_sfc / p_0 are the density / pressure at the surface
   int k0 = 0;
 
@@ -110,8 +108,6 @@ init_isentropic_hse_terrain(int i, int j,
                             const Array4<Real const> z_cc,
                             const int& khi)
 {
-  AMREX_ALWAYS_ASSERT(parms.T_0 > 0);
-
   // r_sfc / p_0 are the density / pressure at the surface
   int k0  = 0;
   Real half_dz = z_cc(i,j,k0);
@@ -201,6 +197,11 @@ erf_init_dens_hse(MultiFab& rho_hse,
                   std::unique_ptr<MultiFab>& z_phys_cc,
                   Geometry const& geom)
 {
+    // if erf.init_type is specified, then the base density should
+    // already have been calculated. In that case, these assumed (dry)
+    // surface conditions are probably incorrect.
+    AMREX_ALWAYS_ASSERT(parms.T_0 > 0);
+
     const Real prob_lo_z = geom.ProbLo()[2];
     const Real dz        = geom.CellSize()[2];
     const int khi        = geom.Domain().bigEnd()[2];

--- a/Exec/Bubble/prob.cpp
+++ b/Exec/Bubble/prob.cpp
@@ -503,6 +503,6 @@ amrex_probinit(
   pp.query("y_r", parms.y_r);
   pp.query("z_r", parms.z_r);
   pp.query("T_pert", parms.T_pert);
-  pp.query("T_pert_potential", parms.T_pert_potential);
+  pp.query("T_pert_is_airtemp", parms.T_pert_is_airtemp);
   pp.query("perturb_rho", parms.perturb_rho);
 }

--- a/Source/DataStruct.H
+++ b/Source/DataStruct.H
@@ -599,6 +599,8 @@ public:
             }
             amrex::Print() << z_inp_sound[k] << " " << pd_integ[k] << " " << rhod_integ[k] << " " << theta_inp_sound[k] << std::endl; // DEBUG
         }
+        // Note: at this point, the surface pressure, density of the dry air
+        // column is stored in pd_integ[0], rhod_integ[0] 
 
         // update
         host_to_device();

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -245,9 +245,9 @@ public:
     void init_bx_scalars_from_input_sounding_hse(
             const amrex::Box &bx,
             amrex::Array4<amrex::Real> const &state,
-            amrex::Array4<amrex::Real> const &r_hse,
-            amrex::Array4<amrex::Real> const &p_hse,
-            amrex::Array4<amrex::Real> const &pi_hse,
+            amrex::Array4<amrex::Real> const &r_hse_arr,
+            amrex::Array4<amrex::Real> const &p_hse_arr,
+            amrex::Array4<amrex::Real> const &pi_hse_arr,
             amrex::GeometryData const &geomdata,
             InputSoundingData const &inputSoundingData);
     void init_bx_velocities_from_input_sounding(

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -350,10 +350,13 @@ private:
     void Advance (int lev, amrex::Real time, amrex::Real dt_lev, int iteration, int ncycle);
 
     //! Initialize HSE
-    void initHSE();
+    void initHSE ();
 
     //! Initialize Rayleigh damping profiles
-    void initRayleigh();
+    void initRayleigh ();
+
+    //! Set Rayleigh mean profiles from input sounding
+    void setRayleighRefFromSounding ();
 
     // a wrapper for estTimeStep()
     void ComputeDt ();

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -584,11 +584,11 @@ private:
                                                      };
 
     // Note that the order of variable names here must match the order in Derive.cpp
-    const amrex::Vector<std::string> derived_names {"pressure", "soundspeed", "temp", "theta", "KE", "QKE", "scalar", "pres_hse",
-                                                    "dens_hse", "pert_pres", "pert_dens", "dpdx", "dpdy",
-                                                    "pres_hse_x", "pres_hse_y", "z_phys", "detJ" , "mapfac"
+    const amrex::Vector<std::string> derived_names {"pressure", "soundspeed", "temp", "theta", "KE", "QKE", "scalar",
+                                                    "pres_hse", "dens_hse", "pert_pres", "pert_dens",
+                                                    "dpdx", "dpdy", "pres_hse_x", "pres_hse_y", "z_phys", "detJ" , "mapfac"
 #ifdef ERF_USE_MOISTURE
-                                                     ,"qt", "qp", "qc", "qi", "qv"
+                                                     ,"qt", "qp", "qv", "qc", "qi"
 #endif
 #ifdef ERF_COMPUTE_ERROR
                                                     ,"xvel_err", "yvel_err", "zvel_err", "pp_err"

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -506,6 +506,12 @@ ERF::InitData ()
     if (solverChoice.use_rayleigh_damping)
     {
         initRayleigh();
+        if (init_type == "input_sounding")
+        {
+            // overwrite Ubar, Tbar, and thetabar with input profiles
+            setRayleighRefFromSounding();
+        }
+            
     }
 
     if (is_it_time_for_action(istep[0], t_new[0], dt[0], sum_interval, sum_per)) {

--- a/Source/ERF_init.cpp
+++ b/Source/ERF_init.cpp
@@ -361,6 +361,7 @@ ERF::init_from_input_sounding(int lev)
         }
         else
         {
+            // HSE arrays will be filled later with call to initHSE()
             init_bx_scalars_from_input_sounding(bx, cons_arr,
                                                 geom[lev].data(), input_sounding_data);
         }
@@ -417,9 +418,9 @@ void
 ERF::init_bx_scalars_from_input_sounding_hse(
         const amrex::Box &bx,
         amrex::Array4<amrex::Real> const &state,
-        amrex::Array4<amrex::Real> const &r_hse,
-        amrex::Array4<amrex::Real> const &p_hse,
-        amrex::Array4<amrex::Real> const &pi_hse,
+        amrex::Array4<amrex::Real> const &r_hse_arr,
+        amrex::Array4<amrex::Real> const &p_hse_arr,
+        amrex::Array4<amrex::Real> const &pi_hse_arr,
         amrex::GeometryData const &geomdata,
         InputSoundingData const &inputSoundingData)
 {
@@ -460,9 +461,9 @@ ERF::init_bx_scalars_from_input_sounding_hse(
         state(i, j, k, RhoScalar_comp) = 0;
 
         // Update hse quantities with values calculated from InputSoundingData.calc_rho_p()
-        r_hse(i, j, k) = rho_k;
-        p_hse(i, j, k) = getPgivenRTh(rhoTh_k);
-        pi_hse(i, j, k) = getExnergivenRTh(rhoTh_k, rdOcp);
+        r_hse_arr (i, j, k) = rho_k;
+        p_hse_arr (i, j, k) = getPgivenRTh(rhoTh_k);
+        pi_hse_arr(i, j, k) = getExnergivenRTh(rhoTh_k, rdOcp);
 
         // Boundary treatment
         if (k==0)
@@ -472,8 +473,8 @@ ERF::init_bx_scalars_from_input_sounding_hse(
                 interpolate_1d(z_inp_sound, rho_inp_sound, 0.0, inp_sound_size);
             amrex::Real rhoTh_surf =
                 rho_surf * interpolate_1d(z_inp_sound, theta_inp_sound, 0.0, inp_sound_size);
-             p_hse(i, j, k-1) = getPgivenRTh(rhoTh_surf) + dx[2]/2 * rho_surf * l_gravity;
-            pi_hse(i, j, k-1) = getExnergivenP(p_hse(i, j, k-1), rdOcp);
+            p_hse_arr (i, j, k-1) = getPgivenRTh(rhoTh_surf) + dx[2]/2 * rho_surf * l_gravity;
+            pi_hse_arr(i, j, k-1) = getExnergivenP(p_hse_arr(i, j, k-1), rdOcp);
         }
         else if (k==ktop)
         {
@@ -482,8 +483,8 @@ ERF::init_bx_scalars_from_input_sounding_hse(
                 interpolate_1d(z_inp_sound, rho_inp_sound, z+dx[2]/2, inp_sound_size);
             amrex::Real rhoTh_top =
                 rho_top * interpolate_1d(z_inp_sound, theta_inp_sound, z+dx[2]/2, inp_sound_size);
-             p_hse(i, j, k+1) = getPgivenRTh(rhoTh_top) - dx[2]/2 * rho_top * l_gravity;
-            pi_hse(i, j, k+1) = getExnergivenP(p_hse(i, j, k+1), rdOcp);
+            p_hse_arr (i, j, k+1) = getPgivenRTh(rhoTh_top) - dx[2]/2 * rho_top * l_gravity;
+            pi_hse_arr(i, j, k+1) = getExnergivenP(p_hse_arr(i, j, k+1), rdOcp);
         }
 
 #ifdef ERF_USE_MOISTURE

--- a/Source/ERF_init.cpp
+++ b/Source/ERF_init.cpp
@@ -448,9 +448,9 @@ ERF::init_bx_scalars_from_input_sounding_hse(
         int ktop = bx.bigEnd(2);
 
         Real rho_k, rhoTh_k;
-        rho_k = interpolate_1d(z_inp_sound, rho_inp_sound, z, inp_sound_size);
 
         // Set the density
+        rho_k = interpolate_1d(z_inp_sound, rho_inp_sound, z, inp_sound_size);
         state(i, j, k, Rho_comp) = rho_k;
 
         // Initial Rho0*Theta0
@@ -471,9 +471,7 @@ ERF::init_bx_scalars_from_input_sounding_hse(
             // set the ghost cell with dz and rho at boundary
             amrex::Real rho_surf =
                 interpolate_1d(z_inp_sound, rho_inp_sound, 0.0, inp_sound_size);
-            amrex::Real rhoTh_surf =
-                rho_surf * interpolate_1d(z_inp_sound, theta_inp_sound, 0.0, inp_sound_size);
-            p_hse_arr (i, j, k-1) = getPgivenRTh(rhoTh_surf) + dx[2]/2 * rho_surf * l_gravity;
+            p_hse_arr (i, j, k-1) = p_hse_arr(i,j,k) + dx[2] * rho_surf * l_gravity;
             pi_hse_arr(i, j, k-1) = getExnergivenP(p_hse_arr(i, j, k-1), rdOcp);
         }
         else if (k==ktop)
@@ -481,9 +479,7 @@ ERF::init_bx_scalars_from_input_sounding_hse(
             // set the ghost cell with dz and rho at boundary
             amrex::Real rho_top =
                 interpolate_1d(z_inp_sound, rho_inp_sound, z+dx[2]/2, inp_sound_size);
-            amrex::Real rhoTh_top =
-                rho_top * interpolate_1d(z_inp_sound, theta_inp_sound, z+dx[2]/2, inp_sound_size);
-            p_hse_arr (i, j, k+1) = getPgivenRTh(rhoTh_top) - dx[2]/2 * rho_top * l_gravity;
+            p_hse_arr (i, j, k+1) = p_hse_arr(i,j,k) - dx[2] * rho_top * l_gravity;
             pi_hse_arr(i, j, k+1) = getExnergivenP(p_hse_arr(i, j, k+1), rdOcp);
         }
 

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -162,17 +162,9 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
         calculate_derived("KE",          derived::erf_derKE);
         calculate_derived("QKE",         derived::erf_derQKE);
         calculate_derived("scalar",      derived::erf_derscalar);
-#ifdef ERF_USE_MOISTURE
-        calculate_derived("qt",          derived::erf_derQt);
-        calculate_derived("qp",          derived::erf_derQp);
 
-        MultiFab qv_fab(qv[lev], make_alias, 0, 1);
-        MultiFab qc_fab(qc[lev], make_alias, 0, 1);
-        MultiFab qi_fab(qi[lev], make_alias, 0, 1);
-#endif
         MultiFab r_hse(base_state[lev], make_alias, 0, 1); // r_0 is first  component
         MultiFab p_hse(base_state[lev], make_alias, 1, 1); // p_0 is second component
-
         if (containerHasElement(plot_var_names, "pres_hse"))
         {
             // p_0 is second component of base_state
@@ -185,28 +177,6 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             MultiFab::Copy(mf[lev],r_hse,0,mf_comp,1,0);
             mf_comp += 1;
         }
-#ifdef ERF_USE_MOISTURE
-        if (containerHasElement(plot_var_names, "qv"))
-        {
-            // r_0 is first component of base_state
-            MultiFab::Copy(mf[lev],qv_fab,0,mf_comp,1,0);
-            mf_comp += 1;
-        }
-
-        if (containerHasElement(plot_var_names, "qc"))
-        {
-            // r_0 is first component of base_state
-            MultiFab::Copy(mf[lev],qc_fab,0,mf_comp,1,0);
-            mf_comp += 1;
-        }
-
-        if (containerHasElement(plot_var_names, "qi"))
-        {
-            // r_0 is first component of base_state
-            MultiFab::Copy(mf[lev],qi_fab,0,mf_comp,1,0);
-            mf_comp += 1;
-        }
-#endif
         if (containerHasElement(plot_var_names, "pert_pres"))
         {
             for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -224,7 +194,6 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             }
             mf_comp += 1;
         }
-
         if (containerHasElement(plot_var_names, "pert_dens"))
         {
             for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
@@ -538,6 +507,36 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             }
             mf_comp ++;
         }
+
+#ifdef ERF_USE_MOISTURE
+        calculate_derived("qt",          derived::erf_derQt);
+        calculate_derived("qp",          derived::erf_derQp);
+
+        MultiFab qv_fab(qv[lev], make_alias, 0, 1);
+        MultiFab qc_fab(qc[lev], make_alias, 0, 1);
+        MultiFab qi_fab(qi[lev], make_alias, 0, 1);
+
+        if (containerHasElement(plot_var_names, "qv"))
+        {
+            // r_0 is first component of base_state
+            MultiFab::Copy(mf[lev],qv_fab,0,mf_comp,1,0);
+            mf_comp += 1;
+        }
+
+        if (containerHasElement(plot_var_names, "qc"))
+        {
+            // r_0 is first component of base_state
+            MultiFab::Copy(mf[lev],qc_fab,0,mf_comp,1,0);
+            mf_comp += 1;
+        }
+
+        if (containerHasElement(plot_var_names, "qi"))
+        {
+            // r_0 is first component of base_state
+            MultiFab::Copy(mf[lev],qi_fab,0,mf_comp,1,0);
+            mf_comp += 1;
+        }
+#endif
 
 #ifdef ERF_COMPUTE_ERROR
         // Next, check for error in velocities and if desired, output them -- note we output none or all, not just some

--- a/Source/Microphysics/IceFall.cpp
+++ b/Source/Microphysics/IceFall.cpp
@@ -49,7 +49,7 @@ void Microphysics::IceFall() {
    kmin = amrex::get<1>(k_max_min);
  }
 
-std::cout << "ice_fall: " << kmin << "; " << kmax << std::endl;
+//std::cout << "ice_fall: " << kmin << "; " << kmax << std::endl;
 
   // for (int k=0; k<nzm; k++) {
   //  for (int icrm=0; icrm<ncrms; icrm++) {


### PR DESCRIPTION
This was of course doomed to fail because I named my branch "squall2d_final". This is my working code, and I'm attaching my current inputs. Currently:
* Rayleigh is implemented
* Code crashes with open BCs, with/without moisture (set through `q_v` in sounding) — problem is diagnosing pressure from EOS [here](https://github.com/ewquon/ERF/blob/squall2d_final/Source/TimeIntegration/TI_utils.H#L24)
* The issue does not appear to be time-step size dependent.

[inputs.tar.gz](https://github.com/erf-model/ERF/files/10297338/inputs.tar.gz)
