### PR TITLE
Clang tidy fixes

### DIFF
--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -33,14 +33,10 @@ public:
 
     // Declare a default move constructor so we ensure the destructor is
     // not called when we return an object of this class by value
-    // MOSTAverage(MOSTAverage&&)  noexcept = default;
+    MOSTAverage(MOSTAverage&&)  noexcept = default;
 
     // Declare a default move assignment operator
     MOSTAverage& operator=(MOSTAverage&& other)  noexcept = default;
-
-    // Delete the copy constructor and copy assignment operators because
-    // the integrator allocates internal memory that is best initialized
-    // from scratch when needed instead of making a copy.
 
     // Delete the copy constructor
     MOSTAverage(const MOSTAverage& other) = delete;

--- a/Source/EOS.H
+++ b/Source/EOS.H
@@ -1,5 +1,5 @@
-#ifndef _EOS_H_
-#define EOS_H_
+#ifndef ERF_EOS_H_
+#define ERF_EOS_H_
 #include <ERF_Constants.H>
 #include <AMReX.H>
 #include <cmath>

--- a/Source/EOS.H
+++ b/Source/EOS.H
@@ -1,6 +1,5 @@
 #ifndef _EOS_H_
-#define _EOS_H_
-
+#define EOS_H_
 #include <ERF_Constants.H>
 #include <AMReX.H>
 #include <cmath>

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -86,6 +86,19 @@ public:
     ERF ();
     ~ERF() override;
 
+    // Declare a default move constructor so we ensure the destructor is
+    // not called when we return an object of this class by value
+    ERF(ERF&&)  noexcept = default;
+
+    // Declare a default move assignment operator
+    ERF& operator=(ERF&& other)  noexcept = default;
+
+    // Delete the copy constructor
+    ERF(const ERF& other) = delete;
+    //
+    // Delete the copy assignment operator
+    ERF& operator=(const ERF& other) = delete;
+
     // Advance solution to final time
     void Evolve ();
 
@@ -836,7 +849,7 @@ private:
         numCores * (amrex::ParallelDescriptor::second() - startCPUTime) +
         previousCPUTimeUsed;
 
-      return static T;
+      return T;
     }
 
     static void setRecordDataInfo (int i, const std::string& filename)

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -852,7 +852,7 @@ private:
       return T;
     }
 
-    static void setRecordDataInfo (int i, const std::string& filename)
+    void setRecordDataInfo (int i, const std::string& filename)
     {
         if (amrex::ParallelDescriptor::IOProcessor())
         {
@@ -865,7 +865,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordDataInfo");
     }
 
-    static void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)
@@ -882,7 +882,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordSamplePointInfo");
     }
 
-    static void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -297,7 +297,7 @@ private:
     // set covered coarse cells to be the average of overlying fine cells
     void AverageDown ();
 
-    static void define_grids_to_evolve (int lev);
+    void define_grids_to_evolve (int lev);
 
     void init1DArrays();
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -208,7 +208,7 @@ public:
     amrex::MultiFab& build_fine_mask(int lev);
 
     void MakeHorizontalAverages();
-    void MakeDiagnosticAverage(amrex::Vector<amrex::Real>& h_havg, amrex::MultiFab& S, int n);
+    static void MakeDiagnosticAverage(amrex::Vector<amrex::Real>& h_havg, amrex::MultiFab& S, int n);
     void derive_upwp          (amrex::Vector<amrex::Real>& h_havg);
 
     // write plotfile to disk

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -284,7 +284,7 @@ private:
     // set covered coarse cells to be the average of overlying fine cells
     void AverageDown ();
 
-    void define_grids_to_evolve (int lev);
+    static void define_grids_to_evolve (int lev);
 
     void init1DArrays();
 
@@ -300,7 +300,7 @@ private:
 #endif // ERF_USE_NETCDF
 
     // more flexible version of AverageDown() that lets you average down across multiple levels
-    void AverageDownTo (int crse_lev);
+    static void AverageDownTo (int crse_lev);
 
     // compute a new multifab by copying in phi from valid region and filling ghost cells
     // works for single level and 2-level cases (fill fine grid ghost by interpolating from coarse)
@@ -348,7 +348,7 @@ private:
     void ComputeDt ();
 
     // get plotfile name
-    std::string PlotFileName (int lev) const;
+    [[nodiscard]] std::string PlotFileName (int lev) const;
 
     // set plotfile variables names
     static amrex::Vector<std::string> PlotFileVarNames (amrex::Vector<std::string> plot_var_names) ;
