### PR TITLE
Add a blended advection scheme option

### DIFF
--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -199,7 +199,7 @@ Refs:
 
 Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). `doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
 
-Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. `doi:10.1029/2020MS002100 <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2020MS002100>`_
+Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. `doi:10.1029/2020MS002100 <http://dx.doi.org/10.1029/2020MS002100>`_
 
 
 WENO Methods

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -186,14 +186,23 @@ The midpoint values given above :math:`q_{m - \frac{1}{2}}`, where :math:`q` may
    \left. q_{m - \frac{1}{2}} \right|^{4th} = \frac{7}{12}\left( q_{m} + q_{m - 1} \right)  & \hspace{-5pt} - \frac{1}{12}\left( q_{m + 1} + q_{m - 2} \right)                                                          & \\
    \left. q_{m - \frac{1}{2}} \right|^{6th} = \frac{37}{60}\left( q_{m} + q_{m - 1} \right) & \hspace{-5pt} - \frac{2}{15}\left( q_{m + 1} + q_{m - 2} \right)                                                          & \hspace{-5pt} + \frac{1}{60}\left( q_{m + 2} + q_{m - 3} \right) \\
     & & \\
-   \left. q_{m - \frac{1}{2}} \right|^{3rd} = \left. q_{m - \frac{1}{2}} \right|^{4th}      & \hspace{-5pt} + \frac{U_{d}}{\left| U_{d} \right|}\frac{1}{12}\left\lbrack \left( q_{m + 1} - q_{m - 2} \right) \right.\  & \hspace{-5pt} - 3\left. \ \left( q_{m} - q_{m - 1} \right) \right\rbrack \\
+   \left. q_{m - \frac{1}{2}} \right|^{3rd} = \left. q_{m - \frac{1}{2}} \right|^{4th}      & \hspace{-5pt} + \beta_{\text{up}}\frac{U_{d}}{\left| U_{d} \right|}\frac{1}{12}\left\lbrack \left( q_{m + 1} - q_{m - 2} \right) \right.\  & \hspace{-5pt} - 3\left. \ \left( q_{m} - q_{m - 1} \right) \right\rbrack \\
     & & \\
-   \left. q_{m - \frac{1}{2}} \right|^{5th} = \left. q_{m - \frac{1}{2}} \right|^{6th}      & \hspace{-5pt} - \frac{U_{d}}{\left| U_{d} \right|}\frac{1}{60}\left\lbrack \left( q_{m + 2} - q_{m - 1} \right) \right.\  & \hspace{-5pt} - 5\left( q_{m + 1} - q_{m - 2} \right) + 10\left. \left( q_{m} - q_{m - 1} \right) \right\rbrack
+   \left. q_{m - \frac{1}{2}} \right|^{5th} = \left. q_{m - \frac{1}{2}} \right|^{6th}      & \hspace{-5pt} - \beta_{\text{up}}\frac{U_{d}}{\left| U_{d} \right|}\frac{1}{60}\left\lbrack \left( q_{m + 2} - q_{m - 1} \right) \right.\  & \hspace{-5pt} - 5\left( q_{m + 1} - q_{m - 2} \right) + 10\left. \left( q_{m} - q_{m - 1} \right) \right\rbrack
    \end{array}
 
+An extra blending factor (:math:`\beta_{\text{up}}`) has been added to allow control
+over the amount of upwinding added to the scheme. This hybrid scheme has been
+demonstrated by Sauer and Muñoz-Esparza (2020, JAMES).
 
-Ref: Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). doi:10.5065/1dfh-6p97
+Refs:
+
+Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). 
 `doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
+
+Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. 
+`doi:10.1029/2020MS002100 <https://doi.org/10.1029/2020MS002100>`_
+
 
 WENO Methods
 ------------

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -197,11 +197,9 @@ demonstrated by Sauer and Muñoz-Esparza (2020, JAMES).
 
 Refs:
 
-Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). 
-`doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
+Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). `doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
 
-Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. 
-`doi:10.1029/2020MS002100 <https://doi.org/10.1029/2020MS002100>`_
+Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. `doi:10.1029/2020MS002100 <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2020MS002100>`_
 
 
 WENO Methods

--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -199,7 +199,7 @@ Refs:
 
 Skamarock, W. C., Klemp, J. B., Dudhia, J., Gill, D. O., Liu, Z., Berner, J., ... Huang, X. -yu. (2019). A Description of the Advanced Research WRF Model Version 4 (No. NCAR/TN-556+STR). `doi:10.5065/1dfh-6p97 <http://dx.doi.org/10.5065/1dfh-6p97>`_
 
-Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. `doi:10.1029/2020MS002100 <http://dx.doi.org/10.1029/2020MS002100>`_
+Sauer, J. A., & Muñoz-Esparza, D. (2020). The FastEddy® resident-GPU accelerated large-eddy simulation framework: Model formulation, dynamical-core validation and performance benchmarks. Journal of Advances in Modeling Earth Systems, 12, e2020MS002100. doi:10.1029/2020MS002100
 
 
 WENO Methods

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -566,7 +566,7 @@ List of Parameters
 |                                  | advection type     |                     |              |
 |                                  | for dry scalars    |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
-| **erf.dryscal_vert_adv_type**    | Vertical           | see below           | Upwind_3rd |
+| **erf.dryscal_vert_adv_type**    | Vertical           | see below           | Upwind_3rd   |
 |                                  | advection type     |                     |              |
 |                                  | for dry scalars    |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
@@ -583,12 +583,13 @@ List of Parameters
 |                                  | for scalars        |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
 
-
 The allowed advection types for the dycore variables are
-"Centered_2nd", "Upwind_3rd", "Centered_4th", "Upwind_5th" and "Centered_6th".
+"Centered_2nd", "Upwind_3rd", "Blended_3rd4th", "Centered_4th", "Upwind_5th", "Blended_5th6th",
+and "Centered_6th".
 
 The allowed advection types for the dry and moist scalars are
-"Centered_2nd", "Upwind_3rd", "Centered_4th", "Upwind_5th", "Centered_6th" and in addition,
+"Centered_2nd", "Upwind_3rd", "Blended_3rd4th", "Centered_4th", "Upwind_5th", "Blended_5th6th",
+"Centered_6th" and in addition,
 "WENO3", "WENOZ3", "WENOMZQ3", "WENO5", and "WENOZ5."
 
 Note: if using WENO schemes, the horizontal and vertical advection types must be set to

--- a/Source/Advection/Advection.H
+++ b/Source/Advection/Advection.H
@@ -40,6 +40,7 @@ void AdvectionSrcForScalars (const amrex::Box& bx,
                              const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                              const amrex::Array4<const amrex::Real>& mf_m,
                              const AdvType horiz_adv_type, const AdvType vert_adv_type,
+                             const amrex::Real horiz_upw_frac, const amrex::Real vert_upw_frac,
                              const bool use_terrain,
                              const amrex::GpuArray<const amrex::Array4<amrex::Real>, AMREX_SPACEDIM>& flx_arr);
 
@@ -57,6 +58,7 @@ void AdvectionSrcForMom (const amrex::Box& bxx, const amrex::Box& bxy, const amr
                          const amrex::Array4<const amrex::Real>& mf_u,
                          const amrex::Array4<const amrex::Real>& mf_v,
                          const AdvType horiz_adv_type, const AdvType vert_adv_type,
+                         const amrex::Real horiz_upw_frac, const amrex::Real vert_upw_frac,
                          const bool use_terrain, const int domhi_z);
 
 AMREX_GPU_HOST_DEVICE

--- a/Source/Advection/AdvectionSrcForMom.cpp
+++ b/Source/Advection/AdvectionSrcForMom.cpp
@@ -51,6 +51,8 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                     const Array4<const Real>& mf_v,
                     const AdvType horiz_adv_type,
                     const AdvType vert_adv_type,
