### PR TITLE
Positive definite advection

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -130,6 +130,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/Utils/ERF_Math.H
        ${SRC_DIR}/Utils/Microphysics_Utils.H
        ${SRC_DIR}/Utils/Interpolation.H
+       ${SRC_DIR}/Utils/Interpolation_WENO.H
        ${SRC_DIR}/Utils/PlaneAverage.H
        ${SRC_DIR}/Utils/VelPlaneAverage.H
        ${SRC_DIR}/Utils/DirectionSelector.H

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -175,7 +175,9 @@ and :math:`\gamma = c_p / (c_p - R_d)` .  :math:`p_0` is a reference value for p
 Differencing of Different Orders
 ================================
 
-:math:`[\rho, u, v, w, \rho\theta]`,  :math:`m = i, j, k`,  and :math:`U_d = [u, v, w]` for :math:`[x, y, z]` directions respectively.
+Interpolation Methods
+---------------------
+The midpoint values given above :math:`q_{m - \frac{1}{2}}`, where :math:`q` may be :math:`[\rho, u, v, w, \rho\theta]`, :math:`m = i, j, k`, :math:`U_d = [u, v, w]` for :math:`[x, y, z]` directions respectively, the following interpolation schemes are available:
 
 .. math::
 
@@ -192,6 +194,45 @@ Differencing of Different Orders
 
 Ref: Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). doi:10.5065/1dfh-6p97
 `doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
+
+WENO Methods
+------------
+Additionally, weighted essentially non-oscillatory (WENO) schemes are available for :math:`3rd` and :math:`5th` order interpolation. The general formulation is as follows:
+
+\begin{array}{ll}
+   \left. q_{m - \frac{1}{2}} = \sum_{n=1}^{N} w_n q_{m - \frac{1}{2}}^{(n)} &  \\
+   \left. w_{n} = \frac{\hat{w}_{n}}{\sum_{l=1}^{N} \hat{w}_{l}} & \hat{w}_{l} = \frac{\omega_{l}}{\left(\epsilon + \beta_{l} \right)^2} \\
+\end{array}
+
+With the WENO3 scheme, one has :math:`N=2 \; \omega_{1} = 1/3, \; \omega_{2} = 2/3` and the following closures
+
+\begin{array}{l}
+   \left. \beta_{1} = \left(q_{m - 1} - q_{m-2} \right)^2 \\
+   \left. \beta_{2} = \left(q_{m} - q_{m-1} \right)^2 \\
+   \left. q_{m - \frac{1}{2}}^{(1)} = -\frac{1}{2} q_{m-2} + \frac{3}{2} q_{m-1} \\
+   \left. q_{m - \frac{1}{2}}^{(2)} = \frac{1}{2} q_{m-1} + \frac{1}{2} q_{m}
+\end{array}
+
+With the WENO5 scheme, one has :math:`N=3, \; \omega_{1} = 1/10, \; \omega_{2} = 3/5, \; \omega_{3} = 3/10` and the following closures
+
+\begin{array}{l}
+   \left. \beta_{1} = \frac{13}{12} \left(q_{m - 3} - 2 q_{m-2} + q_{m-1} \right)^2 + \frac{1}{4} \left(q_{m - 3} - 4 q_{m-2} + 3 q_{m-1} \right)^2  \\
+   \left. \beta_{2} = \frac{13}{12} \left(q_{m - 2} - 2 q_{m-1} + q_{m} \right)^2 + \frac{1}{4} \left(q_{m - 2} - q_{m} \right)^2  \\
+   \left. \beta_{3} = \frac{13}{12} \left(q_{m - 1} - 2 q_{m} + q_{m+1} \right)^2 + \frac{1}{4} \left( 3 q_{m - 1} - 4 q_{m} + q_{m+1} \right)^2  \\
+   \left. q_{m - \frac{1}{2}}^{(1)} = \frac{1}{3} q_{m-3} - \frac{7}{6} q_{m-2} + \frac{11}{6} q_{m-1} \\
+   \left. q_{m - \frac{1}{2}}^{(2)} = -\frac{1}{6} q_{m-2} + \frac{5}{6} q_{m-1} + \frac{1}{3} q_{m} \\
+   \left. q_{m - \frac{1}{2}}^{(3)} = \frac{1}{3} q_{m-1} + \frac{5}{6} q_{m} - \frac{1}{3} q_{m+1} \\
+\end{array}
+
+By default, the WENO3 scheme will be employed for moisture variables if the code is compiled with moisture support. However, users may utilize the WENO scheme for all variables, with a specified order, via the following inputs:
+
+::
+
+   erf.all_use_WENO       = true   # Default is false
+   erf.spatial_order_WENO = 5      # Default is 3
+
+Ref: Muñoz-Esparza, D., Sauer, J. A., Jensen, A. A., Xue, L., & Grabowski, W. W. (2022). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Moist dynamics extension, validation and sensitivities of modeling non-precipitating shallow cumulus clouds. Journal of Advances in Modeling Earth Systems, 14, e2021MS002904.
+`doi:10.1029/2021MS002904 <https://doi.org/10.1029/2021MS002904>`_
 
 Momentum, Thermal, and Scalar Diffusion Contribution to DNS
 ===========================================================

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -199,30 +199,36 @@ WENO Methods
 ------------
 Additionally, weighted essentially non-oscillatory (WENO) schemes are available for :math:`3rd` and :math:`5th` order interpolation. The general formulation is as follows:
 
-\begin{array}{ll}
+.. math::
+   
+   \begin{array}{ll}
    \left. q_{m - \frac{1}{2}} = \sum_{n=1}^{N} w_n q_{m - \frac{1}{2}}^{(n)} &  \\
    \left. w_{n} = \frac{\hat{w}_{n}}{\sum_{l=1}^{N} \hat{w}_{l}} & \hat{w}_{l} = \frac{\omega_{l}}{\left(\epsilon + \beta_{l} \right)^2} \\
 \end{array}
 
 With the WENO3 scheme, one has :math:`N=2 \; \omega_{1} = 1/3, \; \omega_{2} = 2/3` and the following closures
 
-\begin{array}{l}
+.. math::
+  
+   \begin{array}{l}
    \left. \beta_{1} = \left(q_{m - 1} - q_{m-2} \right)^2 \\
    \left. \beta_{2} = \left(q_{m} - q_{m-1} \right)^2 \\
    \left. q_{m - \frac{1}{2}}^{(1)} = -\frac{1}{2} q_{m-2} + \frac{3}{2} q_{m-1} \\
    \left. q_{m - \frac{1}{2}}^{(2)} = \frac{1}{2} q_{m-1} + \frac{1}{2} q_{m}
-\end{array}
+   \end{array}
 
 With the WENO5 scheme, one has :math:`N=3, \; \omega_{1} = 1/10, \; \omega_{2} = 3/5, \; \omega_{3} = 3/10` and the following closures
 
-\begin{array}{l}
+.. math::
+   
+   \begin{array}{l}
    \left. \beta_{1} = \frac{13}{12} \left(q_{m - 3} - 2 q_{m-2} + q_{m-1} \right)^2 + \frac{1}{4} \left(q_{m - 3} - 4 q_{m-2} + 3 q_{m-1} \right)^2  \\
    \left. \beta_{2} = \frac{13}{12} \left(q_{m - 2} - 2 q_{m-1} + q_{m} \right)^2 + \frac{1}{4} \left(q_{m - 2} - q_{m} \right)^2  \\
    \left. \beta_{3} = \frac{13}{12} \left(q_{m - 1} - 2 q_{m} + q_{m+1} \right)^2 + \frac{1}{4} \left( 3 q_{m - 1} - 4 q_{m} + q_{m+1} \right)^2  \\
    \left. q_{m - \frac{1}{2}}^{(1)} = \frac{1}{3} q_{m-3} - \frac{7}{6} q_{m-2} + \frac{11}{6} q_{m-1} \\
    \left. q_{m - \frac{1}{2}}^{(2)} = -\frac{1}{6} q_{m-2} + \frac{5}{6} q_{m-1} + \frac{1}{3} q_{m} \\
    \left. q_{m - \frac{1}{2}}^{(3)} = \frac{1}{3} q_{m-1} + \frac{5}{6} q_{m} - \frac{1}{3} q_{m+1} \\
-\end{array}
+   \end{array}
 
 By default, the WENO3 scheme will be employed for moisture variables if the code is compiled with moisture support. However, users may utilize the WENO scheme for all variables, with a specified order, via the following inputs:
 

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -204,7 +204,7 @@ Additionally, weighted essentially non-oscillatory (WENO) schemes are available 
    \begin{array}{ll}
    \left. q_{m - \frac{1}{2}} = \sum_{n=1}^{N} w_n q_{m - \frac{1}{2}}^{(n)} &  \\
    \left. w_{n} = \frac{\hat{w}_{n}}{\sum_{l=1}^{N} \hat{w}_{l}} & \hat{w}_{l} = \frac{\omega_{l}}{\left(\epsilon + \beta_{l} \right)^2} \\
