### PR TITLE
MOST w/ Charnock

### DIFF
--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -311,6 +311,14 @@ In ERF, when the MOST boundary condition is applied, velocity and temperature in
 
 MOST Inputs
 ~~~~~~~~~~~~~~~~~~~
+To evaluate the fluxes with MOST, the surface rougness parameter :math:`z_{0}` must be specified. This quantity may be considered a constant or may be parameterized through the friction velocity :math:`u_{\star}`. ERF supports three methods for parameterizing the surface roughness: ``constant``, ``charnock``, and ``modified_charnock``. The latter two methods parameterize :math:`z_{0} = f(u_{\star})` and are described in `Jimenez & Dudhia, American Meteorological Society, 2018 <https://doi.org/10.1175/JAMC-D-17-0137.1>`_. The rougness calculation method may be specified with
+
+::
+
+   erf.most.roughness_type    = STRING    #Z_0 type (constant, charnock, modified_charnock)
+
+If the ``charnock`` method is employed, the :math:`a` constant may be specified with ``erf.most.charnock_constant`` (defaults to 0.0185). If the ``modified_charnock`` method is employed, the depth :math:`d` may be specified with ``erf.most.modified_charnock_depth`` (defaults to 30 m).
+
 When computing an average :math:`\overline{\phi}` for the MOST boundary, where :math:`\phi` denotes a generic variable, ERF supports a variety of approaches. Specifically, ``planar averages`` and ``local region averages`` may be computed with or without ``time averaging``. With each averaging methodology, the query point :math:`z` may be determined from the following procedures: specified vertical distance :math:`z_{ref}` from the bottom surface, specified :math:`k_{index}`, or (when employing terrain-fit coordinates) specified normal vector length :math:`z_{ref}`. The available inputs to the MOST boundary and their associated data types are
 
 ::

--- a/Exec/ABL/inputs_ml_most
+++ b/Exec/ABL/inputs_ml_most
@@ -14,8 +14,9 @@ geometry.is_periodic = 1 1 0
 zlo.type = "Most"
 zhi.type = "SlipWall"
 
-erf.most.z0 = 100.0
-erf.most.zref = 200.0
+erf.most.roughness_type = modified_charnock    
+erf.most.z0 = 0.1
+erf.most.zref = 10.0
 erf.most.surf_temp = 1.1
 
 # TIME STEP CONTROL

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -34,6 +34,10 @@ public:
     amrex::Real surf_temp;           ///< Surface temperature
     amrex::Real beta_m{5.0};         ///< Constants from Dyer, BLM, 1974
     amrex::Real beta_h{5.0};         ///< https://doi.org/10.1007/BF00240838
+    amrex::Real Cnk_a{0.0185};       ///< Standard Charnock constant https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_b1{1.0/30.0};    ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_b2{1260.0};      ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_d{30.0};         ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
     amrex::Real gamma_m{16.0};
     amrex::Real gamma_h{16.0};
 
@@ -84,15 +88,34 @@ public:
       : m_geom(geom), m_ma(geom,vars_old,Theta_prim,z_phys_nd)
     {
         amrex::ParmParse pp("erf");
-        pp.query("most.z0"       , z0_const);
+        pp.query("most.z0" , z0_const);
+
+        // Specify the momentum calc type
+        std::string mom_type_in;
+        auto erf_mom = pp.query("most.roughness_type", mom_type_in);
+        if (erf_mom) {
+            if (mom_type_in == "constant") {
+                mom_type = MomCalcType::DEFAULT;
+            } else if (mom_type_in == "charnock") {
+                mom_type = MomCalcType::CHARNOCK;
+                pp.query("most.charnock_constant", Cnk_a);
+            } else if (mom_type_in == "modified_charnock") {
+                mom_type = MomCalcType::MODIFIED_CHARNOCK;
+                pp.query("most.modified_charnock_depth", Cnk_d);
+            } else {
+                amrex::Abort("MOST momentum calc type not recognized!");
+            }
+        } else {
+            mom_type = MomCalcType::DEFAULT;
+        }
 
         // Specify surface temperature or surface flux
         auto erf_st = pp.query("most.surf_temp", surf_temp);
         if (erf_st) {
-            alg_type = SURFACE_TEMPERATURE;
+            theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
         } else {
             pp.query("most.surf_temp_flux", surf_temp_flux);
-            alg_type = HEAT_FLUX;
+            theta_type = ThetaCalcType::HEAT_FLUX;
         }
 
         int nlevs = m_geom.size();
@@ -191,12 +214,19 @@ public:
     const amrex::MultiFab*
     get_mac_avg(int lev, int comp) { return m_ma.get_average(lev,comp); }
 
+    enum MomCalcType {
+        DEFAULT = 0,
+        CHARNOCK,
+        MODIFIED_CHARNOCK
+    };
+
     enum ThetaCalcType {
         HEAT_FLUX = 0,      ///< Heat-flux specified
         SURFACE_TEMPERATURE ///< Surface temperature specified
     };
 
-    ThetaCalcType alg_type;
+    MomCalcType   mom_type;
+    ThetaCalcType theta_type;
 
     void print() const
     {

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -175,7 +175,7 @@ protected:
     int m_navg{4};                                                   // 4 averages for U/V/T/Umag
     int m_maxlev{0};                                                 // Total number of levels
     int m_policy{0};                                                 // Policy for type of averaging
-    amrex::Real m_zref{-1.0};                                        // Height above surface for MOST BC
+    amrex::Real m_zref{10.0};                                        // Height above surface for MOST BC
     std::string m_pp_prefix {"erf"};                                 // ParmParse prefix
     amrex::Vector<amrex::MultiFab*> m_x_pos;                         // Ptr to 2D mf to hold x position (maxlev)
     amrex::Vector<amrex::MultiFab*> m_y_pos;                         // Ptr to 2D mf to hold y position (maxlev)

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -246,10 +246,13 @@ MOSTAverage::set_k_indices_N()
     if (read_z) {
         for (int lev(0); lev < m_maxlev; lev++) {
             Real m_zlo = m_geom[lev].ProbLo(2);
+            Real m_zhi = m_geom[lev].ProbHi(2);
             Real m_dz  = m_geom[lev].CellSize(2);
 
             AMREX_ASSERT_WITH_MESSAGE(m_zref >= m_zlo + 0.5 * m_dz,
                                       "Query point must be past first z-cell!");
+            AMREX_ASSERT_WITH_MESSAGE(m_zref <= m_zhi - + 0.5 * m_dz,
+                                      "Query point must be below the last z-cell!");
 
             int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));
 

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -251,7 +251,7 @@ MOSTAverage::set_k_indices_N()
 
             AMREX_ASSERT_WITH_MESSAGE(m_zref >= m_zlo + 0.5 * m_dz,
                                       "Query point must be past first z-cell!");
-            AMREX_ASSERT_WITH_MESSAGE(m_zref <= m_zhi - + 0.5 * m_dz,
+            AMREX_ASSERT_WITH_MESSAGE(m_zref <= m_zhi - 0.5 * m_dz,
                                       "Query point must be below the last z-cell!");
 
             int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));


### PR DESCRIPTION
Add Charnock. Not integrated into heat flux calculation yet. Also need to consider using structs to contain the iteration code and template the update_fluxes function to pass the struct in.

@ewquon we will want to chat about correctness and interpretation with a heat flux component.

@asalmgren we will want to look at modularizing the functions in ABLMost.cpp (I think we can ask the type question once, instantiate a struct that has the source code, and template in the same manner as the advection operator). This can be connected to requests made by Yorgos.