### PR TITLE
Fix diffusion for slow scalars

### DIFF
--- a/Source/Diffusion/Diffusion.H
+++ b/Source/Diffusion/Diffusion.H
@@ -44,7 +44,8 @@ void DiffusionSrcForMom_T (const amrex::Box& bxx, const amrex::Box& bxy, const a
 
 
 
-void DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_start, int n_end,
+void DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
+                             int start_comp, int num_comp,
                              const amrex::Array4<const amrex::Real>& u,
                              const amrex::Array4<const amrex::Real>& v,
                              const amrex::Array4<const amrex::Real>& w,
@@ -69,7 +70,8 @@ void DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int
                              const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> grav_gpu,
                              const amrex::BCRec* bc_ptr);
 
-void DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_start, int n_end,
+void DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
+                             int start_comp, int num_comp,
                              const amrex::Array4<const amrex::Real>& u,
                              const amrex::Array4<const amrex::Real>& v,
                              const amrex::Array4<const amrex::Real>& w,

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -5,7 +5,8 @@
 using namespace amrex;
 
 void
-DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_start, int n_end,
+DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
+                        int start_comp, int num_comp,
                         const Array4<const Real>& u,
                         const Array4<const Real>& v,
                         const Array4<const Real>& w,
@@ -52,7 +53,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
     const Box ybx = surroundingNodes(bx,1);
     const Box zbx = surroundingNodes(bx,2);
 
-    const int ncomp      = n_end - n_start + 1;
+    const int end_comp   = start_comp + num_comp - 1;
     const int qty_offset = RhoTheta_comp;
 
     // Theta, KE, QKE, Scalar
@@ -151,9 +152,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
     // Compute fluxes at each face
     if (l_consA && l_turb) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
@@ -163,9 +164,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
@@ -175,9 +176,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
@@ -200,9 +201,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             }
         });
     } else if (l_turb) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -211,9 +212,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -222,9 +223,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -246,9 +247,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             }
         });
     } else if(l_consA) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
@@ -256,9 +257,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
@@ -266,9 +267,9 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
@@ -289,27 +290,27 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
             }
         });
     } else {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
 
             xflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
 
             yflux(i,j,k,qty_index) = Alpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -330,22 +331,21 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
         });
     }
 
-
-
     // Use fluxes to compute RHS
-    for (int qty_index = n_start; qty_index <= n_end; qty_index++)
+    for (int n(0); n < num_comp; ++n)
     {
+        int qty_index = start_comp + n;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
 
             cell_rhs(i,j,k,qty_index) += (xflux(i+1,j  ,k  ,qty_index) - xflux(i, j, k, qty_index)) * dx_inv * mf_m(i,j,0)  // Diffusive flux in x-dir
                                         +(yflux(i  ,j+1,k  ,qty_index) - yflux(i, j, k, qty_index)) * dy_inv * mf_m(i,j,0)  // Diffusive flux in y-dir
-                                        +(zflux(i  ,j  ,k+1,qty_index) - zflux(i, j, k, qty_index)) * dz_inv;  // Diffusive flux in z-dir
+                                        +(zflux(i  ,j  ,k+1,qty_index) - zflux(i, j, k, qty_index)) * dz_inv;               // Diffusive flux in z-dir
         });
     }
 
     // Using Deardorff
