### PR TITLE
Generalize ABL prob

### DIFF
--- a/Exec/ABL/inputs_deardorff
+++ b/Exec/ABL/inputs_deardorff
@@ -46,6 +46,7 @@ erf.sigma_k  = 1.0
 erf.Ce       = 0.1
 
 erf.init_type = "uniform"
+erf.KE_0 = 0.1 # for Deardorff
 
 # PROBLEM PARAMETERS
 prob.rho_0 = 1.0

--- a/Exec/ABL/inputs_deardorff_msf
+++ b/Exec/ABL/inputs_deardorff_msf
@@ -51,6 +51,7 @@ erf.sigma_k  = 1.0
 erf.Ce       = 0.1
 
 erf.init_type = "uniform"
+erf.KE_0 = 0.1 # for Deardorff
 
 # PROBLEM PARAMETERS
 prob.rho_0 = 1.0

--- a/Exec/ABL/inputs_deardorff_no_msf
+++ b/Exec/ABL/inputs_deardorff_no_msf
@@ -50,6 +50,7 @@ erf.sigma_k  = 1.0
 erf.Ce       = 0.1
 
 erf.init_type = "uniform"
+erf.KE_0 = 0.1 # for Deardorff
 
 # PROBLEM PARAMETERS
 prob.rho_0 = 1.0

--- a/Exec/ABL/inputs_numdiff
+++ b/Exec/ABL/inputs_numdiff
@@ -49,6 +49,7 @@ erf.use_NumDiff  = true
 erf.NumDiffCoeff = 0.5
 
 erf.init_type = "uniform"
+erf.KE_0 = 0.1 # for Deardorff
 
 # PROBLEM PARAMETERS
 prob.rho_0 = 1.0

