### PR TITLE
Adding inputs for OpenBC squall line verification

### DIFF
--- a/Exec/SquallLine_2D/inputs_moisture_Gabersek
+++ b/Exec/SquallLine_2D/inputs_moisture_Gabersek
@@ -1,5 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 18000
+max_step = 36000
 stop_time = 90000.0
 
 amrex.fpe_trap_invalid = 1
@@ -7,31 +7,22 @@ amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 2048 1024 2048
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_lo     = -60000.   0.    0.
-geometry.prob_hi     =  60000. 400. 20000.
-amr.n_cell           =  384    4    128    # dx=dy=dz=100 m
+geometry.prob_lo     = -75000.   0.    0.
+geometry.prob_hi     =  75000. 400. 24000.
+amr.n_cell           =  1500     4    240    # dx=dy=dz=100 m
 
 # periodic in x to match WRF setup
 # - as an alternative, could use symmetry at x=0 and outflow at x=25600
-geometry.is_periodic = 1 1 0
-#xlo.type = "Outflow"
-#xhi.type = "Outflow"
+geometry.is_periodic = 0 1 0
+xlo.type = "Open"
+xhi.type = "Open"
 zlo.type = "SlipWall"
 zhi.type = "Outflow"
 
-erf.sponge_strength = 2.0
-#erf.use_zhi_sponge_damping = true
-erf.zhi_sponge_start = 12000.0
-
-erf.sponge_density = 1.2
-erf.sponge_x_velocity = 0.0
-erf.sponge_y_velocity = 0.0
-erf.sponge_z_velocity = 0.0
-
 # TIME STEP CONTROL
 erf.use_native_mri = 1
-erf.fixed_dt       = 0.5      # fixed time step [s] -- Straka et al 1993
-erf.fixed_fast_dt  = 0.25     # fixed time step [s] -- Straka et al 1993
+erf.fixed_dt       = 0.25      # fixed time step [s] -- Straka et al 1993
+erf.fixed_fast_dt  = 0.125     # fixed time step [s] -- Straka et al 1993
 #erf.no_substepping  = 1
 
 # DIAGNOSTICS & VERBOSITY
@@ -68,15 +59,19 @@ erf.les_type = "None"
 erf.molec_diff_type = "ConstantAlpha"
 #erf.molec_diff_type = "Constant"
 erf.rho0_trans = 1.0 # [kg/m^3], used to convert input diffusivities
-erf.dynamicViscosity = 100.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
-erf.alpha_T = 00.0 # [m^2/s]
-erf.alpha_C = 50.0
+erf.dynamicViscosity = 200.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T = 200.0 # [m^2/s]
+erf.alpha_C = 200.0
 
 erf.moisture_model = "Kessler"
 erf.use_moist_background = true
 
-erf.moistscal_horiz_adv_string = "Centered_2nd"
-erf.moistscal_vert_adv_string = "Centered_2nd"
+erf.dycore_horiz_adv_type    = "Centered_2nd"
+erf.dycore_vert_adv_type     = "Centered_2nd"
+erf.dryscal_horiz_adv_type   = "Centered_2nd"
+erf.dryscal_vert_adv_type    = "Centered_2nd"
+erf.moistscal_horiz_adv_type = "Centered_2nd"
+erf.moistscal_vert_adv_type  = "Centered_2nd"
 
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0


### PR DESCRIPTION
This PR adds the inputs for the verification of the squall line test case in [Tissaoui et. al. (JAMES 2023)](https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2022MS003283).

Figure shows the comparison of the rain accumulation on the ground in mm with the `OpenBoundary` branch (red line) and the previous verified result (blue line).

![Rain_Accum_9000s](https://github.com/erf-model/ERF/assets/34353555/06aa1e03-3d1b-4bcf-970c-4bdb1457f79f)