### PR TITLE
add default for advtype int_to_string

### DIFF
--- a/Source/DataStruct.H
+++ b/Source/DataStruct.H
@@ -512,6 +512,8 @@ struct SolverChoice {
             return "WENOZ5";
         } else if (adv_int == AdvType::Weno_3MZQ) {
             return "WENOMZQ3";
+        } else {
+            return "Unknown";
         }
     }
 


### PR DESCRIPTION
It was possible for a non-void function to not return anything. This PR fixes that. 

Note this should get rejected during compilation with the `-Werror=return-type` flag, but apparently this doesn't trip in the GNU compilers because the function itself never actually gets called. It can trip up other compilers, though we don't usually use that flag for other compilers.