### PR TITLE
Fill qt

### DIFF
--- a/Source/Microphysics/FastEddy/FastEddy.cpp
+++ b/Source/Microphysics/FastEddy/FastEddy.cpp
@@ -19,6 +19,7 @@ void FastEddy::AdvanceFE ()
     for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         auto qv_array    = mic_fab_vars[MicVar_FE::qv]->array(mfi);
         auto qc_array    = mic_fab_vars[MicVar_FE::qc]->array(mfi);
+        auto qt_array    = mic_fab_vars[MicVar_FE::qt]->array(mfi);
         auto tabs_array  = mic_fab_vars[MicVar_FE::tabs]->array(mfi);
         auto theta_array = mic_fab_vars[MicVar_FE::theta]->array(mfi);
         auto pres_array  = mic_fab_vars[MicVar_FE::pres]->array(mfi);
@@ -67,6 +68,7 @@ void FastEddy::AdvanceFE ()
             qv_array(i,j,k) = std::max(0.0, qv_array(i,j,k));
             qc_array(i,j,k) = std::max(0.0, qc_array(i,j,k));
 
+            qt_array(i,j,k) = qv_array(i,j,k) + qc_array(i,j,k);
         });
     }
 }

--- a/Source/Microphysics/Kessler/Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Init_Kessler.cpp
@@ -68,6 +68,7 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
         auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
         auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
         auto qp_array    = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
+        auto qt_array    = mic_fab_vars[MicVar_Kess::qt]->array(mfi);
 
         auto rho_array   = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
         auto theta_array = mic_fab_vars[MicVar_Kess::theta]->array(mfi);
@@ -82,6 +83,7 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
             qv_array(i,j,k)    = states_array(i,j,k,RhoQ1_comp)/states_array(i,j,k,Rho_comp);
             qc_array(i,j,k)    = states_array(i,j,k,RhoQ2_comp)/states_array(i,j,k,Rho_comp);
             qp_array(i,j,k)    = states_array(i,j,k,RhoQ3_comp)/states_array(i,j,k,Rho_comp);
+            qt_array(i,j,k)    = qv_array(i,j,k) + qc_array(i,j,k);
 
             tabs_array(i,j,k)  = getTgivenRandRTh(states_array(i,j,k,Rho_comp),
                                                   states_array(i,j,k,RhoTheta_comp),

--- a/Source/Microphysics/Kessler/Kessler.cpp
+++ b/Source/Microphysics/Kessler/Kessler.cpp
@@ -70,6 +70,7 @@ void Kessler::AdvanceKessler ()
         auto qv_array   = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
         auto qc_array   = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
         auto qp_array   = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
+        auto qt_array   = mic_fab_vars[MicVar_Kess::qt]->array(mfi);
         auto tabs_array = mic_fab_vars[MicVar_Kess::tabs]->array(mfi);
         auto pres_array = mic_fab_vars[MicVar_Kess::pres]->array(mfi);
         auto theta_array = theta->array(mfi);
@@ -163,6 +164,8 @@ void Kessler::AdvanceKessler ()
             qv_array(i,j,k) = std::max(0.0, qv_array(i,j,k));
             qc_array(i,j,k) = std::max(0.0, qc_array(i,j,k));
             qp_array(i,j,k) = std::max(0.0, qp_array(i,j,k));
+
+            qt_array(i,j,k) = qv_array(i,j,k) + qc_array(i,j,k);
         });
     }
 }


### PR DESCRIPTION
Moisture models own their own local copy of variables. Qt is one of those variables and must be updated internally. This update was not done properly for Kessler and could be out of sync with FastEddy. This PR corrects that behavior.