### PR TITLE
Replace FastEddy with Kessler_NoRain

### DIFF
--- a/Exec/RegTests/Bubble/inputs_BF02_moist_bubble
+++ b/Exec/RegTests/Bubble/inputs_BF02_moist_bubble
@@ -53,7 +53,8 @@ erf.moistscal_vert_adv_type  = "Upwind_3rd"
 # PHYSICS OPTIONS
 erf.les_type        = "None"
 erf.pbl_type        = "None"
-erf.moisture_model  = "FastEddy"
+#erf.moisture_model  = "FastEddy"
+erf.moisture_model  = "Kessler_NoRain"
 erf.buoyancy_type   = 1
 erf.use_moist_background = true
 

--- a/Exec/RegTests/Bubble/prob.cpp
+++ b/Exec/RegTests/Bubble/prob.cpp
@@ -328,6 +328,7 @@ Problem::init_custom_pert(
                 if (use_moisture) {
                     state(i, j, k, RhoQ1_comp) = 0.0;
                     state(i, j, k, RhoQ2_comp) = 0.0;
+                    state(i, j, k, RhoQ3_comp) = 0.0;
                 }
 
             });
@@ -405,6 +406,7 @@ Problem::init_custom_pert(
                 // mean states
                 state(i, j, k, RhoQ1_comp) = rho*q_v_hot;
                 state(i, j, k, RhoQ2_comp) = rho*(parms.qt_init - q_v_hot);
+                state(i, j, k, RhoQ3_comp) = 0.0;
 
                 // Cold microphysics are present
                 int nstate = state.ncomp;
@@ -436,6 +438,7 @@ Problem::init_custom_pert(
                 if (use_moisture) {
                     state(i, j, k, RhoQ1_comp) = 0.0;
                     state(i, j, k, RhoQ2_comp) = 0.0;
+                    state(i, j, k, RhoQ3_comp) = 0.0;
                 }
             });
         } // do_moist_bubble

--- a/Source/DataStructs/DataStruct.H
+++ b/Source/DataStructs/DataStruct.H
@@ -29,7 +29,7 @@ enum struct TerrainType {
 };
 
 enum struct MoistureType {
-    Kessler, SAM, FastEddy, None
+    Kessler, SAM, FastEddy, Kessler_NoRain, None
 };
 
 enum struct WindFarmType {
@@ -89,6 +89,8 @@ struct SolverChoice {
             moisture_type = MoistureType::SAM;
         } else if (moisture_model_string == "Kessler") {
             moisture_type = MoistureType::Kessler;
+        }else if (moisture_model_string == "Kessler_NoRain") {
+            moisture_type = MoistureType::Kessler_NoRain;
         } else if (moisture_model_string == "FastEddy") {
             moisture_type = MoistureType::FastEddy;
         } else {

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1215,7 +1215,8 @@ ERF::ReadParameters ()
     if (solverChoice.moisture_type == MoistureType::SAM) {
         micro.SetModel<SAM>();
         amrex::Print() << "SAM moisture model!\n";
-    } else if (solverChoice.moisture_type == MoistureType::Kessler) {
+    } else if (solverChoice.moisture_type == MoistureType::Kessler or
+               solverChoice.moisture_type == MoistureType::Kessler_NoRain) {
         micro.SetModel<Kessler>();
         amrex::Print() << "Kessler moisture model!\n";
     } else if (solverChoice.moisture_type == MoistureType::FastEddy) {

--- a/Source/Microphysics/FastEddy/FastEddy.H
+++ b/Source/Microphysics/FastEddy/FastEddy.H
@@ -94,7 +94,7 @@ public:
 
     // wrapper to do all the updating
     void
-    Advance (const amrex::Real& dt_advance) override
+    Advance (const amrex::Real& dt_advance, const SolverChoice& solverChoice) override
     {
         dt = dt_advance;
 

--- a/Source/Microphysics/Kessler/Kessler.H
+++ b/Source/Microphysics/Kessler/Kessler.H
@@ -54,7 +54,7 @@ public:
     virtual ~Kessler () = default;
 
     // cloud physics
-    void AdvanceKessler ();
+    void AdvanceKessler (const SolverChoice &solverChoice);
 
     // diagnose
     void Diagnose () override;
@@ -104,11 +104,11 @@ public:
 
     // wrapper to advance micro vars
     void
-    Advance (const amrex::Real& dt_advance) override
+    Advance (const amrex::Real& dt_advance, const SolverChoice &solverChoice) override
     {
         dt = dt_advance;
 
-        this->AdvanceKessler();
+        this->AdvanceKessler(solverChoice);
         this->Diagnose();
     }
 

--- a/Source/Microphysics/Kessler/Kessler.cpp
+++ b/Source/Microphysics/Kessler/Kessler.cpp
@@ -1,14 +1,17 @@
 #include <EOS.H>
 #include <TileNoZ.H>
 #include "Kessler.H"
+#include "DataStruct.H"
 
 using namespace amrex;
 
 /**
  * Compute Precipitation-related Microphysics quantities.
  */
-void Kessler::AdvanceKessler ()
+void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 {
+
+if(solverChoice.moisture_type == MoistureType::Kessler){
     auto qv    = mic_fab_vars[MicVar_Kess::qv];
     auto qc    = mic_fab_vars[MicVar_Kess::qcl];
     auto qp    = mic_fab_vars[MicVar_Kess::qp];
@@ -164,4 +167,68 @@ void Kessler::AdvanceKessler ()
             qt_array(i,j,k) = qv_array(i,j,k) + qc_array(i,j,k);
         });
     }
+}
+
+
+if(solverChoice.moisture_type == MoistureType::Kessler_NoRain){
+
+ auto tabs  = mic_fab_vars[MicVar_Kess::tabs];
+
+    // get the temperature, dentisy, theta, qt and qc from input
+    for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
+        auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
+        auto qt_array    = mic_fab_vars[MicVar_Kess::qt]->array(mfi);
+        auto tabs_array  = mic_fab_vars[MicVar_Kess::tabs]->array(mfi);
+        auto theta_array = mic_fab_vars[MicVar_Kess::theta]->array(mfi);
+        auto pres_array  = mic_fab_vars[MicVar_Kess::pres]->array(mfi);
+
+        const auto& box3d = mfi.tilebox();
+
+        // Expose for GPU
+        Real d_fac_cond = m_fac_cond;
+
+        ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        {
+
+            qc_array(i,j,k) = std::max(0.0, qc_array(i,j,k));
+
+            //------- Autoconversion/accretion
+            Real dq_clwater_to_vapor, dq_vapor_to_clwater, qsat;
+
+            Real pressure = pres_array(i,j,k);
+            erf_qsatw(tabs_array(i,j,k), pressure, qsat);
+
+            // If there is precipitating water (i.e. rain), and the cell is not saturated
+            // then the rain water can evaporate leading to extraction of latent heat, hence
+            // reducing temperature and creating negative buoyancy
+
+            dq_vapor_to_clwater = 0.0;
+            dq_clwater_to_vapor = 0.0;
+
+            //Real fac = qsat*4093.0*L_v/(Cp_d*std::pow(tabs_array(i,j,k)-36.0,2));
+            Real fac = qsat*L_v*L_v/(Cp_d*R_v*tabs_array(i,j,k)*tabs_array(i,j,k));
+
+            // If water vapor content exceeds saturation value, then vapor condenses to waterm and latent heat is released, increasing temperature
+            if(qv_array(i,j,k) > qsat){
+                dq_vapor_to_clwater = std::min(qv_array(i,j,k), (qv_array(i,j,k)-qsat)/(1.0 + fac));
+            }
+            // If water vapor is less than the satruated value, then the cloud water can evaporate, leading to evaporative cooling and
+            // reducing temperature
+            if(qv_array(i,j,k) < qsat and qc_array(i,j,k) > 0.0){
+                dq_clwater_to_vapor = std::min(qc_array(i,j,k), (qsat - qv_array(i,j,k))/(1.0 + fac));
+            }
+
+            qv_array(i,j,k) = qv_array(i,j,k) - dq_vapor_to_clwater + dq_clwater_to_vapor;
+            qc_array(i,j,k) = qc_array(i,j,k) + dq_vapor_to_clwater - dq_clwater_to_vapor;
+
+            theta_array(i,j,k) = theta_array(i,j,k) + theta_array(i,j,k)/tabs_array(i,j,k)*d_fac_cond*(dq_vapor_to_clwater - dq_clwater_to_vapor);
+
+            qv_array(i,j,k) = std::max(0.0, qv_array(i,j,k));
+            qc_array(i,j,k) = std::max(0.0, qc_array(i,j,k));
+
+            qt_array(i,j,k) = qv_array(i,j,k) + qc_array(i,j,k);
+        });
+    }
+}
 }

