### PR TITLE
More radiation fixes

### DIFF
--- a/Source/ERF_make_new_arrays.cpp
+++ b/Source/ERF_make_new_arrays.cpp
@@ -202,6 +202,14 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
         Nturb[lev].define(ba, dm, 1, ngrow_state); // Number of turbines in a cell
     }
 #endif
+
+#if defined(ERF_USE_RRTMGP)
+    //*********************************************************
+    // Radiation heating source terms
+    //*********************************************************
+     qheating_rates[lev].define(ba, dm, 2, ngrow_state);
+     qheating_rates[lev].setVal(0.);
+#endif
 }
 
 void

--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -145,11 +145,11 @@ ERF::WriteCheckpointFile () const
          // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
          // Write the precipitation accumulation component only
         if (solverChoice.moisture_type == MoistureType::Kessler) {
-            ng = qmoist[lev][0]->nGrowVect();
-             int nvar = 1;
-             MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
-             MultiFab::Copy(moist_vars,*(qmoist[lev][0]),0,0,nvar,ng);
-             VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MoistVars"));
+            ng = qmoist[lev][4]->nGrowVect();
+            int nvar = 1;
+            MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
+            MultiFab::Copy(moist_vars,*(qmoist[lev][4]),0,0,nvar,ng);
+            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MoistVars"));
         }
 
 #if defined(ERF_USE_WINDFARM)
@@ -378,11 +378,11 @@ ERF::ReadCheckpointFile ()
 
         // Read in the precipitation accumulation component
         if (solverChoice.moisture_type == MoistureType::Kessler) {
-            ng = qmoist[lev][0]->nGrowVect();
+            ng = qmoist[lev][4]->nGrowVect();
             int nvar = 1;
             MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
             VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "MoistVars"));
-            MultiFab::Copy(*(qmoist[lev][0]),moist_vars,0,0,nvar,ng);
+            MultiFab::Copy(*(qmoist[lev][4]),moist_vars,0,0,nvar,ng);
         }
 
 

--- a/Source/Microphysics/Kessler/Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/Init_Kessler.cpp
@@ -34,7 +34,7 @@ void Kessler::Init (const MultiFab& cons_in,
     m_detJ_cc   = detJ_cc.get();
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_Kess::rain_accum, MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp};
+    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp, MicVar_Kess::rain_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Kess::NumVars; ++ivar) {

--- a/Source/Radiation/Cloud_rad_props.H
+++ b/Source/Radiation/Cloud_rad_props.H
@@ -6,6 +6,7 @@
 
 #include <AMReX_MultiFabUtil.H>
 #include "ERF_Constants.H"
+#include "ERF_Config.H"
 #include "rrtmgp_const.h"
 #include "Water_vapor_saturation.H"
 #include "Linear_interpolate.H"

--- a/Source/Radiation/Cloud_rad_props.cpp
+++ b/Source/Radiation/Cloud_rad_props.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include "YAKL_netcdf.h"
 #include "Cloud_rad_props.H"
+
 using yakl::fortran::parallel_for;
 using yakl::fortran::SimpleBounds;
 
@@ -22,8 +23,7 @@ void CloudRadProps::initialize ()
     realHost2d asm_sw_ice_h;
     realHost2d abs_lw_ice_h;
 
-    const char* erf_home = std::getenv("ERF_HOME");
-    auto erf_rad_data_dir = (std::string)erf_home + "/Source/Radiation/data/";
+    auto erf_rad_data_dir = getRadiationDataDir() + "/";
     liquid_file = erf_rad_data_dir + "F_nwvl200_mu20_lam50_res64_t298_c080428.nc";
     ice_file = erf_rad_data_dir + "iceoptics_c080917.nc";
 

--- a/Source/Radiation/Mam4_aero.H
+++ b/Source/Radiation/Mam4_aero.H
@@ -14,6 +14,7 @@
 #include "Mam4_constituents.H"
 #include "Rad_constants.H"
 #include "ERF_Constants.H"
+#include "ERF_Config.H"
 #include "Modal_aero_wateruptake.H"
 
 using yakl::fortran::parallel_for;
@@ -77,9 +78,8 @@ class Mam4_aer {
             }
         }
 
-        const char* erf_home = std::getenv("ERF_HOME");
-        auto erf_rad_data_dir = (std::string)erf_home + "/Source/Radiation/data/";
-        water_refindex_file = erf_rad_data_dir+"water_refindex_rrtmg_c080910.nc";
+        auto erf_rad_data_dir = getRadiationDataDir() + "/";
+        water_refindex_file   = erf_rad_data_dir + "water_refindex_rrtmg_c080910.nc";
         read_water_refindex(water_refindex_file);
 
         // Allocate dry and wet size variables

