### PR TITLE
Cmake file for compiling with MPI + CUDA.

### DIFF
--- a/Build/cmake_cuda.sh
+++ b/Build/cmake_cuda.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Example CMake config script for an OSX laptop with OpenMPI
+
+cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
+      -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DERF_DIM:STRING=3 \
+      -DERF_ENABLE_MPI:BOOL=ON \
+      -DERF_ENABLE_CUDA:BOOL=ON \
+      -DERF_ENABLE_TESTS:BOOL=ON \
+      -DERF_ENABLE_FCOMPARE:BOOL=ON \
+      -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+      .. && make -j8


### PR DESCRIPTION
Specifying the MPI wrappers and CUDA leads to an error with cmake where the include directories are omitted; thus the necessary header files (mpi.h) are not found. By only specifying that MPI and CUDA are enabled, cmake locates the c++ compiler and then locates MPI and appends the include path.