### PR TITLE
Fixes for ABL case

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -86,7 +86,6 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/ERF.cpp
        ${SRC_DIR}/ERF_init.cpp
        ${SRC_DIR}/ERF_init1d.cpp
-       ${SRC_DIR}/ERF_SumIQ.cpp
        ${SRC_DIR}/ERF_Tagging.cpp
        ${SRC_DIR}/BoundaryConditions/ABLMost.H
        ${SRC_DIR}/BoundaryConditions/ABLMost.cpp
@@ -106,6 +105,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/IO/ERF_WriteBndryPlanes.H
        ${SRC_DIR}/IO/ERF_WriteBndryPlanes.cpp
        ${SRC_DIR}/IO/ERF_Write1DProfiles.cpp
+       ${SRC_DIR}/IO/ERF_WriteScalarProfiles.cpp
        ${SRC_DIR}/IO/Plotfile.cpp
        ${SRC_DIR}/IO/writeJobInfo.cpp
        ${SRC_DIR}/Advection/Advection.H

--- a/Exec/ABL/inputs_most
+++ b/Exec/ABL/inputs_most
@@ -15,8 +15,8 @@ zhi.type = "SlipWall"
 
 # MOST BOUNDARY (DEFAULT IS ADIABATIC FOR THETA)
 zlo.type      = "Most"
-erf.most.z0   = 100.0
-erf.most.zref = 200.0
+erf.most.z0   = 0.1
+erf.most.zref = 8.0
 
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.2  # fixed time step depending on grid resolution

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -179,11 +179,6 @@ ABLMost::impose_most_bcs(const int lev,
             auto dest_arr = (*mfs[var_idx])[mfi].array();
             int zlo = 0;
 
-            bool var_is_derived = false;
-            if (var_idx == Vars::xvel || var_idx == Vars::yvel) {
-                var_is_derived = true;
-            }
-
             if (var_idx == Vars::cons) {
                 amrex::Box b2d = bx; // Copy constructor
                 b2d.setBig(2,zlo-1);
@@ -232,11 +227,7 @@ ABLMost::impose_most_bcs(const int lev,
                     Real moflux  = d_ttau*d_utau*(num1+num2)/((d_thM-d_sfcT)*d_vmM);
                     Real deltaz  = d_dz * (zlo - k);
 
-                    if (!var_is_derived) {
-                        dest_arr(i,j,k,icomp+n) = rho*(theta - moflux*rho/eta*deltaz);
-                    } else {
-                        dest_arr(i,j,k,icomp+n) = theta - moflux*rho/eta*deltaz;
-                    }
+                    dest_arr(i,j,k,icomp+n) = rho*(theta - moflux*rho/eta*deltaz);
                 });
 
             } else if (var_idx == Vars::xvel || var_idx == Vars::xmom) { //for velx
@@ -282,9 +273,10 @@ ABLMost::impose_most_bcs(const int lev,
                                    (d_vmM*d_vmM) * d_utau*d_utau;
                     Real deltaz  = d_dz * (zlo - k);
 
-                    if (!var_is_derived) {
+                    if (var_idx == Vars::xmom) {
                         dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx*rho*rho/eta*deltaz;
                     } else {
+                        AMREX_ALWAYS_ASSERT(var_idx == Vars::xvel);
                         dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx*rho/eta*deltaz;
                     }
                 });
@@ -332,9 +324,10 @@ ABLMost::impose_most_bcs(const int lev,
                                     (d_vmM*d_vmM)*d_utau*d_utau;
                     Real deltaz  = d_dz * (zlo - k);
 
-                    if (!var_is_derived) {
+                    if (var_idx == Vars::ymom) {
                         dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy*rho*rho/eta*deltaz;
                     } else {
+                        AMREX_ALWAYS_ASSERT(var_idx == Vars::yvel);
                         dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy*rho/eta*deltaz;
                     }
                 });

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -218,7 +218,7 @@ ABLMost::impose_most_bcs(const int lev,
                     vely  = 0.5*(vely_arr(iy,jy,zlo)+vely_arr(iy  ,jy+1,zlo));
                     rho   = cons_arr(ic,jc,zlo,Rho_comp);
                     theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
-                    eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v);
+                    eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v); // == rho * alpha [kg/m^3 * m^2/s]
 
                     Real d_thM  =  tm_arr(ic,jc,zlo);
                     Real d_vmM  = umm_arr(ic,jc,zlo);
