### PR TITLE
Tweaks to get FLOWMAS FITCH to start up.

### DIFF
--- a/Exec/DevTests/MetGrid/inputs_fitch_flowmas
+++ b/Exec/DevTests/MetGrid/inputs_fitch_flowmas
@@ -1,0 +1,62 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 100
+
+amrex.fpe_trap_invalid = 1
+amrex.fpe_trap_zero = 1
+amrex.fpe_trap_overflow = 1
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_extent =  447000 387000 15000
+amr.n_cell           =  149    129    40
+
+geometry.is_periodic = 0 0 0
+
+xlo.type = "Outflow"
+xhi.type = "Outflow"
+ylo.type = "Outflow"
+yhi.type = "Outflow"
+zlo.type = "NoSlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.fixed_dt           = 1.0  # fixed time step depending on grid resolution
+
+erf.use_terrain = true
+erf.terrain_smoothing = 2
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = -1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 1          # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 1          # number of timesteps between plotfiles
+erf.plot_vars_1     = qv Rhoqv density dens_hse rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta z_phys mapfac pres_hse pert_pres KE QKE
+
+# SOLVER CHOICE
+erf.alpha_T = 1.0
+erf.alpha_C = 1.0
+erf.use_gravity = true
+
+erf.molec_diff_type = "None"
+erf.les_type        = "Smagorinsky"
+erf.Cs              = 0.1
+
+erf.moisture_model = "Kessler"
+
+# INITIALIZATION WITH ATM DATA
+erf.metgrid_bdy_width = 5
+erf.metgrid_bdy_set_width = 1
+erf.init_type      = "metgrid"
+erf.nc_init_file_0 = "met_em.d01.2015-04-01_00_00_00.nc" "met_em.d01.2015-04-01_08_00_00.nc"
+
+#There will be no OpenMP tiling
+fabarray.mfiter_tile_size = 1024 1024 1024

--- a/Exec/SquallLine_2D/inputs_moisture
+++ b/Exec/SquallLine_2D/inputs_moisture
@@ -14,10 +14,8 @@ amr.n_cell           =  192    4    81    # dx=dy=dz=100 m
 # periodic in x to match WRF setup
 # - as an alternative, could use symmetry at x=0 and outflow at x=25600
 geometry.is_periodic = 1 1 0
-#xlo.type = "Outflow"
-#xhi.type = "Outflow"
 zlo.type = "SlipWall"
-zhi.type = "Outflow"
+zhi.type = "SlipWall"
 
 erf.sponge_strength = 2.0
 #erf.use_zhi_sponge_damping = true
@@ -45,7 +43,6 @@ amr.max_level       = 0       # maximum level number allowed
 # CHECKPOINT FILES
 amr.check_file      = chk        # root name of checkpoint file
 amr.check_int       = 1000       # number of timesteps between checkpoints
-#amr.restart         = chk09000
 
 # PLOTFILES
 erf.plot_file_1         = plt        # root name of plotfile
@@ -54,29 +51,28 @@ erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 rhoQ3 x_velocity y_veloci
 
 # SOLVER CHOICE
 erf.use_gravity = true
-erf.buoyancy_type = 4
+erf.buoyancy_type = 1
 erf.use_coriolis = false
 erf.use_rayleigh_damping = false
-
-#erf.les_type = "Smagorinsky"
-erf.Cs              = 0.25
-erf.les_type = "None"
 
 #
 # diffusion coefficient from Straka, K = 75 m^2/s
 #
 erf.molec_diff_type = "ConstantAlpha"
-#erf.molec_diff_type = "Constant"
 erf.rho0_trans = 1.0 # [kg/m^3], used to convert input diffusivities
-erf.dynamicViscosity = 200.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
-erf.alpha_T = 00.0 # [m^2/s]
+erf.dynamicViscosity = 100.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T = 100.0 # [m^2/s]
 erf.alpha_C = 100.0
 
 erf.moisture_model = "Kessler"
 erf.use_moist_background = true
 
