### PR TITLE
Restart with debug

### DIFF
--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -322,20 +322,23 @@ ERF::ReadCheckpointFile ()
     {
         MultiFab cons(grids[lev],dmap[lev],ncomp_cons,0);
         VisMF::Read(cons, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "Cell"));
-
         MultiFab::Copy(vars_new[lev][Vars::cons],cons,0,0,ncomp_cons,0);
+        vars_new[lev][Vars::cons].setBndry(1.0e34);
 
         MultiFab xvel(convert(grids[lev],IntVect(1,0,0)),dmap[lev],1,0);
         VisMF::Read(xvel, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "XFace"));
         MultiFab::Copy(vars_new[lev][Vars::xvel],xvel,0,0,1,0);
+        vars_new[lev][Vars::xvel].setBndry(1.0e34);
 
         MultiFab yvel(convert(grids[lev],IntVect(0,1,0)),dmap[lev],1,0);
         VisMF::Read(yvel, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "YFace"));
         MultiFab::Copy(vars_new[lev][Vars::yvel],yvel,0,0,1,0);
+        vars_new[lev][Vars::yvel].setBndry(1.0e34);
 
         MultiFab zvel(convert(grids[lev],IntVect(0,0,1)),dmap[lev],1,0);
         VisMF::Read(zvel, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "ZFace"));
         MultiFab::Copy(vars_new[lev][Vars::zvel],zvel,0,0,1,0);
+        vars_new[lev][Vars::zvel].setBndry(1.0e34);
 
         // Note that we read the ghost cells of the base state (unlike above)
         IntVect ng = base_state[lev].nGrowVect();


### PR DESCRIPTION
The state variables are written and read from checkpoint files without their ghost cells. Additionally, the boundary condition operations involve duplicate over-writes into the ghost cells where one may need to access ghost cell data (the final state is correct but intermediate states may not be). Since the ghost cells are not populated with the read from checkpoint, the simulation will break due to an erroneous arithmetic operation when it tries to touch an uninitialized ghost cell. This PR populates the ghost cells during a restart with large values **1.0e34** to avoid the erroneous arithmetic operation; furthermore, the large value will aid in debugging any incorrect BC operations/fills.