### PR TITLE
Terrain with Rayleigh damping

### DIFF
--- a/Exec/DevTests/MovingTerrain/prob.H
+++ b/Exec/DevTests/MovingTerrain/prob.H
@@ -49,7 +49,8 @@ public:
         amrex::Vector<amrex::Real>& vbar,
         amrex::Vector<amrex::Real>& wbar,
         amrex::Vector<amrex::Real>& thetabar,
-        amrex::Geometry      const& geom) override;
+        amrex::Geometry      const& geom,
+        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
 protected:
     std::string name() override { return "MovingTerrain"; }

--- a/Exec/DevTests/MovingTerrain/prob.cpp
+++ b/Exec/DevTests/MovingTerrain/prob.cpp
@@ -137,7 +137,8 @@ Problem::erf_init_rayleigh(
     amrex::Vector<Real>& vbar,
     amrex::Vector<Real>& wbar,
     amrex::Vector<Real>& thetabar,
-    amrex::Geometry      const& geom)
+    amrex::Geometry const& geom,
+    std::unique_ptr<MultiFab>& /*z_phys_cc*/)
 {
    // amrex::Error("Should never get here for MovingTerrain problem");
    const int khi = geom.Domain().bigEnd()[2];

--- a/Exec/Radiation/prob.H
+++ b/Exec/Radiation/prob.H
@@ -52,7 +52,8 @@ public:
         amrex::Vector<amrex::Real>& vbar,
         amrex::Vector<amrex::Real>& wbar,
         amrex::Vector<amrex::Real>& thetabar,
-        amrex::Geometry      const& geom) override;
+        amrex::Geometry      const& geom,
+        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
 protected:
     std::string name() override { return "Supercell"; }

--- a/Exec/Radiation/prob.cpp
+++ b/Exec/Radiation/prob.cpp
@@ -219,7 +219,8 @@ Problem::erf_init_rayleigh(
     amrex::Vector<amrex::Real>& vbar,
     amrex::Vector<amrex::Real>& wbar,
     amrex::Vector<amrex::Real>& thetabar,
-    amrex::Geometry      const& geom)
+    amrex::Geometry      const& geom,
+    std::unique_ptr<amrex::MultiFab>& /*z_phys_cc*/)
 {
   const int khi = geom.Domain().bigEnd()[2];
 

--- a/Exec/RegTests/ScalarAdvDiff/prob.H
+++ b/Exec/RegTests/ScalarAdvDiff/prob.H
@@ -58,7 +58,8 @@ public:
         amrex::Vector<amrex::Real>& vbar,
         amrex::Vector<amrex::Real>& wbar,
         amrex::Vector<amrex::Real>& thetabar,
-        amrex::Geometry      const& geom) override;
+        amrex::Geometry      const& geom,
+        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
 protected:
     std::string name() override { return "Scalar Advection/Diffusion"; }

