### PR TITLE
Fix Clang tidy autofixes

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -297,7 +297,7 @@ private:
     // set covered coarse cells to be the average of overlying fine cells
     void AverageDown ();
 
-    void define_grids_to_evolve (int lev);
+    void define_grids_to_evolve (int lev); // NOLINT
 
     void init1DArrays();
 
@@ -313,7 +313,7 @@ private:
 #endif // ERF_USE_NETCDF
 
     // more flexible version of AverageDown() that lets you average down across multiple levels
-    void AverageDownTo (int crse_lev);
+    void AverageDownTo (int crse_lev); // NOLINT
 
     // compute a new multifab by copying in phi from valid region and filling ghost cells
     // works for single level and 2-level cases (fill fine grid ghost by interpolating from coarse)
@@ -852,7 +852,7 @@ private:
       return T;
     }
 
-    void setRecordDataInfo (int i, const std::string& filename)
+    void setRecordDataInfo (int i, const std::string& filename) // NOLINT
     {
         if (amrex::ParallelDescriptor::IOProcessor())
         {
@@ -865,7 +865,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordDataInfo");
     }
 
-    void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename) // NOLINT
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)
@@ -882,7 +882,7 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordSamplePointInfo");
     }
 
-    void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename)
+    void setRecordSampleLineInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename) // NOLINT
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
         for (amrex::MFIter mfi(dummy); mfi.isValid(); ++mfi)

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1441,7 +1441,8 @@ ERF::MakeHorizontalAverages ()
 
 // Create horizontal average quantities for the MultiFab passed in
 // NOTE: this does not create device versions of the 1d arrays
-void // NOLINT
+// NOLINTNEXTLINE
+void // NOLINTNEXTLINE
 ERF::MakeDiagnosticAverage (Vector<Real>& h_havg, MultiFab& S, int n)
 {
     // Get the number of cells in z at level 0
@@ -1500,7 +1501,7 @@ ERF::AverageDown ()
 
 // Set covered coarse cells to be the average of overlying fine cells at level crse_lev
 void
-ERF::AverageDownTo (int crse_lev)
+ERF::AverageDownTo (int crse_lev) // NOLINT
 {
     for (int var_idx = 0; var_idx < Vars::NumTypes; ++var_idx) {
         const BoxArray& ba(vars_new[crse_lev][var_idx].boxArray());
@@ -1514,7 +1515,7 @@ ERF::AverageDownTo (int crse_lev)
 }
 
 void
-ERF::define_grids_to_evolve (int lev)
+ERF::define_grids_to_evolve (int lev) // NOLINT
 {
    Box domain(geom[lev].Domain());
    if (lev == 0 && ( init_type == "real" || init_type == "metgrid" ) )

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1441,7 +1441,7 @@ ERF::MakeHorizontalAverages ()
 
 // Create horizontal average quantities for the MultiFab passed in
 // NOTE: this does not create device versions of the 1d arrays
-void
+void // NOLINT
 ERF::MakeDiagnosticAverage (Vector<Real>& h_havg, MultiFab& S, int n)
 {
     // Get the number of cells in z at level 0


### PR DESCRIPTION
Adds NOLINT where needed so now when we run ERF through the Clang-tidy linter with autofixes, it makes no changes to ERF.