--- a/Exec/ABL/prob.H
+++ b/Exec/ABL/prob.H
@@ -14,6 +14,9 @@ struct ProbParm : ProbParmDefaults {
   amrex::Real KE_0  = 0.1;
   amrex::Real QKE_0 = 0.1;
 
+  amrex::Real KE_decay_height = -1;
+  amrex::Real KE_decay_order = 1;
+
   amrex::Real U_0 = 0.0;
   amrex::Real V_0 = 0.0;
   amrex::Real W_0 = 0.0;

--- a/Exec/ABL/prob.H
+++ b/Exec/ABL/prob.H
@@ -22,6 +22,7 @@ struct ProbParm : ProbParmDefaults {
   amrex::Real V_0_Pert_Mag = 0.0;
   amrex::Real W_0_Pert_Mag = 0.0;
   amrex::Real T_0_Pert_Mag = 0.0; // perturbation to rho*Theta
+  bool pert_rhotheta = true;
 
   // divergence-free initial perturbations
   amrex::Real pert_deltaU = 0.0;

--- a/Exec/ABL/prob.H
+++ b/Exec/ABL/prob.H
@@ -11,6 +11,7 @@ struct ProbParm : ProbParmDefaults {
   amrex::Real rho_0 = 0.0;
   amrex::Real T_0   = 0.0;
   amrex::Real A_0   = 1.0;
+  amrex::Real KE_0  = 0.1;
   amrex::Real QKE_0 = 0.1;
 
   amrex::Real U_0 = 0.0;

--- a/Exec/ABL/prob.cpp
+++ b/Exec/ABL/prob.cpp
@@ -56,7 +56,7 @@ Problem::init_custom_pert(
     amrex::Array4<amrex::Real      > const& r_hse,
     amrex::Array4<amrex::Real      > const& /*p_hse*/,
     amrex::Array4<amrex::Real const> const& /*z_nd*/,
-    amrex::Array4<amrex::Real const> const& /*z_cc*/,
+    amrex::Array4<amrex::Real const> const& z_cc,
     amrex::GeometryData const& geomdata,
     amrex::Array4<amrex::Real const> const& /*mf_m*/,
     amrex::Array4<amrex::Real const> const& /*mf_u*/,
@@ -68,6 +68,15 @@ Problem::init_custom_pert(
     const bool use_terrain = sc.use_terrain;
 
     if (parms.pert_ref_height > 0) {
+        if ((parms.pert_deltaU != 0.0) || (parms.pert_deltaV != 0.0)) {
+            if (use_terrain) {
+                amrex::Abort("divergence-free perturbations not supported for terrain");
+            } else {
+                amrex::Print() << "Adding divergence-free perturbations "
+                               << parms.pert_deltaU << " "
+                               << parms.pert_deltaV << std::endl;
+            }
+        }
         if (parms.U_0_Pert_Mag != 0.0) {
             amrex::Print() << "Adding random x-velocity perturbations" << std::endl;
         }
@@ -90,7 +99,7 @@ Problem::init_custom_pert(
     const Real* dx = geomdata.CellSize();
     const Real x = prob_lo[0] + (i + 0.5) * dx[0];
     const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-    const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+    const Real z = use_terrain ? z_cc(i,j,k) : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Define a point (xc,yc,zc) at the center of the domain
     const Real xc = 0.5 * (prob_lo[0] + prob_hi[0]);

--- a/Exec/ABL/prob.cpp
+++ b/Exec/ABL/prob.cpp
@@ -70,6 +70,12 @@ Problem::init_custom_pert(
 
     const bool use_terrain = sc.use_terrain;
 
+    if (parms.KE_decay_height > 0) {
+        amrex::Print() << "Initial KE profile (order " << parms.KE_decay_order
+                       << ") will extend up to " << parms.KE_decay_height
+                       << std::endl;
+    }
+
     if (parms.pert_ref_height > 0) {
         if ((parms.pert_deltaU != 0.0) || (parms.pert_deltaV != 0.0)) {
             if (use_terrain) {
@@ -131,7 +137,7 @@ Problem::init_custom_pert(
         if (parms.KE_decay_height > 0) {
             // scale initial SGS kinetic energy with height
             state(i, j, k, RhoKE_comp) *= max(
-                std::pow(1 - z/parms.KE_decay_height, parms.KE_decay_order),
+                std::pow(1 - min(z/parms.KE_decay_height,1.0), parms.KE_decay_order),
                 1e-12);
         }
     }
@@ -141,7 +147,7 @@ Problem::init_custom_pert(
         if (parms.KE_decay_height > 0) {
             // scale initial SGS kinetic energy with height
             state(i, j, k, RhoQKE_comp) *= max(
-                std::pow(1 - z/parms.KE_decay_height, parms.KE_decay_order),
+                std::pow(1 - min(z/parms.KE_decay_height,1.0), parms.KE_decay_order),
                 1e-12);
         }
     }

--- a/Exec/ABL/prob.cpp
+++ b/Exec/ABL/prob.cpp
@@ -58,7 +58,7 @@ Problem::init_custom_pert(
     amrex::Array4<amrex::Real      > const& z_vel,
     amrex::Array4<amrex::Real      > const& r_hse,
     amrex::Array4<amrex::Real      > const& /*p_hse*/,
-    amrex::Array4<amrex::Real const> const& /*z_nd*/,
+    amrex::Array4<amrex::Real const> const& z_nd,
     amrex::Array4<amrex::Real const> const& z_cc,
     amrex::GeometryData const& geomdata,
     amrex::Array4<amrex::Real const> const& /*mf_m*/,
@@ -78,13 +78,9 @@ Problem::init_custom_pert(
 
     if (parms.pert_ref_height > 0) {
         if ((parms.pert_deltaU != 0.0) || (parms.pert_deltaV != 0.0)) {
-            if (use_terrain) {
-                amrex::Abort("divergence-free perturbations not supported for terrain");
-            } else {
-                amrex::Print() << "Adding divergence-free perturbations "
-                               << parms.pert_deltaU << " "
-                               << parms.pert_deltaV << std::endl;
-            }
+            amrex::Print() << "Adding divergence-free perturbations "
+                           << parms.pert_deltaU << " " << parms.pert_deltaV
+                           << std::endl;
         }
         if (parms.U_0_Pert_Mag != 0.0) {
             amrex::Print() << "Adding random x-velocity perturbations" << std::endl;
@@ -163,7 +159,9 @@ Problem::init_custom_pert(
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
     const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-    const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+    const Real z = use_terrain ? 0.25*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+                                      + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
+                               : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the x-velocity
     x_vel(i, j, k) = parms.U_0;
@@ -187,7 +185,9 @@ Problem::init_custom_pert(
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
     const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-    const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+    const Real z = use_terrain ? 0.25*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+                                      + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
+                               : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the y-velocity
     y_vel(i, j, k) = parms.V_0;

--- a/Exec/ABL/prob.cpp
+++ b/Exec/ABL/prob.cpp
@@ -16,6 +16,7 @@ Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
   pp.query("rho_0", parms.rho_0);
   pp.query("T_0", parms.T_0);
   pp.query("A_0", parms.A_0);
+  pp.query("KE_0", parms.KE_0);
   pp.query("QKE_0", parms.QKE_0);
 
   pp.query("U_0", parms.U_0);
@@ -122,7 +123,13 @@ Problem::init_custom_pert(
     state(i, j, k, RhoScalar_comp) = parms.A_0 * exp(-10.*r*r);
 
     // Set an initial value for QKE
-    state(i, j, k, RhoQKE_comp) = parms.QKE_0;
+    if (state.nComp() > RhoKE_comp) {
+        const int KE_idx = (state.nComp() > RhoQKE_comp) ? RhoQKE_comp // PBL scheme
+                                                         : RhoKE_comp; // Deardorff
+        const Real KE_0 = (state.nComp() > RhoQKE_comp) ? parms.QKE_0 // PBL scheme
+                                                        : parms.KE_0; // Deardorff
+        state(i, j, k, KE_idx) = KE_0;
+    }
 
     if (use_moisture) {
         state(i, j, k, RhoQ1_comp) = 0.0;

--- a/Exec/Radiation/inputs_radiation
+++ b/Exec/Radiation/inputs_radiation
@@ -47,6 +47,7 @@ erf.use_rayleigh_damping = false
 
 erf.moisture_model = "SAM"
 erf.les_type = "Deardorff"
+erf.KE_0 = 0.1 # for Deardorff
 #erf.les_type = "None"
 #
 # diffusion coefficient from Straka, K = 75 m^2/s

--- a/Exec/RegTests/Bubble/inputs_squall2d_x
+++ b/Exec/RegTests/Bubble/inputs_squall2d_x
@@ -58,6 +58,7 @@ erf.alpha_T         = 0.0 # [m^2/s]
 erf.init_type           = "input_sounding"
 erf.input_sounding_file = "input_sounding_squall2d"
 erf.init_sounding_ideal = 1
+erf.KE_0 = 0.1 # for Deardorff
 
 # PROBLEM PARAMETERS (optional)
 # warm bubble input

--- a/Exec/SuperCell/inputs_moisture
+++ b/Exec/SuperCell/inputs_moisture
@@ -48,6 +48,7 @@ erf.use_rayleigh_damping = false
 erf.moisture_model = "SAM"
 
 erf.les_type = "Deardorff"
+erf.KE_0 = 0.1 # for Deardorff
 #erf.les_type = "None"
 #
 # diffusion coefficient from Straka, K = 75 m^2/s

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -515,24 +515,31 @@ ERF::InitData ()
         // we initialize rho_KE to be nonzero (and positive) so that we end up
         // with reasonable values for the eddy diffusivity and the MOST fluxes
         // (~ 1/diffusivity) do not blow up
-        Real RhoKE_0 = 0.1;
+        Real RhoKE_0;
         ParmParse pp(pp_prefix);
         if (pp.query("RhoKE_0", RhoKE_0)) {
             // Uniform initial rho*e field
             for (int lev = 0; lev <= finest_level; lev++) {
                 if (solverChoice.turbChoice[lev].les_type == LESType::Deardorff) {
+                    amrex::Print() << "Initializing uniform rhoKE=" << RhoKE_0
+                        << " on level " << lev
+                        << std::endl;
                     vars_new[lev][Vars::cons].setVal(RhoKE_0,RhoKE_comp,1,0);
                 } else {
                     vars_new[lev][Vars::cons].setVal(0.0,RhoKE_comp,1,0);
                 }
             }
-        } else {
-            // default: uniform initial e field
-            Real KE_0 = 0.1;
-            pp.query("KE_0", KE_0);
+        }
+
+        Real KE_0;
+        if (pp.query("KE_0", KE_0)) {
+            // Uniform initial e field
             for (int lev = 0; lev <= finest_level; lev++) {
                 auto& lev_new = vars_new[lev];
                 if (solverChoice.turbChoice[lev].les_type == LESType::Deardorff) {
+                    amrex::Print() << "Initializing uniform KE=" << KE_0
+                        << " on level " << lev
+                        << std::endl;
                     for (MFIter mfi(lev_new[Vars::cons], TilingIfNotGPU()); mfi.isValid(); ++mfi) {
                         const Box &bx = mfi.tilebox();
                         const auto &cons_arr = lev_new[Vars::cons].array(mfi);
@@ -551,6 +558,7 @@ ERF::InitData ()
 
         Real QKE_0;
         if (pp.query("QKE_0", QKE_0)) {
+            amrex::Print() << "Initializing uniform QKE=" << QKE_0 << std::endl;
             for (int lev = 0; lev <= finest_level; lev++) {
                 auto& lev_new = vars_new[lev];
                 for (MFIter mfi(lev_new[Vars::cons], TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Initialization/ERF_init_custom.cpp
+++ b/Source/Initialization/ERF_init_custom.cpp
@@ -89,6 +89,11 @@ ERF::init_custom (int lev)
     MultiFab::Add(lev_new[Vars::cons], cons_pert, RhoTheta_comp, RhoTheta_comp, 1, cons_pert.nGrow());
     MultiFab::Add(lev_new[Vars::cons], cons_pert, RhoScalar_comp,RhoScalar_comp,1, cons_pert.nGrow());
 
+    // RhoKE is only relevant if using Deardorff with LES
+    if (solverChoice.turbChoice[lev].les_type == LESType::Deardorff) {
+        MultiFab::Add(lev_new[Vars::cons], cons_pert, RhoKE_comp,    RhoKE_comp,    1, cons_pert.nGrow());
+    }
+
     // RhoQKE is only relevant if using MYNN2.5 or YSU
     if (solverChoice.turbChoice[lev].pbl_type == PBLType::None) {
         lev_new[Vars::cons].setVal(0.0,RhoQKE_comp,1);


### PR DESCRIPTION
* Provide separate `prob.KE_0` and `prob.QKE_0` for LES and PBL use cases, respectively.
* Allow a (linearly) decaying initial subgrid KE to be specified through the `prob.KE_decay_height` (and `prob. KE_decay_order=1`). Other polynomial profiles are possible and the initial KE will be clipped at `KE_decay_height`.
* Handle terrain