### PR TITLE
Buoyancy term  and bc term for bx_xhi_face

### DIFF
--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -95,7 +95,7 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
             },
             // We only set the values on the domain faces themselves if EXT_DIR
             bx_xhi_face, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                if (bc_ptr[n].lo(3) == ERFBCType::ext_dir)
+                if (bc_ptr[n].hi(0) == ERFBCType::ext_dir)
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][3];
             }
         );

--- a/Source/TimeIntegration/ERF_make_buoyancy.cpp
+++ b/Source/TimeIntegration/ERF_make_buoyancy.cpp
@@ -160,8 +160,14 @@ void make_buoyancy (Vector<MultiFab>& S_data,
 
                 amrex::ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rhop_hi = cell_data(i,j,k  ,Rho_comp) + cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp) + cell_data(i,j,k  ,RhoQ3_comp) - r0_arr(i,j,k  );
-                    Real rhop_lo = cell_data(i,j,k-1,Rho_comp) + cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp) + cell_data(i,j,k-1,RhoQ3_comp)  - r0_arr(i,j,k-1);
+                    Real rhop_lo, rhop_hi;
+                    if(solverChoice.moisture_type == MoistureType::FastEddy){
+                        rhop_hi = cell_data(i,j,k  ,Rho_comp) + cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp) - r0_arr(i,j,k  );
+                        rhop_lo = cell_data(i,j,k-1,Rho_comp) + cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp) - r0_arr(i,j,k-1);
+                    }else{
+                        rhop_hi = cell_data(i,j,k  ,Rho_comp) + cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp) + cell_data(i,j,k  ,RhoQ3_comp) - r0_arr(i,j,k  );
+                        rhop_lo = cell_data(i,j,k-1,Rho_comp) + cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp) + cell_data(i,j,k-1,RhoQ3_comp) - r0_arr(i,j,k-1);
+                    }
                     buoyancy_fab(i, j, k) = grav_gpu[2] * 0.5 * ( rhop_hi + rhop_lo );
                 });
             } // mfi

--- a/Source/TimeIntegration/ERF_make_buoyancy.cpp
+++ b/Source/TimeIntegration/ERF_make_buoyancy.cpp
@@ -160,8 +160,8 @@ void make_buoyancy (Vector<MultiFab>& S_data,
 
                 amrex::ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rhop_hi = cell_data(i,j,k  ,Rho_comp) + cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp) - r0_arr(i,j,k  );
-                    Real rhop_lo = cell_data(i,j,k-1,Rho_comp) + cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp) - r0_arr(i,j,k-1);
+                    Real rhop_hi = cell_data(i,j,k  ,Rho_comp) + cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp) + cell_data(i,j,k  ,RhoQ3_comp) - r0_arr(i,j,k  );
+                    Real rhop_lo = cell_data(i,j,k-1,Rho_comp) + cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp) + cell_data(i,j,k-1,RhoQ3_comp)  - r0_arr(i,j,k-1);
                     buoyancy_fab(i, j, k) = grav_gpu[2] * 0.5 * ( rhop_hi + rhop_lo );
                 });
             } // mfi


### PR DESCRIPTION
This PR 
1. Makes the buoyancy term include `Q3_comp` only for cases with precipitation. So `FastEddy` does not have `Q3_comp` in the buoyancy term.
2. Switching `lo(3)` to `hi(0)` for better readability.