### PR TITLE
Nudging Index Fix

### DIFF
--- a/Source/Utils/InteriorGhostCells.cpp
+++ b/Source/Utils/InteriorGhostCells.cpp
@@ -264,7 +264,7 @@ wrfbdy_compute_interior_ghost_rhs (const std::string& init_type,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             int ii = std::max(i , dom_lo.x);
-                ii = std::min(ii, dom_lo.x+width-1);
+                ii = std::min(ii, dom_lo.x+width);
             int jj = std::max(j , dom_lo.y);
                 jj = std::min(jj, dom_hi.y);
             arr_xlo(i,j,k) = oma   * bdatxlo_n  (ii,jj,k,0)
@@ -272,7 +272,7 @@ wrfbdy_compute_interior_ghost_rhs (const std::string& init_type,
         },
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            int ii = std::max(i , dom_hi.x-width+1);
+            int ii = std::max(i , dom_hi.x-width);
                 ii = std::min(ii, dom_hi.x);
             int jj = std::max(j , dom_lo.y);
                 jj = std::min(jj, dom_hi.y);
@@ -286,7 +286,7 @@ wrfbdy_compute_interior_ghost_rhs (const std::string& init_type,
             int ii = std::max(i , dom_lo.x);
                 ii = std::min(ii, dom_hi.x);
             int jj = std::max(j , dom_lo.y);
-                jj = std::min(jj, dom_lo.y+width-1);
+                jj = std::min(jj, dom_lo.y+width);
             arr_ylo(i,j,k) = oma   * bdatylo_n  (ii,jj,k,0)
                            + alpha * bdatylo_np1(ii,jj,k,0);
         },
@@ -294,7 +294,7 @@ wrfbdy_compute_interior_ghost_rhs (const std::string& init_type,
         {
             int ii = std::max(i , dom_lo.x);
                 ii = std::min(ii, dom_hi.x);
-            int jj = std::max(j , dom_hi.y-width+1);
+            int jj = std::max(j , dom_hi.y-width);
                 jj = std::min(jj, dom_hi.y);
             arr_yhi(i,j,k) = oma   * bdatyhi_n  (ii,jj,k,0)
                            + alpha * bdatyhi_np1(ii,jj,k,0);

--- a/Source/Utils/Utils.H
+++ b/Source/Utils/Utils.H
@@ -214,6 +214,28 @@ wrfbdy_compute_laplacian_relaxation (const amrex::Real& delta_t,
             amrex::Real delta_ym = arr_xlo(i  ,j-1,k,n) - d_jm1;
             amrex::Real Laplacian = delta_xp + delta_xm + delta_yp + delta_ym - 4.0*delta;
             rhs_arr(i,j,k,n) += (F1*delta - F2*Laplacian) * Factor;
+
+            /*
+            if ((std::abs((arr_xlo(i  ,j  ,k,n)-data_arr(i  ,j  ,k  ,n+icomp))/data_arr(i  ,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xlo(i+1,j  ,k,n)-data_arr(i+1,j  ,k  ,n+icomp))/data_arr(i+1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xlo(i-1,j  ,k,n)-data_arr(i-1,j  ,k  ,n+icomp))/data_arr(i-1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xlo(i  ,j+1,k,n)-data_arr(i  ,j+1,k  ,n+icomp))/data_arr(i  ,j+1,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xlo(i  ,j-1,k,n)-data_arr(i  ,j-1,k  ,n+icomp))/data_arr(i  ,j-1,k  ,n+icomp)) > 0.5) ) {
+                amrex::Print() << "XLO error:\n";
+                amrex::Print() << "RELAX x: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j,k) << ' '
+                               << data_arr(i  ,j  ,k  ,n+icomp) << ' ' << arr_xlo(i  ,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i+1,j,k) << ' '
+                               << data_arr(i+1,j  ,k  ,n+icomp) << ' ' << arr_xlo(i+1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xm: " << icomp << ' ' << n << ' ' << amrex::IntVect(i-1,j,k) << ' '
+                               << data_arr(i-1,j  ,k  ,n+icomp) << ' ' << arr_xlo(i-1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX yp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j+1,k) << ' '
+                               << data_arr(i  ,j+1,k  ,n+icomp) << ' ' << arr_xlo(i  ,j+1,k,n) << "\n";
+                amrex::Print() << "RELAX ym: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j-1,k) << ' '
+                               << data_arr(i  ,j-1,k  ,n+icomp) << ' ' << arr_xlo(i  ,j-1,k,n) << "\n";
+                amrex::Print() << "\n";
+                //exit(0);
+            }
+            */
         }
     },
     bx_xhi, num_var, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -239,6 +261,28 @@ wrfbdy_compute_laplacian_relaxation (const amrex::Real& delta_t,
             amrex::Real delta_ym = arr_xhi(i  ,j-1,k,n) - d_jm1;
             amrex::Real Laplacian = delta_xp + delta_xm + delta_yp + delta_ym - 4.0*delta;
             rhs_arr(i,j,k,n) += (F1*delta - F2*Laplacian) * Factor;
+
+            /*
+            if ((std::abs((arr_xhi(i  ,j  ,k,n)-data_arr(i  ,j  ,k  ,n+icomp))/data_arr(i  ,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xhi(i+1,j  ,k,n)-data_arr(i+1,j  ,k  ,n+icomp))/data_arr(i+1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xhi(i-1,j  ,k,n)-data_arr(i-1,j  ,k  ,n+icomp))/data_arr(i-1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xhi(i  ,j+1,k,n)-data_arr(i  ,j+1,k  ,n+icomp))/data_arr(i  ,j+1,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_xhi(i  ,j-1,k,n)-data_arr(i  ,j-1,k  ,n+icomp))/data_arr(i  ,j-1,k  ,n+icomp)) > 0.5) ) {
+                amrex::Print() << "XHI error:\n";
+                amrex::Print() << "RELAX x: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j,k) << ' '
+                               << data_arr(i  ,j  ,k  ,n+icomp) << ' ' << arr_xhi(i  ,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i+1,j,k) << ' '
+                               << data_arr(i+1,j  ,k  ,n+icomp) << ' ' << arr_xhi(i+1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xm: " << icomp << ' ' << n << ' ' << amrex::IntVect(i-1,j,k) << ' '
+                               << data_arr(i-1,j  ,k  ,n+icomp) << ' ' << arr_xhi(i-1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX yp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j+1,k) << ' '
+                               << data_arr(i  ,j+1,k  ,n+icomp) << ' ' << arr_xhi(i  ,j+1,k,n) << "\n";
+                amrex::Print() << "RELAX ym: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j-1,k) << ' '
+                               << data_arr(i  ,j-1,k  ,n+icomp) << ' ' << arr_xhi(i  ,j-1,k,n) << "\n";
+                amrex::Print() << "\n";
+                //exit(0);
+            }
+            */
         }
     });
 
