### PR TITLE
Delete a move assignment operator to eliminate warning from clang-tidy

### DIFF
--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -35,8 +35,8 @@ public:
     // not called when we return an object of this class by value
     MOSTAverage(MOSTAverage&&)  noexcept = default;
 
-    // Declare a default move assignment operator
-    MOSTAverage& operator=(MOSTAverage&& other)  noexcept = default;
+    // Delete the move assignment operator
+    MOSTAverage& operator=(MOSTAverage&& other)  noexcept = delete;
 
     // Delete the copy constructor
     MOSTAverage(const MOSTAverage& other) = delete;


### PR DESCRIPTION
On my system, declaring this as `default` didn't give me a warning, only when I didn't declare anything at all for the move assignment operator.

In any case, I don't see clang-tidy warnings when deleting the operator either.