### PR TITLE
Changes required for coupling with AMR-Wind

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -288,6 +288,10 @@ public:
     // Advance a block specified number of time steps
     void Evolve_MB (int MBstep, int max_block_step);
 
+    // get the current time values
+    amrex::Real get_t_old() {return t_old[0];}
+    amrex::Real get_t_new() {return t_new[0];}
+
     // Set parmparse prefix for MultiBlock
     void SetParmParsePrefix (std::string name) { pp_prefix = name; }
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -494,15 +494,17 @@ ERF::InitData ()
 
         const Real time = start_time;
         InitFromScratch(time);
-/*
+
 #ifdef ERF_USE_MULTIBLOCK
+#ifndef ERF_MB_EXTERN       // enter only if multiblock does not involve an external class
         // Multiblock: hook to set BL & comms once ba/dm are known
         if(domain_p[0].bigEnd(0) < 500 ) {
             m_mbc->SetBoxLists();
             m_mbc->SetBlockCommMetaData();
         }
 #endif
-*/
+#endif
+
         if (solverChoice.use_terrain) {
             if (init_type == "ideal") {
                 amrex::Abort("We do not currently support init_type = ideal with terrain");
@@ -1684,14 +1686,14 @@ ERF::Evolve_MB (int MBstep, int max_block_step)
         int iteration = 1;
         timeStep(lev, cur_time, iteration);
 
-/*
+#ifndef ERF_MB_EXTERN
         // DEBUG
         // Multiblock: hook for erf2 to fill from erf1
         if(domain_p[0].bigEnd(0) < 500) {
             for (int var_idx = 0; var_idx < Vars::NumTypes; ++var_idx)
                 m_mbc->FillPatchBlocks(var_idx,var_idx);
         }
-*/
+#endif
 
         cur_time  += dt[0];
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -494,7 +494,7 @@ ERF::InitData ()
 
         const Real time = start_time;
         InitFromScratch(time);
-
+/*
 #ifdef ERF_USE_MULTIBLOCK
         // Multiblock: hook to set BL & comms once ba/dm are known
         if(domain_p[0].bigEnd(0) < 500 ) {
@@ -502,7 +502,7 @@ ERF::InitData ()
             m_mbc->SetBlockCommMetaData();
         }
 #endif
-
+*/
         if (solverChoice.use_terrain) {
             if (init_type == "ideal") {
                 amrex::Abort("We do not currently support init_type = ideal with terrain");
@@ -1684,12 +1684,14 @@ ERF::Evolve_MB (int MBstep, int max_block_step)
         int iteration = 1;
         timeStep(lev, cur_time, iteration);
 
+/*
         // DEBUG
         // Multiblock: hook for erf2 to fill from erf1
         if(domain_p[0].bigEnd(0) < 500) {
             for (int var_idx = 0; var_idx < Vars::NumTypes; ++var_idx)
                 m_mbc->FillPatchBlocks(var_idx,var_idx);
         }
+*/
 
         cur_time  += dt[0];
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1734,27 +1734,5 @@ ERF::Evolve_MB (int MBstep, int max_block_step)
         if (cur_time >= stop_time - 1.e-6*dt[0]) break;
     }
 
-/*  I don't think we need these for the multiblock Evolve
-**  Results in extraneous plot/checkpoint files
-
-    if (plot_int_1 > 0 && istep[0] > last_plot_file_step_1) {
-        WritePlotFile(1,plot_var_names_1);
-    }
-    if (plot_int_2 > 0 && istep[0] > last_plot_file_step_2) {
-        WritePlotFile(2,plot_var_names_2);
-    }
-
-    if (check_int > 0 && istep[0] > last_check_file_step) {
-#ifdef ERF_USE_NETCDF
-        if (check_type == "netcdf") {
-           WriteNCCheckpointFile();
-        }
-#endif
-        if (check_type == "native") {
-           WriteCheckpointFile();
-        }
-    }
-*/
-
 }
 #endif

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1732,6 +1732,9 @@ ERF::Evolve_MB (int MBstep, int max_block_step)
         if (cur_time >= stop_time - 1.e-6*dt[0]) break;
     }
 
+/*  I don't think we need these for the multiblock Evolve
+**  Results in extraneous plot/checkpoint files
+
     if (plot_int_1 > 0 && istep[0] > last_plot_file_step_1) {
         WritePlotFile(1,plot_var_names_1);
     }
@@ -1749,6 +1752,7 @@ ERF::Evolve_MB (int MBstep, int max_block_step)
            WriteCheckpointFile();
         }
     }
+*/
 
 }
 #endif

--- a/Source/Initialization/ERF_init_bcs.cpp
+++ b/Source/Initialization/ERF_init_bcs.cpp
@@ -48,7 +48,13 @@ void ERF::init_bcs ()
         m_bc_neumann_vals[BCVars::yvel_bc][ori] = 0.0;
         m_bc_neumann_vals[BCVars::zvel_bc][ori] = 0.0;
 
-        ParmParse pp(bcid);
+        std::string pp_text;
+        if (pp_prefix == "erf") {
+          pp_text = bcid;
+        } else {
+          pp_text = pp_prefix + "." + bcid;
+        }
+        ParmParse pp(pp_text);
         std::string bc_type_in = "null";
         pp.query("type", bc_type_in);
         //if (pp.query("type", bc_type_in))


### PR DESCRIPTION
- include functions to return simulation times for external use.
- use a new compile time variable `ERF_MB_EXTERN` to comment out certain code when coupling with an external class instead of another ERF class.
- remove code at the end of `Evolve_MB` that results in extraneous plot/check files.
- manage prefix of BCs for multiblock.