### PR TITLE
Add CMake particle option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ERF_ENABLE_ALL_WARNINGS "Enable all compiler warnings" OFF)
 option(ERF_ENABLE_TESTS "Enable regression and unit tests" OFF)
 option(ERF_ENABLE_NETCDF "Enable NetCDF IO" OFF)
 option(ERF_ENABLE_HDF5 "Enable HDF5 IO" ${ERF_ENABLE_NETCDF})
+option(ERF_ENABLE_PARTICLES "Enable Lagrangian particles" OFF)
 option(ERF_ENABLE_FCOMPARE "Enable building fcompare when not testing" OFF)
 set(ERF_PRECISION "DOUBLE" CACHE STRING "Floating point precision SINGLE or DOUBLE")
 

--- a/Docs/sphinx_doc/building.rst
+++ b/Docs/sphinx_doc/building.rst
@@ -85,6 +85,8 @@ or if using tcsh,
    +--------------------+------------------------------+------------------+-------------+
    | USE_HDF5           | Whether to enable HDF5       | TRUE / FALSE     | FALSE       |
    +--------------------+------------------------------+------------------+-------------+
+   | USE_PARTICLES      | Whether to enable particles  | TRUE / FALSE     | FALSE       |
+   +--------------------+------------------------------+------------------+-------------+
    | USE_WARM_NO_PRECIP | Whether to use warm moisture | TRUE / FALSE     | FALSE       |
    +--------------------+------------------------------+------------------+-------------+
    | USE_MULTIBLOCK     | Whether to enable multiblock | TRUE / FALSE     | FALSE       |
@@ -173,6 +175,8 @@ Analogous to GNU Make, the list of cmake directives is as follows:
    | ERF_ENABLE_NETCDF         | Whether to enable NETCDF     | TRUE / FALSE     | FALSE       |
    +---------------------------+------------------------------+------------------+-------------+
    | ERF_ENABLE_HDF5           | Whether to enable HDF5       | TRUE / FALSE     | FALSE       |
+   +---------------------------+------------------------------+------------------+-------------+
+   | ERF_ENABLE_PARTICLES      | Whether to enable particles  | TRUE / FALSE     | FALSE       |
    +---------------------------+------------------------------+------------------+-------------+
    | ERF_ENABLE_WARM_NO_PRECIP | Whether to use warm moisture | TRUE / FALSE     | FALSE       |
    +---------------------------+------------------------------+------------------+-------------+

--- a/Exec/DevTests/ParticlesOverWoA/CMakeLists.txt
+++ b/Exec/DevTests/ParticlesOverWoA/CMakeLists.txt
@@ -1,17 +1,17 @@
-set(erf_exe_name erf_particles_over_woa)
+if(ERF_ENABLE_PARTICLES)
+  set(erf_exe_name erf_particles_over_woa)
 
-add_executable(${erf_exe_name} "")
-target_sources(${erf_exe_name}
-   PRIVATE
-     prob.cpp
-)
+  add_executable(${erf_exe_name} "")
+  target_sources(${erf_exe_name}
+     PRIVATE
+       prob.cpp
+  )
 
-target_include_directories(${erf_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories(${erf_exe_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
-set(ERF_ENABLE_PARTICLES ON)
+  include(${CMAKE_SOURCE_DIR}/CMake/BuildERFExe.cmake)
+  build_erf_exe(${erf_exe_name})
 
-include(${CMAKE_SOURCE_DIR}/CMake/BuildERFExe.cmake)
-build_erf_exe(${erf_exe_name})
-
-#find_package(AMReX)
-#target_link_libraries( ${_target}  AMReX::amrex)
+  #find_package(AMReX)
+  #target_link_libraries( ${_target}  AMReX::amrex)
+endif()


### PR DESCRIPTION
* Add `ERF_ENABLE_PARTICLES` option to top-level `CMakeLists.txt` so it will show up in `ccmake` and the CMake GUI
* Only build ParticlesOverWoA test if particles are enabled
* Add particle options to table of build options