### PR TITLE
Fix for failing WPS test.

### DIFF
--- a/Source/BoundaryConditions/BoundaryConditions_wrfbdy.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_wrfbdy.cpp
@@ -53,8 +53,7 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs,
     Vector<int> comp_var = {ncomp_cons, 1, 1, 1};
 
     // End of vars loop
-    int var_idx_end = Vars::NumTypes;
-    if (cons_only) var_idx_end = Vars::cons + 1;
+    int var_idx_end = (cons_only) ? Vars::cons + 1 : Vars::NumTypes;
 
     // Loop over all variable types
     for (int var_idx = Vars::cons; var_idx < var_idx_end; ++var_idx)
@@ -70,8 +69,7 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs,
         const auto& dom_hi = amrex::ubound(domain);
 
         // Offset only applys to cons (we may fill a subset of these vars)
-        int offset = 0;
-        if (var_idx == Vars::cons) offset = icomp_cons;
+        int offset = (var_idx == Vars::cons) ? icomp_cons : 0;
 
         // Loop over each component
         for (int comp_idx(offset); comp_idx < (comp_var[var_idx]+offset); ++comp_idx)

--- a/Source/BoundaryConditions/BoundaryConditions_wrfbdy.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_wrfbdy.cpp
@@ -12,7 +12,11 @@ using namespace amrex;
  */
 
 void
-ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs, const Real time)
+ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs,
+                       const Real time,
+                       bool cons_only,
+                       int icomp_cons,
+                       int ncomp_cons)
 {
     int lev = 0;
 
@@ -46,10 +50,14 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs, const Real time)
     ind_map.push_back( {0} );             // zvel
 
     // Nvars to loop over
-    Vector<int> comp_var = {NVAR, 1, 1, 1};
+    Vector<int> comp_var = {ncomp_cons, 1, 1, 1};
+
+    // End of vars loop
+    int var_idx_end = Vars::NumTypes;
+    if (cons_only) var_idx_end = Vars::cons + 1;
 
     // Loop over all variable types
-    for (int var_idx = Vars::cons; var_idx < Vars::NumTypes; ++var_idx)
+    for (int var_idx = Vars::cons; var_idx < var_idx_end; ++var_idx)
     {
         MultiFab& mf = *mfs[var_idx];
 
@@ -61,16 +69,19 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs, const Real time)
         const auto& dom_lo = amrex::lbound(domain);
         const auto& dom_hi = amrex::ubound(domain);
 
+        // Offset only applys to cons (we may fill a subset of these vars)
+        int offset = 0;
+        if (var_idx == Vars::cons) offset = icomp_cons;
+
         // Loop over each component
-        for (int comp_idx(0); comp_idx < comp_var[var_idx]; ++comp_idx)
+        for (int comp_idx(offset); comp_idx < (comp_var[var_idx]+offset); ++comp_idx)
         {
-            int width;
+            int width = wrfbdy_set_width;;
 
             // Variable can be read from wrf bdy
             //------------------------------------
             if (is_read[var_idx][comp_idx])
             {
-                width = wrfbdy_set_width;
                 int ivar  = ind_map[var_idx][comp_idx];
                 IntVect ng_vect = mf.nGrowVect(); ng_vect[2] = 0;
 
@@ -138,7 +149,6 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs, const Real time)
             // Variable not read from wrf bdy
             //------------------------------------
             } else {
-                width = wrfbdy_width - 1;
                 IntVect ng_vect = mf.nGrowVect(); ng_vect[2] = 0;
 
 #ifdef AMREX_USE_OMP
@@ -158,14 +168,14 @@ ERF::fill_from_wrfbdy (const Vector<MultiFab*>& mfs, const Real time)
                     ParallelFor(bx_xlo, bx_xhi,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
-                        int jj = std::max(j , dom_lo.y);
-                            jj = std::min(jj, dom_hi.y);
+                        int jj = std::max(j , dom_lo.y+width);
+                            jj = std::min(jj, dom_hi.y-width);
                             dest_arr(i,j,k,comp_idx) = dest_arr(dom_lo.x+width,jj,k,comp_idx);
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
-                        int jj = std::max(j , dom_lo.y);
-                            jj = std::min(jj, dom_hi.y);
+                        int jj = std::max(j , dom_lo.y+width);
+                            jj = std::min(jj, dom_hi.y-width);
                             dest_arr(i,j,k,comp_idx) = dest_arr(dom_hi.x-width,jj,k,comp_idx);
                     });
 

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -92,7 +92,7 @@ ERF::FillPatch (int lev, Real time, const Vector<MultiFab*>& mfs, bool fillset)
 
 #ifdef ERF_USE_NETCDF
     // We call this here because it is an ERF routine
-    if (init_type=="real" && lev==0) fill_from_wrfbdy(mfs,time);
+    if (init_type=="real" && lev==0) fill_from_wrfbdy(mfs, time);
 #endif
 
     if (m_r2d) fill_from_bndryregs(mfs,time);
@@ -245,8 +245,11 @@ ERF::FillIntermediatePatch (int lev, Real time,
     IntVect ngvect_vels = IntVect(ng_vel ,ng_vel ,ng_vel);
 
 #ifdef ERF_USE_NETCDF
+    // NOTE: This routine needs to be aware of what FillIntermediatePatch is operating on
+    //       --- i.e., cons_only and which cons indices (icomp_cons & ncomp_cons)
+
     // We call this here because it is an ERF routine
-    if (init_type=="real" && lev==0) fill_from_wrfbdy(mfs,time);
+    if (init_type=="real" && lev==0) fill_from_wrfbdy(mfs, time, cons_only, icomp_cons, ncomp_cons);
 #endif
 
     if (m_r2d) fill_from_bndryregs(mfs,time);

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -297,7 +297,10 @@ public:
 
 #ifdef ERF_USE_NETCDF
     void fill_from_wrfbdy (const amrex::Vector<amrex::MultiFab*>& mfs,
-                           amrex::Real time);
+                           amrex::Real time,
+                           bool cons_only = false,
+                           int icomp_cons = 0,
+                           int ncomp_cons = NVAR);
 #endif
 
 #ifdef ERF_USE_PARTICLES


### PR DESCRIPTION
Summary of changes and rationale:

1. The indexing in **fill_from_wrfbdy** needed revamping. This is due to the fact that FillIntermediatePatch may call this routine under conditions when only cons vars should be filled or a subset of cons vars (see set_bcs after fast rhs). The new indexing makes the operations only occur on what we want to set.
2. The corner regions in **bx_xlo** and **bx_xhi** of **fill_from_wrfbdy** will incorrectly reach into a set region when the variable is NOT read. We want to copy from a valid interior cell.
3.  The deletion of **grids_to_evolve** will make the microphysics call **cloud()** in the set region. So the diagnosed quantities (qv, qc) will never match because we now operate on cells we didn't use to. We can remake the benchmark or we can exclude the qv and qc quantities.