### PR TITLE
Fix MOST BCs

### DIFF
--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -302,6 +302,7 @@ ABLMost::compute_most_bcs (const int& lev,
                                                               umm_arr, tm_arr, u_star_arr, q_star_arr, t_surf_arr,
                                                               dest_arr);
 #endif
+                        amrex::ignore_unused(Qflux);
                     });
                 }
 
@@ -330,6 +331,7 @@ ABLMost::compute_most_bcs (const int& lev,
                                                             umm_arr, um_arr, u_star_arr,
                                                             dest_arr);
 #endif
+                    amrex::ignore_unused(stressx);
                 });
 
             } else if (var_idx == Vars::yvel) {
@@ -357,6 +359,7 @@ ABLMost::compute_most_bcs (const int& lev,
                                                             umm_arr, vm_arr, u_star_arr,
                                                             dest_arr);
 #endif
+                    amrex::ignore_unused(stressy);
                 });
             }
         } // var_idx

--- a/Source/BoundaryConditions/ABLMost.cpp
+++ b/Source/BoundaryConditions/ABLMost.cpp
@@ -258,8 +258,6 @@ ABLMost::compute_most_bcs (const int& lev,
 
 #ifdef ERF_EXPLICIT_MOST_STRESS
                     Real dz1 = (zphys_arr) ? ( zphys_arr(i,j,klo+1) - zphys_arr(i,j,klo) ) : dz_no_terrain;
-
-                    // This is the _kinematic_ heat flux [K m/s]
                     Real Tflux = flux_comp.compute_t_flux(i, j, k, n, icomp, dz, dz1,
                                                           cons_arr, velx_arr, vely_arr,
                                                           umm_arr, tm_arr, u_star_arr, t_star_arr, t_surf_arr,
@@ -293,16 +291,16 @@ ABLMost::compute_most_bcs (const int& lev,
                         Real dz = (zphys_arr) ? ( zphys_arr(i,j,klo) - zphys_arr(i,j,klo-1) ) : dz_no_terrain;
 #ifdef ERF_EXPLICIT_MOST_STRESS
                         Real dz1 = (zphys_arr) ? ( zphys_arr(i,j,klo+1) - zphys_arr(i,j,klo) ) : dz_no_terrain;
-                        //Real Qflux = flux_comp.compute_q_flux(i, j, k, n, icomp, dz, dz1,
-                        //                                      cons_arr, velx_arr, vely_arr,
-                        //                                      umm_arr, tm_arr, u_star_arr, q_star_arr, t_surf_arr,
-                        //                                      dest_arr);
+                        Real Qflux = flux_comp.compute_q_flux(i, j, k, n, icomp, dz, dz1,
+                                                              cons_arr, velx_arr, vely_arr,
+                                                              umm_arr, tm_arr, u_star_arr, q_star_arr, t_surf_arr,
+                                                              dest_arr);
 #else
-                        //Real Qflux = flux_comp.compute_q_flux(i, j, k, n, icomp, dz,
-                        //                                      cons_arr, velx_arr, vely_arr,
-                        //                                      eta_arr,
-                        //                                      umm_arr, tm_arr, u_star_arr, q_star_arr, t_surf_arr,
-                        //                                      dest_arr);
+                        Real Qflux = flux_comp.compute_q_flux(i, j, k, n, icomp, dz,
+                                                              cons_arr, velx_arr, vely_arr,
+                                                              eta_arr,
+                                                              umm_arr, tm_arr, u_star_arr, q_star_arr, t_surf_arr,
+                                                              dest_arr);
 #endif
                     });
                 }
@@ -326,11 +324,11 @@ ABLMost::compute_most_bcs (const int& lev,
                         if (t31_arr) t31_arr(i,j,klo) = -stressx;
                     }
 #else
-                    //Real stressx = flux_comp.compute_u_flux(i, j, k, icomp, dz,
-                    //                                        cons_arr, velx_arr, vely_arr,
-                    //                                        eta_arr,
-                    //                                        umm_arr, um_arr, u_star_arr,
-                    //                                        dest_arr);
+                    Real stressx = flux_comp.compute_u_flux(i, j, k, icomp, dz,
+                                                            cons_arr, velx_arr, vely_arr,
+                                                            eta_arr,
+                                                            umm_arr, um_arr, u_star_arr,
+                                                            dest_arr);
 #endif
                 });
 
@@ -353,11 +351,11 @@ ABLMost::compute_most_bcs (const int& lev,
                         if (t32_arr) t32_arr(i,j,klo) = -stressy;
                     }
 #else
-                    //Real stressy = flux_comp.compute_v_flux(i, j, k, icomp, dz,
-                    //                                        cons_arr, velx_arr, vely_arr,
-                    //                                        eta_arr,
-                    //                                        umm_arr, vm_arr, u_star_arr,
-                    //                                        dest_arr);
+                    Real stressy = flux_comp.compute_v_flux(i, j, k, icomp, dz,
+                                                            cons_arr, velx_arr, vely_arr,
+                                                            eta_arr,
+                                                            umm_arr, vm_arr, u_star_arr,
+                                                            dest_arr);
 #endif
                 });
             }