@@ -836,10 +836,10 @@ private:
         numCores * (amrex::ParallelDescriptor::second() - startCPUTime) +
         previousCPUTimeUsed;
 
-      return T;
+      return static T;
     }
 
-    void setRecordDataInfo (int i, const std::string& filename)
+    static void setRecordDataInfo (int i, const std::string& filename)
     {
         if (amrex::ParallelDescriptor::IOProcessor())
         {
@@ -852,7 +852,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordDataInfo");
     }
 
-    void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    static void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)
@@ -869,7 +869,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordSamplePointInfo");
     }
 
-    void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    static void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)
@@ -898,13 +898,13 @@ private:
     amrex::Vector<amrex::IntVect> sampleline;
 
     //! The filename of the ith datalog file.
-    std::string DataLogName (int i) const noexcept { return datalogname[i]; }
+    [[nodiscard]] std::string DataLogName (int i) const noexcept { return datalogname[i]; }
 
     //! The filename of the ith sampleptlog file.
-    std::string SamplePointLogName (int i) const noexcept { return sampleptlogname[i]; }
+    [[nodiscard]] std::string SamplePointLogName (int i) const noexcept { return sampleptlogname[i]; }
 
     //! The filename of the ith samplelinelog file.
-    std::string SampleLineLogName (int i) const noexcept { return samplelinelogname[i]; }
+    [[nodiscard]] std::string SampleLineLogName (int i) const noexcept { return samplelinelogname[i]; }
 
 public:
     void writeJobInfo(const std::string& dir) const;

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -313,7 +313,7 @@ private:
 #endif // ERF_USE_NETCDF
 
     // more flexible version of AverageDown() that lets you average down across multiple levels
-    static void AverageDownTo (int crse_lev);
+    void AverageDownTo (int crse_lev);
 
     // compute a new multifab by copying in phi from valid region and filling ghost cells
     // works for single level and 2-level cases (fill fine grid ghost by interpolating from coarse)

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -208,7 +208,7 @@ public:
     amrex::MultiFab& build_fine_mask(int lev);
 
     void MakeHorizontalAverages();
-    static void MakeDiagnosticAverage(amrex::Vector<amrex::Real>& h_havg, amrex::MultiFab& S, int n);
+    void MakeDiagnosticAverage(amrex::Vector<amrex::Real>& h_havg, amrex::MultiFab& S, int n);
     void derive_upwp          (amrex::Vector<amrex::Real>& h_havg);
 
     // write plotfile to disk

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1441,7 +1441,7 @@ ERF::MakeHorizontalAverages ()
 
 // Create horizontal average quantities for the MultiFab passed in
 // NOTE: this does not create device versions of the 1d arrays
-static void
+void
 ERF::MakeDiagnosticAverage (Vector<Real>& h_havg, MultiFab& S, int n)
 {
     // Get the number of cells in z at level 0

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1441,7 +1441,7 @@ ERF::MakeHorizontalAverages ()
 
 // Create horizontal average quantities for the MultiFab passed in
 // NOTE: this does not create device versions of the 1d arrays
-void
+static void
 ERF::MakeDiagnosticAverage (Vector<Real>& h_havg, MultiFab& S, int n)
 {
     // Get the number of cells in z at level 0

--- a/Source/ERF_Constants.H
+++ b/Source/ERF_Constants.H
@@ -1,5 +1,5 @@
-#ifndef CONSTANTS_H_
-#define CONSTANTS_H_
+#ifndef ERF_CONSTANTS_H_
+#define ERF_CONSTANTS_H_
 
 #include <AMReX_REAL.H>
 

--- a/Source/ERF_Constants.H
+++ b/Source/ERF_Constants.H
@@ -1,5 +1,5 @@
-#ifndef _CONSTANTS_H_
-#define _CONSTANTS_H_
+#ifndef CONSTANTS_H_
+#define CONSTANTS_H_
 
 #include <AMReX_REAL.H>
 

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -1,5 +1,5 @@
-#ifndef _INDEX_DEFINES_H_
-#define _INDEX_DEFINES_H_
+#ifndef INDEX_DEFINES_H_
+#define INDEX_DEFINES_H_
 
 #include <AMReX_REAL.H>
 #include <AMReX_Arena.H>


### PR DESCRIPTION
Fixes for clang-tidy errors in the main ERF class, MOSTAverage class, and a few other places.

Now, when compiling with clang-tidy, there are no remaining clang-tidy errors in ERF files (just various reports from AMReX files).

(Note that some clang-tidy warnings persist, claiming that certain functions can be declared static. These are misleading, as they would require corresponding changes inside AMReX to implement. Those changes may likely break compatibility across codes other than ERF.)