### PR TITLE
Formatting Prob funs

### DIFF
--- a/Source/Prob/init_constant_density_hse.H
+++ b/Source/Prob/init_constant_density_hse.H
@@ -1,8 +1,8 @@
 void
-erf_init_dens_hse(amrex::MultiFab& rho_hse,
-                  std::unique_ptr<amrex::MultiFab>&,
-                  std::unique_ptr<amrex::MultiFab>&,
-                  amrex::Geometry const&) override
+erf_init_dens_hse (amrex::MultiFab& rho_hse,
+                   std::unique_ptr<amrex::MultiFab>&,
+                   std::unique_ptr<amrex::MultiFab>&,
+                   amrex::Geometry const&) override
 {
     amrex::Real rho_0 = parms.rho_0;
     for ( amrex::MFIter mfi(rho_hse, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi )

--- a/Source/Prob/init_density_hse_dry.H
+++ b/Source/Prob/init_density_hse_dry.H
@@ -8,11 +8,10 @@
  * this point.
 */
 void
-erf_init_dens_hse(
-    amrex::MultiFab& rho_hse,
-    std::unique_ptr<amrex::MultiFab>& z_phys_nd,
-    std::unique_ptr<amrex::MultiFab>& z_phys_cc,
-    amrex::Geometry const& geom) override
+erf_init_dens_hse (amrex::MultiFab& rho_hse,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_cc,
+                   amrex::Geometry const& geom) override
 {
     const amrex::Real prob_lo_z = geom.ProbLo()[2];
     const amrex::Real dz        = geom.CellSize()[2];

--- a/Source/Prob/init_density_hse_dry_noterrain.H
+++ b/Source/Prob/init_density_hse_dry_noterrain.H
@@ -7,11 +7,10 @@
  * used at this point.
 */
 void
-erf_init_dens_hse(
-    amrex::MultiFab& rho_hse,
-    std::unique_ptr<amrex::MultiFab>& z_phys_nd,
-    std::unique_ptr<amrex::MultiFab>& z_phys_cc,
-    amrex::Geometry const& geom) override
+erf_init_dens_hse (amrex::MultiFab& rho_hse,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_cc,
+                   amrex::Geometry const& geom) override
 {
     const amrex::Real prob_lo_z = geom.ProbLo()[2];
     const amrex::Real dz        = geom.CellSize()[2];

--- a/Source/Prob/init_density_hse_dry_terrain.H
+++ b/Source/Prob/init_density_hse_dry_terrain.H
@@ -7,11 +7,10 @@
  * used at this point.
 */
 void
-erf_init_dens_hse(
-    amrex::MultiFab& rho_hse,
-    std::unique_ptr<amrex::MultiFab>& z_phys_nd,
-    std::unique_ptr<amrex::MultiFab>& z_phys_cc,
-    amrex::Geometry const& geom) override
+erf_init_dens_hse (amrex::MultiFab& rho_hse,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_cc,
+                   amrex::Geometry const& geom) override
 {
     const int khi               = geom.Domain().bigEnd()[2];
 

--- a/Source/Prob/init_rayleigh_damping.H
+++ b/Source/Prob/init_rayleigh_damping.H
@@ -3,12 +3,12 @@
  * on Durran and Klemp 1983
 */
 void
-erf_init_rayleigh(amrex::Vector<amrex::Real>& tau,
-                  amrex::Vector<amrex::Real>& ubar,
-                  amrex::Vector<amrex::Real>& vbar,
-                  amrex::Vector<amrex::Real>& wbar,
-                  amrex::Vector<amrex::Real>& thetabar,
-                  amrex::Geometry      const& geom) override
+erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
+                   amrex::Vector<amrex::Real>& ubar,
+                   amrex::Vector<amrex::Real>& vbar,
+                   amrex::Vector<amrex::Real>& wbar,
+                   amrex::Vector<amrex::Real>& thetabar,
+                   amrex::Geometry      const& geom) override
 {
     const auto ztop = geom.ProbHi()[2];
     amrex::Print() << "Rayleigh damping (coef="<<parms.dampcoef<<") between "

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -47,7 +47,7 @@ void add_par () {
  * Main driver -- creates the ERF object, calls ERF.InitData() and ERF.Evolve()
  * Also includes the multiblock interface in the case where there is more than one ERF object
 */
-int main(int argc, char* argv[])
+int main (int argc, char* argv[])
 {
     // Check to see if the command line contains --describe
     if (argc >= 2) {

--- a/Source/prob_common.H
+++ b/Source/prob_common.H
@@ -175,13 +175,13 @@ protected:
      * Function to update default base parameters, currently only used for
      * init_type=='uniform'
      */
-    void init_base_parms(amrex::Real rho_0, amrex::Real T_0) {
+    void init_base_parms (amrex::Real rho_0, amrex::Real T_0) {
         base_parms.rho_0 = rho_0;
         base_parms.T_0 = T_0;
     }
 
     // descriptor for problem definition
-    virtual std::string name() = 0;
+    virtual std::string name () = 0;
 };
 
 
@@ -189,8 +189,7 @@ protected:
  * Function to init the physical bounds of the domain
  * and instantiate a Problem derived from ProblemBase
 */
-std::unique_ptr<ProblemBase> amrex_probinit (
-    const amrex_real* problo,
-    const amrex_real* probhi);
+std::unique_ptr<ProblemBase> amrex_probinit (const amrex_real* problo,
+                                             const amrex_real* probhi);
 
 #endif


### PR DESCRIPTION
Function definitions and declarations should have a space before the inputs to facilitate searching.