-erf.moistscal_horiz_adv_string = "Centered_2nd"
-erf.moistscal_vert_adv_string = "Centered_2nd"
+erf.dycore_horiz_adv_type    = "Upwind_3rd"
+erf.dycore_vert_adv_type     = "Upwind_3rd"
+erf.dryscal_horiz_adv_type   = "Upwind_3rd"
+erf.dryscal_vert_adv_type    = "Upwind_3rd"
+erf.moistscal_horiz_adv_type = "Upwind_3rd"
+erf.moistscal_vert_adv_type  = "Upwind_3rd"
 
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0

--- a/Source/BoundaryConditions/BoundaryConditions_metgrid.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_metgrid.cpp
@@ -29,20 +29,9 @@ ERF::fill_from_metgrid (const Vector<MultiFab*>& mfs,
     amrex::Real oma   = 1.0 - alpha;
 
     // Flags for read vars and index mapping
-    // See IndexDefines.H
-#if defined(ERF_USE_MOISTURE)
-    // Cons includes [Rho RhoTheta RhoKE RhoQKE RhoScalar RhoQ1 RhoQ2 NumVars]
-    Vector<int> cons_read = {1, 1, 0, 0, 0, 1, 0};
-    Vector<int> cons_map  = {MetGridBdyVars::R, MetGridBdyVars::T, 0, 0, 0, MetGridBdyVars::QV, 0};
-#elif defined(ERF_USE_WARM_NO_PRECIP)
-    // Cons includes [Rho RhoTheta RhoKE RhoQKE RhoScalar RhoQv RhoQc NumVars]
-    Vector<int> cons_read = {1, 1, 0, 0, 0, 1, 0};
-    Vector<int> cons_map  = {MetGridBdyVars::R, MetGridBdyVars::T, 0, 0, 0, MetGridBdyVars::QV, 0};
-# else
-    // Cons includes [Rho RhoTheta RhoKE RhoQKE RhoScalar NumVars]
-    Vector<int> cons_read = {1, 1, 0, 0, 0};
-    Vector<int> cons_map  = {MetGridBdyVars::R, MetGridBdyVars::T, 0, 0, 0};
-#endif
+    // Cons includes [Rho RhoTheta RhoKE RhoQKE RhoScalar RhoQ1 RhoQ2 RhoQ3]
+    Vector<int> cons_read = {1, 1, 0, 0, 0, 1, 0, 0, 0};
+    Vector<int> cons_map  = {MetGridBdyVars::R, MetGridBdyVars::T, 0, 0, 0, MetGridBdyVars::QV, 0, 0, 0};
 
     Vector<Vector<int>> is_read;
     is_read.push_back( cons_read );

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1126,10 +1126,13 @@ ERF::ReadParameters ()
     // NOTE: Must be checked after init_params
     if (solverChoice.moisture_type == MoistureType::SAM) {
         micro.SetModel<SAM>();
+        amrex::Print() << "SAM moisture model!\n";
     } else if (solverChoice.moisture_type == MoistureType::Kessler) {
         micro.SetModel<Kessler>();
+        amrex::Print() << "Kessler moisture model!\n";
     } else if (solverChoice.moisture_type == MoistureType::FastEddy) {
         micro.SetModel<FastEddy>();
+        amrex::Print() << "FastEddy moisture model!\n";
     } else if (solverChoice.moisture_type == MoistureType::None) {
         micro.SetModel<NullMoist>();
         amrex::Print() << "WARNING: Compiled with moisture but using NullMoist model!\n";

--- a/Source/IO/ReadFromMetgrid.cpp
+++ b/Source/IO/ReadFromMetgrid.cpp
@@ -28,12 +28,22 @@ read_from_metgrid (int lev, const Box& domain, const std::string& fname,
         { // Global Attributes (int)
             std::vector<int> attr;
             ncf.get_attr("FLAG_PSFC", attr);     flag_psfc  = attr[0];
+
+            /* UNCOMMENT FOR FLOWMAS
+            flag_msfu  = 0; //ncf.get_attr("FLAG_MAPFAC_U", attr); flag_msfu  = attr[0];
+            flag_msfv  = 0; //ncf.get_attr("FLAG_MAPFAC_V", attr); flag_msfv  = attr[0];
+            flag_msfm = 0; //ncf.get_attr("FLAG_MAPFAC_M", attr); flag_msfm  = attr[0];
+            flag_hgt = 1; //ncf.get_attr("FLAG_HGT_M", attr);    flag_hgt   = attr[0];
+            flag_sst = 0; //ncf.get_attr("FLAG_SST", attr);      flag_sst   = attr[0];
+            flag_lmask = 0; //ncf.get_attr("FLAG_LANDMASK", attr); flag_lmask = attr[0];
+            */
             ncf.get_attr("FLAG_MAPFAC_U", attr); flag_msfu  = attr[0];
             ncf.get_attr("FLAG_MAPFAC_V", attr); flag_msfv  = attr[0];
             ncf.get_attr("FLAG_MAPFAC_M", attr); flag_msfm  = attr[0];
             ncf.get_attr("FLAG_HGT_M", attr);    flag_hgt   = attr[0];
             ncf.get_attr("FLAG_SST", attr);      flag_sst   = attr[0];
             ncf.get_attr("FLAG_LANDMASK", attr); flag_lmask = attr[0];
+
             ncf.get_attr("WEST-EAST_GRID_DIMENSION", attr);   NC_nx = attr[0];
             ncf.get_attr("SOUTH-NORTH_GRID_DIMENSION", attr); NC_ny = attr[0];
         }

--- a/Source/Initialization/ERF_init_from_metgrid.cpp
+++ b/Source/Initialization/ERF_init_from_metgrid.cpp
@@ -15,7 +15,7 @@ using namespace amrex;
 void
 ERF::init_from_metgrid (int lev)
 {
-    bool use_moisture = (solverChoice.moisture_type == MoistureType::None);
+    bool use_moisture = (solverChoice.moisture_type != MoistureType::None);
     if (use_moisture) {
         amrex::Print() << "Init with met_em with valid moisture model." << std::endl;
     } else {
@@ -230,7 +230,7 @@ ERF::init_from_metgrid (int lev)
     int MetGridBdyEnd = MetGridBdyVars::NumTypes-1;
     if (use_moisture) MetGridBdyEnd = MetGridBdyVars::NumTypes;
 
-    //amrex::Vector<amrex::Vector<amrex::MultiFab> > fabs_for_bcs;
+    // Zero out fabs_for_bcs on the global domain
     amrex::Vector<amrex::Vector<FArrayBox>> fabs_for_bcs;
     fabs_for_bcs.resize(ntimes);
     for (int it(0); it < ntimes; it++) {
@@ -907,7 +907,7 @@ init_base_state_from_metgrid (const bool use_moisture,
         auto const orig_psfc = NC_psfc_fab[it].const_array();
         auto const     new_z = z_phys_nd_fab.const_array();
         auto       Theta_arr = fabs_for_bcs[it][MetGridBdyVars::T].array();
-        auto           Q_arr = fabs_for_bcs[it][MetGridBdyVars::QV].array();
+        auto           Q_arr = (use_moisture ) ? fabs_for_bcs[it][MetGridBdyVars::QV].array() : Array4<Real>{};
         auto r_hse_arr = fabs_for_bcs[it][MetGridBdyVars::R].array();
         auto p_hse_arr = p_hse_bcs_fab.array();
 


### PR DESCRIPTION
**inputs_fitch_flowmas** file is a first start towards initializing from **met_em*.nc** files for FLOWMAS. 

Minor fixes to the MetEm bndry conditions (due to moisture not being compile option now). Also a logical error is fixed that I added when testing for use_moisture. This PR started up and output the IC with the MetEm files provided by Melissa Dumas.