### PR TITLE
GABLS gmake

### DIFF
--- a/Exec/RegTests/GABLS1/GNUmakefile
+++ b/Exec/RegTests/GABLS1/GNUmakefile
@@ -32,6 +32,6 @@ USE_ASSERTION = TRUE
 # GNU Make
 Bpack := ./Make.package
 Blocs := .
-ERF_HOME := ../..
+ERF_HOME := ../../..
 ERF_PROBLEM_DIR = $(ERF_HOME)/Exec/RegTests/GABLS1
 include $(ERF_HOME)/Exec/Make.ERF

--- a/Source/ERF_make_new_level.cpp
+++ b/Source/ERF_make_new_level.cpp
@@ -384,6 +384,10 @@ ERF::update_arrays (int lev, const BoxArray& ba, const DistributionMapping& dm)
         SFS_hfx2_lev[lev] = std::make_unique<MultiFab>( ba  , dm, 1, IntVect(1,1,0) );
         SFS_hfx3_lev[lev] = std::make_unique<MultiFab>( ba  , dm, 1, IntVect(1,1,0) );
         SFS_diss_lev[lev] = std::make_unique<MultiFab>( ba  , dm, 1, IntVect(1,1,0) );
+        SFS_hfx1_lev[lev]->setVal(0.);
+        SFS_hfx2_lev[lev]->setVal(0.);
+        SFS_hfx3_lev[lev]->setVal(0.);
+        SFS_diss_lev[lev]->setVal(0.);
     } else {
       Tau11_lev[lev] = nullptr; Tau22_lev[lev] = nullptr; Tau33_lev[lev] = nullptr;
       Tau12_lev[lev] = nullptr; Tau21_lev[lev] = nullptr;


### PR DESCRIPTION
Compile GABLs with gmake and initialize statistical vars for cases that don't use deardorff.