### PR TITLE
Clean up last PR

### DIFF
--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -320,7 +320,7 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxyz.grow(IntVect(-1,-1,0));
 
                 Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
-                if (!l_use_turb) {
+                if (cons_visc && !l_use_turb) {
                     ComputeStressConsVisc_T(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13,
@@ -417,7 +417,7 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxyz.grow(IntVect(-1,-1,0));
 
                 Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
-                if (!l_use_turb) {
+                if (cons_visc && !l_use_turb) {
                     ComputeStressConsVisc_N(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13, s23,

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -319,8 +319,8 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxxz.grow(IntVect(-1,-1,0));
                 tbxyz.grow(IntVect(-1,-1,0));
 
-                Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
-                if (cons_visc && !l_use_turb) {
+                Real mu_eff = 2.0 * solverChoice.dynamicViscosity; // Initialized to 0
+                if (!l_use_turb) {
                     ComputeStressConsVisc_T(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13,
@@ -416,8 +416,8 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxxz.grow(IntVect(-1,-1,0));
                 tbxyz.grow(IntVect(-1,-1,0));
 
-                Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
-                if (cons_visc && !l_use_turb) {
+                Real mu_eff = 2.0 * solverChoice.dynamicViscosity; // Initialized to 0
+                if (!l_use_turb) {
                     ComputeStressConsVisc_N(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13, s23,

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -319,9 +319,8 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxxz.grow(IntVect(-1,-1,0));
                 tbxyz.grow(IntVect(-1,-1,0));
 
-                Real mu_eff = 0.;
-                if (cons_visc && !l_use_turb) {
-                    mu_eff += 2.0 * solverChoice.dynamicViscosity;
+                Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
+                if (!l_use_turb) {
                     ComputeStressConsVisc_T(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13,
@@ -417,9 +416,8 @@ void erf_slow_rhs_pre (int /*level*/, int nrk,
                 tbxxz.grow(IntVect(-1,-1,0));
                 tbxyz.grow(IntVect(-1,-1,0));
 
-                Real mu_eff = 0.;
-                if (cons_visc && !l_use_turb) {
-                    mu_eff += 2.0 * solverChoice.dynamicViscosity;
+                Real mu_eff = solverChoice.dynamicViscosity; // Initialized to 0
+                if (!l_use_turb) {
                     ComputeStressConsVisc_N(bxcc, tbxxy, tbxxz, tbxyz, mu_eff,
                                             s11, s22, s33,
                                             s12, s13, s23,


### PR DESCRIPTION
This streamlines the last PR fix and catches the case where you have mu_molec && mu_turb. The mu_molec was missed with the turbulence model in the last formulation. Here we rely on the fact that molecular viscosity is initialized to 0 in the SolverChoice.