### PR TITLE
Neumann bc

### DIFF
--- a/Exec/PoiseuilleFlow/inputs_neumann_test
+++ b/Exec/PoiseuilleFlow/inputs_neumann_test
@@ -1,5 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 20
+max_step = 50
 
 amrex.fpe_trap_invalid = 1
 
@@ -20,7 +20,7 @@ zhi.theta_grad = 1.0
 
 # TIME STEP CONTROL
 erf.no_substepping     = 1
-erf.cfl                = 0.5     # cfl number for hyperbolic system
+erf.fixed_dt           = 0.01
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass
@@ -43,7 +43,7 @@ erf.plot_vars_1     = density rhotheta x_velocity y_velocity z_velocity theta
 erf.use_gravity            = false
 
 erf.alpha_T = 1.0
-erf.alpha_C = 1.0
+erf.alpha_C = 0.0
 
 erf.les_type         = "None"
 erf.rho0_trans       = 1.0

--- a/Exec/PoiseuilleFlow/inputs_neumann_test
+++ b/Exec/PoiseuilleFlow/inputs_neumann_test
@@ -1,0 +1,59 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 20
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     =  0    0.  -1.
+geometry.prob_hi     =  4.   1.   1.    
+amr.n_cell           = 32    4   16
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "NoSlipWall"
+zhi.type = "NoSlipWall"
+
+zlo.theta = 300.0
+zhi.theta_grad = 1.0
+
+# TIME STEP CONTROL
+erf.no_substepping     = 1
+erf.cfl                = 0.5     # cfl number for hyperbolic system
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 1000       # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_vars_1     = density rhotheta x_velocity y_velocity z_velocity theta
+
+# SOLVER CHOICE
+erf.use_gravity            = false
+
+erf.alpha_T = 1.0
+erf.alpha_C = 1.0
+
+erf.les_type         = "None"
+erf.rho0_trans       = 1.0
+erf.molec_diff_type  = "Constant"
+erf.dynamicViscosity = 0.1
+
+erf.use_coriolis = false
+
+erf.spatial_order = 2
+
+# PROBLEM PARAMETERS
+prob.rho_0 = 1.0
+prob.T_0   = 300.0

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -161,7 +161,7 @@ ABLMost::impose_most_bcs(const int lev,
         const auto t_surf_arr = t_surf[lev]->array(mfi);
 
         // Define temporaries so we can access these on GPU
-        Real d_dz    = m_geom[lev].CellSize(2);
+        Real d_dz = m_geom[lev].CellSize(2);
 
         for (int var_idx = 0; var_idx < Vars::NumTypes; ++var_idx)
         {

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -65,13 +65,13 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][0];
+                if (bc_ptr[icomp+n].lo(0) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][0];
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].hi(0) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][3];
+                if (bc_ptr[icomp+n].hi(0) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][3];
                 }
             }
         );
@@ -83,13 +83,13 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].lo(1) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][1];
+                if (bc_ptr[icomp+n].lo(1) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][1];
                 }
             },
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].hi(1) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][4];
+                if (bc_ptr[icomp+n].hi(1) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][4];
                 }
             }
         );
@@ -100,13 +100,13 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         Box bx_zhi(bx);  bx_zhi.setSmall(2,dom_hi.z+1);
         ParallelFor(
             bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].lo(2) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][2];
+                if (bc_ptr[icomp+n].lo(2) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][2];
                 }
             },
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].hi(2) == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[n][5];
+                if (bc_ptr[icomp+n].hi(2) == ERFBCType::ext_dir) {
+                    dest_arr(i,j,k,icomp+n) = l_bc_extdir_vals_d[icomp+n][5];
                 }
             }
         );
@@ -122,21 +122,21 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip = dom_lo.x - 1 - i;
-                if (bc_ptr[n].lo(0) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].lo(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(dom_lo.x,j,k,icomp+n);
-                } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].lo(0) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(iflip,j,k,icomp+n);
-                } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].lo(0) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(iflip,j,k,icomp+n);
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip =  2*dom_hi.x + 1 - i;
-                if (bc_ptr[n].hi(0) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].hi(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(dom_hi.x,j,k,icomp+n);
-                } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].hi(0) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(iflip,j,k,icomp+n);
-                } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].hi(0) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(iflip,j,k,icomp+n);
                 }
             }
