### PR TITLE
fix minor MOST zref bug

### DIFF
--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -270,7 +270,7 @@ MOSTAverage::set_k_indices_N()
             AMREX_ASSERT_WITH_MESSAGE(m_zref <= m_zhi - 0.5 * m_dz,
                                       "Query point must be below the last z-cell!");
 
-            int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));
+            int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz));
 
             m_zref = (lk + 0.5) * m_dz + m_zlo;
 


### PR DESCRIPTION
Remove displacement of 1/2 cell when computing index of zref that I believe to be unnecessary.

Example: if current zref requested is 14 and dz is 10, the returned index to average over would be 0 rather than 1.

