### PR TITLE
WRF Init with moisture

### DIFF
--- a/Source/Initialization/ERF_init_from_wrfinput.cpp
+++ b/Source/Initialization/ERF_init_from_wrfinput.cpp
@@ -294,11 +294,13 @@ init_state_from_wrfinput (int lev,
         if (moisture_type != MoistureType::None)
         {
             state_fab.template copy<RunOn::Device>(NC_QVAPOR_fab[idx], 0, RhoQ1_comp, 1);
-            state_fab.template plus<RunOn::Device>(NC_QCLOUD_fab[idx], 0, RhoQ1_comp, 1);
             state_fab.template mult<RunOn::Device>(NC_rho_fab[idx]   , 0, RhoQ1_comp, 1);
 
-            state_fab.template copy<RunOn::Device>(NC_QRAIN_fab[idx], 0, RhoQ2_comp, 1);
-            state_fab.template mult<RunOn::Device>(NC_rho_fab[idx]  , 0, RhoQ2_comp, 1);
+            state_fab.template copy<RunOn::Device>(NC_QCLOUD_fab[idx], 0, RhoQ2_comp, 1);
+            state_fab.template mult<RunOn::Device>(NC_rho_fab[idx]   , 0, RhoQ2_comp, 1);
+
+            state_fab.template copy<RunOn::Device>(NC_QRAIN_fab[idx], 0, RhoQ3_comp, 1);
+            state_fab.template mult<RunOn::Device>(NC_rho_fab[idx]  , 0, RhoQ3_comp, 1);
         }
     } // idx
 }


### PR DESCRIPTION
This corrects legacy code from when we transported Qt = Qv + Qc. We now separate each moisture var. These changes only affect simulations that initialize from wrf input files.