### PR TITLE
Fix logical operator for limiter

### DIFF
--- a/Source/Diffusion/NumericalDiffusion.cpp
+++ b/Source/Diffusion/NumericalDiffusion.cpp
@@ -61,19 +61,19 @@ NumericalDiffusion (const Box& bx,
         Real xflux_lo = 10. * (data(i  ,j,k,n) - data(i-1,j,k,n))
                        - 5. * (data(i+1,j,k,n) - data(i-2,j,k,n))
                             + (data(i+2,j,k,n) - data(i-3,j,k,n));
-        if ( (xflux_lo * (data(i,j,k,n) - data(i-1,j,k,n)) ) > 0.) xflux_lo = 0.;
+        if ( (xflux_lo * (data(i,j,k,n) - data(i-1,j,k,n)) ) < 0.) xflux_lo = 0.;
         Real xflux_hi = 10. * (data(i+1,j,k,n) - data(i  ,j,k,n))
                        - 5. * (data(i+2,j,k,n) - data(i-1,j,k,n))
                             + (data(i+3,j,k,n) - data(i-2,j,k,n));
-        if ( (xflux_hi * (data(i+1,j,k,n) - data(i,j,k,n)) ) > 0.) xflux_hi = 0.;
+        if ( (xflux_hi * (data(i+1,j,k,n) - data(i,j,k,n)) ) < 0.) xflux_hi = 0.;
         Real yflux_lo = 10. * (data(i,j  ,k,n) - data(i,j-1,k,n))
                        - 5. * (data(i,j+1,k,n) - data(i,j-2,k,n))
                             + (data(i,j+2,k,n) - data(i,j-3,k,n));
-        if ( (yflux_lo * (data(i,j,k,n) - data(i,j-1,k,n)) ) > 0.) yflux_lo = 0.;
+        if ( (yflux_lo * (data(i,j,k,n) - data(i,j-1,k,n)) ) < 0.) yflux_lo = 0.;
         Real yflux_hi = 10. * (data(i,j+1,k,n) - data(i,j  ,k,n))
                        - 5. * (data(i,j+2,k,n) - data(i,j-1,k,n))
                             + (data(i,j+3,k,n) - data(i,j-2,k,n));
-        if ( (yflux_hi * (data(i,j+1,k,n) - data(i,j,k,n)) ) > 0.) yflux_hi = 0.;
+        if ( (yflux_hi * (data(i,j+1,k,n) - data(i,j,k,n)) ) < 0.) yflux_hi = 0.;
         rhs(i,j,k,n) += coeff6 * ( (xflux_hi - xflux_lo) * mfx_arr(i,j,0)
                                  + (yflux_hi - yflux_lo) * mfy_arr(i,j,0) );
     });


### PR DESCRIPTION
For `erf.use_NumDiff = true`. Tested with centered 6th-order scheme and `erf.NumDiffCoeff = 0.12` (the WRF default). Solution from middle panels below (with numerical diffusion, before fix) blow up much more quickly than the left panels (without num diff). Solution from the right panel with numerical diffusion (after fix) is more numerically stable.

Horizontal slice through surface layer in doubly periodic LES during turbulence spinup: 
![compare_numdiff_xvel](https://github.com/erf-model/ERF/assets/18267059/f4fcbbbf-77e9-4140-8813-f970d47a156d)
![compare_numdiff_zvel](https://github.com/erf-model/ERF/assets/18267059/f3d8b8bd-e4db-4dee-bd31-843299780bb1)
