### PR TITLE
Fix typo.

### DIFF
--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -171,7 +171,7 @@ ERF::WriteCheckpointFile () const
 
 #ifdef ERF_USE_NETCDF
    // Write bdy_data files
-   if (ParallelDescriptor::IOProcessor() && ((init_type=="real") || (init_type="metgrid"))) {
+   if (ParallelDescriptor::IOProcessor() && ((init_type=="real") || (init_type=="metgrid"))) {
 
      // Vector dimensions
      int num_time = bdy_data_xlo.size();
@@ -372,7 +372,7 @@ ERF::ReadCheckpointFile ()
 
 #ifdef ERF_USE_NETCDF
     // Read bdy_data files
-    if ((init_type=="real") || (init_type="metgrid")) {
+    if ((init_type=="real") || (init_type=="metgrid")) {
         int ioproc = ParallelDescriptor::IOProcessorNumber();  // I/O rank
         int num_time;
         int num_var;


### PR DESCRIPTION
Checkpoint typo got through workflow since it requires NETCDF.