### PR TITLE
Add parentheses around macro expressions

### DIFF
--- a/Source/ERF_Constants.H
+++ b/Source/ERF_Constants.H
@@ -1,5 +1,5 @@
-#ifndef _CONSTANTS_H_
-#define _CONSTANTS_H_
+#ifndef ERF_CONSTANTS_H_
+#define ERF_CONSTANTS_H_
 
 #include <AMReX_REAL.H>
 

--- a/Source/IndexDefines.H
+++ b/Source/IndexDefines.H
@@ -35,8 +35,8 @@
   #define PrimQt_comp    (RhoQt_comp-1)
   #define PrimQp_comp    (RhoQp_comp-1)
 #elif defined(ERF_USE_WARM_NO_PRECIP)
-  #define PrimQv_comp    RhoQv_comp-1
-  #define PrimQc_comp    RhoQc_comp-1
+  #define PrimQv_comp    (RhoQv_comp-1)
+  #define PrimQc_comp    (RhoQc_comp-1)
 #endif
 #define NUM_PRIM         (NVAR-1)
 


### PR DESCRIPTION
Also note that names starting with `_[A-Z]` are reserved.