@@ -151,21 +151,21 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int jflip = dom_lo.y - 1 - j;
-                if (bc_ptr[n].lo(1) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].lo(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,dom_lo.y,k,icomp+n);
-                } else if (bc_ptr[n].lo(1) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].lo(1) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,jflip,k,icomp+n);
-                } else if (bc_ptr[n].lo(1) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].lo(1) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,jflip,k,icomp+n);
                 }
             },
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int jflip =  2*dom_hi.y + 1 - j;
-                if (bc_ptr[n].hi(1) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].hi(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,dom_hi.y,k,icomp+n);
-                } else if (bc_ptr[n].hi(1) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].hi(1) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,jflip,k,icomp+n);
-                } else if (bc_ptr[n].hi(1) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].hi(1) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,jflip,k,icomp+n);
                 }
             }
@@ -179,28 +179,28 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
         ParallelFor(
             bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int kflip = dom_lo.z - 1 - i;
-                if (bc_ptr[n].lo(2) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].lo(2) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,j,dom_lo.z,icomp+n);
-                } else if (bc_ptr[n].lo(2) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].lo(2) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,j,kflip,icomp+n);
-                } else if (bc_ptr[n].lo(2) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].lo(2) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,j,kflip,icomp+n);
-                } else if (bc_ptr[n].lo(2) == ERFBCType::neumann) {
-                    Real delta_z = dxInv[2]*(dom_lo.z - k);
-                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_lo.z,icomp+n) - delta_z*l_bc_neumann_vals_d[n][2];
+                } else if (bc_ptr[icomp+n].lo(2) == ERFBCType::neumann) {
+                    Real delta_z = (dom_lo.z - k) / dxInv[2];
+                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_lo.z,icomp+n) - delta_z*l_bc_neumann_vals_d[icomp+n][2]*dest_arr(i,j,dom_lo.z,bccomp);
                 }
             },
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int kflip =  2*dom_hi.z + 1 - i;
-                if (bc_ptr[n].hi(2) == ERFBCType::foextrap) {
+                if (bc_ptr[icomp+n].hi(2) == ERFBCType::foextrap) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,j,dom_hi.z,icomp+n);
-                } else if (bc_ptr[n].hi(2) == ERFBCType::reflect_even) {
+                } else if (bc_ptr[icomp+n].hi(2) == ERFBCType::reflect_even) {
                     dest_arr(i,j,k,icomp+n) =  dest_arr(i,j,kflip,icomp+n);
-                } else if (bc_ptr[n].hi(2) == ERFBCType::reflect_odd) {
+                } else if (bc_ptr[icomp+n].hi(2) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,j,kflip,icomp+n);
-                } else if (bc_ptr[n].hi(2) == ERFBCType::neumann) {
-                    Real delta_z = dxInv[2]*(k - dom_hi.z);
-                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_lo.z,icomp+n) + delta_z*l_bc_neumann_vals_d[n][5];
+                } else if (bc_ptr[icomp+n].hi(2) == ERFBCType::neumann) {
+                    Real delta_z = (k - dom_hi.z) / dxInv[2];
+                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_hi.z,icomp+n) + delta_z*l_bc_neumann_vals_d[icomp+n][5]*dest_arr(i,j,dom_hi.z,bccomp);
                 }
             }
         );

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -187,7 +187,7 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,j,kflip,icomp+n);
                 } else if (bc_ptr[icomp+n].lo(2) == ERFBCType::neumann) {
                     Real delta_z = (dom_lo.z - k) / dxInv[2];
-                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_lo.z,icomp+n) - delta_z*l_bc_neumann_vals_d[icomp+n][2]*dest_arr(i,j,dom_lo.z,bccomp);
+                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_lo.z,icomp+n) - delta_z*l_bc_neumann_vals_d[icomp+n][2]*dest_arr(i,j,dom_lo.z,Rho_comp);
                 }
             },
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
@@ -200,7 +200,7 @@ void ERFPhysBCFunct::impose_cons_bcs (const Array4<Real>& dest_arr, const Box& b
                     dest_arr(i,j,k,icomp+n) = -dest_arr(i,j,kflip,icomp+n);
                 } else if (bc_ptr[icomp+n].hi(2) == ERFBCType::neumann) {
                     Real delta_z = (k - dom_hi.z) / dxInv[2];
-                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_hi.z,icomp+n) + delta_z*l_bc_neumann_vals_d[icomp+n][5]*dest_arr(i,j,dom_hi.z,bccomp);
+                    dest_arr(i,j,k,icomp+n) = dest_arr(i,j,dom_hi.z,icomp+n) + delta_z*l_bc_neumann_vals_d[icomp+n][5]*dest_arr(i,j,dom_hi.z,Rho_comp);
                 }
             }
         );

