### PR TITLE
Fix WPS Restart

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -673,8 +673,9 @@ private:
                                                     // eddy diffusivity of heat
                                                     "Khv","Khh",
                                                     // mynn pbl lengthscale
-                                                    "Lpbl"
-                                                     ,"qt", "qp", "qv", "qc", "qi", "qrain", "qsnow", "qgraup"
+                                                    "Lpbl",
+                                                    // moisture vars
+                                                    "qt", "qv", "qc", "qi", "qp", "qrain", "qsnow", "qgraup"
 #ifdef ERF_COMPUTE_ERROR
                                                     ,"xvel_err", "yvel_err", "zvel_err", "pp_err"
 #endif

--- a/Source/Microphysics/FastEddy/Diagnose_FE.cpp
+++ b/Source/Microphysics/FastEddy/Diagnose_FE.cpp
@@ -1,4 +1,4 @@
-#include "Microphysics.H"
+#include "FastEddy.H"
 
 /**
  * Computes diagnostic quantities like cloud ice/liquid and precipitation ice/liquid

--- a/Source/Microphysics/FastEddy/FastEddy.H
+++ b/Source/Microphysics/FastEddy/FastEddy.H
@@ -1,5 +1,3 @@
-/*
- */
 #ifndef FastEddy_H
 #define FastEddy_H
 
@@ -16,17 +14,20 @@
 #include "Microphysics_Utils.H"
 #include "IndexDefines.H"
 #include "DataStruct.H"
+#include "NullMoist.H"
 
 namespace MicVar_FE {
    enum {
       // independent variables
-      qv = 0,
-      qc,
-      qt,
-      rho,   // density
+      rho=0, // density
       theta, // liquid/ice water potential temperature
       tabs,  // temperature
       pres,  // pressure
+      // non-precipitating vars
+      qt,    // total cloud
+      qv,    // cloud vapor
+      qc,    // cloud water
+      // derived vars
       NumVars
   };
 }

--- a/Source/Microphysics/FastEddy/FastEddy.cpp
+++ b/Source/Microphysics/FastEddy/FastEddy.cpp
@@ -1,10 +1,6 @@
-/*
- * this file is modified from precip_proc from samxx
- */
-#include "Microphysics.H"
-
 #include <EOS.H>
 #include <TileNoZ.H>
+#include "FastEddy.H"
 
 using namespace amrex;
 

--- a/Source/Microphysics/FastEddy/Init_FE.cpp
+++ b/Source/Microphysics/FastEddy/Init_FE.cpp
@@ -1,5 +1,5 @@
 #include <AMReX_GpuContainers.H>
-#include "Microphysics.H"
+#include "FastEddy.H"
 #include "IndexDefines.H"
 #include "PlaneAverage.H"
 #include "EOS.H"

--- a/Source/Microphysics/FastEddy/Update_FE.cpp
+++ b/Source/Microphysics/FastEddy/Update_FE.cpp
@@ -1,5 +1,4 @@
-
-#include "Microphysics.H"
+#include "FastEddy.H"
 #include "IndexDefines.H"
 #include "TileNoZ.H"
 

--- a/Source/Microphysics/Kessler/Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Init_Kessler.cpp
@@ -1,5 +1,5 @@
 #include <AMReX_GpuContainers.H>
-#include "Microphysics.H"
+#include "Kessler.H"
 #include "IndexDefines.H"
 #include "PlaneAverage.H"
 #include "EOS.H"