+                    const Real horiz_upw_frac,
+                    const Real vert_upw_frac,
                     const bool use_terrain,
                     const int domhi_z)
 {
@@ -147,6 +149,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u, rho_v, Omega, u, v, w,
                                                   cellSizeInv, mf_m,
                                                   mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Upwind_3rd) {
                 AdvectionSrcForMomVert_N<UPWIND3>(bxx, bxy, bxz,
@@ -154,6 +157,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u, rho_v, Omega, u, v, w,
                                                   cellSizeInv, mf_m,
                                                   mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Centered_4th) {
                 AdvectionSrcForMomVert_N<CENTERED4>(bxx, bxy, bxz,
@@ -161,6 +165,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u, rho_v, Omega, u, v, w,
                                                   cellSizeInv, mf_m,
                                                   mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Upwind_5th) {
                 AdvectionSrcForMomVert_N<UPWIND5>(bxx, bxy, bxz,
@@ -168,6 +173,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u, rho_v, Omega, u, v, w,
                                                   cellSizeInv, mf_m,
                                                   mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Centered_6th) {
                 AdvectionSrcForMomVert_N<CENTERED6>(bxx, bxy, bxz,
@@ -175,6 +181,7 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u, rho_v, Omega, u, v, w,
                                                   cellSizeInv, mf_m,
                                                   mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else {
                 AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
@@ -271,30 +278,35 @@ AdvectionSrcForMom (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                   rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Upwind_3rd) {
                 AdvectionSrcForMomVert_T<UPWIND3>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                   rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Centered_4th) {
                 AdvectionSrcForMomVert_T<CENTERED4>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                   rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Upwind_5th) {
                 AdvectionSrcForMomVert_T<UPWIND5>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                   rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else if (horiz_adv_type == AdvType::Centered_6th) {
                 AdvectionSrcForMomVert_T<CENTERED6>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                   rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
                                                   vert_adv_type, domhi_z);
             } else {
                 AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -354,12 +354,12 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
 {
     if (vert_adv_type == AdvType::Centered_2nd) {
         AdvectionSrcForMomWrapper_N<InterpType_H,CENTERED2,UPWINDALL>(bxx, bxy, bxz,
-                                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                                    rho_u, rho_v, rho_w, u, v, w,
-                                                                    cellSizeInv, mf_m,
-                                                                    mf_u_inv, mf_v_inv,
-                                                                    upw_frac_h, upw_frac_v,
-                                                                    vert_adv_type, domhi_z);
+                                                                      rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                                      rho_u, rho_v, rho_w, u, v, w,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
+                                                                      vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_3rd) {
         AdvectionSrcForMomWrapper_N<InterpType_H,UPWIND3,UPWINDALL>(bxx, bxy, bxz,
                                                                     rho_u_rhs, rho_v_rhs, rho_w_rhs,
@@ -370,12 +370,12 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_4th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,CENTERED4,UPWINDALL>(bxx, bxy, bxz,
-                                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                                    rho_u, rho_v, rho_w, u, v, w,
-                                                                    cellSizeInv, mf_m,
-                                                                    mf_u_inv, mf_v_inv,
-                                                                    upw_frac_h, upw_frac_v,
-                                                                    vert_adv_type, domhi_z);
+                                                                      rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                                      rho_u, rho_v, rho_w, u, v, w,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
+                                                                      vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_5th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,UPWIND5,UPWINDALL>(bxx, bxy, bxz,
                                                                     rho_u_rhs, rho_v_rhs, rho_w_rhs,
@@ -386,12 +386,12 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_6th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,CENTERED6,UPWINDALL>(bxx, bxy, bxz,
-                                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                                    rho_u, rho_v, rho_w, u, v, w,
-                                                                    cellSizeInv, mf_m,
-                                                                    mf_u_inv, mf_v_inv,
-                                                                    upw_frac_h, upw_frac_v,
-                                                                    vert_adv_type, domhi_z);
+                                                                      rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                                      rho_u, rho_v, rho_w, u, v, w,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
+                                                                      vert_adv_type, domhi_z);
     } else {
         AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
     }

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -24,6 +24,8 @@ AdvectionSrcForXMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& rho_w,
                        InterpType_H interp_u_h,
                        InterpType_V interp_u_v,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -42,27 +44,27 @@ AdvectionSrcForXMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j,0) + rho_u(i, j, k) * mf_u_inv(i,j,0));
-    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i-1, j, k) * mf_u_inv(i-1,j,0) + rho_u(i, j, k) * mf_u_inv(i,j,0));
-    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) * mf_v_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_v_inv(i-1,j+1,0));
-    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) * mf_v_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_v_inv(i-1,j  ,0));
-    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     rho_w_avg_hi = 0.5 * (rho_w(i, j, k+1) + rho_w(i-1, j, k+1));
-    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
+    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
     zflux_hi = rho_w_avg_hi * interp_hi;
 
     rho_w_avg_lo = 0.5 * (rho_w(i, j, k  ) + rho_w(i-1, j, k  ));
-    interp_u_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo);
+    interp_u_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v);
     zflux_lo = rho_w_avg_lo * interp_lo;
 
     amrex::Real mfsq = 1 / (mf_u_inv(i,j,0) * mf_u_inv(i,j,0));
@@ -97,6 +99,8 @@ AdvectionSrcForYMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& rho_w,
                        InterpType_H interp_v_h,
                        InterpType_V interp_v_v,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -115,27 +119,27 @@ AdvectionSrcForYMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j  ,0) + rho_u(i+1, j-1, k) * mf_u_inv(i+1,j-1,0));
-    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) * mf_u_inv(i  ,j  ,0) + rho_u(i  , j-1, k) * mf_u_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j+1, k) * mf_v_inv(i  ,j+1,0));
-    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j-1, k) * mf_v_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     rho_w_avg_hi = 0.5 * (rho_w(i, j, k+1) + rho_w(i, j-1, k+1));
-    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
+    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
     zflux_hi = rho_w_avg_hi * interp_hi;
 
     rho_w_avg_lo = 0.5 * (rho_w(i, j, k  ) + rho_w(i, j-1, k  ));
-    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,rho_w_avg_lo);
+    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,rho_w_avg_lo,upw_frac_v);
     zflux_lo = rho_w_avg_lo * interp_lo;
 
     amrex::Real mfsq = 1 / (mf_v_inv(i,j,0) * mf_v_inv(i,j,0));
@@ -174,12 +178,14 @@ AdvectionSrcForZMom_N (int i, int j, int k,
                        InterpType_H   interp_w_h,
                        InterpType_V   interp_w_v,
                        WallInterpType interp_w_wall,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_m,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv,
-                       const AdvType vert_adv_type, const int domhi_z)
-
+                       const AdvType vert_adv_type,
+                       const int domhi_z)
 {
 
     amrex::Real advectionSrc;
@@ -196,19 +202,19 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv(i+1,j  ,0);
-    interp_w_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_w_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv(i  ,j  ,0);
-    interp_w_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_w_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv(i  ,j+1,0);
-    interp_w_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_w_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv(i  ,j  ,0);
-    interp_w_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_w_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     // int l_spatial_order_hi = std::min(std::min(vert_spatial_order, 2*(domhi_z+1-k)), 2*(k+1));
@@ -222,15 +228,15 @@ AdvectionSrcForZMom_N (int i, int j, int k,
         rho_w_avg_hi = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
         if (k == domhi_z)
         {
-            interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,AdvType::Centered_2nd);
+            interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,0,AdvType::Centered_2nd);
         } else if (k == domhi_z-1 || k == 1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,AdvType::Centered_4th);
+               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,0,AdvType::Centered_4th);
             } else {
-               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,vert_adv_type);
+               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v,vert_adv_type);
             }
         } else {
-            interp_w_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
+            interp_w_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
         }
         zflux_hi = rho_w_avg_hi * interp_hi;
     }
@@ -245,15 +251,15 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     } else {
         rho_w_avg_lo = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1));
         if (k == 1) {
-            interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,AdvType::Centered_2nd);
+            interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,0,AdvType::Centered_2nd);
         } else if (k == 2 || k == domhi_z) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,AdvType::Centered_4th);
+                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,0,AdvType::Centered_4th);
             } else {
-                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,vert_adv_type);
+                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v,vert_adv_type);
             }
         } else {
-            interp_w_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo);
+            interp_w_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v);
         }
         zflux_lo = rho_w_avg_lo * interp_lo;
     }
@@ -286,6 +292,8 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
                              const amrex::Array4<const amrex::Real>& mf_m,
                              const amrex::Array4<const amrex::Real>& mf_u_inv,
                              const amrex::Array4<const amrex::Real>& mf_v_inv,
