### PR TITLE
GPU reduce z_top 

### DIFF
--- a/Source/Initialization/ERF_init_from_wrfinput.cpp
+++ b/Source/Initialization/ERF_init_from_wrfinput.cpp
@@ -510,7 +510,7 @@ verify_terrain_top_boundary (const Real& z_top,
                                    ph (ii,jj-1,k) + ph (ii-1,jj-1,k) +
                                    phb(ii,jj  ,k) + phb(ii-1,jj  ,k) +
                                    phb(ii,jj-1,k) + phb(ii-1,jj-1,k) ) / CONST_GRAV;
-            mm_d[0] = amrex::max(mm_d[0],z_calc);
+            amrex::Gpu::Atomic::Max(&(mm_d[0]),z_calc);
         },
         [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
@@ -520,7 +520,7 @@ verify_terrain_top_boundary (const Real& z_top,
                                    ph (ii,jj-1,k) + ph (ii-1,jj-1,k) +
                                    phb(ii,jj  ,k) + phb(ii-1,jj  ,k) +
                                    phb(ii,jj-1,k) + phb(ii-1,jj-1,k) ) / CONST_GRAV;
-            mm_d[1] = amrex::max(mm_d[1],z_calc);
+            amrex::Gpu::Atomic::Max(&(mm_d[1]),z_calc);
         });
 
         Gpu::copy(Gpu::deviceToHost, MaxMax_d.begin(), MaxMax_d.end(), MaxMax_h.begin());


### PR DESCRIPTION
Use atomic max to avoid race condition with threads writing to device vector.