-\end{array}
+   \end{array}
 
 With the WENO3 scheme, one has :math:`N=2 \; \omega_{1} = 1/3, \; \omega_{2} = 2/3` and the following closures
 

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -200,7 +200,7 @@ WENO Methods
 Additionally, weighted essentially non-oscillatory (WENO) schemes are available for :math:`3rd` and :math:`5th` order interpolation. The general formulation is as follows:
 
 .. math::
-   
+
    \begin{array}{ll}
    \left. q_{m - \frac{1}{2}} = \sum_{n=1}^{N} w_n q_{m - \frac{1}{2}}^{(n)} &  \\
    \left. w_{n} = \frac{\hat{w}_{n}}{\sum_{l=1}^{N} \hat{w}_{l}} & \hat{w}_{l} = \frac{\omega_{l}}{\left(\epsilon + \beta_{l} \right)^2} \\
@@ -209,7 +209,7 @@ Additionally, weighted essentially non-oscillatory (WENO) schemes are available 
 With the WENO3 scheme, one has :math:`N=2 \; \omega_{1} = 1/3, \; \omega_{2} = 2/3` and the following closures
 
 .. math::
-  
+
    \begin{array}{l}
    \left. \beta_{1} = \left(q_{m - 1} - q_{m-2} \right)^2 \\
    \left. \beta_{2} = \left(q_{m} - q_{m-1} \right)^2 \\