+                             const amrex::Real upw_frac_h,
+                             const amrex::Real upw_frac_v,
                              const AdvType vert_adv_type,
                              const int domhi_z)
 {
@@ -299,17 +307,22 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom_N(i, j, k, rho_u, rho_v, rho_w,
-                                                    interp_u_h, interp_u_v, cellSizeInv, mf_u_inv, mf_v_inv);
+                                                    interp_u_h, interp_u_v,
+                                                    upw_frac_h, upw_frac_v,
+                                                    cellSizeInv, mf_u_inv, mf_v_inv);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom_N(i, j, k, rho_u, rho_v, rho_w,
-                                                    interp_v_h, interp_v_v, cellSizeInv, mf_u_inv, mf_v_inv);
+                                                    interp_v_h, interp_v_v,
+                                                    upw_frac_h, upw_frac_v,
+                                                    cellSizeInv, mf_u_inv, mf_v_inv);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom_N(i, j, k, rho_u, rho_v, rho_w, w,
                                                     interp_w_h, interp_w_v, interp_w_wall,
+                                                    upw_frac_h, upw_frac_v,
                                                     cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
                                                     vert_adv_type, domhi_z);
     });
@@ -334,6 +347,8 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                           const amrex::Array4<const amrex::Real>& mf_m,
                           const amrex::Array4<const amrex::Real>& mf_u_inv,
                           const amrex::Array4<const amrex::Real>& mf_v_inv,
+                          const amrex::Real upw_frac_h,
+                          const amrex::Real upw_frac_v,
                           const AdvType vert_adv_type,
                           const int domhi_z)
 {
@@ -343,6 +358,7 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     rho_u, rho_v, rho_w, u, v, w,
                                                                     cellSizeInv, mf_m,
                                                                     mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_3rd) {
         AdvectionSrcForMomWrapper_N<InterpType_H,UPWIND3,UPWINDALL>(bxx, bxy, bxz,
@@ -350,6 +366,7 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     rho_u, rho_v, rho_w, u, v, w,
                                                                     cellSizeInv, mf_m,
                                                                     mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_4th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,CENTERED4,UPWINDALL>(bxx, bxy, bxz,
@@ -357,6 +374,7 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     rho_u, rho_v, rho_w, u, v, w,
                                                                     cellSizeInv, mf_m,
                                                                     mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_5th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,UPWIND5,UPWINDALL>(bxx, bxy, bxz,
@@ -364,6 +382,7 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     rho_u, rho_v, rho_w, u, v, w,
                                                                     cellSizeInv, mf_m,
                                                                     mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_6th) {
         AdvectionSrcForMomWrapper_N<InterpType_H,CENTERED6,UPWINDALL>(bxx, bxy, bxz,
@@ -371,6 +390,7 @@ AdvectionSrcForMomVert_N (const amrex::Box& bxx, const amrex::Box& bxy, const am
                                                                     rho_u, rho_v, rho_w, u, v, w,
                                                                     cellSizeInv, mf_m,
                                                                     mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else {
         AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -29,6 +29,8 @@ AdvectionSrcForXMom_T (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& detJ,
                        InterpType_H interp_u_h,
                        InterpType_V interp_u_v,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -47,10 +49,10 @@ AdvectionSrcForXMom_T (int i, int j, int k,
     // ****************************************************************************************
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j  ,0) + rho_u(i, j, k) * mf_u_inv(i  ,j  ,0));
-    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
 
     rho_u_avg_lo = 0.5 * (rho_u(i-1, j, k) * mf_u_inv(i-1,j  ,0) + rho_u(i, j, k) * mf_u_inv(i  ,j  ,0));
-    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
 
     amrex::Real centFluxXXNext = rho_u_avg_hi * Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real centFluxXXPrev = rho_u_avg_lo * Compute_h_zeta_AtCellCenter(i-1,j  ,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -59,10 +61,10 @@ AdvectionSrcForXMom_T (int i, int j, int k,
     // Y-fluxes (at edges in k-direction)
     // ****************************************************************************************
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) * mf_v_inv(i  ,j+1,0) + rho_v(i-1, j+1, k) * mf_v_inv(i-1,j+1,0));
-    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) * mf_v_inv(i  ,j  ,0) + rho_v(i-1, j  , k) * mf_v_inv(i-1,j  ,0));
-    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
 
     amrex::Real edgeFluxXYNext = rho_v_avg_hi * Compute_h_zeta_AtEdgeCenterK(i  ,j+1,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real edgeFluxXYPrev = rho_v_avg_lo * Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -73,8 +75,8 @@ AdvectionSrcForXMom_T (int i, int j, int k,
     Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i-1, j, k+1));
     Omega_avg_lo = 0.5 * (Omega(i, j, k  ) + Omega(i-1, j, k  ));
 
-    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
-    interp_u_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo);
+    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
+    interp_u_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo,upw_frac_v);
 
     amrex::Real edgeFluxXZNext = Omega_avg_hi * interp_hi;
     amrex::Real edgeFluxXZPrev = Omega_avg_lo * interp_lo;
@@ -118,6 +120,8 @@ AdvectionSrcForYMom_T (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& detJ,
                        InterpType_H interp_v_h,
                        InterpType_V interp_v_v,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -135,10 +139,10 @@ AdvectionSrcForYMom_T (int i, int j, int k,
     // x-fluxes (at edges in k-direction)
     // ****************************************************************************************
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j  ,0) + rho_u(i+1, j-1, k) * mf_u_inv(i+1,j-1,0));
-    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) * mf_u_inv(i  ,j  ,0) + rho_u(i  , j-1, k) * mf_u_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
 
     amrex::Real edgeFluxYXNext = rho_u_avg_hi * Compute_h_zeta_AtEdgeCenterK(i+1,j  ,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real edgeFluxYXPrev = rho_u_avg_lo * Compute_h_zeta_AtEdgeCenterK(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -147,10 +151,10 @@ AdvectionSrcForYMom_T (int i, int j, int k,
     // y-fluxes (at cell centers)
     // ****************************************************************************************
     rho_v_avg_hi = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j+1, k) * mf_v_inv(i  ,j+1,0));
-    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j-1, k) * mf_v_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
 
     amrex::Real centFluxYYNext = rho_v_avg_hi * Compute_h_zeta_AtCellCenter(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real centFluxYYPrev = rho_v_avg_lo * Compute_h_zeta_AtCellCenter(i  ,j-1,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -161,8 +165,8 @@ AdvectionSrcForYMom_T (int i, int j, int k,
     Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i, j-1, k+1));
     Omega_avg_lo = 0.5 * (Omega(i, j, k  ) + Omega(i, j-1, k  ));
 
-    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
-    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo);
+    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
+    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo,upw_frac_v);
 
     amrex::Real edgeFluxYZNext = Omega_avg_hi * interp_hi;
     amrex::Real edgeFluxYZPrev = Omega_avg_lo * interp_lo;
@@ -211,6 +215,8 @@ AdvectionSrcForZMom_T (int i, int j, int k,
                        InterpType_H interp_omega_h,
                        InterpType_V interp_omega_v,
                        WallInterpType interp_omega_wall,
+                       const amrex::Real upw_frac_h,
+                       const amrex::Real upw_frac_v,
                        const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                        const amrex::Array4<const amrex::Real>& mf_m,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
@@ -231,10 +237,10 @@ AdvectionSrcForZMom_T (int i, int j, int k,
     // x-fluxes (at edges in j-direction)
     // ****************************************************************************************
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv(i+1,j  ,0);
-    interp_omega_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_omega_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv(i  ,j  ,0);
-    interp_omega_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
+    interp_omega_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
 
     amrex::Real edgeFluxZXNext = rho_u_avg_hi * Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real edgeFluxZXPrev = rho_u_avg_lo * Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -243,10 +249,10 @@ AdvectionSrcForZMom_T (int i, int j, int k,
     // y-fluxes (at edges in i-direction)
     // ****************************************************************************************
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv(i  ,j+1,0);
-    interp_omega_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_omega_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv(i  ,j  ,0);
-    interp_omega_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
+    interp_omega_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
 
     amrex::Real edgeFluxZYNext = rho_v_avg_hi * Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd) * interp_hi;
     amrex::Real edgeFluxZYPrev = rho_v_avg_lo * Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd) * interp_lo;
@@ -266,15 +272,15 @@ AdvectionSrcForZMom_T (int i, int j, int k,
         centFluxZZNext *=  w(i,j,k);
     } else {
         if (k == domhi_z) {
-            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,AdvType::Centered_2nd);
+            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,0,Omega_avg_hi,AdvType::Centered_2nd);
         } else if (k == domhi_z-1 || k == 1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,AdvType::Centered_4th);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,0,Omega_avg_hi,AdvType::Centered_4th);
             } else {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,vert_adv_type);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,upw_frac_v,Omega_avg_hi,vert_adv_type);
             }
         } else {
-            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
+            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,upw_frac_v,Omega_avg_hi);
         }
         centFluxZZNext *=  interp_hi;
     }
