### PR TITLE
Moist fp

### DIFF
--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -17,7 +17,7 @@ using namespace amrex;
  */
 
 void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, const Box& bx, const Box& domain,
-                                              int icomp, int ncomp, Real /*time*/, int bccomp)
+                                              int icomp, int ncomp, Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_lateral_cons_bcs()",impose_lateral_cons_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -47,12 +47,12 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> l_bc_extdir_vals_d;
     for (int i = 0; i < icomp+ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
    GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> l_bc_neumann_vals_d;
     for (int i = 0; i < icomp+ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_neumann_vals_d[i][ori] = m_bc_neumann_vals[bccomp+i][ori];
+            l_bc_neumann_vals_d[i][ori] = m_bc_neumann_vals[bccomp+bcoff+i][ori];
 
     GeometryData const& geomdata = m_geom.data();
     bool is_periodic_in_x = geomdata.isPeriodic(0);
@@ -175,7 +175,7 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
 void ERFPhysBCFunct::impose_vertical_cons_bcs (const Array4<Real>& dest_arr, const Box& bx, const Box& domain,
                                                const Array4<Real const>& z_phys_nd,
                                                const GpuArray<Real,AMREX_SPACEDIM> dxInv,
-                                               int icomp, int ncomp, Real /*time*/, int bccomp)
+                                               int icomp, int ncomp, Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_lateral_cons_bcs()",impose_lateral_cons_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -207,12 +207,12 @@ void ERFPhysBCFunct::impose_vertical_cons_bcs (const Array4<Real>& dest_arr, con
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> l_bc_extdir_vals_d;
     for (int i = 0; i < icomp+ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
    GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR> l_bc_neumann_vals_d;
     for (int i = 0; i < icomp+ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_neumann_vals_d[i][ori] = m_bc_neumann_vals[bccomp+i][ori];
+            l_bc_neumann_vals_d[i][ori] = m_bc_neumann_vals[bccomp+bcoff+i][ori];
 
 
     {

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -15,7 +15,7 @@ using namespace amrex;
 
 void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
                                               const Box& bx, const Box& domain,
-                                              Real /*time*/, int bccomp)
+                                              Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_lateral_xvel_bcs()",impose_lateral_xvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -47,7 +47,7 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
     GeometryData const& geomdata = m_geom.data();
     bool is_periodic_in_x = geomdata.isPeriodic(0);
@@ -151,7 +151,7 @@ void ERFPhysBCFunct::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
                                                const Box& bx, const Box& domain,
                                                const Array4<Real const>& z_phys_nd,
                                                const GpuArray<Real,AMREX_SPACEDIM> dxInv,
-                                               Real /*time*/, int bccomp)
+                                               Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_vertical_xvel_bcs()",impose_vertical_xvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -178,7 +178,7 @@ void ERFPhysBCFunct::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
     {
         // Populate ghost cells on lo-z and hi-z domain boundaries

--- a/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
@@ -14,7 +14,7 @@ using namespace amrex;
  */
 void ERFPhysBCFunct::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
                                               const Box& bx, const Box& domain,
-                                              Real /*time*/, int bccomp)
+                                              Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_lateral_yvel_bcs()",impose_lateral_yvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -46,7 +46,7 @@ void ERFPhysBCFunct::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
     GeometryData const& geomdata = m_geom.data();
     bool is_periodic_in_x = geomdata.isPeriodic(0);
@@ -152,7 +152,7 @@ void ERFPhysBCFunct::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
                                                const Box& bx, const Box& domain,
                                                const Array4<Real const>& z_phys_nd,
                                                const GpuArray<Real,AMREX_SPACEDIM> dxInv,
-                                               Real /*time*/, int bccomp)
+                                               Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_vertical_yvel_bcs()",impose_vertical_yvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -184,7 +184,7 @@ void ERFPhysBCFunct::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
     GeometryData const& geomdata = m_geom.data();
 

--- a/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
@@ -20,7 +20,7 @@ void ERFPhysBCFunct::impose_lateral_zvel_bcs (const Array4<Real>& dest_arr,
                                               const Box& bx, const Box& domain,
                                               const Array4<Real const>& z_phys_nd,
                                               const GpuArray<Real,AMREX_SPACEDIM> dxInv,
-                                              Real /*time*/, int bccomp)
+                                              Real /*time*/, int bccomp, int bcoff)
 {
     BL_PROFILE_VAR("impose_lateral_zvel_bcs()",impose_lateral_zvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -54,7 +54,7 @@ void ERFPhysBCFunct::impose_lateral_zvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp+bcoff+i][ori];
 
     GeometryData const& geomdata = m_geom.data();
     bool is_periodic_in_x = geomdata.isPeriodic(0);
@@ -162,7 +162,7 @@ void ERFPhysBCFunct::impose_vertical_zvel_bcs (const Array4<Real>& dest_arr,
                                                const GpuArray<Real,AMREX_SPACEDIM> dxInv,
                                                Real /*time*/, int bccomp_u,
                                                int bccomp_v, int bccomp_w,
-                                               int terrain_type)
+                                               int terrain_type, int bcoff)
 {
     BL_PROFILE_VAR("impose_vertical_zvel_bcs()",impose_vertical_zvel_bcs);
     const auto& dom_lo = amrex::lbound(domain);
@@ -207,7 +207,7 @@ void ERFPhysBCFunct::impose_vertical_zvel_bcs (const Array4<Real>& dest_arr,
 
     for (int i = 0; i < ncomp; i++)
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++)
-            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp_w+i][ori];
+            l_bc_extdir_vals_d[i][ori] = m_bc_extdir_vals[bccomp_w+bcoff+i][ori];
 
     {
         Box bx_zlo(bx);  bx_zlo.setBig  (2,dom_lo.z-1);

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -118,7 +118,7 @@ ERF::FillPatchMoistVars (int lev, Real time, MultiFab& mf)
     // Physical bc's at domain boundary
     // ***************************************************************************
     bool cons_only = true;
-    int icomp_cons = 0;
+    int icomp_cons = RhoQt_comp;
     int ncomp_cons = 1; // We only fill qv, the first component
 
     IntVect ngvect_cons = mf.nGrowVect();

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -118,14 +118,14 @@ ERF::FillPatchMoistVars (int lev, Real time, MultiFab& mf)
     // Physical bc's at domain boundary
     // ***************************************************************************
     bool cons_only = true;
-    int icomp_cons = RhoQt_comp;
+    int icomp_cons = 0;
     int ncomp_cons = 1; // We only fill qv, the first component
 
     IntVect ngvect_cons = mf.nGrowVect();
     IntVect ngvect_vels = {0,0,0};
 
     if (init_type != "real") {
-       (*physbcs[lev])({&mf},icomp_cons,ncomp_cons,ngvect_cons,ngvect_vels,time,init_type,cons_only);
+        (*physbcs[lev])({&mf},icomp_cons,ncomp_cons,ngvect_cons,ngvect_vels,time,init_type,cons_only,RhoQt_comp);
     }
 
     mf.FillBoundary(geom[lev].periodicity());

--- a/Source/BoundaryConditions/ERF_PhysBCFunct.H
+++ b/Source/BoundaryConditions/ERF_PhysBCFunct.H
@@ -56,25 +56,25 @@ public:
     */
     void operator() (const amrex::Vector<amrex::MultiFab*>& mfs, int icomp, int ncomp,
                      amrex::IntVect const& nghost_cons, amrex::IntVect const& nghost_vels,
-                     amrex::Real time, std::string& init_type, bool cons_only);
+                     amrex::Real time, std::string& init_type, bool cons_only, int bcoff=0);
 
     void impose_lateral_xvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                   const amrex::Box& bx, const amrex::Box& domain,
-                                  amrex::Real time, int bccomp);
+                                  amrex::Real time, int bccomp, int bcoff=0);
     void impose_vertical_xvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                   const amrex::Box& bx, const amrex::Box& domain,
                                    const amrex::Array4<amrex::Real const>& z_nd,
                                    const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dxInv,