--- a/Source/BoundaryConditions/ERF_PhysBCFunct.H
+++ b/Source/BoundaryConditions/ERF_PhysBCFunct.H
@@ -27,6 +27,7 @@ public:
                     const amrex::Gpu::DeviceVector<amrex::BCRec>& domain_bcs_type_d,
                     const int& terrain_type,
                     amrex::Array<amrex::Array<amrex::Real,AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> bc_extdir_vals,
+                    amrex::Array<amrex::Array<amrex::Real,AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> bc_neumann_vals,
                     std::unique_ptr<amrex::MultiFab>& z_phys_nd,
                     std::unique_ptr<amrex::MultiFab>& detJ_cc)
         : m_lev(lev),
@@ -34,6 +35,7 @@ public:
           m_domain_bcs_type_d(domain_bcs_type_d),
           m_terrain_type(terrain_type),
           m_bc_extdir_vals(bc_extdir_vals),
+          m_bc_neumann_vals(bc_neumann_vals),
           m_z_phys_nd(z_phys_nd),
           m_detJ_cc(detJ_cc)
           {}
@@ -88,6 +90,7 @@ private:
     amrex::Gpu::DeviceVector<amrex::BCRec> m_domain_bcs_type_d;
     int           m_terrain_type;
     amrex::Array<amrex::Array<amrex::Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> m_bc_extdir_vals;
+    amrex::Array<amrex::Array<amrex::Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> m_bc_neumann_vals;
     std::unique_ptr<amrex::MultiFab>& m_z_phys_nd;
     std::unique_ptr<amrex::MultiFab>&   m_detJ_cc;
 };

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -32,6 +32,8 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
     const Real dy_inv = cellSizeInv[1];
     const Real dz_inv = cellSizeInv[2];
 
+    const auto& dom_hi = amrex::ubound(domain);
+
     bool l_use_QKE       = solverChoice.use_QKE && solverChoice.advect_QKE;
     bool l_use_deardorff = (solverChoice.les_type == LESType::Deardorff);
     Real l_Delta         = std::pow(dx_inv * dy_inv * dz_inv,-1./3.);
@@ -158,12 +160,21 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             const int  qty_index = n_start + n;
             const int prim_index = qty_index - qty_offset;
 
+            bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
+            bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
+
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
             rhoAlpha += 0.5 * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                               + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
 
-            zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            if (ext_dir_on_zlo) {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else if (ext_dir_on_zhi) {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            }
         });
     } else if (l_turb) {
         amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -193,11 +204,20 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             const int  qty_index = n_start + n;
             const int prim_index = qty_index - qty_offset;
 
+            bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
+            bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
+
             Real Alpha = d_alpha_eff[prim_index];
             Alpha += 0.5 * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                            + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
 
-            zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            if (ext_dir_on_zlo) {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else if (ext_dir_on_zhi) {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            }
         });
     } else if(l_consA) {
         amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -225,10 +245,19 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             const int  qty_index = n_start + n;
             const int prim_index = qty_index - qty_offset;
 
+            bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
+            bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
+
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
-            zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            if (ext_dir_on_zlo) {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else if (ext_dir_on_zhi) {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else {
+                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            }
         });
     } else {
         amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -254,11 +283,21 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             const int  qty_index = n_start + n;
             const int prim_index = qty_index - qty_offset;
 
+            bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
+            bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
+
             Real Alpha = d_alpha_eff[prim_index];
 
-            zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            if (ext_dir_on_zlo) {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else if (ext_dir_on_zhi) {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * (Real(2.0)*dz_inv);
+            } else {
+                zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+            }
         });
     }
