### PR TITLE
Bug fixes

### DIFF
--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -62,6 +62,8 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
     {
         Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
+        bx_xlo.setSmall(2,dom_lo.z); bx_xlo.setBig(2,dom_hi.z);
+        bx_xhi.setSmall(2,dom_lo.z); bx_xhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 if (bc_ptr[icomp+n].lo(0) == ERFBCType::ext_dir) {
@@ -80,6 +82,8 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
     {
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
+        bx_ylo.setSmall(2,dom_lo.z); bx_ylo.setBig(2,dom_hi.z);
+        bx_yhi.setSmall(2,dom_lo.z); bx_yhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 if (bc_ptr[icomp+n].lo(1) == ERFBCType::ext_dir) {
@@ -99,8 +103,10 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
     if (!is_periodic_in_x)
     {
         // Populate ghost cells on lo-x and hi-x domain boundaries
-        Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1); bx_xlo.setSmall(2,dom_lo.z); bx_xlo.setBig(2,dom_hi.z);
-        Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1); bx_xhi.setSmall(2,dom_lo.z); bx_xhi.setBig(2,dom_hi.z);
+        Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
+        Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
+        bx_xlo.setSmall(2,dom_lo.z); bx_xlo.setBig(2,dom_hi.z);
+        bx_xhi.setSmall(2,dom_lo.z); bx_xhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip = dom_lo.x - 1 - i;
@@ -128,8 +134,10 @@ void ERFPhysBCFunct::impose_lateral_cons_bcs (const Array4<Real>& dest_arr, cons
     if (!is_periodic_in_y)
     {
         // Populate ghost cells on lo-y and hi-y domain boundaries
-        Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1); bx_ylo.setSmall(2,dom_lo.z); bx_ylo.setBig(2,dom_hi.z);
-        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1); bx_yhi.setSmall(2,dom_lo.z); bx_yhi.setBig(2,dom_hi.z);
+        Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
+        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
+        bx_ylo.setSmall(2,dom_lo.z); bx_ylo.setBig(2,dom_hi.z);
+        bx_yhi.setSmall(2,dom_lo.z); bx_yhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int jflip = dom_lo.y - 1 - j;

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -69,16 +69,18 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int iflip = dom_lo.x - i;
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
                 if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][0];
                 } else if (bc_ptr[n].lo(0) == ERFBCType::foextrap) {
-                    dest_arr(i,j,k) =  dest_arr(dom_lo.x,j,k);
+                    dest_arr(i,j,k) =  dest_arr(dom_lo.x,jj,k);
                 } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_even) {
-                    dest_arr(i,j,k) =  dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) =  dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_odd) {
-                    dest_arr(i,j,k) = -dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) = -dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].lo(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (4.0*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/3.0;
+                    dest_arr(i,j,k) = (4.0*dest_arr(dom_lo.x+1,jj,k) - dest_arr(dom_lo.x+2,jj,k))/3.0;
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR
@@ -87,7 +89,7 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
               if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][0];
               } else if (bc_ptr[n].lo(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (4.0*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/3.0;
+                    dest_arr(i,j,k) = (4.0*dest_arr(dom_lo.x+1,jj,k) - dest_arr(dom_lo.x+2,jj,k))/3.0;
               }
             }
         );
@@ -95,25 +97,29 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int iflip =  2*(dom_hi.x + 1) - i;
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
                 if (bc_ptr[n].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][3];
                 } else if (bc_ptr[n].hi(0) == ERFBCType::foextrap) {
-                    dest_arr(i,j,k) =  dest_arr(dom_hi.x+1,j,k);
+                    dest_arr(i,j,k) =  dest_arr(dom_hi.x+1,jj,k);
                 } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_even) {
-                    dest_arr(i,j,k) =  dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) =  dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_odd) {
-                    dest_arr(i,j,k) = -dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) = -dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].hi(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (4.0*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/3.0;
+                    dest_arr(i,j,k) = (4.0*dest_arr(dom_hi.x,jj,k) - dest_arr(dom_hi.x-1,jj,k))/3.0;
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR
             bx_xhi_face, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
                 if (bc_ptr[n].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][3];
                 } else if (bc_ptr[n].hi(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (4.0*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/3.0;
+                    dest_arr(i,j,k) = (4.0*dest_arr(dom_hi.x,jj,k) - dest_arr(dom_hi.x-1,jj,k))/3.0;
                 }
             }
         );

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -59,8 +59,12 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
     {
         Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+2);
-        Box bx_xlo_face(bx); bx_xlo_face.setSmall(0,dom_lo.x  ); bx_xlo_face.setBig(0,dom_lo.x  );
-        Box bx_xhi_face(bx); bx_xhi_face.setSmall(0,dom_hi.x+1); bx_xhi_face.setBig(0,dom_hi.x+1);
+        Box bx_xlo_face(bx); bx_xlo_face.setSmall(0,dom_lo.x  );
+        Box bx_xhi_face(bx); bx_xhi_face.setSmall(0,dom_hi.x+1);
+        bx_xlo.setSmall(2,dom_lo.z); bx_xlo.setBig(2,dom_hi.z);
+        bx_xhi.setSmall(2,dom_lo.z); bx_xhi.setBig(2,dom_hi.z);
+        bx_xlo_face.setSmall(2,dom_lo.z); bx_xlo_face.setBig(2,dom_hi.z);
+        bx_xhi_face.setSmall(2,dom_lo.z); bx_xhi_face.setBig(2,dom_hi.z);
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
@@ -120,6 +124,8 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
         // Populate ghost cells on lo-y and hi-y domain boundaries
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
+        bx_ylo.setSmall(2,dom_lo.z); bx_ylo.setBig(2,dom_hi.z);
+        bx_yhi.setSmall(2,dom_lo.z); bx_yhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int jflip = dom_lo.y - 1 - j;

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -86,11 +86,13 @@ void ERFPhysBCFunct::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
             // We only set the values on the domain faces themselves if EXT_DIR
             bx_xlo_face, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
-              if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
+                if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][0];
-              } else if (bc_ptr[n].lo(0) == ERFBCType::neumann_int) {
+                } else if (bc_ptr[n].lo(0) == ERFBCType::neumann_int) {
                     dest_arr(i,j,k) = (4.0*dest_arr(dom_lo.x+1,jj,k) - dest_arr(dom_lo.x+2,jj,k))/3.0;
-              }
+                }
             }
         );
         ParallelFor(

--- a/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
@@ -62,26 +62,30 @@ void ERFPhysBCFunct::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip = dom_lo.x - 1- i;
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
                 if (bc_ptr[n].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][0];
                 } else if (bc_ptr[n].lo(0) == ERFBCType::foextrap) {
-                    dest_arr(i,j,k) =  dest_arr(dom_lo.x,j,k);
+                    dest_arr(i,j,k) =  dest_arr(dom_lo.x,jj,k);
                 } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_even) {
-                    dest_arr(i,j,k) =  dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) =  dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].lo(0) == ERFBCType::reflect_odd) {
-                    dest_arr(i,j,k) = -dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) = -dest_arr(iflip,jj,k);
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip =  2*dom_hi.x + 1 - i;
+                int jj = std::max(j , dom_lo.y);
+                    jj = std::min(jj, dom_hi.y);
                 if (bc_ptr[n].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[n][3];
                 } else if (bc_ptr[n].hi(0) == ERFBCType::foextrap) {
-                    dest_arr(i,j,k) =  dest_arr(dom_hi.x,j,k);
+                    dest_arr(i,j,k) =  dest_arr(dom_hi.x,jj,k);
                 } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_even) {
-                    dest_arr(i,j,k) =  dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) =  dest_arr(iflip,jj,k);
                 } else if (bc_ptr[n].hi(0) == ERFBCType::reflect_odd) {
-                    dest_arr(i,j,k) = -dest_arr(iflip,j,k);
+                    dest_arr(i,j,k) = -dest_arr(iflip,jj,k);
                 }
             }
         );

