### PR TITLE
Boundary Register Only Inflow

### DIFF
--- a/Exec/ABL/inputs.read
+++ b/Exec/ABL/inputs.read
@@ -41,7 +41,7 @@ erf.check_int       = -1        # number of timesteps between checkpoints
 
 # PLOTFILES
 erf.plot_file_1     = plt       # prefix of plotfile name
-erf.plot_int_1      = -1        # number of timesteps between plotfiles
+erf.plot_int_1      = 100       # number of timesteps between plotfiles
 erf.plot_vars_1     = density rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta
 
 # SOLVER CHOICE
@@ -65,8 +65,8 @@ prob.W_0 = 0.0
 
 # Higher values of perturbations lead to instability
 # Instability seems to be coming from BC
-prob.U_0_Pert_Mag = 0.08
-prob.V_0_Pert_Mag = 0.08 #
+prob.U_0_Pert_Mag = 0.0
+prob.V_0_Pert_Mag = 0.0
 prob.W_0_Pert_Mag = 0.0
 
 erf.input_bndry_planes = 1

--- a/Source/BoundaryConditions/BoundaryConditions_bndryreg.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_bndryreg.cpp
@@ -25,6 +25,8 @@ ERF::fill_from_bndryregs (const Vector<MultiFab*>& mfs, const Real time)
 
     Vector<std::unique_ptr<PlaneVector>>& bndry_data = m_r2d->interp_in_time(time);
 
+    const BCRec* bc_ptr = domain_bcs_type_d.data();
+
     // xlo: ori = 0
     // ylo: ori = 1
     // zlo: ori = 2
@@ -72,14 +74,18 @@ ERF::fill_from_bndryregs (const Vector<MultiFab*>& mfs, const Real time)
 
             ParallelFor(
                 bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                    int jb = std::min(std::max(j,dom_lo.y),dom_hi.y);
-                    int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
-                    dest_arr(i,j,k,icomp+n) = bdatxlo(dom_lo.x-1,jb,kb,bccomp+n);
+                    if (bc_ptr[icomp+n].lo(0) == ERFBCType::ext_dir_ingested) {
+                        int jb = std::min(std::max(j,dom_lo.y),dom_hi.y);
+                        int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
+                        dest_arr(i,j,k,icomp+n) = bdatxlo(dom_lo.x-1,jb,kb,bccomp+n);
+                    }
                 },
                 bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                    int jb = std::min(std::max(j,dom_lo.y),dom_hi.y);
-                    int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
-                    dest_arr(i,j,k,icomp+n) = bdatxhi(dom_hi.x+1,jb,kb,bccomp+n);
+                    if (bc_ptr[icomp+n].hi(0) == ERFBCType::ext_dir_ingested) {
+                        int jb = std::min(std::max(j,dom_lo.y),dom_hi.y);
+                        int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
+                        dest_arr(i,j,k,icomp+n) = bdatxhi(dom_hi.x+1,jb,kb,bccomp+n);
+                    }
                 }
             );
             } // x-faces
@@ -94,14 +100,18 @@ ERF::fill_from_bndryregs (const Vector<MultiFab*>& mfs, const Real time)
 
             ParallelFor(
                bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                    int ib = std::min(std::max(i,dom_lo.x),dom_hi.x);
-                    int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
-                    dest_arr(i,j,k,icomp+n) = bdatylo(ib,dom_lo.y-1,kb,bccomp+n);
+                    if (bc_ptr[icomp+n].lo(1) == ERFBCType::ext_dir_ingested) {
+                        int ib = std::min(std::max(i,dom_lo.x),dom_hi.x);
+                        int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
+                        dest_arr(i,j,k,icomp+n) = bdatylo(ib,dom_lo.y-1,kb,bccomp+n);
+                    }
                 },
                 bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) {
-                    int ib = std::min(std::max(i,dom_lo.x),dom_hi.x);
-                    int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
-                    dest_arr(i,j,k,icomp+n) = bdatyhi(ib,dom_hi.y+1,kb,bccomp+n);
+                    if (bc_ptr[icomp+n].hi(1) == ERFBCType::ext_dir_ingested) {
+                        int ib = std::min(std::max(i,dom_lo.x),dom_hi.x);
+                        int kb = std::min(std::max(k,dom_lo.z),dom_hi.z);
+                        dest_arr(i,j,k,icomp+n) = bdatyhi(ib,dom_hi.y+1,kb,bccomp+n);
+                    }
                 }
             );
             } // y-faces

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -36,11 +36,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
     setBC(bx, domain, bccomp, 0, icomp+ncomp, m_domain_bcs_type, bcrs);
 
     Gpu::DeviceVector<BCRec> bcrs_d(icomp+ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*(icomp+ncomp));
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*(icomp+ncomp));
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -199,11 +199,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
     setBC(bx, domain, bccomp, 0, icomp+ncomp, m_domain_bcs_type, bcrs);
 
     Gpu::DeviceVector<BCRec> bcrs_d(icomp+ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*(icomp+ncomp));
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*(icomp+ncomp));
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -36,11 +36,7 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
     setBC(enclosedCells(bx), domain, bccomp, 0, ncomp, m_domain_bcs_type, bcrs);
 
     Gpu::DeviceVector<BCRec> bcrs_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_xvel.cpp
