### PR TITLE
Updating dry and moist bubble inputs for RegTests

### DIFF
--- a/Exec/RegTests/Bubble/inputs_BF02_dry_bubble
+++ b/Exec/RegTests/Bubble/inputs_BF02_dry_bubble
@@ -7,8 +7,8 @@ amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 1024 1024 1024
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_extent = 20000.0 312.5  10000.0
-amr.n_cell           = 256     4      128
+geometry.prob_extent = 20000.0 400.0  10000.0
+amr.n_cell           = 200     4      100
 geometry.is_periodic = 0 1 0
 xlo.type = "SlipWall"
 xhi.type = "SlipWall"    
@@ -57,9 +57,9 @@ erf.use_moist_background = false
 
 erf.molec_diff_type  = "ConstantAlpha"
 erf.rho0_trans       = 1.0 # [kg/m^3], used to convert input diffusivities
-erf.dynamicViscosity = 1.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
-erf.alpha_T          = 1.0 # [m^2/s]
-erf.alpha_C          = 1.0
+erf.dynamicViscosity = 0.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T          = 0.0 # [m^2/s]
+erf.alpha_C          = 0.0
 
 # PROBLEM PARAMETERS (optional)
 # warm bubble input

--- a/Exec/RegTests/Bubble/inputs_BF02_moist_bubble
+++ b/Exec/RegTests/Bubble/inputs_BF02_moist_bubble
@@ -7,8 +7,8 @@ amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 1024 1024 1024
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_extent = 20000.0 312.5  10000.0
-amr.n_cell           = 256     4      128
+geometry.prob_extent = 20000.0 400.0  10000.0
+amr.n_cell           = 200     4      100
 geometry.is_periodic = 0 1 0
 xlo.type = "SlipWall"
 xhi.type = "SlipWall"    
@@ -59,9 +59,9 @@ erf.use_moist_background = true
 
 erf.molec_diff_type  = "ConstantAlpha"
 erf.rho0_trans       = 1.0 # [kg/m^3], used to convert input diffusivities
-erf.dynamicViscosity = 1.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
-erf.alpha_T          = 1.0 # [m^2/s]
-erf.alpha_C          = 1.0
+erf.dynamicViscosity = 0.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T          = 0.0 # [m^2/s]
+erf.alpha_C          = 0.0
 
 # INITIAL CONDITIONS
 #erf.init_type = "input_sounding"


### PR DESCRIPTION
This PR updates the inputs for the dry and moist bubble and makes it consistent with [Bryan and Fritsch 2002](https://journals.ametsoc.org/view/journals/mwre/130/12/1520-0493_2002_130_2917_absfmn_2.0.co_2.xml) - 100 m resolution in both x and z directions, and no dissipation. The results of the dry and moist bubble test cases in `Exec/Bubble` are compared and as shown in figures below. We have excellent quantitative comparisons for the contours and the min/max values of delta_potential_temperature and zvel. This is ready to be accepted into `RegTests`.

<img width="896" alt="RegTests_DryBubble" src="https://github.com/erf-model/ERF/assets/34353555/138b99b3-27ab-4a91-a3ec-2884595d83e7">
 
<img width="747" alt="RegTests_MoistBubble" src="https://github.com/erf-model/ERF/assets/34353555/5cde1bc2-aa61-4a63-b9d7-3efea9418134">


