### PR TITLE
Fix for bug that left particle attributes uninitialized

### DIFF
--- a/Source/Particles/ERFPCInitializations.cpp
+++ b/Source/Particles/ERFPCInitializations.cpp
@@ -64,8 +64,8 @@ void ERFPC::initializeParticlesDefaultTracersWoA (const std::unique_ptr<amrex::M
     BL_PROFILE("ERFPC::initializeParticlesDefaultTracersWoA");
 
     const int lev = 0;
-    const Real* dx = Geom(lev).CellSize();
-    const Real* plo = Geom(lev).ProbLo();
+    const auto dx = Geom(lev).CellSizeArray();
+    const auto plo = Geom(lev).ProbLoArray();
 
     iMultiFab num_particles( ParticleBoxArray(lev),
                              ParticleDistributionMap(lev),
@@ -195,8 +195,8 @@ void ERFPC::initializeParticlesDefaultHydro (const std::unique_ptr<amrex::MultiF
     BL_PROFILE("ERFPC::initializeParticlesDefaultHydro");
 
     const int lev = 0;
-    const Real* dx = Geom(lev).CellSize();
-    const Real* plo = Geom(lev).ProbLo();
+    const auto dx = Geom(lev).CellSizeArray();
+    const auto plo = Geom(lev).ProbLoArray();
 
     iMultiFab num_particles( ParticleBoxArray(lev),
                              ParticleDistributionMap(lev),
@@ -328,8 +328,8 @@ void ERFPC::initializeParticlesUniformDistribution (const std::unique_ptr<amrex:
     BL_PROFILE("ERFPC::initializeParticlesUniformDistribution");
 
     const int lev = 0;
-    const Real* dx = Geom(lev).CellSize();
-    const Real* plo = Geom(lev).ProbLo();
+    const auto dx = Geom(lev).CellSizeArray();
+    const auto plo = Geom(lev).ProbLoArray();
 
     int particles_per_cell = m_ppc_init;
 

--- a/Source/Particles/ERFPCInitializations.cpp
+++ b/Source/Particles/ERFPCInitializations.cpp
@@ -106,7 +106,7 @@ void ERFPC::initializeParticlesDefaultTracersWoA (const std::unique_ptr<amrex::M
         auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
         particle_tile.resize(np);
         auto aos = &particle_tile.GetArrayOfStructs()[0];
-        auto soa = particle_tile.GetStructOfArrays();
+        auto& soa = particle_tile.GetStructOfArrays();
         auto vx_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vx).data();
         auto vy_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vy).data();
         auto vz_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vz).data();
@@ -238,7 +238,7 @@ void ERFPC::initializeParticlesDefaultHydro (const std::unique_ptr<amrex::MultiF
         auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
         particle_tile.resize(np);
         auto aos = &particle_tile.GetArrayOfStructs()[0];
-        auto soa = particle_tile.GetStructOfArrays();
+        auto& soa = particle_tile.GetStructOfArrays();
         auto vx_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vx).data();
         auto vy_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vy).data();
         auto vz_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vz).data();
@@ -370,7 +370,7 @@ void ERFPC::initializeParticlesUniformDistribution (const std::unique_ptr<amrex:
         auto& particle_tile = DefineAndReturnParticleTile(lev, mfi);
         particle_tile.resize(np);
         auto aos = &particle_tile.GetArrayOfStructs()[0];
-        auto soa = particle_tile.GetStructOfArrays();
+        auto& soa = particle_tile.GetStructOfArrays();
         auto vx_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vx).data();
         auto vy_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vy).data();
         auto vz_ptr = soa.GetRealData(ERFParticlesRealIdxSoA::vz).data();


### PR DESCRIPTION
Particle initialization wasn't getting the reference to the `SoA` and therefore, not actually setting the value of the particle attributes.