### PR TITLE
Remove explicit AMD_ARCH setting for AMReX

### DIFF
--- a/CMake/SetAmrexOptions.cmake
+++ b/CMake/SetAmrexOptions.cmake
@@ -40,7 +40,6 @@ endif()
 
 if(ERF_ENABLE_HIP)
   set(AMReX_GPU_BACKEND HIP CACHE STRING "AMReX GPU type" FORCE)
-  set(AMReX_AMD_ARCH gfx908 CACHE STRING "AMReX AMD architecture" FORCE)
 endif()
 
 if(ERF_ENABLE_SYCL)


### PR DESCRIPTION
This PR removes the explicit forced setting for `AMReX_AMD_ARCH`. This is necessary to compile on architectures other than `gfx908`.  