### PR TITLE
Moisture typos

### DIFF
--- a/Source/Microphysics/PrecipFall.cpp
+++ b/Source/Microphysics/PrecipFall.cpp
@@ -31,9 +31,9 @@ void Microphysics::PrecipFall(int hydro_type) {
   Real gams3 = erf_gammafff(4.0+b_snow      );
   Real gamg3 = erf_gammafff(4.0+b_grau      );
 
-  Real vrain = a_rain*gamr3/6.0/pow((PI*rhor*nzeror),crain);
-  Real vsnow = a_snow*gams3/6.0/pow((PI*rhos*nzeros),csnow);
-  Real vgrau = a_grau*gamg3/6.0/pow((PI*rhog*nzerog),cgrau);
+  Real vrain = a_rain*gamr3/6.0/pow((PI*rhor*nzeror),-crain);
+  Real vsnow = a_snow*gams3/6.0/pow((PI*rhos*nzeros),-csnow);
+  Real vgrau = a_grau*gamg3/6.0/pow((PI*rhog*nzerog),-cgrau);
 
   Real dt_advance = dt;
   int nz = nlev;

--- a/Source/Utils/Microphysics_Utils.H
+++ b/Source/Utils/Microphysics_Utils.H
@@ -163,13 +163,13 @@ amrex::Real term_vel_qp(int /*i*/, int /*j*/, int /*k*/, amrex::Real qploc, amre
   if(qploc > qp_threshold) {
     amrex::Real omp = std::max(0.0,std::min(1.0,(tabs-tprmin)*a_pr));
     if(omp == 1.0) {
-      term_vel = vrain*std::pow(rho*qploc,crain);
+      term_vel = vrain*std::pow(rho*qploc,1.0+crain);
     }
     else if(omp == 0.0) {
       amrex::Real omg = std::max(0.0,std::min(1.0,(tabs-tgrmin)*a_gr));
       amrex::Real qgg = omg*qploc;
       amrex::Real qss = qploc-qgg;
-      term_vel = (omg*vgrau*std::pow(rho*qgg,cgrau) + (1.0-omg)*vsnow*std::pow(rho*qss,csnow));
+      term_vel = (omg*vgrau*std::pow(rho*qgg,1.0+cgrau) + (1.0-omg)*vsnow*std::pow(rho*qss,1.0+csnow));
     }
     else {
       amrex::Real omg = std::max(0.0,std::min(1.0,(tabs-tgrmin)*a_gr));
@@ -177,7 +177,7 @@ amrex::Real term_vel_qp(int /*i*/, int /*j*/, int /*k*/, amrex::Real qploc, amre
       amrex::Real qss = qploc-qrr;
       amrex::Real qgg = omg*qss;
       qss = qss-qgg;
-      term_vel = (omp*vrain*std::pow(rho*qrr,crain) + (1.0-omp)*(omg*vgrau*std::pow(rho*qgg,cgrau) + (1.0-omg)*vsnow*std::pow(rho*qss,csnow)));
+      term_vel = (omp*vrain*std::pow(rho*qrr,1.0+crain) + (1.0-omp)*(omg*vgrau*std::pow(rho*qgg,1.0+cgrau) + (1.0-omg)*vsnow*std::pow(rho*qss,1.0+csnow)));
     }
   }
   return term_vel;


### PR DESCRIPTION
-  crain is defined on L79 of `ERF_Constans.H` as `constexpr amrex::Real crain = b_rain / 4.0;`. Similarly, the other constants are defined in the same manner.

However, the precipitating fluxes have the following closure:
![image](https://github.com/erf-model/ERF/assets/103702284/c28e0f7d-dfe1-4fb3-ba9f-78714e206187)

Therefore, the std::pow() functions do not utilize the correct exponent. The negative and 1.0 should correct this.