@@ -262,6 +306,28 @@ wrfbdy_compute_laplacian_relaxation (const amrex::Real& delta_t,
             amrex::Real delta_ym = arr_ylo(i  ,j-1,k,n) - d_jm1;
             amrex::Real Laplacian = delta_xp + delta_xm + delta_yp + delta_ym - 4.0*delta;
             rhs_arr(i,j,k,n) += (F1*delta - F2*Laplacian) * Factor;
+
+            /*
+            if ((std::abs((arr_ylo(i  ,j  ,k,n)-data_arr(i  ,j  ,k  ,n+icomp))/data_arr(i  ,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_ylo(i+1,j  ,k,n)-data_arr(i+1,j  ,k  ,n+icomp))/data_arr(i+1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_ylo(i-1,j  ,k,n)-data_arr(i-1,j  ,k  ,n+icomp))/data_arr(i-1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_ylo(i  ,j+1,k,n)-data_arr(i  ,j+1,k  ,n+icomp))/data_arr(i  ,j+1,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_ylo(i  ,j-1,k,n)-data_arr(i  ,j-1,k  ,n+icomp))/data_arr(i  ,j-1,k  ,n+icomp)) > 0.5) ) {
+                amrex::Print() << "YLO error:\n";
+                amrex::Print() << "RELAX x: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j,k) << ' '
+                               << data_arr(i  ,j  ,k  ,n+icomp) << ' ' << arr_ylo(i  ,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i+1,j,k) << ' '
+                               << data_arr(i+1,j  ,k  ,n+icomp) << ' ' << arr_ylo(i+1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xm: " << icomp << ' ' << n << ' ' << amrex::IntVect(i-1,j,k) << ' '
+                               << data_arr(i-1,j  ,k  ,n+icomp) << ' ' << arr_ylo(i-1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX yp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j+1,k) << ' '
+                               << data_arr(i  ,j+1,k  ,n+icomp) << ' ' << arr_ylo(i  ,j+1,k,n) << "\n";
+                amrex::Print() << "RELAX ym: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j-1,k) << ' '
+                               << data_arr(i  ,j-1,k  ,n+icomp) << ' ' << arr_ylo(i  ,j-1,k,n) << "\n";
+                amrex::Print() << "\n";
+                //exit(0);
+            }
+            */
         }
     },
     bx_yhi, num_var, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -284,6 +350,28 @@ wrfbdy_compute_laplacian_relaxation (const amrex::Real& delta_t,
             amrex::Real delta_ym = arr_yhi(i  ,j-1,k,n) - d_jm1;
             amrex::Real Laplacian = delta_xp + delta_xm + delta_yp + delta_ym - 4.0*delta;
             rhs_arr(i,j,k,n) += (F1*delta - F2*Laplacian) * Factor;
+
+            /*
+            if ((std::abs((arr_yhi(i  ,j  ,k,n)-data_arr(i  ,j  ,k  ,n+icomp))/data_arr(i  ,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_yhi(i+1,j  ,k,n)-data_arr(i+1,j  ,k  ,n+icomp))/data_arr(i+1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_yhi(i-1,j  ,k,n)-data_arr(i-1,j  ,k  ,n+icomp))/data_arr(i-1,j  ,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_yhi(i  ,j+1,k,n)-data_arr(i  ,j+1,k  ,n+icomp))/data_arr(i  ,j+1,k  ,n+icomp)) > 0.5) ||
+                (std::abs((arr_yhi(i  ,j-1,k,n)-data_arr(i  ,j-1,k  ,n+icomp))/data_arr(i  ,j-1,k  ,n+icomp)) > 0.5) ) {
+                amrex::Print() << "YHI error:\n";
+                amrex::Print() << "RELAX x: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j,k) << ' '
+                               << data_arr(i  ,j  ,k  ,n+icomp) << ' ' << arr_yhi(i  ,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i+1,j,k) << ' '
+                               << data_arr(i+1,j  ,k  ,n+icomp) << ' ' << arr_yhi(i+1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX xm: " << icomp << ' ' << n << ' ' << amrex::IntVect(i-1,j,k) << ' '
+                               << data_arr(i-1,j  ,k  ,n+icomp) << ' ' << arr_yhi(i-1,j  ,k,n) << "\n";
+                amrex::Print() << "RELAX yp: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j+1,k) << ' '
+                               << data_arr(i  ,j+1,k  ,n+icomp) << ' ' << arr_yhi(i  ,j+1,k,n) << "\n";
+                amrex::Print() << "RELAX ym: " << icomp << ' ' << n << ' ' << amrex::IntVect(i,j-1,k) << ' '
+                               << data_arr(i  ,j-1,k  ,n+icomp) << ' ' << arr_yhi(i  ,j-1,k,n) << "\n";
+                amrex::Print() << "\n";
+                //exit(0);
+            }
+            */
         }
     });
 }


### PR DESCRIPTION
The ii/jj variables ensure that we do not go out of bounds when accessing the bdy data for nudging. The variable **width** that is passed into **wrfbdy_compute_interior_ghost_rh** is 1 less than the total width of the bdy data; this is because the last element of the bdy data is ghost cell for the Laplacian operator. However, when interpolating data into the **FArrayBoxes** we will need to access that ghost cell value; it is needed for the velocity to momentum conversion. Previously, the +/- 1 prevented ii/jj from getting to the last element of the bdy data. Since the FLOWMAS project is heavily using this functionality, I have left the debug statements in **Utils.H**. Once we have confidence everything is good, this should be deleted.