### PR TITLE
SAM Sedimentation Fluxes

### DIFF
--- a/Source/Microphysics/SAM/IceFall.cpp
+++ b/Source/Microphysics/SAM/IceFall.cpp
@@ -5,15 +5,18 @@
 using namespace amrex;
 
 /**
- * Sedimentation of cloud ice (A32/33); sources enthalpy
+ * Sedimentation of cloud ice (A32)
  */
 void SAM::IceFall () {
 
-    Real dz  = m_geom.CellSize(2);
-    Real dtn = dt;
-    int  nz  = nlev;
+    Real dz   = m_geom.CellSize(2);
+    Real dtn  = dt;
+    Real coef = dtn/dz;
 
-    int kmax, kmin;
+    auto domain = m_geom.Domain();
+    int k_lo = domain.smallEnd(2);
+    int k_hi = domain.bigEnd(2);
+
     auto qcl   = mic_fab_vars[MicVar::qcl];
     auto qci   = mic_fab_vars[MicVar::qci];
     auto qn    = mic_fab_vars[MicVar::qn];
@@ -28,97 +31,56 @@ void SAM::IceFall () {
     fz.define(convert(ba, IntVect(0,0,1)), dm, 1, ng);
     fz.setVal(0.);
 
-    kmin = nz;
-    kmax = -1;
+    for (MFIter mfi(fz, TileNoZ()); mfi.isValid(); ++mfi) {
+        auto qci_array = qci->array(mfi);
+        auto rho_array = rho->array(mfi);
+        auto fz_array  = fz.array(mfi);
 
-    { // calculate maximum and minium ice fall vertical region
-        auto const& qcl_arrays  = qcl->const_arrays();
-        auto const& qci_arrays  = qci->const_arrays();
-        auto const& tabs_arrays = tabs->const_arrays();
+        const auto& box3d  = mfi.tilebox();
 
-        GpuTuple<int, int> k_max_min = ParReduce(TypeList<ReduceOpMax, ReduceOpMin>{},
-                                                 TypeList<int, int>{},
-                                                 *qcl, IntVect::TheZeroVector(),
-                                                 [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
-                                                 -> GpuTuple<int, int>
-                                                 {
-                                                     bool is_positive       = qcl_arrays[box_no](i,j,k)+qci_arrays[box_no](i,j,k) > 0.0;
-                                                     bool smaller_than_zero = tabs_arrays[box_no](i,j,k) < 273.15;
-                                                     int mkmin = is_positive && smaller_than_zero ? k : nz-1;
-                                                     int mkmax = is_positive && smaller_than_zero ? k : 0;
-                                                     return {mkmax, mkmin};
-                                                 });
-        kmax = amrex::get<0>(k_max_min);
-        kmin = amrex::get<1>(k_max_min);
+        ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        {
+            Real rho_avg, qci_avg;
+            if (k==k_lo) {
+                rho_avg = rho_array(i,j,k);
+                qci_avg = qci_array(i,j,k);
+            } else if (k==k_hi+1) {
+                rho_avg = rho_array(i,j,k-1);
+                qci_avg = qci_array(i,j,k-1);
+            } else {
+                rho_avg = 0.5*(rho_array(i,j,k-1) + rho_array(i,j,k));
+                qci_avg = 0.5*(qci_array(i,j,k-1) + qci_array(i,j,k));
+            }
+            Real vt_ice = min( 0.4 , 8.66 * pow( (max(0.,qci_avg)+1.e-10) , 0.24) );
+            fz_array(i,j,k) = rho_avg*vt_ice*qci_avg;
+        });
     }
 
-    for ( amrex::MFIter mfi(*tabs, TileNoZ()); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(*qci, TileNoZ()); mfi.isValid(); ++mfi) {
         auto qci_array   = qci->array(mfi);
         auto qn_array    = qn->array(mfi);
         auto qt_array    = qt->array(mfi);
         auto rho_array   = rho->array(mfi);
         auto fz_array    = fz.array(mfi);
 
-        const auto& gbox3d = mfi.tilebox(IntVect(0),IntVect(0,0,1));
         const auto& box3d  = mfi.tilebox();
-
-        ParallelFor(gbox3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            if (k >= std::max(0,kmin-1) && k <= kmax+1 ) {
-                // Set up indices for x-y planes above and below current plane.
-                int kc = std::min(k+1, nz-1);
-                int kb = std::max(k-1, 0);
-
-                // CFL number based on grid spacing interpolated to interface i,j,k-1/2
-                Real coef = dtn/dz;
-
-                // Compute cloud ice density in this cell and the ones above/below.
-                // Since cloud ice is falling, the above cell is u(icrm,upwind),
-                // this cell is c (center) and the one below is d (downwind).
-                Real qiu = rho_array(i,j,kc)*qci_array(i,j,kc);
-                Real qic = rho_array(i,j,k )*qci_array(i,j,k );
-                Real qid = rho_array(i,j,kb)*qci_array(i,j,kb);
-
-                // Ice sedimentation velocity depends on ice content. The fiting is
-                // based on the data by Heymsfield (JAS,2003). -Marat
-                Real vt_ice = min( 0.4 , 8.66 * pow( (max(0.,qic)+1.e-10) , 0.24) );   // Heymsfield (JAS, 2003, p.2607)
-
-                // Use MC flux limiter in computation of flux correction.
-                // (MC = monotonized centered difference).
-                Real tmp_phi;
-                if ( std::abs(qic-qid) < 1.0e-25 ) {  // when qic, and qid is very small, qic_qid can still be zero
-                    // even if qic is not equal to qid. so add a fix here +++mhwang
-                    tmp_phi = 0.;
-                } else {
-                    Real tmp_theta = (qiu-qic)/(qic-qid+1.0e-20);
-                    tmp_phi = max(0., min(0.5*(1.+tmp_theta), min(2., 2.*tmp_theta)));
-                }
-
-                // Compute limited flux.
-                // Since falling cloud ice is a 1D advection problem, this
-                // flux-limited advection scheme is monotonic.
-                fz_array(i,j,k) = -vt_ice*(qic - 0.5*(1.-coef*vt_ice)*tmp_phi*(qic-qid));
-            }
-        });
 
         ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            if ( k >= std::max(0,kmin) && k <= kmax ) {
-                //==================================================
-                // Cloud ice sedimentation (A32)
-                //==================================================
-                Real coef = dtn/dz;
-                Real dqi  = std::max(-qci_array(i,j,k),coef*(fz_array(i,j,k)-fz_array(i,j,k+1)));
+            //==================================================
+            // Cloud ice sedimentation (A32)
+            //==================================================
+            Real dqi  = (1.0/rho_array(i,j,k)) * ( fz_array(i,j,k+1) - fz_array(i,j,k) ) * coef;
+            dqi = std::max(-qci_array(i,j,k), dqi);
 
-                // Add this increment to both non-precipitating and total water.
-                qci_array(i,j,k) += dqi;
-                 qn_array(i,j,k) += dqi;
-                 qt_array(i,j,k) += dqi;
+            // Add this increment to both non-precipitating and total water.
+            qci_array(i,j,k) += dqi;
+            qn_array(i,j,k) += dqi;
+            qt_array(i,j,k) += dqi;
 
-                // NOTE: Sedimentation does not affect the potential temperature,
-                //       but it does affect the liquid/ice static energy.
-                //       No source to Theta occurs here.
-            }
+            // NOTE: Sedimentation does not affect the potential temperature,
+            //       but it does affect the liquid/ice static energy.
+            //       No source to Theta occurs here.
         });
     }
 }