--- a/Source/Microphysics/Microphysics.H
+++ b/Source/Microphysics/Microphysics.H
@@ -5,6 +5,7 @@
 #include <SAM.H>
 #include <Kessler.H>
 #include <FastEddy.H>
+#include <ERF.H>
 
 class Microphysics {
 
@@ -44,9 +45,9 @@ public:
     }
 
     void
-    Advance (const int& lev, const amrex::Real& dt_advance)
+    Advance (const int& lev, const amrex::Real& dt_advance, const SolverChoice &solverChoice)
     {
-        m_moist_model[lev]->Advance(dt_advance);
+        m_moist_model[lev]->Advance(dt_advance, solverChoice);
     }
 
     void

--- a/Source/Microphysics/Null/NullMoist.H
+++ b/Source/Microphysics/Null/NullMoist.H
@@ -24,7 +24,8 @@ class NullMoist {
 
     virtual
     void
-    Advance (const amrex::Real& /*dt_advance*/) { }
+    Advance (const amrex::Real& /*dt_advance*/,
+             const SolverChoice& /*solverChoce*/) { }
 
     virtual
     void

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -118,7 +118,8 @@ public:
 
     // wrapper to do all the updating
     void
-    Advance (const amrex::Real& dt_advance) override
+    Advance (const amrex::Real& dt_advance,
+             const SolverChoice& solverChoice) override
     {
         dt = dt_advance;
 

--- a/Source/TimeIntegration/ERF_advance_microphysics.cpp
+++ b/Source/TimeIntegration/ERF_advance_microphysics.cpp
@@ -8,7 +8,7 @@ void ERF::advance_microphysics (int lev,
 {
     if (solverChoice.moisture_type != MoistureType::None) {
         micro.Update_Micro_Vars_Lev(lev, cons);
-        micro.Advance(lev, dt_advance);
+        micro.Advance(lev, dt_advance, solverChoice);
         micro.Update_State_Vars_Lev(lev, cons);
     }
 }


### PR DESCRIPTION
This PR attempts to remove the `FastEddy` class from the `Microphysics`. The `Kessler` class is used without precipitation to replace `FastEddy`. Have verified that the moist bubble with `FastEddy` and `Kessler_NoRain` produce the same results. Once the regtests pass, `FastEddy` will be removed. 