+
 
 
     // Use fluxes to compute RHS

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -536,6 +536,9 @@ private:
     // These hold the Dirichlet values at walls which need them ...
     amrex::Array<amrex::Array<amrex::Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> m_bc_extdir_vals;
 
+    // These hold the Neumann values at walls which need them ...
+    amrex::Array<amrex::Array<amrex::Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> m_bc_neumann_vals;
+
     // These are the "physical" boundary condition types (e.g. "inflow")
     amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2> phys_bc_type;
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -891,7 +891,7 @@ ERF::initialize_integrator(int lev, MultiFab& cons_mf, MultiFab& vel_mf)
     mri_integrator_mem[lev]->setNoSubstepping(no_substepping);
 
     physbcs[lev] = std::make_unique<ERFPhysBCFunct> (lev, geom[lev], domain_bcs_type, domain_bcs_type_d,
-                                                     solverChoice.terrain_type, m_bc_extdir_vals,
+                                                     solverChoice.terrain_type, m_bc_extdir_vals, m_bc_neumann_vals,
                                                      z_phys_nd[lev], detJ_cc[lev]);
 }
 

--- a/Source/ERF_init_bcs.cpp
+++ b/Source/ERF_init_bcs.cpp
@@ -11,16 +11,27 @@ void ERF::init_bcs ()
     auto f = [this] (std::string const& bcid, Orientation ori)
     {
         // These are simply defaults for Dirichlet faces -- they should be over-written below
-        m_bc_extdir_vals[BCVars::Rho_bc_comp][ori]       =  1.0;
+        m_bc_extdir_vals[BCVars::Rho_bc_comp][ori]      =  1.0;
         m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] = -1.0; // It is important to set this negative
-                                               // because the sign is tested on below
+                                                                // because the sign is tested on below
         m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori]     = 0.0;
-        m_bc_extdir_vals[BCVars::RhoQKE_bc_comp][ori]     = 0.0;
+        m_bc_extdir_vals[BCVars::RhoQKE_bc_comp][ori]    = 0.0;
         m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = 0.0;
 
         m_bc_extdir_vals[BCVars::xvel_bc][ori] = 0.0; // default
         m_bc_extdir_vals[BCVars::yvel_bc][ori] = 0.0;
         m_bc_extdir_vals[BCVars::zvel_bc][ori] = 0.0;
+
+        // These are simply defaults for Neumann gradients -- they should be over-written below
+        m_bc_neumann_vals[BCVars::Rho_bc_comp][ori]      =  0.0;
+        m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori] =  0.0;
+        m_bc_neumann_vals[BCVars::RhoKE_bc_comp][ori]     = 0.0;
+        m_bc_neumann_vals[BCVars::RhoQKE_bc_comp][ori]    = 0.0;
+        m_bc_neumann_vals[BCVars::RhoScalar_bc_comp][ori] = 0.0;
+        m_bc_neumann_vals[BCVars::xvel_bc][ori] = 0.0;
+        m_bc_neumann_vals[BCVars::yvel_bc][ori] = 0.0;
+        m_bc_neumann_vals[BCVars::zvel_bc][ori] = 0.0;
+
 
         ParmParse pp(bcid);
         std::string bc_type_in = "null";
@@ -139,6 +150,12 @@ void ERF::init_bcs ()
             {
                m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] = theta_in*m_bc_extdir_vals[BCVars::Rho_bc_comp][ori];
             }
