### PR TITLE
updating Discre. and TimeAdv. docs and clean up AdvSrcForMom.cpp file

### DIFF
--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -177,7 +177,7 @@ Differencing of Different Orders
 
 Interpolation Methods
 ---------------------
-The midpoint values given above :math:`q_{m - \frac{1}{2}}`, where :math:`q` may be :math:`[\rho, u, v, w, \rho\theta]`, :math:`m = i, j, k`, :math:`U_d = [u, v, w]` for :math:`[x, y, z]` directions respectively, the following interpolation schemes are available:
+The midpoint values given above :math:`q_{m - \frac{1}{2}}`, where :math:`q` may be :math:`[u, v, w, \theta, C]`, :math:`m = i, j, k`, :math:`U_d = [u, v, w]` for :math:`[x, y, z]` directions respectively, the following interpolation schemes are available:
 
 .. math::
 

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -230,7 +230,7 @@ With the WENO5 scheme, one has :math:`N=3, \; \omega_{1} = 1/10, \; \omega_{2} =
    q_{m + \frac{1}{2}}^{(3)} = \frac{1}{3} q_{m} + \frac{5}{6} q_{m+1} - \frac{1}{6} q_{m+2}
    \end{array}
 
-By default, the WENO3 scheme will be employed for moisture variables if the code is compiled with moisture support. However, users may utilize the WENO scheme for all variables, with a specified order, via the following inputs:
+By default, the WENO3 scheme will be employed for moisture variables if the code is compiled with moisture support. However, users may utilize the WENO scheme for all scalar variables, with a specified order, via the following inputs:
 
 ::
 

--- a/Docs/sphinx_doc/TimeAdvance.rst
+++ b/Docs/sphinx_doc/TimeAdvance.rst
@@ -24,9 +24,9 @@ where :math:`\mathbf{S}` is the solution vector, we solve
 
   \mathbf{S}^{*}   &=& \mathbf{S}^n + \frac{1}{3} \Delta t f(\mathbf{S}^n)
 
-  \mathbf{S}^{**}  &=& \mathbf{S}^n + \frac{1}{2} \Delta t f(\mathbf{S}^{*}) )
+  \mathbf{S}^{**}  &=& \mathbf{S}^n + \frac{1}{2} \Delta t f(\mathbf{S}^{*}) 
 
-  \mathbf{S}^{n+1} &=& \mathbf{S}^n +             \Delta t f(\mathbf{S}^{**}) )
+  \mathbf{S}^{n+1} &=& \mathbf{S}^n +             \Delta t f(\mathbf{S}^{**}) 
 
 .. _AcousticSubstep:
 

--- a/Docs/sphinx_doc/TimeAdvance.rst
+++ b/Docs/sphinx_doc/TimeAdvance.rst
@@ -24,9 +24,9 @@ where :math:`\mathbf{S}` is the solution vector, we solve
 
   \mathbf{S}^{*}   &=& \mathbf{S}^n + \frac{1}{3} \Delta t f(\mathbf{S}^n)
 
-  \mathbf{S}^{**}  &=& \mathbf{S}^n + \frac{1}{2} \Delta t f(\mathbf{S}^{*}) 
+  \mathbf{S}^{**}  &=& \mathbf{S}^n + \frac{1}{2} \Delta t f(\mathbf{S}^{*})
 
-  \mathbf{S}^{n+1} &=& \mathbf{S}^n +             \Delta t f(\mathbf{S}^{**}) 
+  \mathbf{S}^{n+1} &=& \mathbf{S}^n +             \Delta t f(\mathbf{S}^{**})
 
 .. _AcousticSubstep:
 

--- a/Source/Advection/AdvectionSrcForMom.cpp
+++ b/Source/Advection/AdvectionSrcForMom.cpp
@@ -27,8 +27,8 @@ using namespace amrex;
  * @param[in] mf_m map factor at cell centers
  * @param[in] mf_u map factor at x-faces
  * @param[in] mf_v map factor at y-faces
- * @param[in] horiz_spatial_order sets the spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order sets the spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order sets the spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order sets the spatial order to be used for vertical derivatives
  * @param[in] use_terrain if true, use the terrain-aware derivatives (with metric terms)
  * @param[in] domhi_z maximum k value in the domain
  */

--- a/Source/Advection/AdvectionSrcForMom.cpp
+++ b/Source/Advection/AdvectionSrcForMom.cpp
@@ -27,8 +27,6 @@ using namespace amrex;
  * @param[in] mf_m map factor at cell centers
  * @param[in] mf_u map factor at x-faces
  * @param[in] mf_v map factor at y-faces
- * @param[in] all_use_WENO defines whether all variables (or just moisture variables) use WENO advection scheme
- * @param[in] spatial_order_WENO sets the spatial order if using WENO (3,5, or 7)
  * @param[in] horiz_spatial_order sets the spatial order to be used for lateral derivatives if not using WENO (2-6)
  * @param[in] vert_spatial_order sets the spatial order to be used for vertical derivatives if not using WENO (2-6)
  * @param[in] use_terrain if true, use the terrain-aware derivatives (with metric terms)

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -13,8 +13,8 @@
  * @param[in] cellSizeInv inverse of the mesh spacing
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  */
 template<typename InterpType_H, typename InterpType_V>
 AMREX_GPU_DEVICE
@@ -88,8 +88,8 @@ AdvectionSrcForXMom_N (int i, int j, int k,
  * @param[in] cellSizeInv inverse of the mesh spacing
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  */
 template<typename InterpType_H, typename InterpType_V>
 AMREX_GPU_DEVICE
@@ -162,8 +162,8 @@ AdvectionSrcForYMom_N (int i, int j, int k,
  * @param[in] mf_m map factor on cell centers
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  * @param[in] domhi_z maximum k value in the domain
  */
 template<typename InterpType_H, typename InterpType_V, typename WallInterpType>

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -4,7 +4,7 @@
 
 /**
  * Function for computing the advective tendency for the x-component of momentum
- * with metric terms and for spatial order > 2 when not using WENO
+ * with metric terms and for spatial order > 2
  *
  * @param[in] i,j,k indices of x-face at which to create tendency
  * @param[in] rho_u x-component of momentum
@@ -16,8 +16,8 @@
  * @param[in] cellSizeInv inverse of the mesh spacing
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  */
 template<typename InterpType_H, typename InterpType_V>
 AMREX_GPU_DEVICE
@@ -98,7 +98,7 @@ AdvectionSrcForXMom_T (int i, int j, int k,
 
 /**
  * Function for computing the advective tendency for the y-component of momentum
- * with metric terms and for spatial order > 2 when not using WENO
+ * with metric terms and for spatial order > 2
  *
  * @param[in] i,j,k indices of y-face at which to create tendency
  * @param[in] rho_u x-component of momentum
@@ -110,8 +110,8 @@ AdvectionSrcForXMom_T (int i, int j, int k,
  * @param[in] cellSizeInv inverse of the mesh spacing
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  */
 template<typename InterpType_H, typename InterpType_V>
 AMREX_GPU_DEVICE
@@ -191,7 +191,7 @@ AdvectionSrcForYMom_T (int i, int j, int k,
 
 /**
  * Function for computing the advective tendency for the z-component of momentum
- * with metric terms and for spatial order > 2 when not using WENO
+ * with metric terms and for spatial order > 2
  *
  * @param[in] i,j,k indices of z-face at which to create tendency
  * @param[in] rho_u x-component of momentum
@@ -204,8 +204,8 @@ AdvectionSrcForYMom_T (int i, int j, int k,
  * @param[in] mf_m map factor on cell centers
  * @param[in] mf_u map factor on x-faces
  * @param[in] mf_v map factor on y-faces
- * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives if not using WENO (2-6)
- * @param[in] vert_spatial_order spatial order to be used for vertical derivatives if not using WENO (2-6)
+ * @param[in] horiz_spatial_order spatial order to be used for lateral derivatives
+ * @param[in] vert_spatial_order spatial order to be used for vertical derivatives
  * @param[in] domhi_z maximum k value in the domain
  */
 template<typename InterpType_H, typename InterpType_V, typename WallInterpType>


### PR DESCRIPTION
Updated the Discretizations.rst documentation - Interpolation Methods q=[u, v ,w, \theta, C] NOT q=[\rho, u, v, w, \rho\theta]
Updated the TimeAdvance.rst  - Time Stepping RK3 last two equations deleted extra parenthesis at end.
Cleaned up AdvectionSrcForMom.cpp - deleted unnecessary "@param[in]" WENO related comments