### PR TITLE
Populate moisture field for init real

### DIFF
--- a/Source/IO/ReadFromWRFInput.cpp
+++ b/Source/IO/ReadFromWRFInput.cpp
@@ -14,6 +14,12 @@ read_from_wrfinput(int lev, const std::string& fname,
                    FArrayBox& NC_MSFM_fab, FArrayBox& NC_SST_fab,
                    FArrayBox& NC_C1H_fab , FArrayBox& NC_C2H_fab,
                    FArrayBox& NC_RDNW_fab,
+#if defined(ERF_USE_MOISTURE)
+                   FArrayBox& NC_QVAPOR_fab,
+                   FArrayBox& NC_QCLOUD_fab,
+                   FArrayBox& NC_QRAIN_fab,
+#elif defined(ERF_USE_WARM_NO_PRECIP)
+#endif
                    FArrayBox& NC_PH_fab  , FArrayBox& NC_PHB_fab,
                    FArrayBox& NC_ALB_fab , FArrayBox& NC_PB_fab)
 {
@@ -43,6 +49,12 @@ read_from_wrfinput(int lev, const std::string& fname,
     NC_fabs.push_back(&NC_C1H_fab);       NC_names.push_back("C1H");  NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT);         // 15
     NC_fabs.push_back(&NC_C2H_fab);       NC_names.push_back("C2H");  NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT);         // 16
     NC_fabs.push_back(&NC_RDNW_fab);      NC_names.push_back("RDNW"); NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT);         // 17
+#if defined(ERF_USE_MOISTURE)
+    NC_fabs.push_back(&NC_QVAPOR_fab);      NC_names.push_back("QVAPOR"); NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE);         // 18
+    NC_fabs.push_back(&NC_QCLOUD_fab);      NC_names.push_back("QCLOUD"); NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE);         // 19
+    NC_fabs.push_back(&NC_QRAIN_fab);      NC_names.push_back("QRAIN"); NC_dim_types.push_back(NC_Data_Dims_Type::Time_BT_SN_WE);         // 20
+# elif defined(ERF_USE_WARM_NO_PRECIP)
+#endif
 
     // Read the netcdf file and fill these FABs
     amrex::Print() << "Building initial FABS from file " << fname << std::endl;
@@ -86,5 +98,23 @@ read_from_wrfinput(int lev, const std::string& fname,
 
     // Now multiply by rho to get (rho theta) instead of theta
     NC_rhotheta_fab.template mult<RunOn::Device>(NC_rho_fab,0,0,1);
+
+    /*
+    // DEBUG
+    {
+    const Box& bx = NC_QVAPOR_fab.box();
+    const Array4<Real>    qv_arr = NC_QVAPOR_fab.array();
+    const Array4<Real>    qc_arr = NC_QCLOUD_fab.array();
+    const Array4<Real>    qr_arr = NC_QRAIN_fab.array();
+    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+    {
+        amrex::Print() << "TEST: " << IntVect(i,j,k) << ' '
+                       << qv_arr(i,j,k) << ' '
+                       << qc_arr(i,j,k) << ' '
+                       << qr_arr(i,j,k) << "\n";
+    });
+    exit(0);
+    }
+    */
 }
 #endif // ERF_USE_NETCDF

--- a/Source/IO/ReadFromWRFInput.cpp
+++ b/Source/IO/ReadFromWRFInput.cpp
@@ -98,23 +98,5 @@ read_from_wrfinput(int lev, const std::string& fname,
 
     // Now multiply by rho to get (rho theta) instead of theta
     NC_rhotheta_fab.template mult<RunOn::Device>(NC_rho_fab,0,0,1);
-
-    /*
-    // DEBUG
-    {
-    const Box& bx = NC_QVAPOR_fab.box();
-    const Array4<Real>    qv_arr = NC_QVAPOR_fab.array();
-    const Array4<Real>    qc_arr = NC_QCLOUD_fab.array();
-    const Array4<Real>    qr_arr = NC_QRAIN_fab.array();
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-    {
-        amrex::Print() << "TEST: " << IntVect(i,j,k) << ' '
-                       << qv_arr(i,j,k) << ' '
-                       << qc_arr(i,j,k) << ' '
-                       << qr_arr(i,j,k) << "\n";
-    });
-    exit(0);
-    }
-    */
 }
 #endif // ERF_USE_NETCDF


### PR DESCRIPTION
Populate RhoQt and RhoQp from wrfinput.

This shows there is an error with wrfbdy data for the **WPS_Test** case since the input file contains values that are O(1e-2) while the bdy files are O(1e3); despite the nc files saying they are the same units. The  **WPS_Test** case will continue to fail until this discrepancy is fixed.