--- a/Source/Radiation/Mam4_constituents.H
+++ b/Source/Radiation/Mam4_constituents.H
@@ -124,8 +124,6 @@ class MamConstituents {
         // we hard-coded the use nmodes = 3, and nspeces = {6, 3, 3}
         //
         // allocate components that depend on nmodes
-        //const char* erf_home = std::getenv("ERF_HOME");
-        //auto erf_rad_data_dir = (std::string)erf_home + "/Source/Radiation/data/";
         auto erf_rad_data_dir = getRadiationDataDir() + "/";
 
         // initialize yakl

--- a/Source/Radiation/Modal_aero_wateruptake.H
+++ b/Source/Radiation/Modal_aero_wateruptake.H
@@ -269,7 +269,7 @@ class ModalAeroWateruptake {
     YAKL_INLINE
     static void modal_aero_kohler (const real& rdry_in,
                                    const real& hygro, const real& s,
-                                  real& rwet_out)
+                                   real& rwet_out)
     {
         const real eps = 1.e-4;
         const real mw = 18.;
@@ -287,8 +287,7 @@ class ModalAeroWateruptake {
         auto b    = vol*hygro;
 
         //quartic
-        auto ss   = std::min(s,1.-eps); // relative humidity
-        ss   = std::max(ss,1.e-10);
+        auto ss   = std::max(std::min(s,1.-eps), 1.e-10); // relative humidity
         auto slog = std::log(ss); // log relative humidity
         auto p43  = -a/slog;
         auto p42  = 0.;
@@ -312,6 +311,7 @@ class ModalAeroWateruptake {
             r=rdry*(1.+p*third/(1.-slog*rdry/a));
         }
         else {
+            // AML TODO: FIX WHATEVER THIS IS TRYING TO DO...
             amrex::GpuComplex<real> cx4[4];
             makoh_quartic(cx4,p43,p42,p41,p40);
             //find smallest real(r8) solution
@@ -422,11 +422,10 @@ class ModalAeroWateruptake {
         const real third=1./3.;
         auto q = -p2*p2/36.+(p3*p1-4*p0)/12.;
         auto r = -std::pow((p2/6), 3.0) + p2*(p3*p1-4.*p0)/48.
-            +(4.*p0*p2-p0*p3*p3-p1*p1)/16.;
+               + (4.*p0*p2-p0*p3*p3-p1*p1)/16.;
 
-        auto crad = amrex::GpuComplex<real>(r*r+q*q*q, 0.);
-        crad = amrex::sqrt(crad);
-        auto cb = r-crad;
+        auto crad = amrex::sqrt(amrex::GpuComplex<real>(r*r+q*q*q, 0.));
+        auto cb   = r-crad;
 
         if (cb.real() == 0. && cb.imag() == 0.) {
             // insoluble particle

--- a/Source/Radiation/Radiation.H
+++ b/Source/Radiation/Radiation.H
@@ -44,7 +44,7 @@ class Radiation {
 
     // init
     void initialize (const amrex::MultiFab& cons_in,
-                     const amrex::MultiFab& qmoist,
+                     amrex::Vector<amrex::MultiFab*> qmoist,
                      const amrex::BoxArray& grids,
                      const amrex::Geometry& geom,
                      const amrex::Real& dt_advance,
@@ -176,8 +176,9 @@ class Radiation {
 
     // k-distribution coefficients files to read from. These are set via namelist
     // variables.
-    std::string rrtmgp_coefficients_file_sw = "/ccs/home/yuanx/erf.git_develop/Source/Radiation/data/rrtmgp_coefficients_sw_20181204.nc";
-    std::string rrtmgp_coefficients_file_lw = "/ccs/home/yuanx/erf.git_develop/Source/Radiation/data/rrtmgp_coefficients_lw_20181204.nc";
+    std::string rrtmgp_file_path;
+    std::string rrtmgp_coefficients_file_sw = "rrtmgp_coefficients_sw_20181204.nc";
+    std::string rrtmgp_coefficients_file_lw = "rrtmgp_coefficients_lw_20181204.nc";
 
     // Band midpoints; these need to be module variables because of how cam_history works;
     // add_hist_coord sets up pointers to these, so they need to persist.

--- a/Source/TimeIntegration/ERF_advance_radiation.cpp
+++ b/Source/TimeIntegration/ERF_advance_radiation.cpp
@@ -14,8 +14,7 @@ void ERF::advance_radiation (int lev,
    bool do_snow_opt {true};
    bool is_cmip6_volcano {false};
 
-    // TODO: Only passing qv from the qmoist vector!!!
-    rad.initialize(cons, *(qmoist[lev][0]),
+    rad.initialize(cons, qmoist[lev],
                    grids[lev],
                    Geom(lev),
                    dt_advance,


### PR DESCRIPTION
The code will now run a step but dies in the radiation module.

Notable changes/issues:

1. qheating_rate MF was never defined and it still is **NOT** passed the radiation module; so we need to figure out what should populate that output.
2. rain_accum was moved to the last qmoist slot since radiation needs to interact with moisture models and this was put at the front for Kessler but is not existent in any other model (breaks indexing)