--- a/Exec/RegTests/ScalarAdvDiff/prob.cpp
+++ b/Exec/RegTests/ScalarAdvDiff/prob.cpp
@@ -41,7 +41,8 @@ Problem::erf_init_rayleigh(
     amrex::Vector<Real>& vbar,
     amrex::Vector<Real>& wbar,
     amrex::Vector<Real>& thetabar,
-    amrex::Geometry      const& geom)
+    amrex::Geometry const& geom,
+    std::unique_ptr<MultiFab>& z_phys_cc)
 {
   const int khi = geom.Domain().bigEnd()[2];
 

--- a/Exec/RegTests/ScalarAdvDiff/prob.cpp.convergence
+++ b/Exec/RegTests/ScalarAdvDiff/prob.cpp.convergence
@@ -16,7 +16,8 @@ erf_init_rayleigh(amrex::Vector<Real>& tau,
                   amrex::Vector<Real>& vbar,
                   amrex::Vector<Real>& wbar,
                   amrex::Vector<Real>& thetabar,
-                  amrex::Geometry      const& geom)
+                  amrex::Geometry const& geom,
+                  std::unique_ptr<MultiFab>& z_phys_cc)
 {
   const int khi = geom.Domain().bigEnd()[2];
 

--- a/Exec/RegTests/WitchOfAgnesi/inputs
+++ b/Exec/RegTests/WitchOfAgnesi/inputs
@@ -41,13 +41,12 @@ erf.check_int       = -57600  # number of timesteps between checkpoints
 
 # PLOTFILES
 erf.plot_file_1     = plt     # prefix of plotfile name
-erf.plot_int_1      = 1       # number of timesteps between plotfiles
+erf.plot_int_1      = 10      # number of timesteps between plotfiles
 erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta pres_hse dens_hse pert_pres pert_dens z_phys detJ dpdx dpdy pres_hse_x pres_hse_y
 
 # SOLVER CHOICE
 erf.use_gravity = true
 erf.use_coriolis = false
-erf.use_rayleigh_damping = false
 erf.les_type = "None"
 
 # TERRRAIN GRID TYPE
@@ -62,5 +61,9 @@ erf.alpha_T = 0.0 # [m^2/s]
 
 # PROBLEM PARAMETERS (optional)
 prob.T_0   = 300.0
-prob.U_0   = 0.0
+prob.U_0   = 1.0
 prob.rho_0 = 1.16
+
+erf.use_rayleigh_damping = true
+prob.dampcoef = 2000. # ==> time scale = 0.0005 s (for testing)
+prob.zdamp = 1.0

--- a/Exec/RegTests/WitchOfAgnesi/prob.H
+++ b/Exec/RegTests/WitchOfAgnesi/prob.H
@@ -9,6 +9,10 @@
 
 struct ProbParm : ProbParmDefaults {
   amrex::Real U_0 = 0.0;
+  amrex::Real V_0 = 0.0;
+  amrex::Real W_0 = 0.0;
+  amrex::Real dampcoef = 0.003;
+  amrex::Real zdamp = 1.0;
 }; // namespace ProbParm
 
 class Problem : public ProblemBase
@@ -17,6 +21,7 @@ public:
     Problem();
 
 #include "Prob/init_density_hse_dry_terrain.H"
+#include "Prob/init_rayleigh_damping.H"
 
     void init_custom_pert (
         const amrex::Box&  bx,

--- a/Exec/RegTests/WitchOfAgnesi/prob.cpp
+++ b/Exec/RegTests/WitchOfAgnesi/prob.cpp
@@ -16,6 +16,10 @@ Problem::Problem()
   // Parse params
   amrex::ParmParse pp("prob");
   pp.query("U_0", parms.U_0);
+  pp.query("V_0", parms.V_0);
+  pp.query("W_0", parms.W_0);
+  pp.query("dampcoef", parms.dampcoef);
+  pp.query("zdamp", parms.zdamp);
 
   init_base_parms(parms.rho_0, parms.T_0);
 }

--- a/Exec/SquallLine_2D/prob.H
+++ b/Exec/SquallLine_2D/prob.H
@@ -67,7 +67,8 @@ public:
         amrex::Vector<amrex::Real>& vbar,
         amrex::Vector<amrex::Real>& wbar,
         amrex::Vector<amrex::Real>& thetabar,
-        amrex::Geometry      const& geom) override;
+        amrex::Geometry      const& geom,
+        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
     amrex::Real compute_theta (amrex::Real z);
 

--- a/Exec/SquallLine_2D/prob.cpp
+++ b/Exec/SquallLine_2D/prob.cpp
@@ -407,7 +407,8 @@ Problem::erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
                             amrex::Vector<amrex::Real>& vbar,
                             amrex::Vector<amrex::Real>& wbar,
                             amrex::Vector<amrex::Real>& thetabar,
-                            amrex::Geometry      const& geom)
+                            amrex::Geometry      const& geom,
+                            std::unique_ptr<amrex::MultiFab>& /*z_phys_cc*/)
 {
   const int khi = geom.Domain().bigEnd()[2];
 

--- a/Exec/SuperCell/prob.H
+++ b/Exec/SuperCell/prob.H
@@ -52,7 +52,8 @@ public:
         amrex::Vector<amrex::Real>& vbar,
         amrex::Vector<amrex::Real>& wbar,
         amrex::Vector<amrex::Real>& thetabar,
-        amrex::Geometry      const& geom) override;
+        amrex::Geometry      const& geom,
+        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
 
 protected:
     std::string name() override { return "Supercell"; }