@@ -235,7 +235,7 @@ ABLMost::impose_most_bcs(const int lev,
                     if (!var_is_derived) {
                         dest_arr(i,j,k,icomp+n) = rho*(theta - moflux*rho/eta*deltaz);
                     } else {
-                        dest_arr(i,j,k,icomp+n) = theta - moflux/eta*deltaz;
+                        dest_arr(i,j,k,icomp+n) = theta - moflux*rho/eta*deltaz;
                     }
                 });
 

--- a/Source/DataStruct.H
+++ b/Source/DataStruct.H
@@ -412,16 +412,16 @@ struct SolverChoice {
     // Smagorinsky CI coefficient
     amrex::Real CI = 0.0;
     // Smagorinsky Turbulent Prandtl Number
-    amrex::Real Pr_t = 1.0;
-    amrex::Real Pr_t_inv = 1.0;
+    amrex::Real Pr_t = 1. / 3.;
+    amrex::Real Pr_t_inv = 3.0;
     // Smagorinsky Turbulent Schmidt Number
     amrex::Real Sc_t = 1.0;
     amrex::Real Sc_t_inv = 1.0;
 
     // Deardorff Ce coefficient
-    amrex::Real Ce = 0.0;
+    amrex::Real Ce = 0.93;
     // Deardorff Ck coefficient
-    amrex::Real Ck = 0.0;
+    amrex::Real Ck = 0.1;
     // Deardorff sigma_k coefficient
     amrex::Real sigma_k = 1.0;
 

--- a/Source/DataStruct.H
+++ b/Source/DataStruct.H
@@ -7,8 +7,10 @@
 #include <AMReX_ParmParse.H>
 #include <AMReX_Print.H>
 #include <AMReX_Gpu.H>
+#include <AMReX_Geometry.H>
 
 #include <ERF_Constants.H>
+#include <ERF_Math.H>
 
 enum class ABLDriverType {
     None, PressureGradient, GeostrophicWind
@@ -471,19 +473,25 @@ public:
     InputSoundingData() {}
 
     void read_from_file(const std::string input_sounding_file,
-                        const amrex::Real ztop)
+                        amrex::Geometry const &geom)
     {
-        z_inp_sound.resize(0);
-        theta_inp_sound.resize(0);
-        qv_inp_sound.resize(0);
-        U_inp_sound.resize(0);
-        V_inp_sound.resize(0);
+        const amrex::Real zbot = geom.ProbLo(AMREX_SPACEDIM-1);
+        AMREX_ALWAYS_ASSERT(zbot == 0);
+        const amrex::Real ztop = geom.ProbHi(AMREX_SPACEDIM-1);
+        const amrex::Real dz = geom.CellSize(AMREX_SPACEDIM-1);
+        const int Nz = geom.Domain().size()[AMREX_SPACEDIM-1];
 
-        pm_integ.resize(0);
-        rhom_integ.resize(0);
+        z_inp_sound.resize(Nz+2);
+        theta_inp_sound.resize(Nz+2);
+        qv_inp_sound.resize(Nz+2);
+        U_inp_sound.resize(Nz+2);
+        V_inp_sound.resize(Nz+2);
 
-        pd_integ.resize(0);
-        rhod_integ.resize(0);
+        pm_integ.resize(Nz+2);
+        rhom_integ.resize(Nz+2);
+
+        pd_integ.resize(Nz+2);
+        rhod_integ.resize(Nz+2);
 
         // Read the input_sounding file
         amrex::Print() << "input_sounding file location : " << input_sounding_file << std::endl;
@@ -494,7 +502,12 @@ public:
         else {
             // Read the contents of the input_sounding file
             amrex::Print() << "Successfully opened the input_sounding file. Now reading... " << std::endl;
-            std::string  line;
+            std::string line;
+
+            // First, read the input data into temp vectors; then, interpolate vectors to the
+            // domain lo/hi and cell centers (from level 0)
+            amrex::Vector<amrex::Real> z_inp_sound_tmp, theta_inp_sound_tmp, qv_inp_sound_tmp,
+                                       U_inp_sound_tmp, V_inp_sound_tmp;
 
             // Read the first line
             std::getline(input_sounding_reader, line);
@@ -504,11 +517,11 @@ public:
             qv_ref_inp_sound *= 0.001; // convert from g/kg to kg/kg
 
             // Add surface
-            z_inp_sound.push_back(0);
-            theta_inp_sound.push_back(theta_ref_inp_sound);
-            qv_inp_sound.push_back(qv_ref_inp_sound);
-            U_inp_sound.push_back(0);
-            V_inp_sound.push_back(0);
+            z_inp_sound_tmp.push_back(0); // height AGL
+            theta_inp_sound_tmp.push_back(theta_ref_inp_sound);
+            qv_inp_sound_tmp.push_back(qv_ref_inp_sound);
+            U_inp_sound_tmp.push_back(0);
+            V_inp_sound_tmp.push_back(0);
 
             // Read the vertical profile at each given height
             amrex::Real z, theta, qv, U, V;
@@ -516,74 +529,51 @@ public:
                 std::istringstream iss_z(line);
                 iss_z >> z >> theta >> qv >> U >> V;
                 if (z == 0) {
-                    AMREX_ALWAYS_ASSERT(theta == theta_inp_sound[0]);
-                    AMREX_ALWAYS_ASSERT(qv == qv_inp_sound[0]);
-                    U_inp_sound[0] = U;
-                    V_inp_sound[0] = V;
+                    AMREX_ALWAYS_ASSERT(theta == theta_inp_sound_tmp[0]);
+                    AMREX_ALWAYS_ASSERT(qv == qv_inp_sound_tmp[0]);
+                    U_inp_sound_tmp[0] = U;
+                    V_inp_sound_tmp[0] = V;
                 } else {
-                    AMREX_ALWAYS_ASSERT(z > z_inp_sound[0]);
-                    z_inp_sound.push_back(z);
-                    theta_inp_sound.push_back(theta);
-                    qv_inp_sound.push_back(qv*0.001);
-                    U_inp_sound.push_back(U);
-                    V_inp_sound.push_back(V);
+                    AMREX_ALWAYS_ASSERT(z > z_inp_sound[z_inp_sound_tmp.size()-1]); // sounding is increasing in height
+                    z_inp_sound_tmp.push_back(z);
+                    theta_inp_sound_tmp.push_back(theta);
+                    qv_inp_sound_tmp.push_back(qv*0.001);
+                    U_inp_sound_tmp.push_back(U);
+                    V_inp_sound_tmp.push_back(V);
                     if (z >= ztop) break;
                 }
             }
 
-            // At this point, we have an input_sounding with
-            // z_inp_sound[N-1] <= ztop
-            if (z != ztop)
-            {
-                int N = size();
-                amrex::Real z1  =     z_inp_sound[N-2];
-                amrex::Real th1 = theta_inp_sound[N-2];
-                amrex::Real qv1 =    qv_inp_sound[N-2];
-                amrex::Real U1  =     U_inp_sound[N-2];
-                amrex::Real V1  =     V_inp_sound[N-2];
-                amrex::Real z2  =     z_inp_sound[N-1];
-                amrex::Real th2 = theta_inp_sound[N-1];
-                amrex::Real qv2 =    qv_inp_sound[N-1];
-                amrex::Real U2  =     U_inp_sound[N-1];
-                amrex::Real V2  =     V_inp_sound[N-1];
-
-                amrex::Real zfrac = (ztop - z1) / (z2 - z1);
-                amrex::Real th_top = th1 + zfrac*(th2 - th1);
-                amrex::Real qv_top = qv1 + zfrac*(qv2 - qv1);
-                amrex::Real  U_top =  U1 + zfrac*( U2 -  U1);
-                amrex::Real  V_top =  V1 + zfrac*( V2 -  V1);
-
-                if (z < ztop)
-                {
-                    amrex::Print() << "Note: sounding zmax=" << z
-                        << ", extrapolating to zhi=" << ztop << std::endl;
-                    // Add domain top with extrapolated values
-                    z_inp_sound.push_back(ztop);
-                    theta_inp_sound.push_back(th_top);
-                    qv_inp_sound.push_back(qv_top);
-                    U_inp_sound.push_back(U_top);
-                    V_inp_sound.push_back(V_top);
-                }
-                else // z > ztop
-                {
-                    amrex::Print() << "Note: sounding zmax=" << z
-                        << ", interpolating to zhi=" << ztop << std::endl;
-                    // Overwrite top value with interpolated values
-                    z_inp_sound[N-1] = ztop;
-                    theta_inp_sound[N-1] = th_top;
-                    qv_inp_sound[N-1] = qv_top;
-                    U_inp_sound[N-1] = U_top;
-                    V_inp_sound[N-1] = V_top;
-                }
+            // At this point, we have an input_sounding from z=0 AGL up to
+            // z_inp_sound_tmp[N-1] >= ztop. Now, interpolate to grid level 0
+            // heights.
+            const int Ninp = z_inp_sound_tmp.size();
+            z_inp_sound[0]     = zbot;
+            theta_inp_sound[0] = theta_inp_sound_tmp[0];
+            qv_inp_sound[0]    = qv_inp_sound_tmp[0];
+            U_inp_sound[0]     = U_inp_sound_tmp[0];
+            V_inp_sound[0]     = V_inp_sound_tmp[0];
+            for (int k=0; k < Nz; ++k) {
+                z_inp_sound[k+1] = zbot + (k + 0.5) * dz;
+                theta_inp_sound[k+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(), theta_inp_sound_tmp.dataPtr(), z_inp_sound[k+1], Ninp);
+                   qv_inp_sound[k+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),    qv_inp_sound_tmp.dataPtr(), z_inp_sound[k+1], Ninp);
+                    U_inp_sound[k+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),     U_inp_sound_tmp.dataPtr(), z_inp_sound[k+1], Ninp);
+                    V_inp_sound[k+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),     V_inp_sound_tmp.dataPtr(), z_inp_sound[k+1], Ninp);
             }