-                                   amrex::Real time, int bccomp);
+                                   amrex::Real time, int bccomp, int bcoff=0);
 
     void impose_lateral_yvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                   const amrex::Box& bx, const amrex::Box& domain,
-                                  amrex::Real time, int bccomp);
+                                  amrex::Real time, int bccomp, int bcoff=0);
     void impose_vertical_yvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                    const amrex::Box& bx, const amrex::Box& domain,
                                    const amrex::Array4<amrex::Real const>& z_nd,
                                    const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dxInv,
-                                   amrex::Real time, int bccomp);
+                                   amrex::Real time, int bccomp, int bcoff=0);
 
 
     void impose_lateral_zvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
@@ -83,7 +83,7 @@ public:
                                   const amrex::Box& bx, const amrex::Box& domain,
                                   const amrex::Array4<amrex::Real const>& z_nd,
                                   const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dxInv,
-                                  amrex::Real time, int bccomp_w);
+                                  amrex::Real time, int bccomp_w, int bcoff=0);
     void impose_vertical_zvel_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                    const amrex::Array4<amrex::Real const>& xvel_arr,
                                    const amrex::Array4<amrex::Real const>& yvel_arr,
@@ -91,16 +91,16 @@ public:
                                    const amrex::Array4<amrex::Real const>& z_nd,
                                    const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dxInv,
                                    amrex::Real time, int bccomp_u, int bccomp_v, int bccomp_w,
-                                   int terrain_type);
+                                   int terrain_type, int bcoff=0);
 
     void impose_lateral_cons_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                   const amrex::Box& bx, const amrex::Box& domain,