--- a/Source/Microphysics/SAM/PrecipFall.cpp
+++ b/Source/Microphysics/SAM/PrecipFall.cpp
@@ -11,10 +11,9 @@ using namespace amrex;
  *
  * @param[in] hydro_type Type selection for the precipitation advection hydrodynamics scheme (0-3)
  */
-void SAM::PrecipFall (int hydro_type)
+void SAM::PrecipFall ()
 {
     Real eps = std::numeric_limits<Real>::epsilon();
-    bool constexpr nonos = true;
     Real rho_0 = 1.29;
 
     Real gamr3 = erf_gammafff(4.0+b_rain);
@@ -25,14 +24,18 @@ void SAM::PrecipFall (int hydro_type)
     Real vsnow = (a_snow*gams3/6.0)*pow((PI*rhos*nzeros),-csnow);
     Real vgrau = (a_grau*gamg3/6.0)*pow((PI*rhog*nzerog),-cgrau);
 
-    Real dt_advance = dt;
-    int nz = nlev;
+    auto dz   = m_geom.CellSize(2);
+    Real dtn  = dt;
+    Real coef = dtn/dz;
+
+    auto domain = m_geom.Domain();
+    int k_lo = domain.smallEnd(2);
+    int k_hi = domain.bigEnd(2);
 
     auto qpr   = mic_fab_vars[MicVar::qpr];
     auto qps   = mic_fab_vars[MicVar::qps];
     auto qpg   = mic_fab_vars[MicVar::qpg];
     auto qp    = mic_fab_vars[MicVar::qp];
-    auto omega = mic_fab_vars[MicVar::omega];
     auto rho   = mic_fab_vars[MicVar::rho];
     auto tabs  = mic_fab_vars[MicVar::tabs];
     auto theta = mic_fab_vars[MicVar::theta];
@@ -41,266 +44,81 @@ void SAM::PrecipFall (int hydro_type)
     auto dm    = tabs->DistributionMap();
     auto ngrow = tabs->nGrowVect();
 
-    MultiFab mx;
-    MultiFab mn;
-    MultiFab lfac;
-    MultiFab www;
     MultiFab fz;
-    MultiFab wp;
-    MultiFab tmp_qp;
-    MultiFab prec_cfl_fab;
-
-    mx.define(ba,dm, 1, ngrow);
-    mn.define(ba,dm, 1, ngrow);
-    lfac.define(ba, dm, 1, ngrow);
-    www.define(ba, dm, 1, ngrow);
-    fz.define(ba, dm, 1, ngrow);
-    wp.define(ba, dm, 1, ngrow);
-    tmp_qp.define(ba, dm, 1, ngrow);
-    prec_cfl_fab.define(ba, dm, 1, ngrow);
-
-    TableData<Real, 1> irho;
-    TableData<Real, 1> iwmax;
-    TableData<Real, 1> rhofac;
-
-    irho.resize({zlo},{zhi});
-    iwmax.resize({zlo},{zhi});
-    rhofac.resize({zlo},{zhi});
-
-    auto irho_t   = irho.table();
-    auto iwmax_t  = iwmax.table();
-    auto rhofac_t = rhofac.table();
-    auto rho1d_t  = rho1d.table();
-
-    auto dz = m_geom.CellSize(2);
-
-    // Precompute omega variable
-    for ( MFIter mfi(*(mic_fab_vars[MicVar::omega]), TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        auto omega_array = mic_fab_vars[MicVar::omega]->array(mfi);
-        auto tabs_array  = mic_fab_vars[MicVar::tabs]->array(mfi);
-
-        const auto& box3d = mfi.tilebox();
-
-        ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-        {
-            omega_array(i,j,k) = std::max(0.0,std::min(1.0,(tabs_array(i,j,k)-tprmin)*a_pr));
-        });
-    }
-
-    ParallelFor(nz, [=] AMREX_GPU_DEVICE (int k) noexcept
-    {
-        rhofac_t(k)  = std::sqrt(rho_0/rho1d_t(k));
-        irho_t(k)    = 1.0/rho1d_t(k);
-        Real wmax    = dz/dt_advance;   // Velocity equivalent to a cfl of 1.0.
-        iwmax_t(k)   = 1.0/wmax;
-    });
+    fz.define(convert(ba, IntVect(0,0,1)), dm, 1, ngrow);
 
     //  Add sedimentation of precipitation field to the vert. vel.
-    for ( MFIter mfi(lfac, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        auto lfac_array     = lfac.array(mfi);
-        auto omega_array    = omega->array(mfi);
-        auto qp_array       = qp->array(mfi);
-        auto rho_array      = rho->array(mfi);
-        auto tabs_array     = tabs->array(mfi);
-        auto wp_array       = wp.array(mfi);
-        auto www_array      = www.array(mfi);
-        auto fz_array       = fz.array(mfi);
-        auto prec_cfl_array = prec_cfl_fab.array(mfi);
+    for (MFIter mfi(fz, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        auto qp_array   = qp->array(mfi);
+        auto rho_array  = rho->array(mfi);
+        auto tabs_array = tabs->array(mfi);
+        auto fz_array   = fz.array(mfi);
 
         const auto& box3d = mfi.tilebox();
-
-        const Real fac_cond = m_fac_cond;
-        const Real fac_sub  = m_fac_sub;
-        const Real fac_fus  = m_fac_fus;
 
         ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            if (hydro_type == 0) {
-                lfac_array(i,j,k) = fac_cond;
+            Real rho_avg, tab_avg, qp_avg;
+            if (k==k_lo) {
+                rho_avg =  rho_array(i,j,k);
+                tab_avg = tabs_array(i,j,k);
+                 qp_avg =   qp_array(i,j,k);
+            } else if (k==k_hi+1) {
+                rho_avg =  rho_array(i,j,k-1);
+                tab_avg = tabs_array(i,j,k-1);
+                 qp_avg =   qp_array(i,j,k-1);
+            } else {
+                rho_avg = 0.5*( rho_array(i,j,k-1) +  rho_array(i,j,k));
+                tab_avg = 0.5*(tabs_array(i,j,k-1) + tabs_array(i,j,k));
+                 qp_avg = 0.5*(  qp_array(i,j,k-1) +   qp_array(i,j,k));
             }
-            else if (hydro_type == 1) {
-                lfac_array(i,j,k) = fac_sub;
+
+            Real Pprecip = 0.0;
+            if(qp_avg > qp_threshold) {
+                Real omp = std::max(0.0,std::min(1.0,(tab_avg-tprmin)*a_pr));
+                Real omg = std::max(0.0,std::min(1.0,(tab_avg-tgrmin)*a_gr));
+                Real qrr = omp*qp_avg;
+                Real qss = (1.0-omp)*(1.0-omg)*qp_avg;
+                Real qgg = (1.0-omp)*(omg)*qp_avg;
+                Pprecip = omp*vrain*std::pow(rho_avg*qrr,1.0+crain)
+                        + (1.0-omp)*( (1.0-omg)*vsnow*std::pow(rho_avg*qss,1.0+csnow)
+                                    +      omg *vgrau*std::pow(rho_avg*qgg,1.0+cgrau) );
             }
-            else if (hydro_type == 2) {
-                lfac_array(i,j,k) = fac_cond + (1.0-omega_array(i,j,k))*fac_fus;
-            }
-            else if (hydro_type == 3) {
-                lfac_array(i,j,k) = 0.0;
-            }
-            Real Veff = term_vel_qp(qp_array(i,j,k), vrain, vsnow, vgrau,
-                                    rho_array(i,j,k), tabs_array(i,j,k));
-            wp_array(i,j,k) = -Veff * std::sqrt(rho_0/rho_array(i,j,k));
-            prec_cfl_array(i,j,k) = wp_array(i,j,k) * iwmax_t(k);
-            wp_array(i,j,k) *= rho_array(i,j,k) * dt_advance/dz;
-            if (k == 0) {
-                fz_array(i,j,nz-1)   = 0.0;
-                www_array(i,j,nz-1)  = 0.0;
-                lfac_array(i,j,nz-1) = 0.0;
-            }
+            fz_array(i,j,k) = Pprecip * std::sqrt(rho_0/rho_avg);
         });
     }
 
-    auto const& cfl_arrays = prec_cfl_fab.const_arrays();
-    Real prec_cfl = ParReduce(TypeList<ReduceOpMax>{}, TypeList<Real>{},
-                              prec_cfl_fab, IntVect(0),
-                              [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
-                              ->GpuTuple<Real>
-    {
-        return { cfl_arrays[box_no](i,j,k) };
-    });
+    for (MFIter mfi(*qp, TileNoZ()); mfi.isValid(); ++mfi) {
+        auto qpr_array    = qpr->array(mfi);
+        auto qps_array    = qps->array(mfi);
+        auto qpg_array    = qpg->array(mfi);
+        auto qp_array     = qp->array(mfi);
+        auto rho_array    = rho->array(mfi);
+        auto tabs_array   = tabs->array(mfi);
+        auto fz_array     = fz.array(mfi);
 
-    // If maximum CFL due to precipitation velocity is greater than 0.9,
-    // take more than one advection step to maintain stability.
-    int nprec;
-    if (prec_cfl > 0.9) {
-        nprec = static_cast<int>(std::ceil(prec_cfl/0.9));
-        for (MFIter mfi(wp, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-            auto wp_array = wp.array(mfi);
-            const auto& box3d = mfi.tilebox();
+        const auto& box3d = mfi.tilebox();
 
-            ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int k, int j, int i)
-            {
-                // wp already includes factor of dt, so reduce it by a
-                // factor equal to the number of precipitation steps.
-                wp_array(i,j,k) = wp_array(i,j,k)/Real(nprec);
-            });
-        }
-    } else {
-        nprec = 1;
-    }
+        // Update precipitation mass fraction and liquid-ice static
+        // energy using precipitation fluxes computed in this column.
+        ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            //==================================================
+            // Precipitating sedimentation (A19)
+            //==================================================
+            Real dqp = (1.0/rho_array(i,j,k)) * ( fz_array(i,j,k+1) - fz_array(i,j,k) ) * coef;
+            Real omp = std::max(0.0,std::min(1.0,(tabs_array(i,j,k)-tprmin)*a_pr));
+            Real omg = std::max(0.0,std::min(1.0,(tabs_array(i,j,k)-tgrmin)*a_gr));
 
-#ifdef ERF_FIXED_SUBCYCLE
-    nprec = 4;
-#endif
+            qpr_array(i,j,k) = std::max(0.0, qpr_array(i,j,k) + dqp*omp);
+            qps_array(i,j,k) = std::max(0.0, qps_array(i,j,k) + dqp*(1.0-omp)*(1.0-omg));
+            qpg_array(i,j,k) = std::max(0.0, qpg_array(i,j,k) + dqp*(1.0-omp)*omg);
+             qp_array(i,j,k) = qpr_array(i,j,k) + qps_array(i,j,k) + qpg_array(i,j,k);
 
-    for(int iprec = 1; iprec<=nprec; iprec++) {
-        for ( MFIter mfi(tmp_qp, TileNoZ()); mfi.isValid(); ++mfi) {
-            auto qpr_array    = qpr->array(mfi);
-            auto qps_array    = qps->array(mfi);
-            auto qpg_array    = qpg->array(mfi);
-            auto qp_array     = qp->array(mfi);
-            auto rho_array    = rho->array(mfi);
-            auto tabs_array   = tabs->array(mfi);
-            auto tmp_qp_array = tmp_qp.array(mfi);
-            auto mx_array     = mx.array(mfi);
-            auto mn_array     = mn.array(mfi);
-            auto fz_array     = fz.array(mfi);
-            auto wp_array     = wp.array(mfi);
-            auto lfac_array   = lfac.array(mfi);
-            auto www_array    = www.array(mfi);
-
-            const auto& box3d = mfi.tilebox();
-
-            ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                tmp_qp_array(i,j,k) = qp_array(i,j,k); // Temporary array for qp in this column
-            });
-
-            ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                if (nonos) {
-                    int kc=min(nz-1,k+1);
-                    int kb=max(0,k-1);
-                    mx_array(i,j,k) = max(tmp_qp_array(i,j,kb), max(tmp_qp_array(i,j,kc), tmp_qp_array(i,j,k)));
-                    mn_array(i,j,k) = min(tmp_qp_array(i,j,kb), min(tmp_qp_array(i,j,kc), tmp_qp_array(i,j,k)));
-                }
-                // Define upwind precipitation flux
-                fz_array(i,j,k) = tmp_qp_array(i,j,k)*wp_array(i,j,k);
-            });
-
-            ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                int kc = min(k+1, nz-1);
-                Real dqp = (fz_array(i,j,kc)-fz_array(i,j,k)) / rho_array(i,j,k);
-                tmp_qp_array(i,j,k) = tmp_qp_array(i,j,k) + dqp; //Update temporary qp
-            });
-
-            ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                // Also, compute anti-diffusive correction to previous
-                // (upwind) approximation to the flux
-                int kb=max(0,k-1);
-                // The precipitation velocity is a cell-centered quantity,
-                // since it is computed from the cell-centered
-                // precipitation mass fraction.  Therefore, a reformulated
-                // anti-diffusive flux is used here which accounts for
-                // this and results in reduced numerical diffusion.
-                www_array(i,j,k) = 0.5*(1.0+wp_array(i,j,k)/rho_array(i,j,k))*(tmp_qp_array(i,j,kb)*wp_array(i,j,kb) -
-                                                                        tmp_qp_array(i,j,k)*wp_array(i,j,k)); // works for wp(k)<0
-            });
-
-            if (nonos) {
-                ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                {
-                    int kc=min(nz-1,k+1);
-                    int kb=max(0,k-1);
-                    mx_array(i,j,k) = max(tmp_qp_array(i,j,kb),max(tmp_qp_array(i,j,kc), max(tmp_qp_array(i,j,k), mx_array(i,j,k))));
-                    mn_array(i,j,k) = min(tmp_qp_array(i,j,kb),min(tmp_qp_array(i,j,kc), min(tmp_qp_array(i,j,k), mn_array(i,j,k))));
-                    kc = min(nz-1,k+1);
-                    mx_array(i,j,k) = rho_array(i,j,k)*(mx_array(i,j,k)-tmp_qp_array(i,j,k))/(pn(www_array(i,j,kc)) +
-                                                                                        pp(www_array(i,j,k))+eps);
-                    mn_array(i,j,k) = rho_array(i,j,k)*(tmp_qp_array(i,j,k)-mn_array(i,j,k))/(pp(www_array(i,j,kc)) +
-                                                                                        pn(www_array(i,j,k))+eps);
-                });
-
-                ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                {
-                    int kb=max(0,k-1);
-                    // Add limited flux correction to fz(k).
-                    fz_array(i,j,k) = fz_array(i,j,k)
-                                    + pp(www_array(i,j,k))*std::min(1.0,std::min(mx_array(i,j,k), mn_array(i,j,kb)))
-                                    - pn(www_array(i,j,k))*std::min(1.0,std::min(mx_array(i,j,kb),mn_array(i,j,k))); // Anti-diffusive flux
-                });
-            }
-
-            // Update precipitation mass fraction and liquid-ice static
-            // energy using precipitation fluxes computed in this column.
-            ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                int kc=min(k+1, nz-1);
-                // Update precipitation mass fraction.
-                // Note that fz is the total flux, including both the
-                // upwind flux and the anti-diffusive correction.
-
-                //==================================================
-                // Precipitating sedimentation (A19)
-                //==================================================
-                Real dqp = ( fz_array(i,j,kc) - fz_array(i,j,k) ) / rho_array(i,j,k);
-                Real omp = std::max(0.0,std::min(1.0,(tabs_array(i,j,k)-tprmin)*a_pr));
-                Real omg = std::max(0.0,std::min(1.0,(tabs_array(i,j,k)-tgrmin)*a_gr));
-
-                qpr_array(i,j,k) = std::max(0.0, qpr_array(i,j,k) + dqp*omp);
-                qps_array(i,j,k) = std::max(0.0, qps_array(i,j,k) + dqp*(1.0-omp)*(1.0-omg));
-                qpg_array(i,j,k) = std::max(0.0, qpg_array(i,j,k) + dqp*(1.0-omp)*omg);
-                 qp_array(i,j,k) = qpr_array(i,j,k) + qps_array(i,j,k) + qpg_array(i,j,k);
-
-                // NOTE: Sedimentation does not affect the potential temperature,
-                //       but it does affect the liquid/ice static energy.
-                //       No source to Theta occurs here.
-            });
-
-            if (iprec < nprec) {
-                // Re-compute precipitation velocity using new value of qp.
-                ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                {
-                    Real tmp = term_vel_qp(qp_array(i,j,k),
-                                           vrain, vsnow, vgrau,
-                                           rho_array(i,j,k), tabs_array(i,j,k));
-                    wp_array(i,j,k) = std::sqrt(rho_0/rho_array(i,j,k))*tmp;
-                    // Decrease precipitation velocity by factor of nprec
-                    wp_array(i,j,k) = -wp_array(i,j,k)*rho_array(i,j,k)*dt_advance/dz/nprec;
-                    // Note: Don't bother checking CFL condition at each
-                    // substep since it's unlikely that the CFL will
-                    // increase very much between substeps when using
-                    // monotonic advection schemes.
-                    if (k == 0) {
-                          fz_array(i,j,nz-1) = 0.0;
-                         www_array(i,j,nz-1) = 0.0;
-                        lfac_array(i,j,nz-1) = 0.0;
-                    }
-                });
-            }
-        } // mfi
-    } // iprec loop
+            // NOTE: Sedimentation does not affect the potential temperature,
+            //       but it does affect the liquid/ice static energy.
+            //       No source to Theta occurs here.
+        });
+    } // mfi
 }
 

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -69,7 +69,7 @@ public:
     void Precip ();
 
     // precip fall
-    void PrecipFall (int hydro_type=2);
+    void PrecipFall ();
 
     // diagnose
     void Diagnose () override;


### PR DESCRIPTION
The rewrites the sedimentation fluxes for ice and precipitation quantities with the SAM micro model. The fluxes were not located at the correct place (z faces), the terminal velocity had the wrong sign, and there was CFL sub-stepping that I removed for clarity (potential candidate for reintroduction when things are ironed out).