+            z_inp_sound[Nz+1]     = ztop;
+            theta_inp_sound[Nz+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(), theta_inp_sound_tmp.dataPtr(), ztop, Ninp);
+               qv_inp_sound[Nz+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),    qv_inp_sound_tmp.dataPtr(), ztop, Ninp);
+                U_inp_sound[Nz+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),     U_inp_sound_tmp.dataPtr(), ztop, Ninp);
+                V_inp_sound[Nz+1] = interpolate_1d(z_inp_sound_tmp.dataPtr(),     V_inp_sound_tmp.dataPtr(), ztop, Ninp);
         }
+
         amrex::Print() << "Successfully read the input_sounding file..." << std::endl;
         input_sounding_reader.close();
 
         host_to_device();
     }
 
-    void calc_rho_p(const amrex::Real ztop)
+    void calc_rho_p()
     {
         /* Calculate density and pressure, roughly following the procedure in
          * WRF dyn_em/module_initialize_ideal.F. We integrate hydrostatically
@@ -612,7 +602,6 @@ public:
 
         amrex::Print() << "ideal sounding init: surface density of moist air = "
             << rhom_integ[0] << " kg/m^3" << std::endl;
-        amrex::Print() << "integrating moist air column up to " << ztop << std::endl;
 
         // Note:
         //   p_dry = rho_d R_d T

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -186,9 +186,13 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                          + 3. * cell_prim(i, j, k  , prim_index)
+                                                     - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                          - 3. * cell_prim(i, j, k  , prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else {
                 zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
@@ -228,9 +232,13 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = Alpha * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = Alpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                       + 3. * cell_prim(i, j, k  , prim_index)
+                                                  - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = Alpha * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = Alpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                       - 3. * cell_prim(i, j, k  , prim_index)
+                                                  + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else {
                 zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
@@ -267,9 +275,13 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                          + 3. * cell_prim(i, j, k  , prim_index)
+                                                     - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                          - 3. * cell_prim(i, j, k  , prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else {
                 zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
@@ -303,9 +315,13 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = Alpha * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = Alpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                       + 3. * cell_prim(i, j, k  , prim_index)
+                                                  - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = Alpha * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) ) * dz_inv;
+                zflux(i,j,k,qty_index) = Alpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                                       - 3. * cell_prim(i, j, k  , prim_index)
+                                                  + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else {
                 zflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -211,9 +211,13 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                GradCz = dz_inv * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        + 3. * cell_prim(i, j, k  , prim_index)
+                                   - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        - 3. * cell_prim(i, j, k  , prim_index)
+                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -277,9 +281,13 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                GradCz = dz_inv * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        + 3. * cell_prim(i, j, k  , prim_index)
+                                   - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        - 3. * cell_prim(i, j, k  , prim_index)
+                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -339,9 +347,13 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                GradCz = dz_inv * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        + 3. * cell_prim(i, j, k  , prim_index)
+                                   - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        - 3. * cell_prim(i, j, k  , prim_index)
+                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -398,9 +410,13 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
             bool ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) && k == 0);
             bool ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc+qty_index].lo(5) == ERFBCType::ext_dir) && k == dom_hi.z);
             if (ext_dir_on_zlo) {
-                GradCz = dz_inv * ( -(8./3.) * cell_prim(i,j,k-1) + 3. * cell_prim(i,j,k) - (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        + 3. * cell_prim(i, j, k  , prim_index)
+                                   - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i,j,k-1) - 3. * cell_prim(i,j,k) + (1./3.) * cell_prim(i,j,k+1) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
+                                        - 3. * cell_prim(i, j, k ), prim_index
+                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }

--- a/Source/ERF_init.cpp
+++ b/Source/ERF_init.cpp
@@ -327,10 +327,9 @@ ERF::init_from_input_sounding(int lev)
     if (lev == 0) {
         if (input_sounding_file.empty())
             amrex::Error("input_sounding file name must be provided via input");
-        Real ztop = geom[0].ProbHi(AMREX_SPACEDIM-1);
-        input_sounding_data.read_from_file(input_sounding_file, ztop);
+        input_sounding_data.read_from_file(input_sounding_file, geom[lev]);
 
-        if (init_sounding_ideal) input_sounding_data.calc_rho_p(ztop);
+        if (init_sounding_ideal) input_sounding_data.calc_rho_p();
     }
 
     auto& lev_new = vars_new[lev];

--- a/Source/ERF_init1d.cpp
+++ b/Source/ERF_init1d.cpp
@@ -58,8 +58,7 @@ ERF::setRayleighRefFromSounding(bool restarting)
     //    so we need to read it here
     // TODO: should we store this information in the checkpoint file instead?
     if (restarting) {
-        Real ztop = geom[0].ProbHi(AMREX_SPACEDIM-1);
-        input_sounding_data.read_from_file(input_sounding_file, ztop);
+        input_sounding_data.read_from_file(input_sounding_file, geom[0]);
     }
 
     const Real* z_inp_sound     = input_sounding_data.z_inp_sound.dataPtr();


### PR DESCRIPTION
Bug fixes
* When initializing from sounding, interpolate input profiles to grid heights prior to integrating through column in order to more strictly enforce HSE initially (https://github.com/erf-model/ERF/commit/7bc4bb8df6c109502a568c087351e3a70432d5b2)
* Calculate fluxes based on the correct state variable if dirichlet is used for zlo/zhi (https://github.com/erf-model/ERF/commit/8bfbe3572101c557c7e49e74d043d9875fb099f9)
* Clean up/clarify ABLMost::impose_most_bcs()

Other changes — these will probably affect nightly tests
* ABL/inputs_most https://github.com/erf-model/ERF/commit/a63c0b37b17bec207a8e6a4c9141a1cb24001aca
* default turbulence modeling params, `Pr_t`, `Ck` and `Ce` https://github.com/erf-model/ERF/commit/74d71fae8761de1bb9bcf17745c5455d561a669a