### PR TITLE
Scalar AdvDiffOutflow RegTest

### DIFF
--- a/Exec/RegTests/ScalarAdvDiff/inputs_advdiffinflowoutflow
+++ b/Exec/RegTests/ScalarAdvDiff/inputs_advdiffinflowoutflow
@@ -23,7 +23,7 @@ xlo.theta = 1.
 xlo.scalar = 0.
 
 # TIME STEP CONTROL
-erf.fixed_dt           = 2.e-4
+erf.fixed_dt           = 1.e-4
 erf.fixed_mri_dt_ratio = 4
 
 # DIAGNOSTICS & VERBOSITY


### PR DESCRIPTION
Preserve stability with cfl=0.5. The GPU error is a precision error when resolving the fluctuations from a numerical instability. Reducing the CFL and running the same amount of time allows for smooth exit of the passive scalar. 

The benchmark will be remade and the number of max steps increased to 100.