--- a/Exec/SuperCell/prob.cpp
+++ b/Exec/SuperCell/prob.cpp
@@ -219,7 +219,8 @@ Problem::erf_init_rayleigh(
     amrex::Vector<amrex::Real>& vbar,
     amrex::Vector<amrex::Real>& wbar,
     amrex::Vector<amrex::Real>& thetabar,
-    amrex::Geometry      const& geom)
+    amrex::Geometry      const& geom,
+    std::unique_ptr<MultiFab>& /*z_phys_cc*/)
 {
   const int khi = geom.Domain().bigEnd()[2];
 

--- a/Source/Initialization/ERF_init1d.cpp
+++ b/Source/Initialization/ERF_init1d.cpp
@@ -44,7 +44,8 @@ ERF::initRayleigh ()
         d_rayleigh_thetabar[lev].resize(zlen_rayleigh, 0.0_rt);
 
         prob->erf_init_rayleigh(h_rayleigh_tau[lev], h_rayleigh_ubar[lev], h_rayleigh_vbar[lev],
-                          h_rayleigh_wbar[lev], h_rayleigh_thetabar[lev], geom[lev]);
+                                h_rayleigh_wbar[lev], h_rayleigh_thetabar[lev], geom[lev],
+                                z_phys_cc[lev]);
 
         // Copy from host version to device version
         amrex::Gpu::copy(amrex::Gpu::hostToDevice, h_rayleigh_tau[lev].begin(), h_rayleigh_tau[lev].end(),

--- a/Source/Prob/init_rayleigh_damping.H
+++ b/Source/Prob/init_rayleigh_damping.H
@@ -8,7 +8,8 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
                    amrex::Vector<amrex::Real>& vbar,
                    amrex::Vector<amrex::Real>& wbar,
                    amrex::Vector<amrex::Real>& thetabar,
-                   amrex::Geometry      const& geom) override
+                   amrex::Geometry      const& geom,
+                   std::unique_ptr<amrex::MultiFab>& z_phys_cc) override
 {
     const auto ztop = geom.ProbHi()[2];
     amrex::Print() << "Rayleigh damping (coef="<<parms.dampcoef<<" s^-1)"

--- a/Source/Prob/init_rayleigh_damping.H
+++ b/Source/Prob/init_rayleigh_damping.H
@@ -11,19 +11,41 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
                    amrex::Geometry      const& geom,
                    std::unique_ptr<amrex::MultiFab>& z_phys_cc) override
 {
-    const auto ztop = geom.ProbHi()[2];
+    const int khi = geom.Domain().bigEnd()[2];
+    amrex::Vector<amrex::Real> zcc(khi);
+
+    if (z_phys_cc) {
+        // use_terrain=1
+        // calculate the damping strength based on the max height at each k
+        amrex::MultiArray4<const amrex::Real> const& ma_z_phys  = z_phys_cc->const_arrays();
+        for (int k = 0; k <= khi; k++) {
+            zcc[k] = amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMax>{},
+                                      amrex::TypeList<amrex::Real>{},
+                                      *z_phys_cc,
+                                      amrex::IntVect(0),
+            [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int) noexcept
+                -> amrex::GpuTuple<amrex::Real>
+            {
+                return { ma_z_phys[box_no](i,j,k) };
+            });
+        }
+    } else {
+        const amrex::Real* prob_lo = geom.ProbLo();
+        const auto dx              = geom.CellSize();
+        for (int k = 0; k <= khi; k++)
+        {
+            zcc[k] = prob_lo[2] + (k+0.5) * dx[2];
+        }
+    }
+
+    const auto ztop = zcc[khi-1];
     amrex::Print() << "Rayleigh damping (coef="<<parms.dampcoef<<" s^-1)"
         << " between " << ztop-parms.zdamp << " and " << ztop << " m"
         << std::endl;
 
