### PR TITLE
RhoKE fix

### DIFF
--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -342,7 +342,6 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
     // Using Deardorff
     if (l_use_deardorff && n_end >= RhoKE_comp) {
-      amrex::Print() << "STARTED...\n";
         int qty_index = RhoKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -342,6 +342,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
     // Using Deardorff
     if (l_use_deardorff && n_end >= RhoKE_comp) {
+      amrex::Print() << "STARTED...\n";
         int qty_index = RhoKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
@@ -353,7 +354,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             if (dtheta_dz <= 0.) {
                 length = l_Delta;
             } else {
-                length = 0.76*std::sqrt(E)*(grav_gpu[2]/theta)*dtheta_dz;
+              length = 0.76*std::sqrt(E) / std::sqrt((std::abs(grav_gpu[2])/theta)*dtheta_dz);
             }
             Real KH   = 0.1 * (1.+2.*length/l_Delta) * std::sqrt(E);
             cell_rhs(i,j,k,qty_index) += cell_data(i,j,k,Rho_comp) * grav_gpu[2] * KH * dtheta_dz;

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -530,7 +530,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
             if (dtheta_dz <= 0.) {
                 length = l_Delta;
             } else {
-                length = 0.76*std::sqrt(E)*(grav_gpu[2]/theta)*dtheta_dz;
+                length = 0.76*std::sqrt(E) / std::sqrt((std::abs(grav_gpu[2])/theta)*dtheta_dz);
             }
             Real KH   = 0.1 * (1.+2.*length/l_Delta) * std::sqrt(E);
             cell_rhs(i,j,k,qty_index) += cell_data(i,j,k,Rho_comp) * grav_gpu[2] * KH * dtheta_dz;


### PR DESCRIPTION
1. We were not updating the RhoKE or RhoQKE variables in the slow RHS post function.

2. The length variable used to define the source for KE was computed incorrectly; thereby leading to potential divide by zero cases and erroneous source terms.