### PR TITLE
Minor cleanup and formatting.

### DIFF
--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -20,35 +20,35 @@ ABLMost::update_fluxes (int lev,
     if (flux_type == FluxCalcType::MOENG) {
         if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type == RoughCalcType::CONSTANT) {
-                surface_flux most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux);
+                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux);
                 compute_fluxes(lev, max_iters, most_flux);
             } else if (rough_type == RoughCalcType::CHARNOCK) {
-                surface_flux_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, cnk_a);
+                surface_flux_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a);
                 compute_fluxes(lev, max_iters, most_flux);
             } else {
-                surface_flux_mod_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, depth);
+                surface_flux_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
                 compute_fluxes(lev, max_iters, most_flux);
             }
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
             if (rough_type == RoughCalcType::CONSTANT) {
-                surface_temp most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux);
+                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux);
                 compute_fluxes(lev, max_iters, most_flux);
             } else if (rough_type == RoughCalcType::CHARNOCK) {
-                surface_temp_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, cnk_a);
+                surface_temp_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a);
                 compute_fluxes(lev, max_iters, most_flux);
             } else {
-                surface_temp_mod_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, depth);
+                surface_temp_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
                 compute_fluxes(lev, max_iters, most_flux);
             }
         } else {
             if (rough_type == RoughCalcType::CONSTANT) {
-                adiabatic most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux);
+                adiabatic most_flux(m_ma.get_zref(), surf_temp_flux);
                 compute_fluxes(lev, max_iters, most_flux);
             } else if (rough_type == RoughCalcType::CHARNOCK) {
-                adiabatic_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, cnk_a);
+                adiabatic_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a);
                 compute_fluxes(lev, max_iters, most_flux);
             } else {
-                adiabatic_mod_charnock most_flux(m_ma.get_zref(),surf_temp, surf_temp_flux, depth);
+                adiabatic_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
                 compute_fluxes(lev, max_iters, most_flux);
             }
         } // theta flux

--- a/Source/BoundaryConditions/MOSTStress.H
+++ b/Source/BoundaryConditions/MOSTStress.H
@@ -15,7 +15,6 @@ public:
     amrex::Real kappa{KAPPA};        ///< von Karman constant
     amrex::Real gravity{CONST_GRAV}; ///< Acceleration due to gravity (m/s^2)
     amrex::Real surf_temp_flux{0.0}; ///< Heat flux
-    amrex::Real surf_temp;           ///< Surface temperature
     amrex::Real Cnk_a{0.0185};       ///< Standard Charnock constant https://doi.org/10.1175/JAMC-D-17-0137.1
     amrex::Real Cnk_b1{1.0/30.0};    ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
     amrex::Real Cnk_b2{1260.0};      ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
@@ -70,11 +69,9 @@ private:
 struct adiabatic
 {
     adiabatic (amrex::Real zref,
-               amrex::Real temp,
                amrex::Real flux)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
     }
 
@@ -110,12 +107,10 @@ private:
 struct adiabatic_charnock
 {
     adiabatic_charnock (amrex::Real zref,
-                        amrex::Real temp,
                         amrex::Real flux,
                         amrex::Real cnk_a)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_a = cnk_a;
     }