@@ -29,8 +29,7 @@ void Kessler::Init (const MultiFab& cons_in,
     m_gtoe = grids;
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qci,
-                 MicVar_Kess::qp, MicVar_Kess::qpl, MicVar_Kess::qpi};
+    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Kess::NumVars; ++ivar) {
@@ -65,10 +64,11 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
 
         auto states_array = cons_in.array(mfi);
 
+        auto qt_array    = mic_fab_vars[MicVar_Kess::qt]->array(mfi);
         auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
         auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
+
         auto qp_array    = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
-        auto qt_array    = mic_fab_vars[MicVar_Kess::qt]->array(mfi);
 
         auto rho_array   = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
         auto theta_array = mic_fab_vars[MicVar_Kess::theta]->array(mfi);

--- a/Source/Microphysics/Kessler/Kessler.H
+++ b/Source/Microphysics/Kessler/Kessler.H
@@ -22,27 +22,22 @@
 #include "Microphysics_Utils.H"
 #include "IndexDefines.H"
 #include "DataStruct.H"
+#include "NullMoist.H"
 
 namespace MicVar_Kess {
    enum {
       // independent variables
-      qt = 0,
-      qp,
+      rho=0, // density
       theta, // liquid/ice water potential temperature
       tabs,  // temperature
-      rho,   // density
       pres,  // pressure
-      // derived variables
-      qr,   // rain water
-      qv,   // water vapor
-      qn,   // cloud condensate (liquid+ice), initial to zero
-      qci,  // cloud ice
-      qcl,  // cloud water
-      qpl,  // precip rain
-      qpi,  // precip ice
-      qg,   // graupel
-      // temporary variable
-      omega,
+      // non-precipitating vars
+      qt,    // total cloud
+      qv,    // cloud vapor
+      qcl,   // cloud water
+      // precipitating vars
+      qp,    // total precip
+      // derived vars
       NumVars
   };
 }
@@ -134,8 +129,8 @@ public:
     Qstate_Size () override { return Kessler::m_qstate_size; }
 
 private:
-    // Number of qmoist variables (qt, qv, qcl, qci, qp, qpl, qpi)
-    int m_qmoist_size = 7;
+    // Number of qmoist variables (qt, qv, qcl, qp)
+    int m_qmoist_size = 4;
 
     // Number of qstate variables
     int m_qstate_size = 3;

--- a/Source/Microphysics/Kessler/Kessler.cpp
+++ b/Source/Microphysics/Kessler/Kessler.cpp
@@ -1,10 +1,6 @@
-/*
- * this file is modified from precip_proc from samxx
- */
-#include "Microphysics.H"
-
 #include <EOS.H>
 #include <TileNoZ.H>
+#include "Kessler.H"
 
 using namespace amrex;
 
@@ -13,11 +9,11 @@ using namespace amrex;
  */
 void Kessler::AdvanceKessler ()
 {
-    auto qv   = mic_fab_vars[MicVar_Kess::qv];
-    auto qc   = mic_fab_vars[MicVar_Kess::qcl];
-    auto qp   = mic_fab_vars[MicVar_Kess::qp];
-    auto tabs = mic_fab_vars[MicVar_Kess::tabs];
-    auto pres = mic_fab_vars[MicVar_Kess::pres];
+    auto qv    = mic_fab_vars[MicVar_Kess::qv];
+    auto qc    = mic_fab_vars[MicVar_Kess::qcl];
+    auto qp    = mic_fab_vars[MicVar_Kess::qp];
+    auto tabs  = mic_fab_vars[MicVar_Kess::tabs];
+    auto pres  = mic_fab_vars[MicVar_Kess::pres];
     auto theta = mic_fab_vars[MicVar_Kess::theta];
     auto rho   = mic_fab_vars[MicVar_Kess::rho];
 

--- a/Source/Microphysics/Kessler/Update_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Update_Kessler.cpp
@@ -1,5 +1,4 @@
-
-#include "Microphysics.H"
+#include "Kessler.H"
 #include "IndexDefines.H"
 #include "TileNoZ.H"
 

--- a/Source/Microphysics/SAM/Diagnose_SAM.cpp
+++ b/Source/Microphysics/SAM/Diagnose_SAM.cpp
@@ -1,4 +1,4 @@
-#include "Microphysics.H"
+#include "SAM.H"
 #include "EOS.H"
 
 /**
@@ -15,7 +15,7 @@ void SAM::Diagnose () {
     auto qci  = mic_fab_vars[MicVar::qci];
     auto qpl  = mic_fab_vars[MicVar::qpl];
     auto qpi  = mic_fab_vars[MicVar::qpi];
-    auto qg  = mic_fab_vars[MicVar::qg];
+    auto qg   = mic_fab_vars[MicVar::qg];
     auto tabs = mic_fab_vars[MicVar::tabs];
 
     for ( amrex::MFIter mfi(*tabs, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Microphysics/SAM/IceFall.cpp
+++ b/Source/Microphysics/SAM/IceFall.cpp
@@ -1,6 +1,5 @@
-
 #include <AMReX_ParReduce.H>
-#include "Microphysics.H"
+#include "SAM.H"
 #include "TileNoZ.H"
 
 using namespace amrex;

--- a/Source/Microphysics/SAM/Init_SAM.cpp
+++ b/Source/Microphysics/SAM/Init_SAM.cpp
@@ -1,5 +1,5 @@
 #include <AMReX_GpuContainers.H>
-#include "Microphysics.H"
+#include "SAM.H"
 #include "IndexDefines.H"
 #include "PlaneAverage.H"
 #include "EOS.H"

--- a/Source/Microphysics/SAM/Precip.cpp
+++ b/Source/Microphysics/SAM/Precip.cpp
@@ -1,7 +1,4 @@
-/*
- * this file is modified from precip_proc from samxx
- */
-#include "Microphysics.H"
+#include "SAM.H"
 
 using namespace amrex;
 

--- a/Source/Microphysics/SAM/PrecipFall.cpp
+++ b/Source/Microphysics/SAM/PrecipFall.cpp
@@ -1,5 +1,5 @@
 #include "ERF_Constants.H"
-#include "Microphysics.H"
+#include "SAM.H"
 #include "TileNoZ.H"
 
 using namespace amrex;

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -22,25 +22,27 @@
 #include "Microphysics_Utils.H"
 #include "IndexDefines.H"
 #include "DataStruct.H"
+#include "NullMoist.H"
 
 namespace MicVar {
    enum {
       // independent variables
-      qt = 0,
-      qp,
+      rho=0, // density
       theta, // liquid/ice water potential temperature
       tabs,  // temperature
-      rho,   // density
       pres,  // pressure
-      // derived variables
-      qv,   // water vapor
-      qn,   // cloud condensate (liquid+ice), initial to zero
-      qci,  // cloud ice
-      qcl,  // cloud water
-      qpl,  // precip rain
-      qpi,  // precip ice
-      qg,   // graupel
-      // temporary variable
+      // non-precipitating vars
+      qt,    // total cloud
+      qn,    // cloud condesnate (liquid + ice)
+      qv,    // cloud vapor
+      qcl,   // cloud water
+      qci,   // cloud ice
+      // precipitating vars
+      qp,    // total precip
+      qpl,   // precip rain
+      qpi,   // precip ice
+      qg,    // graupel
+      // derived vars
       omega,
       NumVars
   };

--- a/Source/Microphysics/SAM/Update_SAM.cpp
+++ b/Source/Microphysics/SAM/Update_SAM.cpp
@@ -1,5 +1,4 @@
-
-#include "Microphysics.H"
+#include "SAM.H"
 #include "IndexDefines.H"
 #include "TileNoZ.H"
 


### PR DESCRIPTION
This PR cleans up header includes and makes sure the local micro enum can't get twisted between different models.