--- a/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
@@ -57,6 +57,8 @@ void ERFPhysBCFunct::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
         // Populate ghost cells on lo-x and hi-x domain boundaries
         Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
+        bx_xlo.setSmall(2,dom_lo.z); bx_xlo.setBig(2,dom_hi.z);
+        bx_xhi.setSmall(2,dom_lo.z); bx_xhi.setBig(2,dom_hi.z);
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
                 int iflip = dom_lo.x - 1- i;
@@ -92,7 +94,10 @@ void ERFPhysBCFunct::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+2);
         Box bx_ylo_face(bx); bx_ylo_face.setSmall(1,dom_lo.y  ); bx_ylo_face.setBig(1,dom_lo.y  );
         Box bx_yhi_face(bx); bx_yhi_face.setSmall(1,dom_hi.y+1); bx_yhi_face.setBig(1,dom_hi.y+1);
-
+        bx_ylo.setSmall(2,dom_lo.z); bx_ylo.setBig(2,dom_hi.z);
+        bx_yhi.setSmall(2,dom_lo.z); bx_yhi.setBig(2,dom_hi.z);
+        bx_ylo_face.setSmall(2,dom_lo.z); bx_ylo_face.setBig(2,dom_hi.z);
+        bx_yhi_face.setSmall(2,dom_lo.z); bx_yhi_face.setBig(2,dom_hi.z);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {

--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -171,7 +171,7 @@ ERF::WriteCheckpointFile () const
 
 #ifdef ERF_USE_NETCDF
    // Write bdy_data files
-   if (ParallelDescriptor::IOProcessor() && (init_type == "real")) {
+   if (ParallelDescriptor::IOProcessor() && ((init_type == "real") || (init_type == "metgrid"))) {
 
      // Vector dimensions
      int num_time = bdy_data_xlo.size();
@@ -372,7 +372,7 @@ ERF::ReadCheckpointFile ()
 
 #ifdef ERF_USE_NETCDF
     // Read bdy_data files
-    if (init_type == "real") {
+    if ((init_type == "real") || (init_type == "metgrid")) {
         int ioproc = ParallelDescriptor::IOProcessorNumber();  // I/O rank
         int num_time;
         int num_var;

--- a/Source/Initialization/ERF_init_from_metgrid.cpp
+++ b/Source/Initialization/ERF_init_from_metgrid.cpp
@@ -499,7 +499,7 @@ ERF::init_from_metgrid (int lev)
                 xlo_plane = xlo_plane_no_stag; xhi_plane = xhi_plane_no_stag;
                 ylo_plane = ylo_plane_no_stag; yhi_plane = yhi_plane_no_stag;
             } else if (ivar == MetGridBdyVars::QV) {
-                multiply_rho = true;
+                multiply_rho = false;
                 xlo_plane = xlo_plane_no_stag; xhi_plane = xhi_plane_no_stag;
                 ylo_plane = ylo_plane_no_stag; yhi_plane = yhi_plane_no_stag;
             } // MetGridBdyVars::QV


### PR DESCRIPTION
This PR corrects 3 bugs.

1. The bdy data must be written and read with **init_type=metgrid**
2. The metgrid initialization should not multiply Qv by rho when populating the FABs_for_BCs. The rho multiplication is already done in init_base_state.
3. The lateral BC routines do not protect against accessing z<dom_lo.z or z>dom_hi.z and they should. These guards were on specific loops for cons vars but not everywhere. This can cause some erroneous operations when restarting from a chk file.