@@ -292,15 +298,15 @@ AdvectionSrcForZMom_T (int i, int j, int k,
         centFluxZZPrev *=  w(i,j,k);
     } else {
         if (k == 1) {
-            interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,AdvType::Centered_2nd);
+            interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,0,AdvType::Centered_2nd);
         } else if (k == 2 || k == domhi_z) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,AdvType::Centered_4th);
+                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,0,AdvType::Centered_4th);
             } else {
-                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,vert_adv_type);
+                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,upw_frac_v,vert_adv_type);
             }
         } else {
-            interp_omega_v.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo);
+            interp_omega_v.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,upw_frac_v);
         }
         centFluxZZPrev *=  interp_lo;
     }
@@ -340,6 +346,8 @@ AdvectionSrcForMomWrapper_T (const amrex::Box& bxx, const amrex::Box& bxy, const
                              const amrex::Array4<const amrex::Real>& mf_m,
                              const amrex::Array4<const amrex::Real>& mf_u_inv,
                              const amrex::Array4<const amrex::Real>& mf_v_inv,
+                             const amrex::Real upw_frac_h,
+                             const amrex::Real upw_frac_v,
                              const AdvType vert_adv_type,
                              const int domhi_z)
 {
@@ -353,17 +361,22 @@ AdvectionSrcForMomWrapper_T (const amrex::Box& bxx, const amrex::Box& bxy, const
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom_T(i, j, k, rho_u, rho_v, Omega, z_nd, detJ,
-                                                    interp_u_h, interp_u_v, cellSizeInv, mf_u_inv, mf_v_inv);
+                                                    interp_u_h, interp_u_v,
+                                                    upw_frac_h, upw_frac_v,
+                                                    cellSizeInv, mf_u_inv, mf_v_inv);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom_T(i, j, k, rho_u, rho_v, Omega, z_nd, detJ,
-                                                    interp_v_h, interp_v_v, cellSizeInv, mf_u_inv, mf_v_inv);
+                                                    interp_v_h, interp_v_v,
+                                                    upw_frac_h, upw_frac_v,
+                                                    cellSizeInv, mf_u_inv, mf_v_inv);
     },
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom_T(i, j, k, rho_u, rho_v, Omega, w, z_nd, detJ,
                                                     interp_w_h, interp_w_v, interp_w_wall,
+                                                    upw_frac_h, upw_frac_v,
                                                     cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
                                                     vert_adv_type, domhi_z);
     });
@@ -390,37 +403,50 @@ AdvectionSrcForMomVert_T (const amrex::Box& bxx, const amrex::Box& bxy, const am
                           const amrex::Array4<const amrex::Real>& mf_m,
                           const amrex::Array4<const amrex::Real>& mf_u_inv,
                           const amrex::Array4<const amrex::Real>& mf_v_inv,
-                          const AdvType vert_adv_type, const int domhi_z)
+                          const amrex::Real upw_frac_h,
+                          const amrex::Real upw_frac_v,
+                          const AdvType vert_adv_type,
+                          const int domhi_z)
 {
     if (vert_adv_type == AdvType::Centered_2nd) {
         AdvectionSrcForMomWrapper_T<InterpType_H,CENTERED2,UPWINDALL>(bxx, bxy, bxz,
                                                                       rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                                       rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
-                                                                      cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
                                                                       vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_3rd) {
         AdvectionSrcForMomWrapper_T<InterpType_H,UPWIND3,UPWINDALL>(bxx, bxy, bxz,
                                                                     rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                                     rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
-                                                                    cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                                    cellSizeInv, mf_m,
+                                                                    mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_4th) {
         AdvectionSrcForMomWrapper_T<InterpType_H,CENTERED4,UPWINDALL>(bxx, bxy, bxz,
                                                                       rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                                       rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
-                                                                      cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
                                                                       vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Upwind_5th) {
         AdvectionSrcForMomWrapper_T<InterpType_H,UPWIND5,UPWINDALL>(bxx, bxy, bxz,
                                                                     rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                                     rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
-                                                                    cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                                    cellSizeInv, mf_m,
+                                                                    mf_u_inv, mf_v_inv,
+                                                                    upw_frac_h, upw_frac_v,
                                                                     vert_adv_type, domhi_z);
     } else if (vert_adv_type == AdvType::Centered_6th) {
         AdvectionSrcForMomWrapper_T<InterpType_H,CENTERED6,UPWINDALL>(bxx, bxy, bxz,
                                                                       rho_u_rhs, rho_v_rhs, rho_w_rhs,
                                                                       rho_u, rho_v, Omega, u, v, w, z_nd, detJ,
-                                                                      cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                                      cellSizeInv, mf_m,
+                                                                      mf_u_inv, mf_v_inv,
+                                                                      upw_frac_h, upw_frac_v,
                                                                       vert_adv_type, domhi_z);
     } else {
         AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -212,8 +212,8 @@ AdvectionSrcForZMom_T (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& w,
                        const amrex::Array4<const amrex::Real>& z_nd,
                        const amrex::Array4<const amrex::Real>& detJ,
-                       InterpType_H interp_omega_h,
-                       InterpType_V interp_omega_v,
+                       InterpType_H   interp_omega_h,
+                       InterpType_V   interp_omega_v,
                        WallInterpType interp_omega_wall,
                        const amrex::Real upw_frac_h,
                        const amrex::Real upw_frac_v,
@@ -271,16 +271,17 @@ AdvectionSrcForZMom_T (int i, int j, int k,
     if (k == domhi_z+1) {
         centFluxZZNext *=  w(i,j,k);
     } else {
-        if (k == domhi_z) {
-            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,0,Omega_avg_hi,AdvType::Centered_2nd);
+        if (k == domhi_z)
+        {
+            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,0,AdvType::Centered_2nd);
         } else if (k == domhi_z-1 || k == 1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,0,Omega_avg_hi,AdvType::Centered_4th);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,0,AdvType::Centered_4th);
             } else {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,upw_frac_v,Omega_avg_hi,vert_adv_type);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v,vert_adv_type);
             }
         } else {
-            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,upw_frac_v,Omega_avg_hi);
+            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
         }
         centFluxZZNext *=  interp_hi;
     }

--- a/Source/Advection/AdvectionSrcForScalars.H
+++ b/Source/Advection/AdvectionSrcForScalars.H
@@ -12,7 +12,9 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                                const amrex::Array4<const amrex::Real>& cell_prim,
                                const amrex::Array4<const amrex::Real>& avg_xmom,
                                const amrex::Array4<const amrex::Real>& avg_ymom,
-                               const amrex::Array4<const amrex::Real>& avg_zmom)
+                               const amrex::Array4<const amrex::Real>& avg_zmom,
+                               const amrex::Real horiz_upw_frac,
+                               const amrex::Real vert_upw_frac)
 {
     // Instantiate structs for vert/horiz interp
     InterpType_H interp_prim_h(cell_prim);
@@ -29,7 +31,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
 
         amrex::Real interpx(0.);
 
-        interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i  ,j  ,k  ));
+        interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i  ,j  ,k  ),horiz_upw_frac);
         (flx_arr[0])(i,j,k,cons_index) = avg_xmom(i,j,k) * interpx;
     });
     amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -38,7 +40,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         const int prim_index = cons_index - 1;
 
         amrex::Real interpy(0.);
-        interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ));
+        interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ),horiz_upw_frac);
 
         (flx_arr[1])(i,j,k,cons_index) = avg_ymom(i,j,k) * interpy;
     });
@@ -49,7 +51,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
 
         amrex::Real interpz(0.);
 
-        interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i  ,j  ,k  ));
+        interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i  ,j  ,k  ),vert_upw_frac);
 
         (flx_arr[2])(i,j,k,cons_index) = avg_zmom(i,j,k) * interpz;
     });