-                                  int icomp, int ncomp, amrex::Real time, int bccomp);
+                                  int icomp, int ncomp, amrex::Real time, int bccomp, int bcoff=0);
     void impose_vertical_cons_bcs (const amrex::Array4<amrex::Real>& dest_arr,
                                    const amrex::Box& bx, const amrex::Box& domain,
                                    const amrex::Array4<amrex::Real const>& z_nd,
                                    const amrex::GpuArray<amrex::Real,AMREX_SPACEDIM> dxInv,
-                                   int icomp, int ncomp, amrex::Real time, int bccomp);
+                                   int icomp, int ncomp, amrex::Real time, int bccomp, int bcoff=0);
 
 private:
     int                  m_lev;

--- a/Source/BoundaryConditions/ERF_PhysBCFunct.cpp
+++ b/Source/BoundaryConditions/ERF_PhysBCFunct.cpp
@@ -19,7 +19,7 @@ using namespace amrex;
 
 void ERFPhysBCFunct::operator() (const Vector<MultiFab*>& mfs, int icomp_cons, int ncomp_cons,
                                  IntVect const& nghost_cons, IntVect const& nghost_vels, Real time,
-                                 std::string& init_type, bool cons_only)
+                                 std::string& init_type, bool cons_only, int bcoff)
 {
     BL_PROFILE("ERFPhysBCFunct::()");
 
@@ -91,7 +91,7 @@ void ERFPhysBCFunct::operator() (const Vector<MultiFab*>& mfs, int icomp_cons, i
                 if (!gdomain.contains(cbx))
                 {
                     int bccomp = BCVars::cons_bc;
-                    impose_lateral_cons_bcs(cons_arr,cbx,domain,icomp_cons,ncomp_cons,time,bccomp);
+                    impose_lateral_cons_bcs(cons_arr,cbx,domain,icomp_cons,ncomp_cons,time,bccomp,bcoff);
                 }
 
                 if (!cons_only)
@@ -101,15 +101,15 @@ void ERFPhysBCFunct::operator() (const Vector<MultiFab*>& mfs, int icomp_cons, i
                     const Array4<      Real> velz_arr = mfs[Vars::zvel]->array(mfi);;
                     if (!gdomainx.contains(xbx))
                     {
-                        impose_lateral_xvel_bcs(velx_arr,xbx,domain,time,BCVars::xvel_bc);
+                        impose_lateral_xvel_bcs(velx_arr,xbx,domain,time,BCVars::xvel_bc,bcoff);
                     }
 
                     if (!gdomainy.contains(ybx))
                     {
-                        impose_lateral_yvel_bcs(vely_arr,ybx,domain,time,BCVars::yvel_bc);
+                        impose_lateral_yvel_bcs(vely_arr,ybx,domain,time,BCVars::yvel_bc,bcoff);
                     }
 
-                    impose_lateral_zvel_bcs(velz_arr,velx_arr,vely_arr,zbx,domain,z_nd_arr,dxInv,time,BCVars::zvel_bc);
+                    impose_lateral_zvel_bcs(velz_arr,velx_arr,vely_arr,zbx,domain,z_nd_arr,dxInv,time,BCVars::zvel_bc,bcoff);
                 } // !cons_only
             } // init_type != "real"
 
@@ -118,7 +118,7 @@ void ERFPhysBCFunct::operator() (const Vector<MultiFab*>& mfs, int icomp_cons, i
             {
             int bccomp = BCVars::cons_bc;
             impose_vertical_cons_bcs(cons_arr,cbx,domain,z_nd_arr,dxInv,
-                                     icomp_cons,ncomp_cons,time,bccomp);
+                                     icomp_cons,ncomp_cons,time,bccomp,bcoff);
             }
 
             if (!cons_only) {
@@ -126,12 +126,12 @@ void ERFPhysBCFunct::operator() (const Vector<MultiFab*>& mfs, int icomp_cons, i
                 const Array4<      Real> vely_arr = mfs[Vars::yvel]->array(mfi);;
                 const Array4<      Real> velz_arr = mfs[Vars::zvel]->array(mfi);;
                 impose_vertical_xvel_bcs(velx_arr,xbx,domain,z_nd_arr,dxInv,
-                                         time,BCVars::xvel_bc);
+                                         time,BCVars::xvel_bc,bcoff);
                 impose_vertical_yvel_bcs(vely_arr,ybx,domain,z_nd_arr,dxInv,
-                                         time,BCVars::yvel_bc);
+                                         time,BCVars::yvel_bc,bcoff);
                 impose_vertical_zvel_bcs(velz_arr,velx_arr,vely_arr,zbx,domain,z_nd_arr,dxInv,time,
                                          BCVars::xvel_bc, BCVars::yvel_bc, BCVars::zvel_bc,
-                                         m_terrain_type);
+                                         m_terrain_type,bcoff);
             } // !cons_only
 
         } // MFIter

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -733,8 +733,8 @@ private:
 
     static AMREX_FORCE_INLINE
     int
