### PR TITLE
Init real Z bounds checking

### DIFF
--- a/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
+++ b/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
@@ -7,7 +7,7 @@ amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 1024 1024 1024
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_extent = 3750000. 	3750000. 	5000.
+geometry.prob_extent = 3750000. 	3750000. 	16500.
 amr.n_cell           = 200   		200   		176
 #amr.blocking_factor  = 1
 


### PR DESCRIPTION
This corrects the z bounds checking on device and is a more robust approach. Since WRF does not enforce a constant height top lid with pressure coordinates, we look over the top 2 layers and ensure the user defined `z_max` is between them; this ensures we do not have terrain height coordinates that cross.