### PR TITLE
Create NullMoist ptr.

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -966,6 +966,7 @@ ERF::ReadParameters ()
         if (moisture_model == "SAM") {
             micro.SetModel<SAM>();
         } else {
+            micro.SetModel<NullMoist>();
             amrex::Print() << "WARNING: Compiled with moisture but using NullMoist model!\n";
         }
 #endif


### PR DESCRIPTION
The ptr in Microphysics was not created if the moisture model is Null. Add the needed SetModel call.