### PR TITLE
add option erf.init_sounding_ideal = 1

### DIFF
--- a/Exec/EkmanSpiral_input_sounding/inputs_input_sounding_EkmanSpiral
+++ b/Exec/EkmanSpiral_input_sounding/inputs_input_sounding_EkmanSpiral
@@ -57,4 +57,5 @@ prob.T_0 = 300.0
 
 # INITIALIZATION WITH ATM DATA
 erf.init_type = "input_sounding"
+erf.init_sounding_ideal = 1
 erf.input_sounding_file = "input_sounding_file"


### PR DESCRIPTION
add option erf.init_sounding_ideal=1 to fix the difference between pres, and pres_hse