-    if (l_use_deardorff && n_end >= RhoKE_comp) {
+    if (l_use_deardorff && start_comp <= RhoKE_comp && end_comp >=RhoKE_comp) {
         int qty_index = RhoKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
@@ -374,7 +374,7 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain, int n_st
     }
 
     // Using Deardorff
-    if (l_use_QKE && n_end >= RhoQKE_comp) {
+    if (l_use_QKE && start_comp <= RhoQKE_comp && end_comp >=RhoQKE_comp) {
         int qty_index = RhoQKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -6,7 +6,8 @@
 using namespace amrex;
 
 void
-DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_start, int n_end,
+DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
+                        int start_comp, int num_comp,
                         const Array4<const Real>& u,
                         const Array4<const Real>& v,
                         const Array4<const Real>& w,
@@ -56,7 +57,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
     const Box zbx = surroundingNodes(bx,2);
     Box zbx3 = zbx;
 
-    const int ncomp      = n_end - n_start + 1;
+    const int end_comp   = start_comp + num_comp - 1;
     const int qty_offset = RhoTheta_comp;
 
     // Theta, KE, QKE, Scalar
@@ -156,9 +157,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
     // RhoAlpha & Turb model
     if (l_consA && l_turb) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
@@ -176,9 +177,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
@@ -196,9 +197,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
@@ -228,9 +229,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
         });
     // Alpha & Turb model
     } else if (l_turb) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -247,9 +248,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = Alpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -266,9 +267,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = Alpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -298,9 +299,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
         });
     // RhoAlpha
     } else if(l_consA) {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
@@ -316,9 +317,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
@@ -334,9 +335,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
@@ -364,9 +365,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
         });
     // Alpha
     } else {
-        amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(xbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -381,9 +382,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             xflux(i,j,k,qty_index) = Alpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -398,9 +399,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
             yflux(i,j,k,qty_index) = Alpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
-        amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        amrex::ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            const int  qty_index = n_start + n;
+            const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
             Real Alpha = d_alpha_eff[prim_index];
@@ -434,9 +435,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
       Box planexy = zbx; planexy.setBig(2, planexy.smallEnd(2) );
       int k_lo = zbx.smallEnd(2); int k_hi = zbx.bigEnd(2);
       zbx3.growLo(2,-1); zbx3.growHi(2,-1);
-      amrex::ParallelFor(planexy, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int , int n) noexcept
+      amrex::ParallelFor(planexy, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int , int n) noexcept
       {
-          const int  qty_index = n_start + n;
+          const int  qty_index = start_comp + n;
           Real met_h_xi,met_h_eta;
 
           { // Bottom face
@@ -471,9 +472,9 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
       });
     }
     // Average interior cells
-    amrex::ParallelFor(zbx3, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(zbx3, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-      const int  qty_index = n_start + n;
+      const int  qty_index = start_comp + n;
 
       Real met_h_xi,met_h_eta;
       met_h_xi  = Compute_h_xi_AtKface (i,j,k,dxInv,z_nd);
@@ -487,15 +488,15 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
       zflux(i,j,k,qty_index) -= met_h_xi*xfluxbar + met_h_eta*yfluxbar;
     });
     // Multiply h_zeta by x/y-fluxes
-    amrex::ParallelFor(xbx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(xbx, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-      const int  qty_index = n_start + n;
+      const int  qty_index = start_comp + n;
       Real met_h_zeta      = Compute_h_zeta_AtIface(i,j,k,dxInv,z_nd);
       xflux(i,j,k,qty_index) *= met_h_zeta;
     });
-    amrex::ParallelFor(ybx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(ybx, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-      const int  qty_index = n_start + n;
+      const int  qty_index = start_comp + n;
       Real met_h_zeta      = Compute_h_zeta_AtJface(i,j,k,dxInv,z_nd);
       yflux(i,j,k,qty_index) *= met_h_zeta;
     });
@@ -503,8 +504,10 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
 
     // Use fluxes to compute RHS
     //-----------------------------------------------------------------------------------
-    for (int qty_index = n_start; qty_index <= n_end; qty_index++)
+    // Use fluxes to compute RHS
+    for (int n(0); n < num_comp; ++n)
     {
+        int qty_index = start_comp + n;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real stateContrib = (xflux(i+1,j  ,k  ,qty_index) - xflux(i, j, k, qty_index)) * dx_inv * mf_m(i,j,0)  // Diffusive flux in x-dir
@@ -518,7 +521,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
     }
 
     // Using Deardorff
-    if (l_use_deardorff && n_end >= RhoKE_comp) {
+    if (l_use_deardorff && start_comp <= RhoKE_comp && end_comp >=RhoKE_comp) {
         int qty_index = RhoKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
@@ -547,7 +550,7 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain, int n_st
     }
 
     // Using Deardorff
-    if (l_use_QKE && n_end >= RhoQKE_comp) {
+    if (l_use_QKE && start_comp <= RhoQKE_comp && end_comp >=RhoQKE_comp) {
         int qty_index = RhoQKE_comp;
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {

--- a/Source/Diffusion/NumericalDiffusion.H
+++ b/Source/Diffusion/NumericalDiffusion.H
@@ -6,8 +6,8 @@
 #include <AMReX_MultiFab.H>
 
 void NumericalDiffusion (const amrex::Box& bx,
-                         const int n_start,
-                         const int n_end,
+                         const int start_comp,
+                         const int num_comp,
                          const amrex::Real dt,
                          const SolverChoice& solverChoice,
                          const amrex::Array4<const amrex::Real>& data,

--- a/Source/Diffusion/NumericalDiffusion.cpp
+++ b/Source/Diffusion/NumericalDiffusion.cpp
@@ -4,8 +4,8 @@ using namespace amrex;
 
 void
 NumericalDiffusion (const Box& bx,
-                    const int  n_start,
-                    const int  n_end,
+                    const int  start_comp,
+                    const int  num_comp,
                     const Real dt,
                     const SolverChoice& solverChoice,
                     const Array4<const Real>& data,
@@ -39,16 +39,13 @@ NumericalDiffusion (const Box& bx,
         }
     });
 
-    // Set indices for components
-    const int ncomp = n_end - n_start + 1;
-
     // Capture diffusion coeff
     Real coeff6 = solverChoice.NumDiffCoeff / (2.0 * dt);
 
     // Compute 5th order derivative and augment RHS
-    amrex::ParallelFor(bx,ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int m) noexcept
+    amrex::ParallelFor(bx, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int m) noexcept
     {
-        int n = n_start + m;
+        int n = start_comp + m;
         Real xflux_lo = 10. * (data(i  ,j,k,n) - data(i-1,j,k,n))
                        - 5. * (data(i+1,j,k,n) - data(i-2,j,k,n))
                             + (data(i+2,j,k,n) - data(i-3,j,k,n));

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -60,6 +60,7 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
 
     int start_comp = 0;
     int   num_comp = 2;
+    int   end_comp = start_comp + num_comp - 1;
 
     const int  l_horiz_spatial_order = solverChoice.horiz_spatial_order;
     const int  l_vert_spatial_order  = solverChoice.vert_spatial_order;
@@ -624,17 +625,17 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
 
             // NOTE: No diffusion for continuity, so n starts at 1.
             int n_start = amrex::max(start_comp,RhoTheta_comp);
-            int n_end   = start_comp + num_comp - 1;
+            int n_comp  = end_comp - n_start + 1;
 
             if (l_use_terrain) {
-                DiffusionSrcForState_T(bx, domain, n_start, n_end, u, v, w,
+                DiffusionSrcForState_T(bx, domain, n_start, n_comp, u, v, w,
                                        cell_data, cell_prim, cell_rhs,
                                        diffflux_x, diffflux_y, diffflux_z, z_nd, detJ,
                                        dxInv, SmnSmn_a, mf_m, mf_u, mf_v,
                                        hfx_x, hfx_y, hfx_z, diss,
                                        mu_turb, solverChoice, tm_arr, grav_gpu, bc_ptr);
             } else {
-                DiffusionSrcForState_N(bx, domain, n_start, n_end, u, v, w,
+                DiffusionSrcForState_N(bx, domain, n_start, n_comp, u, v, w,
                                        cell_data, cell_prim, cell_rhs,
                                        diffflux_x, diffflux_y, diffflux_z,
                                        dxInv, SmnSmn_a, mf_m, mf_u, mf_v,
@@ -644,10 +645,7 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
         }
 
         if (l_use_ndiff) {
-            // NOTE: numerical diffusion for all slow vars
-            int n_start = Rho_comp;
-            int n_end   = start_comp + num_comp - 1;
-            NumericalDiffusion(bx, n_start, n_end, dt, solverChoice,
+            NumericalDiffusion(bx, start_comp, num_comp, dt, solverChoice,
                                cell_data, cell_rhs, mf_u, mf_v, false, false);
         }
 
@@ -718,11 +716,11 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
         }
 
         if (l_use_ndiff) {
-            NumericalDiffusion(tbx, 0, 0, dt, solverChoice,
+            NumericalDiffusion(tbx, 0, 1, dt, solverChoice,
                                rho_u, rho_u_rhs, mf_m, mf_v, false, true);
-            NumericalDiffusion(tby, 0, 0, dt, solverChoice,
+            NumericalDiffusion(tby, 0, 1, dt, solverChoice,
                                rho_v, rho_v_rhs, mf_u, mf_m, true, false);
-            NumericalDiffusion(tbz, 0, 0, dt, solverChoice,
+            NumericalDiffusion(tbz, 0, 1, dt, solverChoice,
                                rho_w, rho_w_rhs, mf_u, mf_v, false, false);
         }
 


### PR DESCRIPTION
The diffusion operator was not properly called for slow components except for the scalar. This PR fixes that issue and should impact LES simulations with KE/QKE.