@@ -67,33 +69,40 @@ AdvectionSrcForScalarsVert (const amrex::Box& bx,
                             const amrex::Array4<const amrex::Real>& avg_xmom,
                             const amrex::Array4<const amrex::Real>& avg_ymom,
                             const amrex::Array4<const amrex::Real>& avg_zmom,
+                            const amrex::Real horiz_upw_frac,
+                            const amrex::Real vert_upw_frac,
                             const AdvType vert_adv_type)
 {
     switch(vert_adv_type) {
     case AdvType::Centered_2nd:
         AdvectionSrcForScalarsWrapper<InterpType_H,CENTERED2>(bx, ncomp, icomp,
                                                               flx_arr, cell_prim,
-                                                              avg_xmom, avg_ymom, avg_zmom);
+                                                              avg_xmom, avg_ymom, avg_zmom,
+                                                              horiz_upw_frac, vert_upw_frac);
         break;
     case AdvType::Upwind_3rd:
         AdvectionSrcForScalarsWrapper<InterpType_H,UPWIND3>(bx, ncomp, icomp,
                                                             flx_arr, cell_prim,
-                                                            avg_xmom, avg_ymom, avg_zmom);
+                                                            avg_xmom, avg_ymom, avg_zmom,
+                                                            horiz_upw_frac, vert_upw_frac);
         break;
     case AdvType::Centered_4th:
         AdvectionSrcForScalarsWrapper<InterpType_H,CENTERED4>(bx, ncomp, icomp,
                                                               flx_arr, cell_prim,
-                                                              avg_xmom, avg_ymom, avg_zmom);
+                                                              avg_xmom, avg_ymom, avg_zmom,
+                                                              horiz_upw_frac, vert_upw_frac);
         break;
     case AdvType::Upwind_5th:
         AdvectionSrcForScalarsWrapper<InterpType_H,UPWIND5>(bx, ncomp, icomp,
                                                             flx_arr, cell_prim,
-                                                            avg_xmom, avg_ymom, avg_zmom);
+                                                            avg_xmom, avg_ymom, avg_zmom,
+                                                            horiz_upw_frac, vert_upw_frac);
         break;
     case AdvType::Centered_6th:
         AdvectionSrcForScalarsWrapper<InterpType_H,CENTERED6>(bx, ncomp, icomp,
                                                               flx_arr, cell_prim,
-                                                              avg_xmom, avg_ymom, avg_zmom);
+                                                              avg_xmom, avg_ymom, avg_zmom,
+                                                              horiz_upw_frac, vert_upw_frac);
         break;
     default:
         AMREX_ASSERT_WITH_MESSAGE(false, "Unknown vertical advection scheme!");

--- a/Source/Advection/AdvectionSrcForState.cpp
+++ b/Source/Advection/AdvectionSrcForState.cpp
@@ -26,7 +26,9 @@ using namespace amrex;
  * @param[in] mf_u map factor at x-faces
  * @param[in] mf_v map factor at y-faces
  * @param[in] horiz_adv_type advection scheme to be used in horiz. directions for dry scalars
- * @param[in] vert_adv_type advection scheme to be used in horiz. directions for dry scalars
+ * @param[in] vert_adv_type advection scheme to be used in vert. directions for dry scalars
+ * @param[in] horiz_upw_frac upwinding fraction to be used in horiz. directions for dry scalars (for Blended schemes only)
+ * @param[in] vert_upw_frac upwinding fraction to be used in vert. directions for dry scalars (for Blended schemes only)
  * @param[in] use_terrain if true, use the terrain-aware derivatives (with metric terms)
  */
 
@@ -118,7 +120,9 @@ AdvectionSrcForRho (const Box& bx,
  * @param[in] cellSizeInv inverse of the mesh spacing
  * @param[in] mf_m map factor at cell centers
  * @param[in] horiz_adv_type advection scheme to be used in horiz. directions for dry scalars
- * @param[in] vert_adv_type advection scheme to be used in horiz. directions for dry scalars
+ * @param[in] vert_adv_type advection scheme to be used in vert. directions for dry scalars
+ * @param[in] horiz_upw_frac upwinding fraction to be used in horiz. directions for dry scalars (for Blended schemes only)
+ * @param[in] vert_upw_frac upwinding fraction to be used in vert. directions for dry scalars (for Blended schemes only)
  * @param[in] use_terrain if true, use the terrain-aware derivatives (with metric terms)
  */
 
@@ -134,6 +138,8 @@ AdvectionSrcForScalars (const Box& bx, const int icomp, const int ncomp,
                         const Array4<const Real>& mf_m,
                         const AdvType horiz_adv_type,
                         const AdvType vert_adv_type,
+                        const Real horiz_upw_frac,
+                        const Real vert_upw_frac,
                         const bool use_terrain,
                         const GpuArray<const Array4<Real>, AMREX_SPACEDIM>& flx_arr)
 {
@@ -176,43 +182,53 @@ AdvectionSrcForScalars (const Box& bx, const int icomp, const int ncomp,
         switch(horiz_adv_type) {
         case AdvType::Centered_2nd:
             AdvectionSrcForScalarsVert<CENTERED2>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                  avg_xmom, avg_ymom, avg_zmom, vert_adv_type);
+                                                  avg_xmom, avg_ymom, avg_zmom,
+                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
         case AdvType::Upwind_3rd:
             AdvectionSrcForScalarsVert<UPWIND3>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                avg_xmom, avg_ymom, avg_zmom, vert_adv_type);
+                                                avg_xmom, avg_ymom, avg_zmom,
+                                                horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
         case AdvType::Centered_4th:
             AdvectionSrcForScalarsVert<CENTERED4>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                  avg_xmom, avg_ymom, avg_zmom, vert_adv_type);
+                                                  avg_xmom, avg_ymom, avg_zmom,
+                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
         case AdvType::Upwind_5th:
             AdvectionSrcForScalarsVert<UPWIND5>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                avg_xmom, avg_ymom, avg_zmom, vert_adv_type);
+                                                avg_xmom, avg_ymom, avg_zmom,
+                                                horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
         case AdvType::Centered_6th:
             AdvectionSrcForScalarsVert<CENTERED6>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                  avg_xmom, avg_ymom, avg_zmom, vert_adv_type);
+                                                  avg_xmom, avg_ymom, avg_zmom,
+                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
         case AdvType::Weno_3:
             AdvectionSrcForScalarsWrapper<WENO3,WENO3>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                       avg_xmom, avg_ymom, avg_zmom);
+                                                       avg_xmom, avg_ymom, avg_zmom,
+                                                       horiz_upw_frac, vert_upw_frac);
             break;
         case AdvType::Weno_5:
             AdvectionSrcForScalarsWrapper<WENO5,WENO5>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                       avg_xmom, avg_ymom, avg_zmom);
+                                                       avg_xmom, avg_ymom, avg_zmom,
+                                                       horiz_upw_frac, vert_upw_frac);
             break;
         case AdvType::Weno_3Z:
             AdvectionSrcForScalarsWrapper<WENO_Z3,WENO_Z3>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                           avg_xmom, avg_ymom, avg_zmom);
+                                                           avg_xmom, avg_ymom, avg_zmom,
+                                                           horiz_upw_frac, vert_upw_frac);
             break;
         case AdvType::Weno_3MZQ:
             AdvectionSrcForScalarsWrapper<WENO_MZQ3,WENO_MZQ3>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                               avg_xmom, avg_ymom, avg_zmom);
+                                                               avg_xmom, avg_ymom, avg_zmom,
+                                                               horiz_upw_frac, vert_upw_frac);
             break;
         case AdvType::Weno_5Z:
             AdvectionSrcForScalarsWrapper<WENO_Z5,WENO_Z5>(bx, ncomp, icomp, flx_arr, cell_prim,
-                                                           avg_xmom, avg_ymom, avg_zmom);
+                                                           avg_xmom, avg_ymom, avg_zmom,
+                                                           horiz_upw_frac, vert_upw_frac);
             break;
         default:
             AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");

--- a/Source/DataStructs/AdvStruct.H
+++ b/Source/DataStructs/AdvStruct.H
@@ -39,10 +39,60 @@ struct AdvChoice {
            amrex::Print() << "Using efficient advection scheme" << std::endl;;
         }
 
