### PR TITLE
Radiation Data Files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,13 @@ if(ERF_ENABLE_RRTMGP)
    # Build the static rrtmgp library
    set(RRTMGP_BIN ${CMAKE_BINARY_DIR}/rrtmgp)
    add_subdirectory(${CMAKE_SOURCE_DIR}/Submodules/RRTMGP/cpp ${RRTMGP_BIN})
+
+   # Find the radiation data files
+   if (DEFINED ENV{ERF_RADIATION_DATA_DIR})
+       set(ERF_RADIATION_DATA_DIR "$ENV{ERF_RADIATION_DATA_DIR}")
+   else()
+       message(FATAL_ERROR "Environment variable ERF_RADIATION_DATA_DIR not set!")
+   endif()
 endif()
 
 ########################### ERF #####################################
@@ -137,6 +144,7 @@ endif()
 configure_file(
   ${CMAKE_SOURCE_DIR}/Source/ERF_Config.H.in
   ${CMAKE_BINARY_DIR}/ERF_Config.H
+  @ONLY
 )
 
 # General information about machine, compiler, and build type

--- a/Source/ERF_Config.H.in
+++ b/Source/ERF_Config.H.in
@@ -1,4 +1,3 @@
-
 #ifndef ERF_CONFIG_H_
 #define ERF_CONFIG_H_
 
@@ -7,7 +6,7 @@
 
 // functions to get the radiation data directory
 inline
-std::string getRadiationDataDir()
+std::string getRadiationDataDir ()
 {
    return "@ERF_RADIATION_DATA_DIR@";
 }

--- a/Source/Radiation/Mam4_constituents.H
+++ b/Source/Radiation/Mam4_constituents.H
@@ -10,6 +10,7 @@
 #include "rrtmgp_const.h"
 #include "Phys_prop.H"
 #include "Rad_constants.H"
+#include "ERF_Config.H"
 
 #ifndef ERF_MAM4_CONSTITUENTS_H_
 #define ERF_MAM4_CONSTITUENTS_H_
@@ -123,8 +124,10 @@ class MamConstituents {
         // we hard-coded the use nmodes = 3, and nspeces = {6, 3, 3}
         //
         // allocate components that depend on nmodes
-        const char* erf_home = std::getenv("ERF_HOME");
-        auto erf_rad_data_dir = (std::string)erf_home + "/Source/Radiation/data/";
+        //const char* erf_home = std::getenv("ERF_HOME");
+        //auto erf_rad_data_dir = (std::string)erf_home + "/Source/Radiation/data/";
+        auto erf_rad_data_dir = getRadiationDataDir() + "/";
+
         // initialize yakl
         if (!yakl::isInitialized()) yakl::init();
 


### PR DESCRIPTION
Cmake compilation was incorrect and the path to the data files was hard coded (rather than using the inlined string function). The code will now try to take a step.