### PR TITLE
alter displayed filepath in doxygen generated docs

### DIFF
--- a/Docs/Doxyfile.in
+++ b/Docs/Doxyfile.in
@@ -153,7 +153,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = "/home/runner/work/ERF/ERF/"
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -782,7 +782,7 @@ INPUT                  = main.dox \
 #                         ../../amrex/Src/AMRex_MultiFab.H \
 #                         ../../amrex/Src/AMReX_IntVect.H \
 #                         ../../amrex/Src/Base/AMReX_RealBox.H \
-#                         ../../amrex/Src/EB/AMReX_EB2_GeometryShop.H 
+#                         ../../amrex/Src/EB/AMReX_EB2_GeometryShop.H
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
Letting CI test a fix to long file paths shown in Doxygen