### PR TITLE
Changed dry scalars to moist scalars in Advection inputs description …

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -512,11 +512,11 @@ List of Parameters
 +----------------------------------+--------------------+---------------------+--------------+
 | **erf.moistscal_horiz_adv_type** | Horizontal         | see below           | WENO3        |
 |                                  | advection type     |                     |              |
-|                                  | for dry scalars    |                     |              |
+|                                  | for moist scalars  |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
 | **erf.moistscal_vert_adv_type**  | Vertical           | see below           | WENO3        |
 |                                  | advection type     |                     |              |
-|                                  | for dry scalars    |                     |              |
+|                                  | for moist scalars  |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
 
 The allowed advection types for the dycore variables are


### PR DESCRIPTION
…table 

Changed wording from dry scalars to moist scalars in the last two rows of the Advection schemes inputs description table