@@ -220,7 +220,7 @@ With the WENO3 scheme, one has :math:`N=2 \; \omega_{1} = 1/3, \; \omega_{2} = 2
 With the WENO5 scheme, one has :math:`N=3, \; \omega_{1} = 1/10, \; \omega_{2} = 3/5, \; \omega_{3} = 3/10` and the following closures
 
 .. math::
-   
+
    \begin{array}{l}
    \left. \beta_{1} = \frac{13}{12} \left(q_{m - 3} - 2 q_{m-2} + q_{m-1} \right)^2 + \frac{1}{4} \left(q_{m - 3} - 4 q_{m-2} + 3 q_{m-1} \right)^2  \\
    \left. \beta_{2} = \frac{13}{12} \left(q_{m - 2} - 2 q_{m-1} + q_{m} \right)^2 + \frac{1}{4} \left(q_{m - 2} - q_{m} \right)^2  \\

--- a/Exec/ScalarAdvDiff/inputs_WENO
+++ b/Exec/ScalarAdvDiff/inputs_WENO
@@ -1,0 +1,67 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 20
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_extent =  1     1     1
+amr.n_cell           = 64     64    4
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.use_lowM_dt    = 1
+erf.cfl            = 0.5     # cfl number for hyperbolic system
+
+# TEST WENO SCHEMES
+erf.all_use_WENO = true
+erf.spatial_order_WENO = 3 # MUST BE 3 or 5
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta
+
+# SOLVER CHOICE
+erf.alpha_T = 0.0
+erf.alpha_C = 0.0
+erf.use_gravity = false
+
+erf.les_type         = "None"
+erf.molec_diff_type  = "None"
+erf.dynamicViscosity = 0.0
+
+# PROBLEM PARAMETERS
+prob.rho_0 = 1.0
+prob.T_0   = 1.0
+prob.A_0   = 1.0
+prob.B_0   = 0.0
+prob.u_0   = 10.0
+prob.v_0   = 0.0
+prob.rad_0 = 0.125
+prob.uRef  = 0.0
+
+prob.prob_type = 11
+
+#prob.prob_type = -1
+#prob.rad_0     = 0.25
+#prob.xc_frac   = 0.5
+#prob.yc_frac   = 0.5
+#prob.zc_frac   = 0.5

--- a/Source/Advection/Advection.H
+++ b/Source/Advection/Advection.H
@@ -27,6 +27,8 @@ void AdvectionSrcForRhoAndTheta (const amrex::Box& bx, const amrex::Box& valid_b
                                  const amrex::Array4<const amrex::Real>& mf_m,
                                  const amrex::Array4<const amrex::Real>& mf_u,
                                  const amrex::Array4<const amrex::Real>& mf_v,
+                                 const bool all_use_WENO,
+                                 const int  spatial_order_WENO,
                                  const int horiz_spatial_order, const int vert_spatial_order,
                                  const int use_terrain);
 
@@ -40,6 +42,9 @@ void AdvectionSrcForScalars (const amrex::Box& bx,
                              const amrex::Array4<const amrex::Real>& detJ,
                              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSize,
                              const amrex::Array4<const amrex::Real>& mf_m,
+                             const bool all_use_WENO,
+                             const bool moist_use_WENO,
+                             const int  spatial_order_WENO,
                              const int horiz_spatial_order, const int vert_spatial_order, const int use_terrain);
 
 void AdvectionSrcForMom (const amrex::Box& bxx, const amrex::Box& bxy, const amrex::Box& bxz,
@@ -54,6 +59,8 @@ void AdvectionSrcForMom (const amrex::Box& bxx, const amrex::Box& bxy, const amr
                          const amrex::Array4<const amrex::Real>& mf_m,
                          const amrex::Array4<const amrex::Real>& mf_u,
                          const amrex::Array4<const amrex::Real>& mf_v,
+                         const bool all_use_WENO,
+                         const int  spatial_order_WENO,
                          const int horiz_spatial_order, const int vert_spatial_order,
                          const int use_terrain, const int domhi_z);
 

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -1,6 +1,7 @@
 #include <IndexDefines.H>
 #include <TerrainMetrics.H>
 #include <Interpolation.H>
+#include <Interpolation_WENO.H>
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
@@ -162,6 +163,171 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     } else {
         rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
         zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, w, 0, rho_w_avg, l_spatial_order_hi);
+    }
+
+    amrex::Real mfsq = mf_m(i,j,0) * mf_m(i,j,0);
+
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
+                 + (yflux_hi - yflux_lo) * dyInv * mfsq
+                 + (zflux_hi - zflux_lo) * dzInv;
+
+   return advectionSrc;
+}
+
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForXMom_WENO_N (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& rho_w, const amrex::Array4<const amrex::Real>& u,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_u,
+                            const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO)
+{
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, rho_w_avg;
+
+    amrex::Real xflux_hi; amrex::Real xflux_lo;
+    amrex::Real yflux_hi; amrex::Real yflux_lo;
+    amrex::Real zflux_hi; amrex::Real zflux_lo;
+
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_mid = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i-1,j  ,0);
+    amrex::Real mf_v_inv_1  = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_2   = 1. / mf_v(i-1,j+1,0); amrex::Real mf_v_inv_3  = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_4 = 1. / mf_v(i-1,j  ,0);
+
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_hi + rho_u(i, j, k) * mf_u_inv_mid);
+    xflux_hi = rho_u_avg * InterpolateInX_WENO(i+1, j, k, u, 0, spatial_order_WENO);
+
+    rho_u_avg = 0.5 * (rho_u(i-1, j, k) * mf_u_inv_lo + rho_u(i, j, k) * mf_u_inv_mid);
+    xflux_lo = rho_u_avg * InterpolateInX_WENO(i  , j, k, u, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) * mf_v_inv_1 + rho_v(i-1, j+1, k) * mf_v_inv_2);
+    yflux_hi = rho_v_avg * InterpolateInY_WENO(i, j+1, k, u, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) * mf_v_inv_3 + rho_v(i-1, j  , k) * mf_v_inv_4);
+    yflux_lo = rho_v_avg * InterpolateInY_WENO(i, j  , k, u, 0, spatial_order_WENO);
+
+    rho_w_avg = 0.5 * (rho_w(i, j, k+1) + rho_w(i-1, j, k+1));
+    zflux_hi = rho_w_avg * InterpolateInZ_WENO(i, j, k+1, u, 0, spatial_order_WENO);
+
+    rho_w_avg = 0.5 * (rho_w(i, j, k) + rho_w(i-1, j, k));
+    zflux_lo = rho_w_avg * InterpolateInZ_WENO(i, j, k  , u, 0, spatial_order_WENO);
+
+    amrex::Real mfsq = mf_u(i,j,0) * mf_u(i,j,0);
+
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
+                 + (yflux_hi - yflux_lo) * dyInv * mfsq
+                 + (zflux_hi - zflux_lo) * dzInv;
+
+    return advectionSrc;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForYMom_WENO_N (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& rho_w, const amrex::Array4<const amrex::Real>& v,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_u,
+                            const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO)
+{
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, rho_w_avg;
+
+    amrex::Real xflux_hi; amrex::Real xflux_lo;
+    amrex::Real yflux_hi; amrex::Real yflux_lo;
+    amrex::Real zflux_hi; amrex::Real zflux_lo;
+
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_mid = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j-1,0);
+    amrex::Real mf_u_inv_1  = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_2   = 1. / mf_u(i+1,j-1,0); amrex::Real mf_u_inv_3  = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_4 = 1. / mf_u(i  ,j-1,0);
+
+    rho_u_avg = 0.5*(rho_u(i+1, j, k) * mf_u_inv_1 + rho_u(i+1, j-1, k) * mf_u_inv_2);
+    xflux_hi = rho_u_avg * InterpolateInX_WENO(i+1, j, k, v, 0, spatial_order_WENO);
+
+    rho_u_avg = 0.5*(rho_u(i  , j, k) * mf_u_inv_3 + rho_u(i  , j-1, k) * mf_u_inv_4);
+    xflux_lo = rho_u_avg * InterpolateInX_WENO(i  , j, k, v, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5*(rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j+1, k) * mf_v_inv_hi);
+    yflux_hi = rho_v_avg * InterpolateInY_WENO(i, j+1, k, v, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5*(rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j-1, k) * mf_v_inv_lo);
+    yflux_lo = rho_v_avg * InterpolateInY_WENO(i, j  , k, v, 0, spatial_order_WENO);
+
+    rho_w_avg = 0.5*(rho_w(i, j, k+1) + rho_w(i, j-1, k+1));
+    zflux_hi = rho_w_avg * InterpolateInZ_WENO(i, j, k+1, v, 0, spatial_order_WENO);
+
+    rho_w_avg = 0.5*(rho_w(i, j, k) + rho_w(i, j-1, k));
+    zflux_lo = rho_w_avg * InterpolateInZ_WENO(i, j, k  , v, 0, spatial_order_WENO);
+
+    amrex::Real mfsq = mf_v(i,j,0) * mf_v(i,j,0);
+
+    advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
+                 + (yflux_hi - yflux_lo) * dyInv * mfsq
+                 + (zflux_hi - zflux_lo) * dzInv;
+
+   return advectionSrc;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForZMom_WENO_N (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& rho_w, const amrex::Array4<const amrex::Real>& w,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_m,
+                            const amrex::Array4<const amrex::Real>& mf_u,
+                            const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO, int domhi_z)
+{
+
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, rho_w_avg;
+
+    amrex::Real xflux_hi; amrex::Real xflux_lo;
+    amrex::Real yflux_hi; amrex::Real yflux_lo;
+    amrex::Real zflux_hi; amrex::Real zflux_lo;
+
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i  ,j  ,0);
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j  ,0);
+
+    rho_u_avg = 0.5*(rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv_hi;
+    xflux_hi = rho_u_avg * InterpolateInX_WENO(i+1, j, k, w, 0, spatial_order_WENO);
+
+    rho_u_avg = 0.5*(rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv_lo;
+    xflux_lo = rho_u_avg * InterpolateInX_WENO(i  , j, k, w, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5*(rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv_hi;
+    yflux_hi = rho_v_avg * InterpolateInY_WENO(i, j+1, k, w, 0, spatial_order_WENO);
+
+    rho_v_avg = 0.5*(rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv_lo;
+    yflux_lo = rho_v_avg * InterpolateInY_WENO(i, j  , k, w, 0, spatial_order_WENO);
+
+    // Constrain to 2nd order near top and bottom
+    if (k == 0) {
+        zflux_lo = rho_w(i,j,k) * w(i,j,k);
+    } else if ((k > domhi_z-2) || (k < 3)) {
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1));
+        zflux_lo = rho_w_avg * InterpolateInZ(i, j, k  , w, 0, rho_w_avg, 2);
+    } else {
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1));
+        zflux_lo = rho_w_avg * InterpolateInZ_WENO(i, j, k  , w, 0, spatial_order_WENO);
+    }
+
+    if (k == domhi_z+1) {
+        zflux_hi =  rho_w(i,j,k) * w(i,j,k);
+    } else if ((k > domhi_z-2) || (k < 3)) {
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
+        zflux_hi = rho_w_avg * InterpolateInZ(i, j, k+1, w, 0, rho_w_avg, 2);
+    } else {
+        rho_w_avg = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
+        zflux_hi = rho_w_avg * InterpolateInZ_WENO(i, j, k+1, w, 0, spatial_order_WENO);
     }
 
     amrex::Real mfsq = mf_m(i,j,0) * mf_m(i,j,0);

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -1,6 +1,7 @@
 #include <IndexDefines.H>
 #include <TerrainMetrics.H>
 #include <Interpolation.H>
+#include <Interpolation_WENO.H>
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
@@ -244,6 +245,269 @@ AdvectionSrcForZMom_T (int i, int j, int k,
     // If k == 2 and spatial_order >= 5 we would reach to k = -1 so we set to spatial_order = min(spatial_order,4)
     int l_spatial_order_lo = std::min(std::min(vert_spatial_order, 2*(domhi_z+2-k)), 2*k);
     centFluxZZPrev *= (k == 0) ? w(i,j,k) : InterpolateInZ(i, j, k  , w, 0, Omega_avg, l_spatial_order_lo);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    amrex::Real mfsq = mf_m(i,j,0) * mf_m(i,j,0);
+
+    advectionSrc = (edgeFluxZXNext - edgeFluxZXPrev) * dxInv * mfsq
+                 + (edgeFluxZYNext - edgeFluxZYPrev) * dyInv * mfsq
+                 + (centFluxZZNext - centFluxZZPrev) * dzInv;
+
+    amrex::Real denom = 0.5*(detJ(i,j,k) + detJ(i,j,k-1));
+    advectionSrc /= denom;
+
+    return advectionSrc;
+}
+
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForXMom_WENO_T (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& Omega, const amrex::Array4<const amrex::Real>& u,
+                            const amrex::Array4<const amrex::Real>& z_nd,  const amrex::Array4<const amrex::Real>& detJ,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_u, const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO)
+{
+    //used when spatial order > 2
+
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, Omega_avg_lo, Omega_avg_hi;
+
+    amrex::Real met_h_zeta;
+
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_mid = 1. / mf_u(i  ,j  ,0);
+    amrex::Real mf_u_inv_lo = 1. / mf_u(i-1,j  ,0);
+    amrex::Real mf_v_inv_1  = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_2   = 1. / mf_v(i-1,j+1,0);
+    amrex::Real mf_v_inv_3  = 1. / mf_v(i  ,j  ,0); amrex::Real mf_v_inv_4 = 1. / mf_v(i-1,j  ,0);
+
+    // ****************************************************************************************
+    // X-fluxes (at cell centers)
+    // ****************************************************************************************
+
+    met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_hi + rho_u(i, j, k) * mf_u_inv_mid);
+    amrex::Real centFluxXXNext = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i+1, j, k, u, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    met_h_zeta = Compute_h_zeta_AtCellCenter(i-1,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i-1, j, k) * mf_u_inv_lo + rho_u(i, j, k) * mf_u_inv_mid);
+    amrex::Real centFluxXXPrev = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i  , j, k, u, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+    // Y-fluxes (at edges in k-direction)
+    // ****************************************************************************************
+
+    // Metric is at edge and center Z (red pentagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j+1,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) * mf_v_inv_1 + rho_v(i-1, j+1, k) * mf_v_inv_2);
+    amrex::Real edgeFluxXYNext = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i, j+1, k, u, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    // Metric is at edge and center Z (red pentagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) * mf_v_inv_3 + rho_v(i-1, j  , k) * mf_v_inv_4);
+    amrex::Real edgeFluxXYPrev = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i, j  , k, u, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+    // Z-fluxes (at edges in j-direction)
+    // ****************************************************************************************
+
+    Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i-1, j, k+1));
+    amrex::Real edgeFluxXZNext = Omega_avg_hi * InterpolateInZ_WENO(i,j,k+1,u,0,spatial_order_WENO);
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    Omega_avg_lo = 0.5 * (Omega(i, j, k) + Omega(i-1, j, k));
+    amrex::Real edgeFluxXZPrev = Omega_avg_lo * InterpolateInZ_WENO(i,j,k  ,u,0,spatial_order_WENO);
+
+    // ****************************************************************************************
+
+    amrex::Real mfsq = mf_u(i,j,0) * mf_u(i,j,0);
+
+    advectionSrc = (centFluxXXNext - centFluxXXPrev) * dxInv * mfsq
+                 + (edgeFluxXYNext - edgeFluxXYPrev) * dyInv * mfsq
+                 + (edgeFluxXZNext - edgeFluxXZPrev) * dzInv;
+    advectionSrc /= 0.5*(detJ(i,j,k) + detJ(i-1,j,k));
+
+    return advectionSrc;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForYMom_WENO_T (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& Omega, const amrex::Array4<const amrex::Real>& v,
+                            const amrex::Array4<const amrex::Real>& z_nd, const amrex::Array4<const amrex::Real>& detJ,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_u,  const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO)
+{
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, Omega_avg_lo, Omega_avg_hi;
+
+    amrex::Real met_h_zeta;
+
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_mid = 1. / mf_v(i  ,j  ,0);
+    amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j-1,0);
+    amrex::Real mf_u_inv_1  = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_2   = 1. / mf_u(i+1,j-1,0);
+    amrex::Real mf_u_inv_3  = 1. / mf_u(i  ,j  ,0); amrex::Real mf_u_inv_4 = 1. / mf_u(i  ,j-1,0);
+
+    // ****************************************************************************************
+    // x-fluxes (at edges in k-direction)
+    // ****************************************************************************************
+
+    // Metric is at edge and center Z (red pentagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i+1,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) * mf_u_inv_1 + rho_u(i+1, j-1, k) * mf_u_inv_2);
+    amrex::Real edgeFluxYXNext = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i+1, j, k, v, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    // Metric is at edge and center Z (red pentagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i  , j, k) * mf_u_inv_3 + rho_u(i  , j-1, k) * mf_u_inv_4);
+    amrex::Real edgeFluxYXPrev = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i  , j, k, v, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+    // y-fluxes (at cell centers)
+    // ****************************************************************************************
+
+    met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j+1, k) * mf_v_inv_hi);
+    amrex::Real centFluxYYNext = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i, j+1, k, v, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    met_h_zeta = Compute_h_zeta_AtCellCenter(i  ,j-1,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j, k) * mf_v_inv_mid + rho_v(i, j-1, k) * mf_v_inv_lo);
+    amrex::Real centFluxYYPrev = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i  , j, k, v, 0, spatial_order_WENO);
+
+
+    // ****************************************************************************************
+    // Z-fluxes (at edges in j-direction)
+    // ****************************************************************************************
+
+    Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i, j-1, k+1));
+    amrex::Real edgeFluxYZNext = Omega_avg_hi *
+                          InterpolateInZ_WENO(i, j, k+1, v, 0, spatial_order_WENO);
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    Omega_avg_lo = 0.5 * (Omega(i, j, k)+ Omega(i, j-1, k));
+    amrex::Real edgeFluxYZPrev = Omega_avg_lo*
+                          InterpolateInZ_WENO(i, j, k  , v, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+
+    amrex::Real mfsq = mf_v(i,j,0) * mf_v(i,j,0);
+
+    advectionSrc = (edgeFluxYXNext - edgeFluxYXPrev) * dxInv * mfsq
+                 + (centFluxYYNext - centFluxYYPrev) * dyInv * mfsq
+                 + (edgeFluxYZNext - edgeFluxYZPrev) * dzInv;
+    advectionSrc /= 0.5*(detJ(i,j,k) + detJ(i,j-1,k));
+
+    return advectionSrc;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+AdvectionSrcForZMom_WENO_T (int i, int j, int k,
+                            const amrex::Array4<const amrex::Real>& rho_u, const amrex::Array4<const amrex::Real>& rho_v,
+                            const amrex::Array4<const amrex::Real>& Omega, const amrex::Array4<const amrex::Real>& w,
+                            const amrex::Array4<const amrex::Real>& z_nd, const amrex::Array4<const amrex::Real>& detJ,
+                            const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
+                            const amrex::Array4<const amrex::Real>& mf_m,  const amrex::Array4<const amrex::Real>& mf_u,
+                            const amrex::Array4<const amrex::Real>& mf_v,
+                            int spatial_order_WENO, int domhi_z)
+{
+    amrex::Real advectionSrc;
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
+    amrex::Real rho_u_avg, rho_v_avg, Omega_avg;
+
+    amrex::Real met_h_zeta;
+
+    amrex::Real mf_u_inv_hi = 1. / mf_u(i+1,j  ,0); amrex::Real mf_u_inv_lo = 1. / mf_u(i  ,j  ,0);
+    amrex::Real mf_v_inv_hi = 1. / mf_v(i  ,j+1,0); amrex::Real mf_v_inv_lo = 1. / mf_v(i  ,j  ,0);
+
+    // ****************************************************************************************
+    // x-fluxes (at edges in j-direction)
+    // ****************************************************************************************
+
+    // Metric is at edge and center Y (magenta cross)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv_hi;
+    amrex::Real edgeFluxZXNext = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i+1, j, k, w, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    // Metric is at edge and center Y (magenta cross)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_u_avg = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv_lo;
+    amrex::Real edgeFluxZXPrev = rho_u_avg * met_h_zeta *
+                          InterpolateInX_WENO(i  , j, k, w, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+    // y-fluxes (at edges in i-direction)
+    // ****************************************************************************************
+
+    // Metric is at edge and center I (purple hexagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv_hi;
+    amrex::Real edgeFluxZYNext = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i, j+1, k, w, 0, spatial_order_WENO);
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    // Metric is at edge and center I (purple hexagon)
+    met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd);
+    rho_v_avg = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv_lo;
+    amrex::Real edgeFluxZYPrev = rho_v_avg * met_h_zeta *
+                          InterpolateInY_WENO(i, j  , k, w, 0, spatial_order_WENO);
+
+    // ****************************************************************************************
+    // z-fluxes (at cell centers)
+    // ****************************************************************************************
+
+    Omega_avg = (k == domhi_z+1) ? Omega(i,j,k) : 0.5 * (Omega(i,j,k) + Omega(i,j,k+1));
+    amrex::Real centFluxZZNext = Omega_avg;
+
+    if (k == domhi_z+1) {
+        centFluxZZNext *= w(i,j,k);
+    } else if ((k > domhi_z-2) || (k < 3)) {
+        centFluxZZNext *= InterpolateInZ(i, j, k+1, w, 0, Omega_avg, 2);
+    } else {
+        centFluxZZNext *= InterpolateInZ_WENO(i, j, k+1, w, 0, spatial_order_WENO);
+    }
+
+    // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+
+    Omega_avg = (k == 0) ? Omega(i,j,k) : 0.5 * (Omega(i,j,k) + Omega(i,j,k-1));
+    amrex::Real centFluxZZPrev = Omega_avg;
+
+    if (k == 0) {
+        centFluxZZNext *= w(i,j,k);
+    } else if ((k > domhi_z-2) || (k < 3)) {
+        centFluxZZNext *= InterpolateInZ(i, j, k  , w, 0, Omega_avg, 2);
+    } else {
+        centFluxZZNext *= InterpolateInZ_WENO(i, j, k  , w, 0, spatial_order_WENO);
+    }
 
     // * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 

--- a/Source/Advection/AdvectionSrcForState.cpp
+++ b/Source/Advection/AdvectionSrcForState.cpp
@@ -2,6 +2,7 @@
 #include <TerrainMetrics.H>
 #include <Advection.H>
 #include <Interpolation.H>
+#include <Interpolation_WENO.H>
 
 using namespace amrex;
 
@@ -20,6 +21,8 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
                             const Array4<const Real>& mf_m,
                             const Array4<const Real>& mf_u,
                             const Array4<const Real>& mf_v,
+                            const bool all_use_WENO,
+                            const int  spatial_order_WENO,
                             const int horiz_spatial_order,
                             const int vert_spatial_order,
                             const int use_terrain)
@@ -30,7 +33,7 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
     // We note that valid_bx is the actual grid, while bx may be a tile within that grid
     const auto& vbx_hi = amrex::ubound(valid_bx);
 
-    if ( use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) == 2) ) {
+    if ( use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) == 2) && !all_use_WENO) {
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real invdetJ = 1./ detJ(i,j,k);
@@ -77,8 +80,8 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
                   yflux_lo * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index)) ) * dyInv * mfsq +
                 ( zflux_hi * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k+1,prim_index)) -
                   zflux_lo * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index)) ) * dzInv);
-    });
-    } else if ( use_terrain ) {
+        });
+    } else if ( use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) > 2) && !all_use_WENO) {
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real invdetJ = 1./ detJ(i,j,k);
@@ -121,8 +124,52 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
                   yflux_lo * InterpolateInY(i  ,j  , k  , cell_prim, prim_index, rho_v(i  ,j,k), horiz_spatial_order) ) * dyInv * mfsq +
                 ( zflux_hi * InterpolateInZ(i  ,j  , k+1, cell_prim, prim_index, Omega(i,j,k+1), vert_spatial_order) -
                   zflux_lo * InterpolateInZ(i  ,j  , k  , cell_prim, prim_index, Omega(i  ,j,k), vert_spatial_order) ) * dzInv);
-    });
-    } else if ( !use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) == 2) ) {
+        });
+    } else if (use_terrain) {
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real invdetJ = 1./ detJ(i,j,k);
+
+            Real zflux_lo = Omega(i,j,k  );
+            Real zflux_hi = Omega(i,j,k+1);
+
+            Real met_h_zeta_xhi = Compute_h_zeta_AtIface(i+1,j  ,k,cellSizeInv,z_nd);
+            Real xflux_hi = rho_u(i+1,j  ,k) * met_h_zeta_xhi * 1./mf_u(i  ,j  ,0);
+            Real met_h_zeta_xlo = Compute_h_zeta_AtIface(i  ,j  ,k,cellSizeInv,z_nd);
+            Real xflux_lo = rho_u(i  ,j  ,k) * met_h_zeta_xlo * 1./mf_u(i+1,j  ,0);
+            Real met_h_zeta_yhi = Compute_h_zeta_AtJface(i  ,j+1,k,cellSizeInv,z_nd);
+            Real yflux_hi = rho_v(i  ,j+1,k) * met_h_zeta_yhi * 1./mf_v(i  ,j  ,0);
+            Real met_h_zeta_ylo = Compute_h_zeta_AtJface(i  ,j  ,k,cellSizeInv,z_nd);
+            Real yflux_lo = rho_v(i  ,j  ,k) * met_h_zeta_ylo * 1./mf_v(i  ,j+1,0);
+
+            avg_xmom(i  ,j,k) += fac*xflux_lo;
+            if (i == vbx_hi.x)
+                avg_xmom(i+1,j,k) += fac*xflux_hi;
+            avg_ymom(i,j  ,k) += fac*yflux_lo;
+            if (j == vbx_hi.y)
+                avg_ymom(i,j+1,k) += fac*yflux_hi;
+            avg_zmom(i,j,k  ) += fac*zflux_lo;
+            if (k == vbx_hi.z)
+                avg_zmom(i,j,k+1) += fac*zflux_hi;
+
+            Real mf   = mf_m(i,j,0);
+            Real mfsq = mf*mf;
+
+            advectionSrc(i,j,k,0) = - invdetJ * (
+                ( xflux_hi - xflux_lo ) * dxInv * mfsq +
+                ( yflux_hi - yflux_lo ) * dyInv * mfsq +
+                ( zflux_hi - zflux_lo ) * dzInv);
+
+            const int prim_index = 0;
+            advectionSrc(i,j,k,1) = - invdetJ * (
+                ( xflux_hi * InterpolateInX_WENO(i+1,j  , k  , cell_prim, prim_index, spatial_order_WENO) -
+                  xflux_lo * InterpolateInX_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dxInv * mfsq +
+                ( yflux_hi * InterpolateInY_WENO(i  ,j+1, k  , cell_prim, prim_index, spatial_order_WENO) -
+                  yflux_lo * InterpolateInY_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dyInv * mfsq +
+                ( zflux_hi * InterpolateInZ_WENO(i  ,j  , k+1, cell_prim, prim_index, spatial_order_WENO) -
+                  zflux_lo * InterpolateInZ_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dzInv);
+        });
+    } else if ( !use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) == 2) && !all_use_WENO) {
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real xflux_lo = rho_u(i  ,j,k) / mf_u(i  ,j  ,0);
@@ -158,7 +205,7 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
               ( zflux_hi * (cell_prim(i,j,k+1,prim_index) + cell_prim(i,j,k,prim_index)) -
                 zflux_lo * (cell_prim(i,j,k-1,prim_index) + cell_prim(i,j,k,prim_index)) ) * dzInv);
         });
-    } else { // order > 2
+    } else if ( !use_terrain && (std::max(horiz_spatial_order,vert_spatial_order) > 2) && !all_use_WENO) {
         amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real xflux_lo = rho_u(i  ,j,k) / mf_u(i  ,j  ,0);
@@ -195,6 +242,43 @@ AdvectionSrcForRhoAndTheta (const Box& bx, const Box& valid_bx,
               ( zflux_hi * InterpolateInZ(i  ,j  , k+1, cell_prim, prim_index, Omega(i,j,k+1), vert_spatial_order) -
                 zflux_lo * InterpolateInZ(i  ,j  , k  , cell_prim, prim_index, Omega(i  ,j,k), vert_spatial_order) ) * dzInv);
         });
+    } else {
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real xflux_lo = rho_u(i  ,j,k) / mf_u(i  ,j  ,0);
+            Real xflux_hi = rho_u(i+1,j,k) / mf_u(i+1,j  ,0);
+            Real yflux_lo = rho_v(i,j  ,k) / mf_v(i  ,j  ,0);
+            Real yflux_hi = rho_v(i,j+1,k) / mf_v(i  ,j+1,0);
+            Real zflux_lo = Omega(i,j,k  );
+            Real zflux_hi = Omega(i,j,k+1);
+
+            avg_xmom(i  ,j,k) += fac*xflux_lo;
+            if (i == vbx_hi.x)
+                avg_xmom(i+1,j,k) += fac*xflux_hi;
+            avg_ymom(i,j  ,k) += fac*yflux_lo;
+            if (j == vbx_hi.y)
+                avg_ymom(i,j+1,k) += fac*yflux_hi;
+            avg_zmom(i,j,k  ) += fac*zflux_lo;
+            if (k == vbx_hi.z)
+               avg_zmom(i,j,k+1) += fac*zflux_hi;
+
+            Real mf   = mf_m(i,j,0);
+            Real mfsq = mf*mf;
+
+            advectionSrc(i,j,k,0) = -(
+                ( xflux_hi - xflux_lo ) * dxInv * mfsq +
+                ( yflux_hi - yflux_lo ) * dyInv * mfsq +
+                ( zflux_hi - zflux_lo ) * dzInv);
+
+            const int prim_index = 0;
+            advectionSrc(i,j,k,1) = -(
+                ( xflux_hi * InterpolateInX_WENO(i+1,j  , k  , cell_prim, prim_index, spatial_order_WENO) -
+                  xflux_lo * InterpolateInX_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dxInv * mfsq +
+                ( yflux_hi * InterpolateInY_WENO(i  ,j+1, k  , cell_prim, prim_index, spatial_order_WENO) -
+                  yflux_lo * InterpolateInY_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dyInv * mfsq +
+                ( zflux_hi * InterpolateInZ_WENO(i  ,j  , k+1, cell_prim, prim_index, spatial_order_WENO) -
+                  zflux_lo * InterpolateInZ_WENO(i  ,j  , k  , cell_prim, prim_index, spatial_order_WENO) ) * dzInv);
+        });
     }
 }
 
@@ -207,15 +291,57 @@ AdvectionSrcForScalars (const Box& bx, const int &icomp, const int &ncomp,
                         const Array4<const Real>& detJ,
                         const GpuArray<Real, AMREX_SPACEDIM>& cellSizeInv,
                         const Array4<const Real>& mf_m,
+                        const bool all_use_WENO,
+                        const bool moist_use_WENO,
+                        const int  spatial_order_WENO,
                         const int horiz_spatial_order, const int vert_spatial_order,
                         const int use_terrain)
 {
     BL_PROFILE_VAR("AdvectionSrcForScalars", AdvectionSrcForScalars);
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    if (std::max(horiz_spatial_order,vert_spatial_order) == 2)
-    {
-        amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    int ncomp_end{ncomp};
+    int moist_off = RhoScalar_comp;
+#if defined(ERF_USE_MOISTURE)
+    moist_off = RhoQt_comp;
+#elif defined(ERF_USE_WARM_NO_PRECIP)
+    moist_off = RhoQv_comp;
+#endif
+
+    // Running with WENO for moisture but not for other vars
+    if(moist_use_WENO && ((icomp+ncomp)==NVAR) ) {
+        ncomp_end -= 2;
+        amrex::ParallelFor(bx, 2, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        {
+            Real invdetJ = (use_terrain) ?  1. / detJ(i,j,k) : 1.;
+
+            // NOTE: we don't need to weight avg_xmom, avg_ymom, avg_zmom with terrain metrics
+            //       because that was done when they were constructed in AdvectionSrcForRhoAndTheta
+
+            const int cons_index = moist_off + n;
+            const int prim_index = cons_index - 1;
+
+            Real mfsq = mf_m(i,j,0) * mf_m(i,j,0);
+
+            advectionSrc(i,j,k,cons_index) = - invdetJ * (
+            ( avg_xmom(i+1,j,k) *
+                InterpolateInX_WENO(i+1,j,k,cell_prim, prim_index, spatial_order_WENO) -
+              avg_xmom(i  ,j,k) *
+                InterpolateInX_WENO(i  ,j,k,cell_prim, prim_index, spatial_order_WENO) ) * dxInv * mfsq +
+            ( avg_ymom(i,j+1,k) *
+                InterpolateInY_WENO(i,j+1,k,cell_prim, prim_index, spatial_order_WENO) -
+              avg_ymom(i,j  ,k) *
+                InterpolateInY_WENO(i,j  ,k,cell_prim, prim_index, spatial_order_WENO) ) * dyInv * mfsq +
+            ( avg_zmom(i,j,k+1) *
+                InterpolateInZ_WENO(i,j,k+1,cell_prim, prim_index, spatial_order_WENO) -
+              avg_zmom(i,j,k  ) *
+                InterpolateInZ_WENO(i,j,k  ,cell_prim, prim_index, spatial_order_WENO) ) * dzInv );
+        });
+    }
+
+    if ((std::max(horiz_spatial_order,vert_spatial_order) == 2) && !all_use_WENO) {
+
+        amrex::ParallelFor(bx, ncomp_end, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             Real invdetJ = (use_terrain) ?  1. / detJ(i,j,k) : 1.;
 
@@ -236,9 +362,9 @@ AdvectionSrcForScalars (const Box& bx, const int &icomp, const int &ncomp,
                 avg_zmom(i,j,k  ) * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index)) ) * dzInv);
         });
 
-    } else { // order > 2
+    } else if ((std::max(horiz_spatial_order,vert_spatial_order) > 2) && !all_use_WENO) { // order > 2
 
-        amrex::ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(bx, ncomp_end, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             Real invdetJ = (use_terrain) ?  1. / detJ(i,j,k) : 1.;
 
@@ -261,8 +387,38 @@ AdvectionSrcForScalars (const Box& bx, const int &icomp, const int &ncomp,
                 InterpolateInY(i,j  ,k,cell_prim, prim_index, avg_ymom(i  ,j,k), horiz_spatial_order) ) * dyInv * mfsq +
             ( avg_zmom(i,j,k+1) *
                 InterpolateInZ(i,j,k+1,cell_prim, prim_index, avg_zmom(i,j,k+1), vert_spatial_order) -
-                avg_zmom(i,j,k  ) *
+              avg_zmom(i,j,k  ) *
                 InterpolateInZ(i,j,k  ,cell_prim, prim_index, avg_zmom(i  ,j,k), vert_spatial_order) ) * dzInv );
         });
+
+    } else { // all_use_WENO
+
+        amrex::ParallelFor(bx, ncomp_end, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        {
+            Real invdetJ = (use_terrain) ?  1. / detJ(i,j,k) : 1.;
+
+            // NOTE: we don't need to weight avg_xmom, avg_ymom, avg_zmom with terrain metrics
+            //       because that was done when they were constructed in AdvectionSrcForRhoAndTheta
+
+            const int cons_index = icomp + n;
+            const int prim_index = cons_index - 1;
+
+            Real mfsq = mf_m(i,j,0) * mf_m(i,j,0);
+
+            advectionSrc(i,j,k,cons_index) = - invdetJ * (
+            ( avg_xmom(i+1,j,k) *
+                InterpolateInX_WENO(i+1,j,k,cell_prim, prim_index, spatial_order_WENO) -
+              avg_xmom(i  ,j,k) *
+                InterpolateInX_WENO(i  ,j,k,cell_prim, prim_index, spatial_order_WENO) ) * dxInv * mfsq +
+            ( avg_ymom(i,j+1,k) *
+                InterpolateInY_WENO(i,j+1,k,cell_prim, prim_index, spatial_order_WENO) -
+              avg_ymom(i,j  ,k) *
+                InterpolateInY_WENO(i,j  ,k,cell_prim, prim_index, spatial_order_WENO) ) * dyInv * mfsq +
+            ( avg_zmom(i,j,k+1) *
+                InterpolateInZ_WENO(i,j,k+1,cell_prim, prim_index, spatial_order_WENO) -
+              avg_zmom(i,j,k  ) *
+                InterpolateInZ_WENO(i,j,k  ,cell_prim, prim_index, spatial_order_WENO) ) * dzInv );
+        });
+
     }
 }

--- a/Source/DataStruct.H
+++ b/Source/DataStruct.H
@@ -227,7 +227,17 @@ struct SolverChoice {
 #ifdef ERF_USE_MOISTURE
         pp.query("mp_clouds", do_cloud);
         pp.query("mp_precip", do_precip);
+        moist_use_WENO = true;
 #endif
+
+        // Use WENO for advection?
+        pp.query("all_use_WENO", all_use_WENO);
+        if (all_use_WENO || moist_use_WENO) {
+            pp.query("spatial_order_WENO", spatial_order_WENO);
+            AMREX_ASSERT_WITH_MESSAGE(( (spatial_order_WENO==3) || (spatial_order_WENO==5) ),
+                                      "WENO advection only supports orders 3 & 5.");
+        }
+
     }
 
     void display()
@@ -409,6 +419,11 @@ struct SolverChoice {
     // Spatial discretization
     int   horiz_spatial_order = 2;
     int    vert_spatial_order = 2;
+
+    // Positive definite advection scheme (3/5 order)
+    bool all_use_WENO{false};
+    bool moist_use_WENO{false};
+    int  spatial_order_WENO{3};
 
     ABLDriverType abl_driver_type;
     amrex::GpuArray<amrex::Real, AMREX_SPACEDIM> abl_pressure_grad;

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -44,8 +44,6 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
                       (solverChoice.les_type == LESType::Deardorff  ) ||
                       (solverChoice.pbl_type == PBLType::MYNN25     ) );
 
-    int l_use_terrain = solverChoice.use_terrain;
-
     const Box xbx = surroundingNodes(bx,0);
     const Box ybx = surroundingNodes(bx,1);
     const Box zbx = surroundingNodes(bx,2);

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -47,8 +47,6 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
                       (solverChoice.les_type == LESType::Deardorff  ) ||
                       (solverChoice.pbl_type == PBLType::MYNN25     ) );
 
-    int l_use_terrain = solverChoice.use_terrain;
-
     const Box xbx = surroundingNodes(bx,0);
     const Box ybx = surroundingNodes(bx,1);
     const Box zbx = surroundingNodes(bx,2);
@@ -415,7 +413,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
                                    - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
                 GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                        - 3. * cell_prim(i, j, k ), prim_index
+                                        - 3. * cell_prim(i, j, k  , prim_index)
                                    + (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -692,29 +692,43 @@ private:
 
     AMREX_FORCE_INLINE
     int
-    ComputeGhostCells(const int& horiz_spatial_order, const int& vert_spatial_order) {
+    ComputeGhostCells(const int& horiz_spatial_order, const int& vert_spatial_order,
+                      const int& spatial_order_WENO,  const bool& use_WENO) {
       int nGhostCells;
 
       int spatial_order = std::max(horiz_spatial_order, vert_spatial_order);
 
-      switch (spatial_order) {
-        case 2:
-          nGhostCells = 2; // We need this many to compute the eddy viscosity in the ghost cells
-          break;
-        case 3:
-          nGhostCells = 2;
-          break;
-        case 4:
-          nGhostCells = 2;
-          break;
-        case 5:
-          nGhostCells = 3;
-          break;
-        case 6:
-          nGhostCells = 3;
-          break;
-        default:
-          amrex::Error("Must specify spatial order to be 2,3,4,5 or 6");
+      if(!use_WENO) {
+          switch (spatial_order) {
+          case 2:
+              nGhostCells = 2; // We need this many to compute the eddy viscosity in the ghost cells
+              break;
+          case 3:
+              nGhostCells = 2;
+              break;
+          case 4:
+              nGhostCells = 2;
+              break;
+          case 5:
+              nGhostCells = 3;
+              break;
+          case 6:
+              nGhostCells = 3;
+              break;
+          default:
+              amrex::Error("Must specify spatial order to be 2,3,4,5 or 6");
+          }
+      } else {
+          switch (spatial_order_WENO) {
+          case 3:
+              nGhostCells = 2;
+              break;
+          case 5:
+              nGhostCells = 3;
+              break;
+          default:
+              amrex::Error("Must specify WENO spatial order to be 3 or 5");
+          }
       }
 
       return nGhostCells;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -686,8 +686,10 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
     Vector<MultiFab> temp_lev_new(Vars::NumTypes);
     Vector<MultiFab> temp_lev_old(Vars::NumTypes);
 
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order);
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO))+1;
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO);
 
     temp_lev_new[Vars::cons].define(ba, dm, Cons::NumVars, ngrow_state);
     temp_lev_old[Vars::cons].define(ba, dm, Cons::NumVars, ngrow_state);
@@ -781,8 +783,10 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
 
     // The number of ghost cells for density must be 1 greater than that for velocity
     //     so that we can go back in forth betwen velocity and momentum on all faces
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order);
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO))+1;
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO);
 
     auto& lev_new = vars_new[lev];
     auto& lev_old = vars_old[lev];
@@ -949,7 +953,8 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
         ba_nd.surroundingNodes();
 
         // We need this to be one greater than the ghost cells to handle levels > 0
-        int ngrow = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order)+2;
+        int ngrow = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                      solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO))+2;
         z_phys_nd[lev].reset(new MultiFab(ba_nd,dm,1,IntVect(ngrow,ngrow,1)));
         if (solverChoice.terrain_type > 0) {
             z_phys_nd_new[lev].reset(new MultiFab(ba_nd,dm,1,IntVect(ngrow,ngrow,1)));

--- a/Source/IO/NCCheckpoint.cpp
+++ b/Source/IO/NCCheckpoint.cpp
@@ -150,9 +150,10 @@ ERF::ReadNCCheckpointFile ()
     ncf.var("dt")   .get(dt.data(),    {0}, {static_cast<long unsigned int>(ndt)});
     ncf.var("t_new").get(t_new.data(), {0}, {static_cast<long unsigned int>(ntime)});
 
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order);
-
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO))+1;
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
+                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO);
     for (int lev = 0; lev <= finest_level; ++lev) {
 
         int num_box = static_cast<int>(ncf.dim("Nbox_"+std::to_string(lev)).len());

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -55,9 +55,12 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
     const bool l_use_diff       = ( (solverChoice.molec_diff_type != MolecDiffType::None) ||
                                     (solverChoice.les_type        !=       LESType::None) ||
                                     (solverChoice.pbl_type        !=       PBLType::None) );
-    bool       l_use_turb       = ( solverChoice.les_type == LESType::Smagorinsky ||
+    const bool l_use_turb       = ( solverChoice.les_type == LESType::Smagorinsky ||
                                     solverChoice.les_type == LESType::Deardorff   ||
                                     solverChoice.pbl_type == PBLType::MYNN25 );
+    const bool l_all_WENO       = solverChoice.all_use_WENO;
+    const bool l_moist_WENO     = solverChoice.moist_use_WENO;
+    const int  l_spatial_order_WENO = solverChoice.spatial_order_WENO;
 
     const amrex::BCRec* bc_ptr = domain_bcs_type_d.data();
 
@@ -170,20 +173,23 @@ void erf_slow_rhs_post (int /*level*/, Real dt,
             int   num_comp = 1;
             AdvectionSrcForScalars(bx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                    cur_prim, cell_rhs, detJ,
-                                   dxInv, mf_m, l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
+                                   dxInv, mf_m, l_all_WENO, l_moist_WENO, l_spatial_order_WENO,
+                                   l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
         }
         if (l_use_QKE) {
             int start_comp = RhoQKE_comp;
             int   num_comp = 1;
             AdvectionSrcForScalars(bx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                    cur_prim, cell_rhs, detJ,
-                                   dxInv, mf_m, l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
+                                   dxInv, mf_m, l_all_WENO, l_moist_WENO, l_spatial_order_WENO,
+                                   l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
         }
         int start_comp = RhoScalar_comp;
         int   num_comp = S_data[IntVar::cons].nComp() - start_comp;
         AdvectionSrcForScalars(bx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                cur_prim, cell_rhs, detJ,
-                               dxInv, mf_m, l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
+                               dxInv, mf_m, l_all_WENO, l_moist_WENO, l_spatial_order_WENO,
+                               l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
 
         if (l_use_diff) {
             Array4<Real> diffflux_x = dflux_x->array(mfi);

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -72,6 +72,8 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
     bool       l_use_turb       = ( solverChoice.les_type == LESType::Smagorinsky ||
                                     solverChoice.les_type == LESType::Deardorff   ||
                                     solverChoice.pbl_type == PBLType::MYNN25 );
+    const bool l_all_WENO       = solverChoice.all_use_WENO;
+    const int  l_spatial_order_WENO = solverChoice.spatial_order_WENO;
 
     const amrex::BCRec* bc_ptr   = domain_bcs_type_d.data();
     const amrex::BCRec* bc_ptr_h = domain_bcs_type.data();
@@ -449,12 +451,12 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
         // Define updates in the RHS of continuity, temperature, and scalar equations
         // **************************************************************************
         Real fac = 1.0;
-
         AdvectionSrcForRhoAndTheta(bx, valid_bx, cell_rhs,       // these are being used to build the fluxes
                                    rho_u, rho_v, omega_arr, fac,
                                    avg_xmom, avg_ymom, avg_zmom, // these are being defined from the rho fluxes
                                    cell_prim, z_nd, detJ,
                                    dxInv, mf_m, mf_u, mf_v,
+                                   l_all_WENO, l_spatial_order_WENO,
                                    l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain);
 
         if (l_use_diff) {
@@ -528,7 +530,7 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
         AdvectionSrcForMom(tbx, tby, tbz,
                            rho_u_rhs, rho_v_rhs, rho_w_rhs, u, v, w,
                            rho_u    , rho_v    , omega_arr,
-                           z_nd, detJ, dxInv, mf_m, mf_u, mf_v,
+                           z_nd, detJ, dxInv, mf_m, mf_u, mf_v, l_all_WENO, l_spatial_order_WENO,
                            l_horiz_spatial_order, l_vert_spatial_order, l_use_terrain, domhi_z);
 
         if (l_use_diff) {

--- a/Source/Utils/Interpolation_WENO.H
+++ b/Source/Utils/Interpolation_WENO.H
@@ -1,0 +1,173 @@
+#ifndef INTERPOLATE_WENO_H_
+#define INTERPOLATE_WENO_H_
+
+#include "DataStruct.H"
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+InterpolateInX_WENO (int i, int j, int k, const amrex::Array4<const amrex::Real>& qty,
+                     int qty_index, int spatial_order)
+{
+    amrex::Real eps=1.0e-6;
+    amrex::Real beta1=0., beta2=0., beta3=0.;
+    amrex::Real w1=0.   , w2=0.   , w3=0.   , sum_wl=0.;
+    amrex::Real phi1=0. , phi2=0. , phi3=0. ;
+
+    // WENO3
+    if (spatial_order == 3) {
+        beta1  = ( qty(i-1,j,k,qty_index) - qty(i-2,j,k,qty_index) ) *
+                 ( qty(i-1,j,k,qty_index) - qty(i-2,j,k,qty_index) );
+        beta2  = ( qty(i  ,j,k,qty_index) - qty(i-1,j,k,qty_index) ) *
+                 ( qty(i  ,j,k,qty_index) - qty(i-1,j,k,qty_index) );
+
+        w1     = ( (1./3.) / ((eps+beta1)*(eps+beta1)) );
+        w2     = ( (2./3.) / ((eps+beta2)*(eps+beta2)) );
+
+        phi1   = 0.5 * ( -qty(i-2,j,k,qty_index) + 3.*qty(i-1,j,k,qty_index) );
+        phi2   = 0.5 * (  qty(i-1,j,k,qty_index) +    qty(i  ,j,k,qty_index) );
+    // WENO5
+    } else {
+        beta1  = (13./12.) * (    qty(i-3,j,k,qty_index) - 2.*qty(i-2,j,k,qty_index) +    qty(i-1,j,k,qty_index) ) *
+                             (    qty(i-3,j,k,qty_index) - 2.*qty(i-2,j,k,qty_index) +    qty(i-1,j,k,qty_index) );
+        beta1 += (1./4.)   * (    qty(i-3,j,k,qty_index) - 4.*qty(i-2,j,k,qty_index) + 3.*qty(i-1,j,k,qty_index) ) *
+                             (    qty(i-3,j,k,qty_index) - 4.*qty(i-2,j,k,qty_index) + 3.*qty(i-1,j,k,qty_index) );
+
+        beta2  = (13./12.) * (    qty(i-2,j,k,qty_index) - 2.*qty(i-1,j,k,qty_index) +    qty(i  ,j,k,qty_index) ) *
+                             (    qty(i-2,j,k,qty_index) - 2.*qty(i-1,j,k,qty_index) +    qty(i  ,j,k,qty_index) );
+        beta2 += (1./4.)   * (    qty(i-2,j,k,qty_index) -    qty(i  ,j,k,qty_index) ) *
+                             (    qty(i-2,j,k,qty_index) -    qty(i  ,j,k,qty_index) );
+
+        beta3  = (13./12.) * (    qty(i-1,j,k,qty_index) - 2.*qty(i  ,j,k,qty_index) +    qty(i+1,j,k,qty_index) ) *
+                             (    qty(i-1,j,k,qty_index) - 2.*qty(i  ,j,k,qty_index) +    qty(i+1,j,k,qty_index) );
+        beta3 += (1./4.)   * ( 3.*qty(i-1,j,k,qty_index) - 4.*qty(i  ,j,k,qty_index) +    qty(i+1,j,k,qty_index) ) *
+                             ( 3.*qty(i-1,j,k,qty_index) - 4.*qty(i  ,j,k,qty_index) +    qty(i+1,j,k,qty_index) );
+
+        w1   = ( (1./10.) / ((eps+beta1)*(eps+beta1)) );
+        w2   = ( (3./5. ) / ((eps+beta2)*(eps+beta2)) );
+        w3   = ( (3./10.) / ((eps+beta3)*(eps+beta3)) );
+
+        phi1 =  (1./3.)*qty(i-3,j,k,qty_index) - (7./6.)*qty(i-2,j,k,qty_index) + (11./6.)*qty(i-1,j,k,qty_index);
+        phi2 = -(1./6.)*qty(i-2,j,k,qty_index) + (5./6.)*qty(i-1,j,k,qty_index) + ( 1./3.)*qty(i  ,j,k,qty_index);
+        phi3 =  (1./3.)*qty(i-1,j,k,qty_index) + (5./6.)*qty(i  ,j,k,qty_index) - ( 1./6.)*qty(i+1,j,k,qty_index);
+    }
+
+    sum_wl = w1 + w2 + w3;
+    w1    /= sum_wl;
+    w2    /= sum_wl;
+    w3    /= sum_wl;
+    return w1*phi1 + w2*phi2 + w3*phi3;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+InterpolateInY_WENO (int i, int j, int k, const amrex::Array4<const amrex::Real>& qty,
+                     int qty_index, int spatial_order)
+{
+    amrex::Real eps=1.0e-6;
+    amrex::Real beta1=0., beta2=0., beta3=0.;
+    amrex::Real w1=0.   , w2=0.   , w3=0.   , sum_wl=0.;
+    amrex::Real phi1=0. , phi2=0. , phi3=0. ;
+
+    // WENO3
+    if (spatial_order == 3) {
+        beta1  = ( qty(i,j-1,k,qty_index) - qty(i,j-2,k,qty_index) ) *
+                 ( qty(i,j-1,k,qty_index) - qty(i,j-2,k,qty_index) );
+        beta2  = ( qty(i,j  ,k,qty_index) - qty(i,j-1,k,qty_index) ) *
+                 ( qty(i,j  ,k,qty_index) - qty(i,j-1,k,qty_index) );
+
+        w1     = ( (1./3.) / ((eps+beta1)*(eps+beta1)) );
+        w2     = ( (2./3.) / ((eps+beta2)*(eps+beta2)) );
+
+        phi1   = 0.5 * ( -qty(i,j-2,k,qty_index) + 3.*qty(i,j-1,k,qty_index) );
+        phi2   = 0.5 * (  qty(i,j-1,k,qty_index) +    qty(i,j  ,k,qty_index) );
+    // WENO5
+    } else {
+        beta1  = (13./12.) * (    qty(i,j-3,k,qty_index) - 2.*qty(i,j-2,k,qty_index) +    qty(i,j-1,k,qty_index) ) *
+                             (    qty(i,j-3,k,qty_index) - 2.*qty(i,j-2,k,qty_index) +    qty(i,j-1,k,qty_index) );
+        beta1 += (1./4.)   * (    qty(i,j-3,k,qty_index) - 4.*qty(i,j-2,k,qty_index) + 3.*qty(i,j-1,k,qty_index) ) *
+                             (    qty(i,j-3,k,qty_index) - 4.*qty(i,j-2,k,qty_index) + 3.*qty(i,j-1,k,qty_index) );
+
+        beta2  = (13./12.) * (    qty(i,j-2,k,qty_index) - 2.*qty(i,j-1,k,qty_index) +    qty(i,j  ,k,qty_index) ) *
+                             (    qty(i,j-2,k,qty_index) - 2.*qty(i,j-1,k,qty_index) +    qty(i,j  ,k,qty_index) );
+        beta2 += (1./4.)   * (    qty(i,j-2,k,qty_index) -    qty(i,j  ,k,qty_index) ) *
+                             (    qty(i,j-2,k,qty_index) -    qty(i,j  ,k,qty_index) );
+
+        beta3  = (13./12.) * (    qty(i,j-1,k,qty_index) - 2.*qty(i,j  ,k,qty_index) +    qty(i,j+1,k,qty_index) ) *
+                             (    qty(i,j-1,k,qty_index) - 2.*qty(i,j  ,k,qty_index) +    qty(i,j+1,k,qty_index) );
+        beta3 += (1./4.)   * ( 3.*qty(i,j-1,k,qty_index) - 4.*qty(i,j  ,k,qty_index) +    qty(i,j+1,k,qty_index) ) *
+                             ( 3.*qty(i,j-1,k,qty_index) - 4.*qty(i,j  ,k,qty_index) +    qty(i,j+1,k,qty_index) );
+
+        w1     = ( (1./10.) / ((eps+beta1)*(eps+beta1)) );
+        w2     = ( (3./5. ) / ((eps+beta2)*(eps+beta2)) );
+        w3     = ( (3./10.) / ((eps+beta3)*(eps+beta3)) );
+
+        phi1 =  (1./3.)*qty(i,j-3,k,qty_index) - (7./6.)*qty(i,j-2,k,qty_index) + (11./6.)*qty(i,j-1,k,qty_index);
+        phi2 = -(1./6.)*qty(i,j-2,k,qty_index) + (5./6.)*qty(i,j-1,k,qty_index) + ( 1./3.)*qty(i,j  ,k,qty_index);
+        phi3 =  (1./3.)*qty(i,j-1,k,qty_index) + (5./6.)*qty(i,j  ,k,qty_index) - ( 1./6.)*qty(i,j+1,k,qty_index);
+    }
+
+    sum_wl = w1 + w2 + w3;
+    w1    /= sum_wl;
+    w2    /= sum_wl;
+    w3    /= sum_wl;
+    return w1*phi1 + w2*phi2 + w3*phi3;
+}
+
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+InterpolateInZ_WENO (int i, int j, int k, const amrex::Array4<const amrex::Real>& qty,
+                     int qty_index, int spatial_order)
+{
+    amrex::Real eps=1.0e-6;
+    amrex::Real beta1=0., beta2=0., beta3=0.;
+    amrex::Real w1=0.   , w2=0.   , w3=0.   , sum_wl=0.;
+    amrex::Real phi1=0. , phi2=0. , phi3=0. ;
+
+    // WENO3
+    if (spatial_order == 3) {
+        beta1  = ( qty(i,j,k-1,qty_index) - qty(i,j,k-2,qty_index) ) *
+                 ( qty(i,j,k-1,qty_index) - qty(i,j,k-2,qty_index) );
+        beta2  = ( qty(i,j,k  ,qty_index) - qty(i,j,k-1,qty_index) ) *
+                 ( qty(i,j,k  ,qty_index) - qty(i,j,k-1,qty_index) );
+
+        w1     = ( (1./3.) / ((eps+beta1)*(eps+beta1)) );
+        w2     = ( (2./3.) / ((eps+beta2)*(eps+beta2)) );
+
+        phi1   = 0.5 * ( -qty(i,j,k-2,qty_index) + 3.*qty(i,j,k-1,qty_index) );
+        phi2   = 0.5 * (  qty(i,j,k-1,qty_index) +    qty(i,j,k  ,qty_index) );
+    // WENO5
+    } else {
+        beta1  = (13./12.) * (    qty(i,j,k-3,qty_index) - 2.*qty(i,j,k-2,qty_index) +    qty(i,j,k-1,qty_index) ) *
+                             (    qty(i,j,k-3,qty_index) - 2.*qty(i,j,k-2,qty_index) +    qty(i,j,k-1,qty_index) );
+        beta1 += (1./4.)   * (    qty(i,j,k-3,qty_index) - 4.*qty(i,j,k-2,qty_index) + 3.*qty(i,j,k-1,qty_index) ) *
+                             (    qty(i,j,k-3,qty_index) - 4.*qty(i,j,k-2,qty_index) + 3.*qty(i,j,k-1,qty_index) );
+
+        beta2  = (13./12.) * (    qty(i,j,k-2,qty_index) - 2.*qty(i,j,k-1,qty_index) +    qty(i,j,k  ,qty_index) ) *
+                             (    qty(i,j,k-2,qty_index) - 2.*qty(i,j,k-1,qty_index) +    qty(i,j,k  ,qty_index) );
+        beta2 += (1./4.)   * (    qty(i,j,k-2,qty_index) -    qty(i,j,k  ,qty_index) ) *
+                             (    qty(i,j,k-2,qty_index) -    qty(i,j,k  ,qty_index) );
+
+        beta3  = (13./12.) * (    qty(i,j,k-1,qty_index) - 2.*qty(i,j,k  ,qty_index) +    qty(i,j,k+1,qty_index) ) *
+                             (    qty(i,j,k-1,qty_index) - 2.*qty(i,j,k  ,qty_index) +    qty(i,j,k+1,qty_index) );
+        beta3 += (1./4.)   * ( 3.*qty(i,j,k-1,qty_index) - 4.*qty(i,j,k  ,qty_index) +    qty(i,j,k+1,qty_index) ) *
+                             ( 3.*qty(i,j,k-1,qty_index) - 4.*qty(i,j,k  ,qty_index) +    qty(i,j,k+1,qty_index) );
+
+        w1   = ( (1./10.) / ((eps+beta1)*(eps+beta1)) );
+        w2   = ( (3./5. ) / ((eps+beta2)*(eps+beta2)) );
+        w3   = ( (3./10.) / ((eps+beta3)*(eps+beta3)) );
+
+        phi1 =  (1./3.)*qty(i,j,k-3,qty_index) - (7./6.)*qty(i,j,k-2,qty_index) + (11./6.)*qty(i,j,k-1,qty_index);
+        phi2 = -(1./6.)*qty(i,j,k-2,qty_index) + (5./6.)*qty(i,j,k-1,qty_index) + ( 1./3.)*qty(i,j,k  ,qty_index);
+        phi3 =  (1./3.)*qty(i,j,k-1,qty_index) + (5./6.)*qty(i,j,k  ,qty_index) - ( 1./6.)*qty(i,j,k+1,qty_index);
+    }
+
+    sum_wl = w1 + w2 + w3;
+    w1    /= sum_wl;
+    w2    /= sum_wl;
+    w3    /= sum_wl;
+    return w1*phi1 + w2*phi2 + w3*phi3;
+}
+#endif

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -6,6 +6,7 @@ CEXE_headers += TerrainMetrics.H
 CEXE_headers += Microphysics_Utils.H
 CEXE_headers += Utils.H
 CEXE_headers += Interpolation.H
+CEXE_headers += Interpolation_WENO.H
 CEXE_sources += TerrainMetrics.cpp
 
 CEXE_headers += DirectionSelector.H


### PR DESCRIPTION
The WENO 3/5 schemes were implemented to give us a positive definite advection scheme for moisture variables. 

The code should default to WENO3 for moisture variables (when compiled with moisture support). However, users may use WENO for computing all the advective sources.