@@ -189,11 +189,7 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
     setBC(enclosedCells(bx), domain, bccomp, 0, ncomp, m_domain_bcs_type, bcrs);
 
     Gpu::DeviceVector<BCRec> bcrs_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
@@ -189,11 +189,7 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
     // zhi: ori = 5
 
     Gpu::DeviceVector<BCRec> bcrs_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>, AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_yvel.cpp
@@ -34,11 +34,7 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
     // zhi: ori = 5
 
     Gpu::DeviceVector<BCRec> bcrs_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#else
-    std::memcpy(bcrs_d.data(), bcrs.data(), sizeof(BCRec)*ncomp);
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs.begin(), bcrs.end(), bcrs_d.begin());
     const BCRec* bc_ptr = bcrs_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>, AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
@@ -314,11 +314,7 @@ void ERFPhysBCFunct_w_no_terrain::impose_lateral_zvel_bcs (const Array4<Real    
     // zhi: ori = 5
 
     Gpu::DeviceVector<BCRec> bcrs_w_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_w_d.data(), bcrs_w.data(), sizeof(BCRec));
-#else
-    std::memcpy(bcrs_w_d.data(), bcrs_w.data(), sizeof(BCRec));
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs_w.begin(), bcrs_w.end(), bcrs_w_d.begin());
     const BCRec* bc_ptr_w = bcrs_w_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;

--- a/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_zvel.cpp
@@ -40,11 +40,7 @@ void ERFPhysBCFunct_w::impose_lateral_zvel_bcs (const Array4<Real      >& dest_a
     // zhi: ori = 5
 
     Gpu::DeviceVector<BCRec> bcrs_w_d(ncomp);
-#ifdef AMREX_USE_GPU
-    Gpu::htod_memcpy_async(bcrs_w_d.data(), bcrs_w.data(), sizeof(BCRec));
-#else
-    std::memcpy(bcrs_w_d.data(), bcrs_w.data(), sizeof(BCRec));
-#endif
+    Gpu::copyAsync(Gpu::hostToDevice, bcrs_w.begin(), bcrs_w.end(), bcrs_w_d.begin());
     const BCRec* bc_ptr_w = bcrs_w_d.data();
 
     GpuArray<GpuArray<Real, AMREX_SPACEDIM*2>,AMREX_SPACEDIM+NVAR_max> l_bc_extdir_vals_d;


### PR DESCRIPTION
The boundary register data should only be used on a face if that face is defined as an external Dirichlet ingested `ext_dir_ingested`. Also, I've cleaned up some async copies to the GPU; there is no reason to have the compile macros switch between an async gpu copy and memcpy because the AMReX gpu container already does this for us.

Results **before** change (perturbed flow fed into uniform u=10 IC):
![image (3)](https://github.com/erf-model/ERF/assets/103702284/9019b396-79a3-48ff-98e7-2089c725f15d)

Results **after** change (perturbed flow fed into uniform u=10 IC):
![image (2)](https://github.com/erf-model/ERF/assets/103702284/f8cdeef1-9c16-4ce0-97d7-cdaf0ab0cb22)