+
+            Real theta_grad_in;
+            if (pp.query("theta_grad", theta_grad_in))
+            {
+                m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori] = theta_grad_in;
+            }
         }
         else if (bc_type == "slipwall")
         {
@@ -153,6 +170,11 @@ void ERF::init_bcs ()
                m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] = theta_in*m_bc_extdir_vals[BCVars::Rho_bc_comp][ori];
             }
 
+            Real theta_grad_in;
+            if (pp.query("theta_grad", theta_grad_in))
+            {
+               m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori] = theta_grad_in;
+            }
         }
         else if (bc_type == "most")
         {
@@ -327,11 +349,15 @@ void ERF::init_bcs ()
                         domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::foextrap);
                     if (m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] > 0.)
                         domain_bcs_type[BCVars::RhoTheta_bc_comp].setLo(dir, ERFBCType::ext_dir);
+                    if (std::abs(m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]) > 0.)
+                        domain_bcs_type[BCVars::RhoTheta_bc_comp].setLo(dir, ERFBCType::neumann);
                 } else {
                     for (int i = 0; i < NVAR; i++)
                         domain_bcs_type[BCVars::cons_bc+i].setHi(dir, ERFBCType::foextrap);
                     if (m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] > 0.)
                         domain_bcs_type[BCVars::RhoTheta_bc_comp].setHi(dir, ERFBCType::ext_dir);
+                    if (std::abs(m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]) > 0.)
+                        domain_bcs_type[BCVars::RhoTheta_bc_comp].setHi(dir, ERFBCType::neumann);
                 }
             }
             else if (bct == ERF_BC::slip_wall)
@@ -341,11 +367,15 @@ void ERF::init_bcs ()
                         domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::foextrap);
                     if (m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] > 0.)
                         domain_bcs_type[BCVars::RhoTheta_bc_comp].setLo(dir, ERFBCType::ext_dir);
+                    if (std::abs(m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]) > 0.)
+                        domain_bcs_type[BCVars::RhoTheta_bc_comp].setLo(dir, ERFBCType::neumann);
                 } else {
                     for (int i = 0; i < NVAR; i++)
                         domain_bcs_type[BCVars::cons_bc+i].setHi(dir, ERFBCType::foextrap);
                     if (m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] > 0.)
                         domain_bcs_type[BCVars::RhoTheta_bc_comp].setHi(dir, ERFBCType::ext_dir);
+                    if (std::abs(m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]) > 0.)
+                        domain_bcs_type[BCVars::RhoTheta_bc_comp].setHi(dir, ERFBCType::neumann);
                 }
             }
             else if (bct == ERF_BC::inflow)

--- a/Source/ERF_init_bcs.cpp
+++ b/Source/ERF_init_bcs.cpp
@@ -145,6 +145,12 @@ void ERF::init_bcs ()
                 m_bc_extdir_vals[BCVars::zvel_bc][ori] = v[2];
             }
 
+            Real rho_in;
+            if (pp.query("density", rho_in))
+            {
+                m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = rho_in;
+            }
+
             Real theta_in;
             if (pp.query("theta", theta_in))
             {
@@ -163,6 +169,12 @@ void ERF::init_bcs ()
 
             phys_bc_type[ori] = ERF_BC::slip_wall;
             domain_bc_type[ori] = "SlipWall";
+
+            Real rho_in;
+            if (pp.query("density", rho_in))
+            {
+                m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = rho_in;
+            }
 
             Real theta_in;
             if (pp.query("theta", theta_in))

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -161,7 +161,8 @@ enum mathematicalBndryTypes : int { bogus        = -666,
     foextrap     =  2,
     ext_dir      =  3,
     MOST         =  101,
-    ext_dir_ingested =  102
+    ext_dir_ingested =  102,
+    neumann          =  103,
 };
 }
 


### PR DESCRIPTION
Introduces the capability of a Neumann BC. However, the BC is only imposed for theta at the current moment. The flux may be specified with **zlo/zhi.theta_grad = val**.