### PR TITLE
Compute rain accumulation on ground for squall line

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -704,7 +704,7 @@ private:
                                                     // mynn pbl lengthscale
                                                     "Lpbl",
                                                     // moisture vars
-                                                    "qt", "qv", "qc", "qi", "qp", "qrain", "qsnow", "qgraup"
+                                                    "qt", "qv", "qc", "qi", "qp", "qrain", "qsnow", "qgraup", "rain_accum",
 #ifdef ERF_COMPUTE_ERROR
                                                     ,"xvel_err", "yvel_err", "zvel_err", "pp_err"
 #endif

--- a/Source/Microphysics/Kessler/Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Init_Kessler.cpp
@@ -29,7 +29,7 @@ void Kessler::Init (const MultiFab& cons_in,
     m_gtoe = grids;
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp};
+    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp, MicVar_Kess::rain_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Kess::NumVars; ++ivar) {

--- a/Source/Microphysics/Kessler/Kessler.H
+++ b/Source/Microphysics/Kessler/Kessler.H
@@ -38,6 +38,7 @@ namespace MicVar_Kess {
       // precipitating vars
       qp,    // total precip
       // derived vars
+      rain_accum,
       NumVars
   };
 }
@@ -127,7 +128,7 @@ public:
 
 private:
     // Number of qmoist variables (qt, qv, qcl, qp)
-    int m_qmoist_size = 4;
+    int m_qmoist_size = 5;
 
     // Number of qstate variables
     int m_qstate_size = 3;

--- a/Source/Microphysics/Kessler/Kessler.cpp
+++ b/Source/Microphysics/Kessler/Kessler.cpp
@@ -29,10 +29,12 @@ void Kessler::AdvanceKessler ()
     auto dm    = tabs->DistributionMap();
     fz.define(convert(ba, IntVect(0,0,1)), dm, 1, 0); // No ghost cells
 
+    Real dtn = dt;
+
     for ( MFIter mfi(fz, TilingIfNotGPU()); mfi.isValid(); ++mfi ){
         auto rho_array = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
         auto qp_array  = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
-        auto rain_accum_array = rain_accum->array(mfi);
+        auto rain_accum_array = mic_fab_vars[MicVar_Kess::rain_accum]->array(mfi);
 
         auto fz_array  = fz.array(mfi);
         const Box& tbz = mfi.tilebox();
@@ -59,7 +61,7 @@ void Kessler::AdvanceKessler ()
             fz_array(i,j,k) = rho_avg*V_terminal*qp_avg;
 
             if(k==k_lo){
-                rain_accum_array(i,j,k) = rain_accum_array(i,j,k) + rho_avg*qp_avg*V_terminal*dt/1000.0*1000.0; // Divide by rho_water and convert to mm
+                rain_accum_array(i,j,k) = rain_accum_array(i,j,k) + rho_avg*qp_avg*V_terminal*dtn/1000.0*1000.0; // Divide by rho_water and convert to mm
             }
 
             /*if(k==0){
@@ -68,7 +70,6 @@ void Kessler::AdvanceKessler ()
         });
     }
 
-    Real dtn = dt;
 
     for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
         auto qv_array   = mic_fab_vars[MicVar_Kess::qv]->array(mfi);

--- a/Source/Microphysics/Kessler/Kessler.cpp
+++ b/Source/Microphysics/Kessler/Kessler.cpp
@@ -16,6 +16,8 @@ void Kessler::AdvanceKessler ()
     auto pres  = mic_fab_vars[MicVar_Kess::pres];
     auto theta = mic_fab_vars[MicVar_Kess::theta];
     auto rho   = mic_fab_vars[MicVar_Kess::rho];
+    auto rain_accum = mic_fab_vars[MicVar_Kess::rain_accum];
+
 
     auto dz = m_geom.CellSize(2);
     auto domain = m_geom.Domain();
@@ -30,6 +32,8 @@ void Kessler::AdvanceKessler ()
     for ( MFIter mfi(fz, TilingIfNotGPU()); mfi.isValid(); ++mfi ){
         auto rho_array = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
         auto qp_array  = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
+        auto rain_accum_array = rain_accum->array(mfi);
+
         auto fz_array  = fz.array(mfi);
         const Box& tbz = mfi.tilebox();
 
@@ -53,6 +57,10 @@ void Kessler::AdvanceKessler ()
             Real V_terminal = 36.34*std::pow(rho_avg*0.001*qp_avg, 0.1346)*std::pow(rho_avg/1.16, -0.5); // in m/s
 
             fz_array(i,j,k) = rho_avg*V_terminal*qp_avg;
+
+            if(k==k_lo){
+                rain_accum_array(i,j,k) = rain_accum_array(i,j,k) + rho_avg*qp_avg*V_terminal*dt/1000.0*1000.0; // Divide by rho_water and convert to mm
+            }
 
             /*if(k==0){
               fz_array(i,j,k) = 0;


### PR DESCRIPTION
This PR adds a new variable to `mic_fab_var` to compute the rain accumulation on the ground for the squall line test case. Attached figure shows the comparison with WRF. The plotting of the rain accumulation variable in `PlotFile.cpp` is not done yet. Some restructuring is needed in the way the hydrometeors are written out in `PlotFile.cpp` which will be done in another PR soon.

<img width="959" alt="ERF_vs_WRF_rain_accumulation" src="https://github.com/erf-model/ERF/assets/34353555/b2938102-51b0-4b9a-857e-dc811822db9f">