### PR TITLE
Allow more than 1 substep in RK stage 1; fix cmake setup for metgrid IO

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -51,6 +51,7 @@ function(build_erf_lib erf_lib_name)
                    ${SRC_DIR}/IO/NCPlotFile.cpp
                    ${SRC_DIR}/IO/NCCheckpoint.cpp
                    ${SRC_DIR}/IO/NCMultiFabFile.cpp
+                   ${SRC_DIR}/IO/ReadFromMetgrid.cpp
                    ${SRC_DIR}/IO/ReadFromWRFBdy.cpp
                    ${SRC_DIR}/IO/ReadFromWRFInput.cpp
                    ${SRC_DIR}/IO/NCColumnFile.cpp)

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -701,6 +701,7 @@ private:
     static int verbose;
     static int use_native_mri;
     static int no_substepping;
+    static int force_stage1_single_substep;
 
     // mesh refinement
     static std::string coupling_type;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -43,6 +43,7 @@ int         ERF::verbose       = 0;
 // Use the native ERF MRI integrator
 int         ERF::use_native_mri = 1;
 int         ERF::no_substepping = 0;
+int         ERF::force_stage1_single_substep = 1;
 
 // Frequency of diagnostic output
 int         ERF::sum_interval  = -1;
@@ -1001,6 +1002,7 @@ ERF::initialize_integrator(int lev, MultiFab& cons_mf, MultiFab& vel_mf)
 
     mri_integrator_mem[lev] = std::make_unique<MRISplitIntegrator<amrex::Vector<amrex::MultiFab> > >(int_state);
     mri_integrator_mem[lev]->setNoSubstepping(no_substepping);
+    mri_integrator_mem[lev]->setForceFirstStageSingleSubstep(force_stage1_single_substep);
 
     physbcs[lev] = std::make_unique<ERFPhysBCFunct> (lev, geom[lev], domain_bcs_type, domain_bcs_type_d,
                                                      solverChoice.terrain_type, m_bc_extdir_vals, m_bc_neumann_vals,
@@ -1098,6 +1100,7 @@ ERF::ReadParameters ()
         // Use the native ERF MRI integrator
         pp.query("use_native_mri", use_native_mri);
         pp.query("no_substepping", no_substepping);
+        pp.query("force_stage1_single_substep", force_stage1_single_substep);
 
         // Frequency of diagnostic output
         pp.query("sum_interval", sum_interval);

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -134,7 +134,15 @@ ERF::estTimeStep(int level, long& dt_fast_ratio) const
   }
 
   // Force time step ratio to be an even value
-  if ( dt_fast_ratio%2 != 0) dt_fast_ratio += 1;
+  if (force_stage1_single_substep) {
+      if ( dt_fast_ratio%2 != 0) dt_fast_ratio += 1;
+  } else {
+      if ( dt_fast_ratio%6 != 0) {
+          amrex::Print() << "mri_dt_ratio = " << dt_fast_ratio
+            << " not divisible by 6 for N/3 substeps in stage 1" << std::endl;
+          dt_fast_ratio = std::ceil(dt_fast_ratio/6.0) * 6;
+      }
+  }
 
   if (verbose)
     amrex::Print() << "smallest even ratio is: " << dt_fast_ratio << std::endl;

--- a/Source/TimeIntegration/ERF_MRI.H
+++ b/Source/TimeIntegration/ERF_MRI.H
@@ -36,6 +36,11 @@ private:
     int no_substepping;
 
    /**
+    * \brief Do we follow the recommendation to only perform a single substep in the first RK stage
+    */
+    int force_stage1_single_substep;
+
+   /**
     * \brief The  pre_update function is called by the integrator on stage data before using it to evaluate a right-hand side.
     * \brief The post_update function is called by the integrator on stage data at the end of the stage
     */
@@ -80,6 +85,11 @@ public:
     void setNoSubstepping(int _no_substepping)
     {
         no_substepping = _no_substepping;
+    }
+
+    void setForceFirstStageSingleSubstep(int _force_stage1_single_substep)
+    {
+        force_stage1_single_substep = _force_stage1_single_substep;
     }
 
     void set_rhs (std::function<void(T&, const T&, const amrex::Real, const amrex::Real, int)> F)
@@ -274,7 +284,12 @@ public:
             // Capture the time we got to in the previous RK step
             old_time_stage = time_stage;
 
-            if (nrk == 0) { nsubsteps = 1;               dtau = timestep / 3.0; time_stage = time + timestep / 3.0;}
+            if (nrk == 0) {
+                if (force_stage1_single_substep)
+                          { nsubsteps = 1;               dtau = timestep / 3.0; time_stage = time + timestep / 3.0;}
+                else
+                          { nsubsteps = substep_ratio/3; dtau = sub_timestep  ; time_stage = time + timestep / 3.0;}
+            }
             if (nrk == 1) { nsubsteps = substep_ratio/2; dtau = sub_timestep  ; time_stage = time + timestep / 2.0;}
             if (nrk == 2) { nsubsteps = substep_ratio;   dtau = sub_timestep  ; time_stage = time + timestep      ;}
 


### PR DESCRIPTION
To enable, set `ERF.force_stage1_single_substep = 0` to run with N/3 substeps in stage 1 (where N is the substep ratio). The substep ratio must be a multiple of 6. 