-    const amrex::Real* prob_lo = geom.ProbLo();
-    const auto dx              = geom.CellSize();
-    const int khi              = geom.Domain().bigEnd()[2];
-
     for (int k = 0; k <= khi; k++)
     {
-        const amrex::Real z = prob_lo[2] + (k + 0.5) * dx[2];
-        const amrex::Real zfrac = 1 - (ztop - z) / parms.zdamp;
+        const amrex::Real zfrac = 1 - (ztop - zcc[k]) / parms.zdamp;
         if (zfrac >= 0)
         {
             const amrex::Real sinefac = std::sin(PIoTwo*zfrac);
@@ -32,6 +54,7 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
             vbar[k]     = parms.V_0;
             wbar[k]     = parms.W_0;
             thetabar[k] = parms.T_0;
+            amrex::Print() << "  " << zcc[k] << " " << sinefac*sinefac << std::endl;
         }
         else
         {

--- a/Source/Prob/init_rayleigh_damping.H
+++ b/Source/Prob/init_rayleigh_damping.H
@@ -12,12 +12,12 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
                    std::unique_ptr<amrex::MultiFab>& z_phys_cc) override
 {
     const int khi = geom.Domain().bigEnd()[2];
-    amrex::Vector<amrex::Real> zcc(khi);
+    amrex::Vector<amrex::Real> zcc(khi+1);
 
     if (z_phys_cc) {
         // use_terrain=1
         // calculate the damping strength based on the max height at each k
-        amrex::MultiArray4<const amrex::Real> const& ma_z_phys  = z_phys_cc->const_arrays();
+        amrex::MultiArray4<const amrex::Real> const& ma_z_phys = z_phys_cc->const_arrays();
         for (int k = 0; k <= khi; k++) {
             zcc[k] = amrex::ParReduce(amrex::TypeList<amrex::ReduceOpMax>{},
                                       amrex::TypeList<amrex::Real>{},
@@ -29,6 +29,8 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
                 return { ma_z_phys[box_no](i,j,k) };
             });
         }
+        amrex::ParallelDescriptor::ReduceRealMax(zcc.data(), zcc.size());
+
     } else {
         const amrex::Real* prob_lo = geom.ProbLo();
         const auto dx              = geom.CellSize();
@@ -38,7 +40,7 @@ erf_init_rayleigh (amrex::Vector<amrex::Real>& tau,
         }
     }
 
-    const auto ztop = zcc[khi-1];
+    const auto ztop = zcc[khi];
     amrex::Print() << "Rayleigh damping (coef="<<parms.dampcoef<<" s^-1)"
         << " between " << ztop-parms.zdamp << " and " << ztop << " m"
         << std::endl;

--- a/Source/prob_common.H
+++ b/Source/prob_common.H
@@ -150,12 +150,13 @@ public:
     /**
      * Function to define the quantities needed to impose Rayleigh damping
      *
-     * @param[in] tau  strength of Rayleigh damping
-     * @param[in] ubar reference value for x-velocity used to define Rayleigh damping
-     * @param[in] vbar reference value for y-velocity used to define Rayleigh damping
-     * @param[in] wbar reference value for z-velocity used to define Rayleigh damping
-     * @param[in] thetabar reference value for potential temperature used to define Rayleigh damping
+     * @param[out] tau  strength of Rayleigh damping
+     * @param[out] ubar reference value for x-velocity used to define Rayleigh damping
+     * @param[out] vbar reference value for y-velocity used to define Rayleigh damping
+     * @param[out] wbar reference value for z-velocity used to define Rayleigh damping
+     * @param[out] thetabar reference value for potential temperature used to define Rayleigh damping
      * @param[in] geom container for geometric information
+     * @param[in] z_phys_cc height coordinate at cell centers
     */
     virtual void
     erf_init_rayleigh (amrex::Vector<amrex::Real>& /*tau*/,
@@ -163,7 +164,8 @@ public:
                        amrex::Vector<amrex::Real>& /*vbar*/,
                        amrex::Vector<amrex::Real>& /*wbar*/,
                        amrex::Vector<amrex::Real>& /*thetabar*/,
-                       amrex::Geometry      const& /*geom*/)
+                       amrex::Geometry      const& /*geom*/,
+                       std::unique_ptr<amrex::MultiFab>& /*z_phys_cc*/)
     {
         amrex::Error("Should never call erf_init_rayleigh for "+name()+" problem");
     }


### PR DESCRIPTION
Add `z_phys_cc` to parameter list for `erf_init_rayleigh`; update default implementation to handle cases with and without terrain. Caveats:
1. Previously, the damping strength was determined by the distance from the top of the domain; now the damping strength is determined by the distance from the top-most cell height. This simplifies the implementation with terrain and also ensures the maximum damping value is attained within the computational domain.
2. Damping is still applied uniformly at each k-level, even with terrain. The implicitly assumes that where the damping is active, the grid is approximately uniformly spaced. Because the terrain heights at each k are not necessarily constant, the _maximum_ value is taken to represent that level.

The Witch of Agnesi hill example has been updated to allow damping. Example results (hill height=1, zhi=2) without damping:
![WoA_undamped](https://github.com/erf-model/ERF/assets/18267059/51048044-f2a3-4c01-bbe8-9b1d44691137)
and with damping (zdamp=1, noting that the resulting damping will increase gradually from z=1 to z=2; dampcoef is chosen to have a time constant equal to the simulation length):
![WoA_damped](https://github.com/erf-model/ERF/assets/18267059/57c601e9-0f8a-45d3-b4e7-c8d47b6c3bb0)