@@ -373,9 +371,9 @@ ABLMost::time_interp_sst (const int& lev,
     Real dT = m_bdy_time_interval;
     Real time_since_start = time - m_start_bdy_time;
     int n_time = static_cast<int>( time_since_start /  dT);
-    amrex::Real alpha = (time_since_start - n_time * dT) / dT;
+    Real alpha = (time_since_start - n_time * dT) / dT;
     AMREX_ALWAYS_ASSERT( alpha >= 0. && alpha <= 1.0);
-    amrex::Real oma   = 1.0 - alpha;
+    Real oma   = 1.0 - alpha;
     AMREX_ALWAYS_ASSERT( (n_time >= 0) && (n_time < (m_sst_lev[lev].size()-1)));
 
     // Populate t_surf

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -131,6 +131,7 @@ public:
             }
         }
 
+        amrex::ignore_unused(found);
         AMREX_ASSERT_WITH_MESSAGE(found, "MOSTAverage: Height above terrain not found, try increasing z_ref!");
 
         const amrex::RealVect lx((xp - plo[0])*dxi[0] + 0.5,

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -62,6 +62,8 @@ DiffusionSrcForState_N (const amrex::Box& bx, const amrex::Box& domain,
 {
     BL_PROFILE_VAR("DiffusionSrcForState_N()",DiffusionSrcForState_N);
 
+    amrex::ignore_unused(use_most);
+
     const Real dx_inv = cellSizeInv[0];
     const Real dy_inv = cellSizeInv[1];
     const Real dz_inv = cellSizeInv[2];

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -67,6 +67,8 @@ DiffusionSrcForState_T (const amrex::Box& bx, const amrex::Box& domain,
 {
     BL_PROFILE_VAR("DiffusionSrcForState_T()",DiffusionSrcForState_T);
 
+    amrex::ignore_unused(use_most);
+
     const Real dx_inv = cellSizeInv[0];
     const Real dy_inv = cellSizeInv[1];
     const Real dz_inv = cellSizeInv[2];

--- a/Source/IO/ERF_Write1DProfiles_stag.cpp
+++ b/Source/IO/ERF_Write1DProfiles_stag.cpp
@@ -129,10 +129,11 @@ ERF::write_1D_profiles_stag(Real time)
                       Real uuface = 0.5*(h_avg_uu[k] + h_avg_uu[k-1]);
                       Real uvface = 0.5*(h_avg_uv[k] + h_avg_uv[k-1]);
                       Real vvface = 0.5*(h_avg_vv[k] + h_avg_vv[k-1]);
-                      Real w_cc   = 0.5*(h_avg_w[k-1]  + h_avg_w[k]);
-                      Real uw_cc  = 0.5*(h_avg_uw[k-1] + h_avg_uw[k]);
-                      Real vw_cc  = 0.5*(h_avg_vw[k-1] + h_avg_vw[k]);
-                      Real ww_cc  = 0.5*(h_avg_ww[k-1] + h_avg_ww[k]);
+                      w_cc   = 0.5*(h_avg_w[k-1]  + h_avg_w[k]);
+                      uw_cc  = 0.5*(h_avg_uw[k-1] + h_avg_uw[k]);
+                      vw_cc  = 0.5*(h_avg_vw[k-1] + h_avg_vw[k]);
+                      ww_cc  = 0.5*(h_avg_ww[k-1] + h_avg_ww[k]);
+                      amrex::ignore_unused(uvface);
                       data_log2 << std::setw(datwidth) << std::setprecision(timeprecision) << time << " "
                                 << std::setw(datwidth) << std::setprecision(datprecision) << z << " "
                                 << h_avg_uu[k]   - h_avg_u[k]*h_avg_u[k]   << " " // u'u'
@@ -179,6 +180,7 @@ ERF::write_1D_profiles_stag(Real time)
                   Real uuface = 1.5*h_avg_uu[k-1] - 0.5*h_avg_uu[k-2];
                   Real uvface = 1.5*h_avg_uv[k-1] - 0.5*h_avg_uv[k-2];
                   Real vvface = 1.5*h_avg_vv[k-1] - 0.5*h_avg_vv[k-2];
+                  amrex::ignore_unused(uvface);
                   data_log2 << std::setw(datwidth) << std::setprecision(timeprecision) << time << " "
                             << std::setw(datwidth) << std::setprecision(datprecision) << k * dx[2] << " "
                             << 0                                     << " " // u'u'

--- a/Source/TimeIntegration/ERF_advance_dycore.cpp
+++ b/Source/TimeIntegration/ERF_advance_dycore.cpp
@@ -77,6 +77,7 @@ void ERF::advance_dycore(int level,
                            (tc.pbl_type != PBLType::None) );
 
     const bool use_most = (m_most != nullptr);
+    amrex::ignore_unused(use_most);
 
     const BoxArray& ba            = state_old[IntVars::cons].boxArray();
     const BoxArray& ba_z          = zvel_old.boxArray();


### PR DESCRIPTION
The compute flux functions are needed to fill BC vals and/or tau_{13/23}. We will have to live with debug compiler warnings for unused vars here until MOST is completely overhauled and/or the LSMs plug in and use the returned fluxes.