### PR TITLE
Some PBL Fixes

### DIFF
--- a/Source/Diffusion/ComputeQKESourceTerm.H
+++ b/Source/Diffusion/ComputeQKESourceTerm.H
@@ -26,7 +26,13 @@ ComputeQKESourceTerms (int i, int j, int k,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Box& domain,
                        amrex::Real pbl_B1_l,
-                       const amrex::Real theta_mean)
+                       const amrex::Real theta_mean,
+                       bool c_ext_dir_on_zlo,
+                       bool c_ext_dir_on_zhi,
+                       bool u_ext_dir_on_zlo,
+                       bool u_ext_dir_on_zhi,
+                       bool v_ext_dir_on_zlo,
+                       bool v_ext_dir_on_zhi)
 {
   // Compute some relevant derivatives
   amrex::Real dz_inv = cellSizeInv[2];
@@ -34,25 +40,44 @@ ComputeQKESourceTerms (int i, int j, int k,
   int izmax = domain.bigEnd(2);
   amrex::Real dthetadz, dudz, dvdz;
   amrex::Real source_term = 0.0;
-  if (k == izmax) {
-    dthetadz = (cell_prim(i,j,k,PrimTheta_comp) - cell_prim(i,j,k-1,PrimTheta_comp))*dz_inv;
-    dudz = 0.5*(uvel(i,j,k) - uvel(i,j,k-1) + uvel(i+1,j,k) - uvel(i+1,j,k-1))*dz_inv;
-    dvdz = 0.5*(vvel(i,j,k) - vvel(i,j,k-1) + vvel(i,j+1,k) - vvel(i,j+1,k-1))*dz_inv;
-  } else if (k == izmin){
-    dthetadz = (cell_prim(i,j,k+1,PrimTheta_comp) - cell_prim(i,j,k,PrimTheta_comp))*dz_inv;
-    dudz = 0.5*(uvel(i,j,k+1) - uvel(i,j,k) + uvel(i+1,j,k+1) - uvel(i+1,j,k))*dz_inv;
-    dvdz = 0.5*(vvel(i,j,k+1) - vvel(i,j,k) + vvel(i,j+1,k+1) - vvel(i,j+1,k))*dz_inv;
+  if ( k==izmax && c_ext_dir_on_zhi ) {
+      dthetadz = (1.0/3.0)*(-cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp)
+                     - 3.0 * cell_data(i,j,k  ,RhoTheta_comp)/cell_data(i,j,k  ,Rho_comp)
+                     + 4.0 * cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp) )*dz_inv;
+  } else if ( k==izmin && c_ext_dir_on_zlo ) {
+      dthetadz = (1.0/3.0)*( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
+                     + 3.0 * cell_data(i,j,k  ,RhoTheta_comp)/cell_data(i,j,k  ,Rho_comp)
+                     - 4.0 * cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dz_inv;
   } else {
-    dthetadz = 0.5*(cell_prim(i,j,k+1,PrimTheta_comp) - cell_prim(i,j,k-1,PrimTheta_comp))*dz_inv;
-    dudz = 0.25*(uvel(i,j,k+1) - uvel(i,j,k-1) + uvel(i+1,j,k+1) - uvel(i+1,j,k-1))*dz_inv;
-    dvdz = 0.25*(vvel(i,j,k+1) - vvel(i,j,k-1) + vvel(i,j+1,k+1) - vvel(i,j+1,k-1))*dz_inv;
+      dthetadz = 0.5*( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
+                     - cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dz_inv;
   }
 
-  // Production
-  source_term += K_turb(i,j,k,EddyDiff::Mom_v) * (dudz*dudz + dvdz*dvdz);
+  if ( k==izmax && u_ext_dir_on_zhi ) {
+      dudz = (1.0/6.0)*( (-uvel(i  ,j,k-1) - 3.0 * uvel(i  ,j,k  ) + 4.0 * uvel(i  ,j,k+1))
+                       + (-uvel(i+1,j,k-1) - 3.0 * uvel(i+1,j,k  ) + 4.0 * uvel(i+1,j,k+1)) )*dz_inv;
+  } else if ( k==izmin && u_ext_dir_on_zlo ) {
+      dudz = (1.0/6.0)*( (uvel(i  ,j,k+1) + 3.0 * uvel(i  ,j,k  ) - 4.0 * uvel(i  ,j,k-1))
+                       + (uvel(i+1,j,k+1) + 3.0 * uvel(i+1,j,k  ) - 4.0 * uvel(i+1,j,k-1)) )*dz_inv;
+  } else {
+      dudz = 0.25*( uvel(i,j,k+1) - uvel(i,j,k-1) + uvel(i+1,j,k+1) - uvel(i+1,j,k-1) )*dz_inv;
+  }
+
+  if ( k==izmax && v_ext_dir_on_zhi ) {
+      dvdz = (1.0/6.0)*( (-vvel(i,j  ,k-1) - 3.0 * vvel(i,j  ,k  ) + 4.0 * vvel(i,j  ,k+1))
+                       + (-vvel(i,j+1,k-1) - 3.0 * vvel(i,j+1,k  ) + 4.0 * vvel(i,j+1,k+1)) )*dz_inv;
+  } else if ( k==izmin && v_ext_dir_on_zlo ) {
+      dvdz = (1.0/6.0)*( (vvel(i,j  ,k+1) + 3.0 * vvel(i,j  ,k  ) - 4.0 * vvel(i,j  ,k-1))
+                       + (vvel(i,j+1,k+1) + 3.0 * vvel(i,j+1,k  ) - 4.0 * vvel(i,j+1,k-1)) )*dz_inv;
+  } else {
+      dvdz = 0.25*( vvel(i,j,k+1) - vvel(i,j,k-1) + vvel(i,j+1,k+1) - vvel(i,j+1,k-1) )*dz_inv;
+  }
+
+  // Production (We store mu_turb, which is 0.5*K_turb)
+  source_term += 4.0*K_turb(i,j,k,EddyDiff::Mom_v) * (dudz*dudz + dvdz*dvdz);
 
   // Bouyancy
-  source_term -= 2*(CONST_GRAV/theta_mean)*K_turb(i,j,k,EddyDiff::Theta_v)*dthetadz;
+  source_term -= 2.0*(CONST_GRAV/theta_mean)*K_turb(i,j,k,EddyDiff::Theta_v)*dthetadz;
 
   // Dissipation
   amrex::Real qke = cell_prim(i,j,k,PrimQKE_comp);

--- a/Source/Diffusion/ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ComputeTurbulentViscosity.cpp
@@ -15,6 +15,7 @@ ComputeTurbulentViscosityPBL (const amrex::MultiFab& xvel,
                               const amrex::Geometry& geom,
                               const TurbChoice& turbChoice,
                               std::unique_ptr<ABLMost>& most,
+                              const amrex::BCRec* bc_ptr,
                               bool /*vert_only*/);
 
 /**
@@ -373,6 +374,7 @@ void ComputeTurbulentViscosity (const amrex::MultiFab& xvel , const amrex::Multi
                                 const amrex::MultiFab& mapfac_u, const amrex::MultiFab& mapfac_v,
                                 const TurbChoice& turbChoice, const Real const_grav,
                                 std::unique_ptr<ABLMost>& most,
+                                const amrex::BCRec* bc_ptr,
                                 bool vert_only)
 {
     BL_PROFILE_VAR("ComputeTurbulentViscosity()",ComputeTurbulentViscosity);
@@ -412,6 +414,6 @@ void ComputeTurbulentViscosity (const amrex::MultiFab& xvel , const amrex::Multi
 
     if (turbChoice.pbl_type != PBLType::None) {
         ComputeTurbulentViscosityPBL(xvel, yvel, cons_in, eddyViscosity,
-                                     geom, turbChoice, most, vert_only);
+                                     geom, turbChoice, most, bc_ptr, vert_only);
     }
 }

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -404,10 +404,20 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
     if (l_use_QKE && start_comp <= RhoQKE_comp && end_comp >=RhoQKE_comp) {
         int qty_index = RhoQKE_comp;
         auto pbl_B1_l = turbChoice.pbl_B1;
+        bool c_ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc].lo(2) == ERFBCType::ext_dir) );
+        bool c_ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc].lo(5) == ERFBCType::ext_dir) );
+        bool u_ext_dir_on_zlo = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir) );
+        bool u_ext_dir_on_zhi = ( (bc_ptr[BCVars::xvel_bc].lo(5) == ERFBCType::ext_dir) );
+        bool v_ext_dir_on_zlo = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir) );
+        bool v_ext_dir_on_zhi = ( (bc_ptr[BCVars::yvel_bc].lo(5) == ERFBCType::ext_dir) );
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cell_rhs(i, j, k, qty_index) += ComputeQKESourceTerms(i,j,k,u,v,cell_data,cell_prim,
-                                                                  mu_turb,cellSizeInv,domain,pbl_B1_l,tm_arr(i,j,0));
+                                                                  mu_turb,cellSizeInv,domain,
+                                                                  pbl_B1_l,tm_arr(i,j,0),
+                                                                  c_ext_dir_on_zlo, c_ext_dir_on_zhi,
+                                                                  u_ext_dir_on_zlo, u_ext_dir_on_zhi,
+                                                                  v_ext_dir_on_zlo, v_ext_dir_on_zhi);
         });
     }
 

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -583,10 +583,19 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
     if (l_use_QKE && start_comp <= RhoQKE_comp && end_comp >=RhoQKE_comp) {
         int qty_index = RhoQKE_comp;
         auto pbl_B1_l = turbChoice.pbl_B1;
+        bool c_ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc].lo(2) == ERFBCType::ext_dir) );
+        bool c_ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc].lo(5) == ERFBCType::ext_dir) );
+        bool u_ext_dir_on_zlo = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir) );
+        bool u_ext_dir_on_zhi = ( (bc_ptr[BCVars::xvel_bc].lo(5) == ERFBCType::ext_dir) );
+        bool v_ext_dir_on_zlo = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir) );
+        bool v_ext_dir_on_zhi = ( (bc_ptr[BCVars::yvel_bc].lo(5) == ERFBCType::ext_dir) );
         amrex::ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             cell_rhs(i, j, k, qty_index) += ComputeQKESourceTerms(i,j,k,u,v,cell_data,cell_prim,
-                                                                  mu_turb,dxInv,domain,pbl_B1_l,tm_arr(i,j,0));
+                                                                  mu_turb,dxInv,domain,pbl_B1_l,tm_arr(i,j,0),
+                                                                  c_ext_dir_on_zlo, c_ext_dir_on_zhi,
+                                                                  u_ext_dir_on_zlo, u_ext_dir_on_zhi,
+                                                                  v_ext_dir_on_zlo, v_ext_dir_on_zhi);
         });
     }
 }

--- a/Source/Diffusion/EddyViscosity.H
+++ b/Source/Diffusion/EddyViscosity.H
@@ -5,6 +5,7 @@
 
 #include <ABLMost.H>
 #include <DataStruct.H>
+#include <AMReX_BCRec.H>
 
 void
 ComputeTurbulentViscosity (const amrex::MultiFab& xvel , const amrex::MultiFab& yvel ,
@@ -17,6 +18,7 @@ ComputeTurbulentViscosity (const amrex::MultiFab& xvel , const amrex::MultiFab& 
                            const amrex::MultiFab& mapfac_u, const amrex::MultiFab& mapfac_v,
                            const TurbChoice& turbChoice, const amrex::Real const_grav,
                            std::unique_ptr<ABLMost>& most,
+                           const amrex::BCRec* bc_ptr,
                            bool vert_only = false);
 
 AMREX_GPU_DEVICE

--- a/Source/TimeIntegration/ERF_advance_dycore.cpp
+++ b/Source/TimeIntegration/ERF_advance_dycore.cpp
@@ -216,13 +216,14 @@ void ERF::advance_dycore(int level,
     // *************************************************************************
     if (l_use_kturb)
     {
+        const amrex::BCRec* bc_ptr_d = domain_bcs_type_d.data();
         ComputeTurbulentViscosity(xvel_old, yvel_old,
                                   *Tau11, *Tau22, *Tau33,
                                   *Tau12, *Tau13, *Tau23,
                                   state_old[IntVar::cons],
                                   *eddyDiffs, *Hfx1, *Hfx2, *Hfx3, *Diss, // to be updated
                                   fine_geom, *mapfac_u[level], *mapfac_v[level],
-                                  tc, solverChoice.gravity, m_most);
+                                  tc, solverChoice.gravity, m_most, bc_ptr_d);
     }
 
     // ***********************************************************************************************


### PR DESCRIPTION
1. Make the z-derivs in PBL and QKE src second order. These need to be aware of dirichlet BCs (stencil image below); with other BCs we just access the ghost cell.
![image](https://github.com/erf-model/ERF/assets/103702284/d6fefa70-a416-4de4-b5cf-d793c936ae41)
2. The source term for shear production was incorrect. First there should have been a factor of 2. Next, we store mu_turb and not K_turb=2*mu_turb. So there should in fact be a 4 in this line.