+        if ( (dycore_horiz_adv_string == "Blended_3rd4th") ||
+             (dycore_horiz_adv_string == "Blended_5th6th") )
+        {
+            pp.query("dycore_horiz_upw_frac" , dycore_horiz_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((dycore_horiz_upw_frac >= 0.) && (dycore_horiz_upw_frac <= 1.),
+                                      "The dycore horizontal upwinding fraction must be between 0 and 1");
+        }
+
+        if ( (dycore_vert_adv_string == "Blended_3rd4th") ||
+             (dycore_vert_adv_string == "Blended_5th6th") )
+        {
+            pp.query("dycore_vert_upw_frac" , dycore_vert_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((dycore_vert_upw_frac >= 0.) && (dycore_vert_upw_frac <= 1.),
+                                      "The dycore vertical upwinding fraction must be between 0 and 1");
+        }
+
+        if ( (dryscal_horiz_adv_string == "Blended_3rd4th") ||
+             (dryscal_horiz_adv_string == "Blended_5th6th") )
+        {
+            pp.query("dryscal_horiz_upw_frac" , dryscal_horiz_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((dryscal_horiz_upw_frac >= 0.) && (dryscal_horiz_upw_frac <= 1.),
+                                      "The dry scalar horizontal upwinding fraction must be between 0 and 1");
+        }
+
+        if ( (dryscal_vert_adv_string == "Blended_3rd4th") ||
+             (dryscal_vert_adv_string == "Blended_5th6th") )
+        {
+            pp.query("dryscal_vert_upw_frac" , dryscal_vert_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((dryscal_vert_upw_frac >= 0.) && (dryscal_vert_upw_frac <= 1.),
+                                      "The dry scalar vertical upwinding fraction must be between 0 and 1");
+        }
+
+        if ( (moistscal_horiz_adv_string == "Blended_3rd4th") ||
+             (moistscal_horiz_adv_string == "Blended_5th6th") )
+        {
+            pp.query("moistscal_horiz_upw_frac" , moistscal_horiz_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((moistscal_horiz_upw_frac >= 0.) && (moistscal_horiz_upw_frac <= 1.),
+                                      "The moist scalar horizontal upwinding fraction must be between 0 and 1");
+        }
+
+        if ( (moistscal_vert_adv_string == "Blended_3rd4th") ||
+             (moistscal_vert_adv_string == "Blended_5th6th") )
+        {
+            pp.query("moistscal_vert_upw_frac" , moistscal_vert_upw_frac);
+            AMREX_ASSERT_WITH_MESSAGE((moistscal_vert_upw_frac >= 0.) && (moistscal_vert_upw_frac <= 1.),
+                                      "The moist scalar vertical upwinding fraction must be between 0 and 1");
+        }
+
         if ( (dycore_horiz_adv_string == "Centered_2nd") ||
              (dycore_horiz_adv_string == "Upwind_3rd"  ) ||
+             (dycore_horiz_adv_string == "Blended_3rd4th") ||
              (dycore_horiz_adv_string == "Centered_4th") ||
              (dycore_horiz_adv_string == "Upwind_5th"  ) ||
+             (dycore_horiz_adv_string == "Blended_5th6th") ||
              (dycore_horiz_adv_string == "Centered_6th") )
         {
             dycore_horiz_adv_type = adv_type_convert_string_to_advtype(dycore_horiz_adv_string);
@@ -53,8 +103,10 @@ struct AdvChoice {
 
         if ( (dycore_vert_adv_string == "Centered_2nd") ||
              (dycore_vert_adv_string == "Upwind_3rd"  ) ||
+             (dycore_vert_adv_string == "Blended_3rd4th") ||
              (dycore_vert_adv_string == "Centered_4th") ||
              (dycore_vert_adv_string == "Upwind_5th"  ) ||
+             (dycore_vert_adv_string == "Blended_5th6th") ||
              (dycore_vert_adv_string == "Centered_6th") )
         {
             dycore_vert_adv_type = adv_type_convert_string_to_advtype(dycore_vert_adv_string);
@@ -65,8 +117,10 @@ struct AdvChoice {
 
         if ( (dryscal_horiz_adv_string == "Centered_2nd") ||
              (dryscal_horiz_adv_string == "Upwind_3rd"  ) ||
+             (dryscal_horiz_adv_string == "Blended_3rd4th") ||
              (dryscal_horiz_adv_string == "Centered_4th") ||
              (dryscal_horiz_adv_string == "Upwind_5th"  ) ||
+             (dryscal_horiz_adv_string == "Blended_5th6th") ||
              (dryscal_horiz_adv_string == "Centered_6th") ||
              (dryscal_horiz_adv_string == "WENO3"       ) ||
              (dryscal_horiz_adv_string == "WENOZ3"      ) ||
@@ -82,8 +136,10 @@ struct AdvChoice {
 
         if ( (dryscal_vert_adv_string == "Centered_2nd") ||
              (dryscal_vert_adv_string == "Upwind_3rd"  ) ||
+             (dryscal_vert_adv_string == "Blended_3rd4th") ||
              (dryscal_vert_adv_string == "Centered_4th") ||
              (dryscal_vert_adv_string == "Upwind_5th"  ) ||
+             (dryscal_vert_adv_string == "Blended_5th6th") ||
              (dryscal_vert_adv_string == "Centered_6th") ||
              (dryscal_vert_adv_string == "WENO3"       ) ||
              (dryscal_vert_adv_string == "WENOZ3"      ) ||
@@ -99,8 +155,10 @@ struct AdvChoice {
 
         if ( (moistscal_horiz_adv_string == "Centered_2nd") ||
              (moistscal_horiz_adv_string == "Upwind_3rd"  ) ||
+             (moistscal_horiz_adv_string == "Blended_3rd4th") ||
              (moistscal_horiz_adv_string == "Centered_4th") ||
              (moistscal_horiz_adv_string == "Upwind_5th"  ) ||
+             (moistscal_horiz_adv_string == "Blended_5th6th") ||
              (moistscal_horiz_adv_string == "Centered_6th") ||
              (moistscal_horiz_adv_string == "WENO3"       ) ||
              (moistscal_horiz_adv_string == "WENOZ3"      ) ||
@@ -116,8 +174,10 @@ struct AdvChoice {
 
         if ( (moistscal_vert_adv_string == "Centered_2nd") ||
              (moistscal_vert_adv_string == "Upwind_3rd"  ) ||
+             (moistscal_vert_adv_string == "Blended_3rd4th") ||
              (moistscal_vert_adv_string == "Centered_4th") ||
              (moistscal_vert_adv_string == "Upwind_5th"  ) ||
+             (moistscal_vert_adv_string == "Blended_5th6th") ||
              (moistscal_vert_adv_string == "Centered_6th") ||
              (moistscal_vert_adv_string == "WENO3"       ) ||
              (moistscal_vert_adv_string == "WENOZ3"      ) ||
@@ -135,12 +195,24 @@ struct AdvChoice {
     void display()
     {
         amrex::Print() << "Advection Choices: " << std::endl;
-        amrex::Print() << "dycore_horiz_adv_type       : " << adv_type_convert_int_to_string(dycore_horiz_adv_type) << std::endl;
-        amrex::Print() << "dycore_vert_adv_type        : " << adv_type_convert_int_to_string(dycore_vert_adv_type) << std::endl;
-        amrex::Print() << "dryscal_horiz_adv_type      : " << adv_type_convert_int_to_string(dryscal_horiz_adv_type) << std::endl;
-        amrex::Print() << "dryscal_vert_adv_type       : " << adv_type_convert_int_to_string(dryscal_vert_adv_type) << std::endl;
-        amrex::Print() << "moistscal_horiz_adv_type    : " << adv_type_convert_int_to_string(moistscal_horiz_adv_type) << std::endl;
-        amrex::Print() << "moistscal_vert_adv_type     : " << adv_type_convert_int_to_string(moistscal_vert_adv_type) << std::endl;
+        amrex::Print() << "dycore_horiz_adv_type       : " << adv_type_convert_int_to_string(dycore_horiz_adv_type);
+        if (dycore_horiz_upw_frac < 1) amrex::Print() << " with " << 100*dycore_horiz_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
+        amrex::Print() << "dycore_vert_adv_type        : " << adv_type_convert_int_to_string(dycore_vert_adv_type);
+        if (dycore_vert_upw_frac < 1) amrex::Print() << " with " << 100*dycore_vert_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
+        amrex::Print() << "dryscal_horiz_adv_type      : " << adv_type_convert_int_to_string(dryscal_horiz_adv_type);
+        if (dryscal_horiz_upw_frac < 1) amrex::Print() << " with " << 100*dryscal_horiz_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
+        amrex::Print() << "dryscal_vert_adv_type       : " << adv_type_convert_int_to_string(dryscal_vert_adv_type);
+        if (dryscal_vert_upw_frac < 1) amrex::Print() << " with " << 100*dryscal_vert_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
+        amrex::Print() << "moistscal_horiz_adv_type    : " << adv_type_convert_int_to_string(moistscal_horiz_adv_type);
+        if (moistscal_horiz_upw_frac < 1) amrex::Print() << " with " << 100*moistscal_horiz_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
+        amrex::Print() << "moistscal_vert_adv_type     : " << adv_type_convert_int_to_string(moistscal_vert_adv_type);
+        if (moistscal_vert_upw_frac < 1) amrex::Print() << " with " << 100*moistscal_vert_upw_frac << "% upwinding";
+        amrex::Print() << std::endl;
     }
 
     std::string
@@ -175,11 +247,11 @@ struct AdvChoice {
     {
         if (adv_string == "Centered_2nd") {
             return AdvType::Centered_2nd;
-        } else if (adv_string == "Upwind_3rd") {
+        } else if ((adv_string == "Upwind_3rd") || (adv_string == "Blended_3rd4th")) {
             return AdvType::Upwind_3rd;
         } else if (adv_string == "Centered_4th") {
             return AdvType::Centered_4th;
-        } else if (adv_string == "Upwind_5th") {
+        } else if (adv_string == "Upwind_5th" || (adv_string == "Blended_5th6th")) {
             return AdvType::Upwind_5th;
         } else if (adv_string == "Centered_6th") {
             return AdvType::Centered_6th;
@@ -210,5 +282,13 @@ struct AdvChoice {
     AdvType dryscal_vert_adv_type    = AdvType::Upwind_3rd;
     AdvType moistscal_horiz_adv_type = AdvType::Weno_3;
     AdvType moistscal_vert_adv_type  = AdvType::Weno_3;
+
+    // Blending between upwind and the next-highest order central scheme
+    amrex::Real dycore_horiz_upw_frac    = 1.0;
+    amrex::Real dycore_vert_upw_frac     = 1.0;
+    amrex::Real dryscal_horiz_upw_frac   = 1.0;
+    amrex::Real dryscal_vert_upw_frac    = 1.0;
+    amrex::Real moistscal_horiz_upw_frac = 1.0;
+    amrex::Real moistscal_vert_upw_frac  = 1.0;
 };
 #endif

--- a/Source/DataStructs/AdvStruct.H
+++ b/Source/DataStructs/AdvStruct.H
@@ -284,6 +284,8 @@ struct AdvChoice {
     AdvType moistscal_vert_adv_type  = AdvType::Weno_3;
 
     // Blending between upwind and the next-highest order central scheme
+    // Note: This is used by both Upwind_* and Blended_* schemes -- the default
+    //       is a pure upwind scheme
     amrex::Real dycore_horiz_upw_frac    = 1.0;
     amrex::Real dycore_vert_upw_frac     = 1.0;
     amrex::Real dryscal_horiz_upw_frac   = 1.0;

--- a/Source/TimeIntegration/ERF_slow_rhs_inc.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_inc.cpp
@@ -111,9 +111,12 @@ void erf_slow_rhs_inc (int /*level*/, int nrk,
     int   num_comp = 2;
     int   end_comp = start_comp + num_comp - 1;
 
-    const int l_horiz_adv_type = solverChoice.dycore_horiz_adv_type;
-    const int l_vert_adv_type  = solverChoice.dycore_vert_adv_type;
-    const bool l_use_terrain    = solverChoice.use_terrain;
+    const int  l_horiz_adv_type = solverChoice.dycore_horiz_adv_type;
+    const int   l_vert_adv_type = solverChoice.dycore_vert_adv_type;
+    const Real l_horiz_upw_frac = solverChoice.dycore_horiz_upw_frac;
+    const Real  l_vert_upw_frac = solverChoice.dycore_vert_upw_frac;
+
+    const bool l_use_terrain = solverChoice.use_terrain;
 
     AMREX_ALWAYS_ASSERT (!l_use_terrain);
 
@@ -596,13 +599,17 @@ void erf_slow_rhs_inc (int /*level*/, int nrk,
                            avg_xmom, avg_ymom, avg_zmom, // these are being defined from the fluxes
                            cell_prim, z_nd, detJ_arr,
                            dxInv, mf_m, mf_u, mf_v,
-                           l_horiz_adv_type, l_vert_adv_type, l_use_terrain, flx_arr);
+                           //l_horiz_adv_type, l_vert_adv_type,
+                           //l_horiz_upw_frac, l_vert_upw_frac,
+                           l_use_terrain, flx_arr);
 
         int icomp = RhoTheta_comp; int ncomp = 1;
         AdvectionSrcForScalars(bx, icomp, ncomp,
                                avg_xmom, avg_ymom, avg_zmom,
                                cell_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                               l_horiz_adv_type, l_vert_adv_type, l_use_terrain, flx_arr);
+                               l_horiz_adv_type, l_vert_adv_type,
+                               l_horiz_upw_frac, l_vert_upw_frac,
+                               l_use_terrain, flx_arr);
 
         if (l_use_diff) {
             Array4<Real> diffflux_x = dflux_x->array(mfi);
@@ -689,7 +696,9 @@ void erf_slow_rhs_inc (int /*level*/, int nrk,
                            rho_u_rhs, rho_v_rhs, rho_w_rhs, u, v, w,
                            rho_u    , rho_v    , omega_arr,
                            z_nd, detJ_arr, dxInv, mf_m, mf_u, mf_v,
-                           horiz_adv_type, vert_adv_type, l_use_terrain, domhi_z);
+                           l_horiz_adv_type, l_vert_adv_type,
+                           l_horiz_upw_frac, l_vert_upw_frac,
+                           l_use_terrain, domhi_z);
 
         if (l_use_diff) {
             DiffusionSrcForMom_N(tbx, tby, tbz,

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -265,8 +265,10 @@ void erf_slow_rhs_post (int level, int finest_level,
         // **************************************************************************
         // Define updates in the RHS of continuity, temperature, and scalar equations
         // **************************************************************************
-        AdvType horiz_adv_type = ac.dryscal_horiz_adv_type;
-        AdvType  vert_adv_type = ac.dryscal_vert_adv_type;
+        AdvType    horiz_adv_type = ac.dryscal_horiz_adv_type;
+        AdvType     vert_adv_type = ac.dryscal_vert_adv_type;
+        const Real horiz_upw_frac = ac.dryscal_horiz_upw_frac;
+        const Real  vert_upw_frac = ac.dryscal_vert_upw_frac;
 
         if (ac.use_efficient_advection){
              horiz_adv_type = EfficientAdvType(nrk,ac.dryscal_horiz_adv_type);
@@ -278,14 +280,18 @@ void erf_slow_rhs_post (int level, int finest_level,
               num_comp = 1;
             AdvectionSrcForScalars(tbx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                    cur_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                                   horiz_adv_type, vert_adv_type, l_use_terrain, flx_arr);
+                                   horiz_adv_type, vert_adv_type,
+                                   horiz_upw_frac, vert_upw_frac,
+                                   l_use_terrain, flx_arr);
         }
         if (l_use_QKE) {
             start_comp = RhoQKE_comp;
               num_comp = 1;
             AdvectionSrcForScalars(tbx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                    cur_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                                   horiz_adv_type, vert_adv_type, l_use_terrain, flx_arr);
+                                   horiz_adv_type, vert_adv_type,
+                                   horiz_upw_frac, vert_upw_frac,
+                                   l_use_terrain, flx_arr);
         }
 
         // This is simply an advected scalar for convenience
@@ -293,23 +299,30 @@ void erf_slow_rhs_post (int level, int finest_level,
         num_comp = 1;
         AdvectionSrcForScalars(tbx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                cur_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                               horiz_adv_type, vert_adv_type, l_use_terrain, flx_arr);
+                               horiz_adv_type, vert_adv_type,
+                               horiz_upw_frac, vert_upw_frac,
+                               l_use_terrain, flx_arr);
 
         if (solverChoice.moisture_type != MoistureType::None)
         {
             start_comp = RhoQ1_comp;
               num_comp = nvars - start_comp;
 
-            AdvType moist_horiz_adv_type = ac.moistscal_horiz_adv_type;
-            AdvType  moist_vert_adv_type = ac.moistscal_vert_adv_type;
+            AdvType    moist_horiz_adv_type = ac.moistscal_horiz_adv_type;
+            AdvType     moist_vert_adv_type = ac.moistscal_vert_adv_type;
+            const Real moist_horiz_upw_frac = ac.moistscal_horiz_upw_frac;
+            const Real  moist_vert_upw_frac = ac.moistscal_vert_upw_frac;
 
             if (ac.use_efficient_advection){
                  moist_horiz_adv_type = EfficientAdvType(nrk,ac.moistscal_horiz_adv_type);
                  moist_vert_adv_type  = EfficientAdvType(nrk,ac.moistscal_vert_adv_type);
             }
+
             AdvectionSrcForScalars(tbx, start_comp, num_comp, avg_xmom, avg_ymom, avg_zmom,
                                    cur_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                                   moist_horiz_adv_type, moist_vert_adv_type, l_use_terrain, flx_arr);
+                                   moist_horiz_adv_type, moist_vert_adv_type,
+                                   moist_horiz_upw_frac, moist_vert_upw_frac,
+                                   l_use_terrain, flx_arr);
         }
 
         if (l_use_diff) {

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -119,6 +119,8 @@ void erf_slow_rhs_pre (int level, int finest_level,
 
     const AdvType l_horiz_adv_type = solverChoice.advChoice.dycore_horiz_adv_type;
     const AdvType l_vert_adv_type  = solverChoice.advChoice.dycore_vert_adv_type;
+    const Real    l_horiz_upw_frac = solverChoice.advChoice.dycore_horiz_upw_frac;
+    const Real    l_vert_upw_frac  = solverChoice.advChoice.dycore_vert_upw_frac;
     const bool    l_use_terrain    = solverChoice.use_terrain;
     const bool    l_moving_terrain = (solverChoice.terrain_type == TerrainType::Moving);
     if (l_moving_terrain) AMREX_ALWAYS_ASSERT (l_use_terrain);
@@ -649,7 +651,9 @@ void erf_slow_rhs_pre (int level, int finest_level,
         AdvectionSrcForScalars(bx, icomp, ncomp,
                                avg_xmom, avg_ymom, avg_zmom,
                                cell_prim, cell_rhs, detJ_arr, dxInv, mf_m,
-                               l_horiz_adv_type, l_vert_adv_type, l_use_terrain, flx_arr);
+                               l_horiz_adv_type, l_vert_adv_type,
+                               l_horiz_upw_frac, l_vert_upw_frac,
+                               l_use_terrain, flx_arr);
 
         if (l_use_diff) {
             Array4<Real> diffflux_x = dflux_x->array(mfi);
@@ -764,7 +768,9 @@ void erf_slow_rhs_pre (int level, int finest_level,
                            rho_u_rhs, rho_v_rhs, rho_w_rhs, u, v, w,
                            rho_u    , rho_v    , omega_arr,
                            z_nd, detJ_arr, dxInv, mf_m, mf_u, mf_v,
-                           l_horiz_adv_type, l_vert_adv_type, l_use_terrain, domhi_z);
+                           l_horiz_adv_type, l_vert_adv_type,
+                           l_horiz_upw_frac, l_vert_upw_frac,
+                           l_use_terrain, domhi_z);
 
         if (l_use_diff) {
             // Note: tau** were calculated with calls to

--- a/Source/Utils/Interpolation_UPW.H
+++ b/Source/Utils/Interpolation_UPW.H
@@ -19,7 +19,8 @@ struct CENTERED2
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -37,7 +38,8 @@ struct CENTERED2
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -51,11 +53,12 @@ struct CENTERED2
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real /*upw_lo*/) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -99,7 +102,8 @@ struct UPWIND3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -122,7 +126,8 @@ struct UPWIND3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -141,11 +146,12 @@ struct UPWIND3
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -202,7 +208,8 @@ struct CENTERED4
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -222,7 +229,8 @@ struct CENTERED4
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -238,11 +246,12 @@ struct CENTERED4
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real /*upw_lo*/) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -292,7 +301,8 @@ struct UPWIND5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -317,7 +327,8 @@ struct UPWIND5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -338,11 +349,12 @@ struct UPWIND5
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -405,7 +417,8 @@ struct CENTERED6
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -427,7 +440,8 @@ struct CENTERED6
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/) const
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -445,11 +459,12 @@ struct CENTERED6
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real /*upw_lo*/) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real /*upw_lo*/,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -501,12 +516,13 @@ struct UPWINDALL
     AMREX_FORCE_INLINE
     void
     InterpolateInZ (const int& i,
-                       const int& j,
-                       const int& k,
-                       const int& qty_index,
-                       amrex::Real& val_lo,
-                       amrex::Real upw_lo,
-                       const AdvType adv_type) const
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo,
+                    const amrex::Real upw_frac,
+                    const AdvType adv_type) const
     {
         if (adv_type == AdvType::Centered_2nd) {
             val_lo = 0.5 * ( m_phi(i,j,k,qty_index) + m_phi(i,j,k-1,qty_index) );

--- a/Source/Utils/Interpolation_UPW.H
+++ b/Source/Utils/Interpolation_UPW.H
@@ -114,6 +114,9 @@ struct UPWIND3
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
+        // Add blending
+        upw_lo *= upw_frac;
+
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
     }
@@ -138,6 +141,9 @@ struct UPWIND3
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
+        // Add blending
+        upw_lo *= upw_frac;
+
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
     }
@@ -161,6 +167,9 @@ struct UPWIND3
 
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+        // Add blending
+        upw_lo *= upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
@@ -315,6 +324,9 @@ struct UPWIND5
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
+        // Add blending
+        upw_lo *= upw_frac;
+
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
     }
@@ -341,6 +353,9 @@ struct UPWIND5
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
+        // Add blending
+        upw_lo *= upw_frac;
+
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
     }
@@ -366,6 +381,9 @@ struct UPWIND5
 
         // Upwinding flags
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+        // Add blending
+        upw_lo *= upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
@@ -538,6 +556,9 @@ struct UPWINDALL
 
             // Upwinding flags
             if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+            // Add blending
+            upw_lo *= upw_frac;
 
             // Interpolate lo
             val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo,adv_type);

--- a/Source/Utils/Interpolation_WENO.H
+++ b/Source/Utils/Interpolation_WENO.H
@@ -19,7 +19,8 @@ struct WENO3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -44,7 +45,8 @@ struct WENO3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -69,7 +71,8 @@ struct WENO3
                        const int& k,
                        const int& qty_index,
                        amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                       amrex::Real upw_lo,
+                       const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -136,7 +139,8 @@ struct WENO5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -163,7 +167,8 @@ struct WENO5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -190,7 +195,8 @@ struct WENO5
                        const int& k,
                        const int& qty_index,
                        amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                       amrex::Real upw_lo,
+                       const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);

--- a/Source/Utils/Interpolation_WENO_Z.H
+++ b/Source/Utils/Interpolation_WENO_Z.H
@@ -19,7 +19,8 @@ struct WENO_Z3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -44,7 +45,8 @@ struct WENO_Z3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -69,7 +71,8 @@ struct WENO_Z3
                        const int& k,
                        const int& qty_index,
                        amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                       amrex::Real upw_lo,
+                       const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -137,7 +140,8 @@ struct WENO_MZQ3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -162,7 +166,8 @@ struct WENO_MZQ3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -187,7 +192,8 @@ struct WENO_MZQ3
                        const int& k,
                        const int& qty_index,
                        amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                       amrex::Real upw_lo,
+                       const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -260,7 +266,8 @@ struct WENO_Z5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -287,7 +294,8 @@ struct WENO_Z5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo) const
+                    amrex::Real upw_lo,
+                    const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -314,7 +322,8 @@ struct WENO_Z5
                        const int& k,
                        const int& qty_index,
                        amrex::Real& val_lo,
-                       amrex::Real upw_lo) const
+                       amrex::Real upw_lo,
+                       const amrex::Real /*upw_frac*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);


### PR DESCRIPTION
New options include "Blended_3rd4th" and "Blended_5th6th", which allows for a mix between upwind and central differencing. This is motivated by the hybrid schemes evaluated in Sauer & Muñoz-Esparza 2020 https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2020MS002100. 

The amount of upwinding that is added is controlled by `dycore_horiz_upw_frac`, `dycore_vert_upw_frac`, `dryscal_horiz_upw_frac`, `dryscal_vert_upw_frac`, `moistscal_horiz_upw_frac`, `moistscal_vert_upw_frac`. I have verified that a value of 1 (100% upwinding) exactly recovers the lower-ordered upwind scheme and a value of 0 (no upwinding) recovers the higher-ordered central scheme. 

The blending is achieved by generalizing the Upwind interpolation, which has a default upwinding factor of 1. 