@@ -164,12 +159,10 @@ private:
 struct adiabatic_mod_charnock
 {
     adiabatic_mod_charnock (amrex::Real zref,
-                            amrex::Real temp,
                             amrex::Real flux,
                             amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
@@ -219,11 +212,9 @@ private:
 struct surface_flux
 {
     surface_flux (amrex::Real zref,
-                  amrex::Real temp,
                   amrex::Real flux)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
     }
 
@@ -279,12 +270,10 @@ private:
 struct surface_flux_charnock
 {
     surface_flux_charnock (amrex::Real zref,
-                           amrex::Real temp,
                            amrex::Real flux,
                            amrex::Real cnk_a)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_a = cnk_a;
     }
@@ -339,17 +328,15 @@ private:
 
 
 /**
- * Surface flux with charnock roughness
+ * Surface flux with modified charnock roughness
  */
 struct surface_flux_mod_charnock
 {
     surface_flux_mod_charnock (amrex::Real zref,
-                               amrex::Real temp,
                                amrex::Real flux,
                                amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
@@ -410,11 +397,9 @@ private:
 struct surface_temp
 {
     surface_temp (amrex::Real zref,
-                  amrex::Real temp,
                   amrex::Real flux)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
     }
 
@@ -467,17 +452,15 @@ private:
 
 
 /**
- * Surface temperature with constant roughness
+ * Surface temperature with charnock roughness
  */
 struct surface_temp_charnock
 {
     surface_temp_charnock (amrex::Real zref,
-                           amrex::Real temp,
                            amrex::Real flux,
                            amrex::Real cnk_a)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_a = cnk_a;
     }
@@ -534,17 +517,15 @@ private:
 
 
 /**
- * Surface temperature with constant roughness
+ * Surface temperature with modified charnock roughness
  */
 struct surface_temp_mod_charnock
 {
     surface_temp_mod_charnock (amrex::Real zref,
-                               amrex::Real temp,
                                amrex::Real flux,
                                amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp = temp;
         mdata.surf_temp_flux = flux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
@@ -606,7 +587,7 @@ private:
  */
 struct moeng_flux
 {
-    moeng_flux(int l_zlo,
+    moeng_flux (int l_zlo,
                amrex::Real l_dz)
       :  zlo(l_zlo), dz(l_dz) {}
 
@@ -809,7 +790,7 @@ private:
  */
 struct donelan_flux
 {
-    donelan_flux(int l_zlo,
+    donelan_flux (int l_zlo,
                amrex::Real l_dz)
       :  zlo(l_zlo), dz(l_dz) {}
 

--- a/Source/Microphysics/Cloud.cpp
+++ b/Source/Microphysics/Cloud.cpp
@@ -8,7 +8,7 @@ using namespace amrex;
 /**
  * Compute Cloud-related Microphysics quantities.
  */
-void Microphysics::Cloud() {
+void Microphysics::Cloud () {
 
   constexpr Real an   = 1.0/(tbgmax-tbgmin);
   constexpr Real bn   = tbgmin*an;

--- a/Source/Microphysics/Diagnose.cpp
+++ b/Source/Microphysics/Diagnose.cpp
@@ -4,7 +4,7 @@
  * Computes diagnostic quantities like cloud ice/liquid and precipitation ice/liquid
  * from the existing Microphysics variables.
  */
-void Microphysics::Diagnose() {
+void Microphysics::Diagnose () {
 
   auto qt   = mic_fab_vars[MicVar::qt];
   auto qp   = mic_fab_vars[MicVar::qp];
@@ -44,7 +44,7 @@ void Microphysics::Diagnose() {
 /**
  * Wrapper for the PrecipFall, Cloud, Precipitation, and Diagnostics routines.
  */
-void Microphysics::Proc() {
+void Microphysics::Proc () {
 
     MicroPrecipFall();
 

--- a/Source/Microphysics/IceFall.cpp
+++ b/Source/Microphysics/IceFall.cpp
@@ -8,7 +8,7 @@ using namespace amrex;
 /**
  * Computes contributions to Microphysics and thermodynamic variables from falling cloud ice in each column.
  */
-void Microphysics::IceFall() {
+void Microphysics::IceFall () {
 
   Real dz  = m_geom.CellSize(2);
   Real dtn = dt;

--- a/Source/Microphysics/Init.cpp
+++ b/Source/Microphysics/Init.cpp
@@ -19,10 +19,10 @@ using namespace amrex;
  * @param[in] geom Geometry associated with these MultiFabs and grids
  * @param[in] dt_advance Timestep for the advance
  */
-void Microphysics::Init(const MultiFab& cons_in, MultiFab& qmoist,
-                        const BoxArray& grids_to_evolve,
-                        const Geometry& geom,
-                        const Real& dt_advance)
+void Microphysics::Init (const MultiFab& cons_in, MultiFab& qmoist,
+                         const BoxArray& grids_to_evolve,
+                         const Geometry& geom,
+                         const Real& dt_advance)
  {
   m_geom = geom;
   m_gtoe = grids_to_evolve;

--- a/Source/Microphysics/Microphysics.H
+++ b/Source/Microphysics/Microphysics.H
@@ -55,10 +55,10 @@ class Microphysics {
 
  public:
   // constructor
-  Microphysics() {}
+  Microphysics () {}
 
   // Set up for first time
-  void define(SolverChoice& sc)
+  void define (SolverChoice& sc)
   {
       docloud = sc.do_cloud;
       doprecip = sc.do_precip;
@@ -70,39 +70,39 @@ class Microphysics {
   }
 
   // destructor
-  ~Microphysics() = default;
+  ~Microphysics () = default;
 
   // cloud physics
-  void Cloud();
+  void Cloud ();
 
   // ice physics
-  void IceFall();
+  void IceFall ();
 
   // precip
-  void Precip();
+  void Precip ();
 
   // precip fall
-  void PrecipFall(int hydro_type);
+  void PrecipFall (int hydro_type);
 
   // micro interface for precip fall
-  void MicroPrecipFall();
+  void MicroPrecipFall ();
 
   // init
-  void Init(const amrex::MultiFab& cons_in,
-            amrex::MultiFab& qmoist,
-            const amrex::BoxArray& grids_to_evolve,
-            const amrex::Geometry& geom,
-            const amrex::Real& dt_advance);
+  void Init (const amrex::MultiFab& cons_in,
+             amrex::MultiFab& qmoist,
+             const amrex::BoxArray& grids_to_evolve,
+             const amrex::Geometry& geom,
+             const amrex::Real& dt_advance);
 
   // update ERF variables
-  void Update(amrex::MultiFab& cons_in,
-              amrex::MultiFab& qmoist);
+  void Update (amrex::MultiFab& cons_in,
+               amrex::MultiFab& qmoist);
 
   // diagnose
-  void Diagnose();
+  void Diagnose ();
 
   // process microphysics
-  void Proc();
+  void Proc ();
 
  private:
   // geometry

--- a/Source/Microphysics/Precip.cpp
+++ b/Source/Microphysics/Precip.cpp
@@ -8,7 +8,7 @@ using namespace amrex;
 /**
  * Compute Precipitation-related Microphysics quantities.
  */
-void Microphysics::Precip() {
+void Microphysics::Precip () {
 
   Real powr1 = (3.0 + b_rain) / 4.0;
   Real powr2 = (5.0 + b_rain) / 8.0;
@@ -107,7 +107,7 @@ void Microphysics::Precip() {
             qii = (qii+dtn*autos*qci0)/(1.0+dtn*(accris+accrig+autos));
             dq = dtn *(accrr*qcc + autor*(qcc-qcw0)+(accris+accrig)*qii + (accrcs+accrcg)*qcc + autos*(qii-qci0));
             dq = std::min(dq,qn_array(i,j,k));
-        qt_array(i,j,k) = qt_array(i,j,k) - dq;
+            qt_array(i,j,k) = qt_array(i,j,k) - dq;
             qp_array(i,j,k) = qp_array(i,j,k) + dq;
             qn_array(i,j,k) = qn_array(i,j,k) - dq;
             amrex::Gpu::Atomic::Add(&qpsrc_t(k), dq);
@@ -138,8 +138,8 @@ void Microphysics::Precip() {
           }
           dq = dq * dtn * (qt_array(i,j,k) / qsatt-1.0);
           dq = std::max(-0.5*qp_array(i,j,k),dq);
-      qt_array(i,j,k) = qt_array(i,j,k) - dq;
-      qp_array(i,j,k) = qp_array(i,j,k) + dq;
+          qt_array(i,j,k) = qt_array(i,j,k) - dq;
+          qp_array(i,j,k) = qp_array(i,j,k) + dq;
           amrex::Gpu::Atomic::Add(&qpevp_t(k), dq);
 
         } else {

--- a/Source/Microphysics/Update.cpp
+++ b/Source/Microphysics/Update.cpp
@@ -10,8 +10,8 @@
  * @param[out] cons Conserved variables
  * @param[out] qmoist: qv, qc, qi, qr, qs, qg
  */
-void Microphysics::Update(amrex::MultiFab& cons,
-                          amrex::MultiFab& qmoist)
+void Microphysics::Update (amrex::MultiFab& cons,
+                           amrex::MultiFab& qmoist)
 {
   // copy multifab data to qc, qv, and qi
   amrex::MultiFab::Copy(qmoist, *mic_fab_vars[MicVar::qv],  0, 0, 1, mic_fab_vars[MicVar::qv]->nGrowVect());  // vapor


### PR DESCRIPTION
1. Remove surface temp from **most_data**, the surface temperature as an Array4 is passed through the call signature (more general and will play with SST/LSM).
2. Formatting microphysics functions for easier searching