-    ComputeGhostCells(const int& horiz_spatial_order, const int& vert_spatial_order,
-                      const int& spatial_order_WENO,  const bool& use_WENO,
+    ComputeGhostCells(const int& horiz_spatial_order,
+                      const int& vert_spatial_order,
                       const bool& use_numerical_diff)
     {
       int spatial_order = std::max(horiz_spatial_order, vert_spatial_order);
@@ -742,18 +742,6 @@ private:
       int nGhostCells = 0;
       if (use_numerical_diff) {
           nGhostCells = 3;
-      } else if(use_WENO) {
-          switch (spatial_order_WENO) {
-          case 3:
-              nGhostCells = 2;
-              break;
-          case 5:
-              nGhostCells = 3;
-              break;
-          default:
-              amrex::Error("Must specify WENO spatial order to be 3 or 5");
-              break;
-          }
       } else {
           switch (spatial_order) {
           case 2: case 3: case 4:

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -781,11 +781,11 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
     Vector<MultiFab> temp_lev_new(Vars::NumTypes);
     Vector<MultiFab> temp_lev_old(Vars::NumTypes);
 
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO),
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO,
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff);
 
     temp_lev_new[Vars::cons].define(ba, dm, Cons::NumVars, ngrow_state);
@@ -878,11 +878,11 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
 
     // The number of ghost cells for density must be 1 greater than that for velocity
     //     so that we can go back in forth betwen velocity and momentum on all faces
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO),
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO,
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff);
 
     auto& lev_new = vars_new[lev];
@@ -1054,8 +1054,8 @@ void ERF::MakeNewLevelFromScratch (int lev, Real /*time*/, const BoxArray& ba,
         ba_nd.surroundingNodes();
 
         // We need this to be one greater than the ghost cells to handle levels > 0
-        int ngrow = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                      solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO),
+        int ngrow = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                      solverChoice.vert_spatial_order,
                                       solverChoice.use_NumDiff)+2;
         z_phys_nd[lev] = std::make_unique<MultiFab>(ba_nd,dm,1,IntVect(ngrow,ngrow,1));
         if (solverChoice.terrain_type > 0) {

--- a/Source/IO/NCCheckpoint.cpp
+++ b/Source/IO/NCCheckpoint.cpp
@@ -153,11 +153,11 @@ ERF::ReadNCCheckpointFile ()
     ncf.var("dt")   .get(dt.data(),    {0}, {static_cast<long unsigned int>(ndt)});
     ncf.var("t_new").get(t_new.data(), {0}, {static_cast<long unsigned int>(ntime)});
 
-    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, (solverChoice.all_use_WENO || solverChoice.moist_use_WENO),
+    int ngrow_state = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff)+1;
-    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order, solverChoice.vert_spatial_order,
-                                        solverChoice.spatial_order_WENO, solverChoice.all_use_WENO,
+    int ngrow_vels  = ComputeGhostCells(solverChoice.horiz_spatial_order,
+                                        solverChoice.vert_spatial_order,
                                         solverChoice.use_NumDiff);
     for (int lev = 0; lev <= finest_level; ++lev) {
 

--- a/Source/Initialization/ERF_init_bcs.cpp
+++ b/Source/Initialization/ERF_init_bcs.cpp
@@ -30,6 +30,14 @@ void ERF::init_bcs ()
         m_bc_extdir_vals[BCVars::RhoQKE_bc_comp][ori]    = 0.0;
         m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = 0.0;
 
+#if defined(ERF_USE_MOISTURE)
+        m_bc_extdir_vals[BCVars::RhoQt_bc_comp][ori] = 0.0;
+        m_bc_extdir_vals[BCVars::RhoQp_bc_comp][ori] = 0.0;
+#elif defined(ERF_USE_WARM_NO_PRECIP)
+        m_bc_extdir_vals[BCVars::RhoQv_bc_comp][ori] = 0.0;
+        m_bc_extdir_vals[BCVars::RhoQc_bc_comp][ori] = 0.0;
+#endif
+
         m_bc_extdir_vals[BCVars::xvel_bc][ori] = 0.0; // default
         m_bc_extdir_vals[BCVars::yvel_bc][ori] = 0.0;
         m_bc_extdir_vals[BCVars::zvel_bc][ori] = 0.0;


### PR DESCRIPTION
Add an optional bc offset parameter for indexing into extdir and neumann arrays. This alleviates the issue where qmoist is filling its 0th array slot from the RhoQt_comp slot in extdir/neumann arrays.