### PR TITLE
Microphysics enum fix

### DIFF
--- a/Source/Microphysics/Kessler/Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Init_Kessler.cpp
@@ -72,8 +72,8 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
 
         auto rho_array   = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
         auto theta_array = mic_fab_vars[MicVar_Kess::theta]->array(mfi);
-        auto tabs_array  = mic_fab_vars[MicVar::tabs]->array(mfi);
-        auto pres_array  = mic_fab_vars[MicVar::pres]->array(mfi);
+        auto tabs_array  = mic_fab_vars[MicVar_Kess::tabs]->array(mfi);
+        auto pres_array  = mic_fab_vars[MicVar_Kess::pres]->array(mfi);
 
         // Get pressure, theta, temperature, density, and qt, qp
         ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)

--- a/Source/Microphysics/SAM/Init_SAM.cpp
+++ b/Source/Microphysics/SAM/Init_SAM.cpp
@@ -90,14 +90,14 @@ void SAM::Copy_State_to_Micro (const MultiFab& cons_in)
 
         auto states_array = cons_in.array(mfi);
 
-        auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
-        auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
-        auto qi_array    = mic_fab_vars[MicVar_Kess::qci]->array(mfi);
-        auto qn_array    = mic_fab_vars[MicVar_Kess::qn]->array(mfi);
-        auto qp_array    = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
+        auto qv_array    = mic_fab_vars[MicVar::qv]->array(mfi);
+        auto qc_array    = mic_fab_vars[MicVar::qcl]->array(mfi);
+        auto qi_array    = mic_fab_vars[MicVar::qci]->array(mfi);
+        auto qn_array    = mic_fab_vars[MicVar::qn]->array(mfi);
+        auto qp_array    = mic_fab_vars[MicVar::qp]->array(mfi);
 
-        auto rho_array   = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
-        auto theta_array = mic_fab_vars[MicVar_Kess::theta]->array(mfi);
+        auto rho_array   = mic_fab_vars[MicVar::rho]->array(mfi);
+        auto theta_array = mic_fab_vars[MicVar::theta]->array(mfi);
         auto tabs_array  = mic_fab_vars[MicVar::tabs]->array(mfi);
         auto pres_array  = mic_fab_vars[MicVar::pres]->array(mfi);
 

--- a/Source/Microphysics/SAM/Update_SAM.cpp
+++ b/Source/Microphysics/SAM/Update_SAM.cpp
@@ -18,11 +18,11 @@ void SAM::Copy_Micro_to_State (amrex::MultiFab& cons)
 
         auto states_arr = cons.array(mfi);
 
-        auto rho_arr    = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
-        auto theta_arr  = mic_fab_vars[MicVar_Kess::theta]->array(mfi);
-        auto qv_arr     = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
-        auto qc_arr     = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
-        auto qp_arr     = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
+        auto rho_arr    = mic_fab_vars[MicVar::rho]->array(mfi);
+        auto theta_arr  = mic_fab_vars[MicVar::theta]->array(mfi);
+        auto qv_arr     = mic_fab_vars[MicVar::qv]->array(mfi);
+        auto qc_arr     = mic_fab_vars[MicVar::qcl]->array(mfi);
+        auto qp_arr     = mic_fab_vars[MicVar::qp]->array(mfi);
 
         // get potential total density, temperature, qt, qp
         ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)


### PR DESCRIPTION
The microphysics classes have their own enum for their local variables. We must use the enum that is defined in the respective micro class. Not even sure how this compiled...