### PR TITLE
Precipitation accumulation for SAM

### DIFF
--- a/Exec/SquallLine_2D/inputs_moisture_SAM
+++ b/Exec/SquallLine_2D/inputs_moisture_SAM
@@ -1,0 +1,79 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 14400
+stop_time = 90000.0
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 2048 1024 2048
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     = -25000.   0.    0.
+geometry.prob_hi     =  25000. 400. 20000.
+amr.n_cell           =  192    4    128
+
+geometry.is_periodic = 0 1 0
+
+xlo.type = "Open"
+xhi.type = "Open"
+zlo.type = "SlipWall"
+zhi.type = "Outflow"
+
+# TIME STEP CONTROL
+erf.use_native_mri = 1
+erf.fixed_dt       = 1.0      # fixed time step [s] -- Straka et al 1993
+erf.fixed_fast_dt  = 0.5     # fixed time step [s] -- Straka et al 1993
+#erf.no_substepping  = 1
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+amr.check_file      = chk        # root name of checkpoint file
+amr.check_int       = 1000       # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1         = plt        # root name of plotfile
+erf.plot_int_1          = 60         # number of timesteps between plotfiles
+erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 rhoQ3 x_velocity y_velocity z_velocity pressure theta temp qv qc qrain rain_accum pert_dens
+
+# SOLVER CHOICE
+erf.use_gravity = true
+erf.buoyancy_type = 1
+erf.use_coriolis = false
+erf.use_rayleigh_damping = false
+
+#
+# diffusion coefficient from Straka, K = 75 m^2/s
+#
+erf.molec_diff_type = "ConstantAlpha"
+erf.rho0_trans = 1.0 # [kg/m^3], used to convert input diffusivities
+erf.dynamicViscosity = 100.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T = 100.0 # [m^2/s]
+erf.alpha_C = 100.0
+
+erf.moisture_model = "SAM"
+erf.use_moist_background = true
+
+erf.dycore_horiz_adv_type    = "Centered_2nd"
+erf.dycore_vert_adv_type     = "Centered_2nd"
+erf.dryscal_horiz_adv_type   = "Centered_2nd"
+erf.dryscal_vert_adv_type    = "Centered_2nd"
+erf.moistscal_horiz_adv_type = "Centered_2nd"
+erf.moistscal_vert_adv_type  = "Centered_2nd"
+
+# PROBLEM PARAMETERS (optional)
+prob.z_tr = 12000.0
+prob.height = 1200.0
+prob.theta_0 = 300.0
+prob.theta_tr = 343.0
+prob.T_tr = 213.0
+prob.x_c = 0.0
+prob.z_c = 1500.0
+prob.x_r = 4000.0
+prob.z_r = 1500.0
+prob.theta_c = 3.0

--- a/Exec/SquallLine_2D/inputs_moisture_SAM
+++ b/Exec/SquallLine_2D/inputs_moisture_SAM
@@ -11,10 +11,10 @@ geometry.prob_lo     = -25000.   0.    0.
 geometry.prob_hi     =  25000. 400. 20000.
 amr.n_cell           =  192    4    128
 
-geometry.is_periodic = 0 1 0
+geometry.is_periodic = 1 1 0
 
-xlo.type = "Open"
-xhi.type = "Open"
+#xlo.type = "Open"
+#xhi.type = "Open"
 zlo.type = "SlipWall"
 zhi.type = "Outflow"
 
@@ -35,11 +35,12 @@ amr.max_level       = 0       # maximum level number allowed
 # CHECKPOINT FILES
 amr.check_file      = chk        # root name of checkpoint file
 amr.check_int       = 1000       # number of timesteps between checkpoints
+#amr.restart			= chk01000
 
 # PLOTFILES
 erf.plot_file_1         = plt        # root name of plotfile
 erf.plot_int_1          = 60         # number of timesteps between plotfiles
-erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 rhoQ3 x_velocity y_velocity z_velocity pressure theta temp qv qc qrain rain_accum pert_dens
+erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 rhoQ3 x_velocity y_velocity z_velocity pressure theta temp qv qc qrain qsnow qgraup rain_accum snow_accum graup_accum pert_dens
 
 # SOLVER CHOICE
 erf.use_gravity = true

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -753,7 +753,7 @@ private:
                                                     // mynn pbl lengthscale
                                                     "Lpbl",
                                                     // moisture vars
-                                                    "qt", "qv", "qc", "qi", "qp", "qrain", "qsnow", "qgraup", "rain_accum"
+                                                    "qt", "qv", "qc", "qi", "qp", "qrain", "qsnow", "qgraup", "rain_accum", "snow_accum", "graup_accum"
 #ifdef ERF_COMPUTE_ERROR
                                                     ,"xvel_err", "yvel_err", "zvel_err", "pp_err"
 #endif

--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -149,8 +149,27 @@ ERF::WriteCheckpointFile () const
             int nvar = 1;
             MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
             MultiFab::Copy(moist_vars,*(qmoist[lev][4]),0,0,nvar,ng);
-            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MoistVars"));
+            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
         }
+
+		if(solverChoice.moisture_type == MoistureType::SAM){
+			ng = qmoist[lev][8]->nGrowVect();
+            int nvar = 1;
+            MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
+            MultiFab::Copy(rain_accum,*(qmoist[lev][8]),0,0,nvar,ng);
+            VisMF::Write(rain_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
+		
+			ng = qmoist[lev][9]->nGrowVect();
+            MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
+            MultiFab::Copy(snow_accum,*(qmoist[lev][9]),0,0,nvar,ng);
+            VisMF::Write(snow_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "SnowAccum"));
+	
+			ng = qmoist[lev][10]->nGrowVect();
+            MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
+            MultiFab::Copy(graup_accum,*(qmoist[lev][10]),0,0,nvar,ng);
+            VisMF::Write(graup_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "GraupAccum"));
+		}
+
 
 #if defined(ERF_USE_WINDFARM)
         if(solverChoice.windfarm_type == WindFarmType::Fitch){
@@ -381,10 +400,28 @@ ERF::ReadCheckpointFile ()
             ng = qmoist[lev][4]->nGrowVect();
             int nvar = 1;
             MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
-            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "MoistVars"));
+            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "RainAccum"));
             MultiFab::Copy(*(qmoist[lev][4]),moist_vars,0,0,nvar,ng);
         }
 
+		 if (solverChoice.moisture_type == MoistureType::SAM) {
+            ng = qmoist[lev][8]->nGrowVect();
+            int nvar = 1;
+            MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
+            VisMF::Read(rain_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "RainAccum"));
+            MultiFab::Copy(*(qmoist[lev][8]),rain_accum,0,0,nvar,ng);
+
+			ng = qmoist[lev][9]->nGrowVect();
+            MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
+            VisMF::Read(snow_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "SnowAccum"));
+            MultiFab::Copy(*(qmoist[lev][9]),snow_accum,0,0,nvar,ng);
+
+			ng = qmoist[lev][10]->nGrowVect();
+            MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
+            VisMF::Read(graup_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "GraupAccum"));
+            MultiFab::Copy(*(qmoist[lev][10]),graup_accum,0,0,nvar,ng);
+
+        }
 
 #if defined(ERF_USE_WINDFARM)
         if(solverChoice.windfarm_type == WindFarmType::Fitch){

--- a/Source/IO/Checkpoint.cpp
+++ b/Source/IO/Checkpoint.cpp
@@ -152,23 +152,23 @@ ERF::WriteCheckpointFile () const
             VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
         }
 
-		if(solverChoice.moisture_type == MoistureType::SAM){
-			ng = qmoist[lev][8]->nGrowVect();
+        if(solverChoice.moisture_type == MoistureType::SAM){
+            ng = qmoist[lev][8]->nGrowVect();
             int nvar = 1;
             MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
             MultiFab::Copy(rain_accum,*(qmoist[lev][8]),0,0,nvar,ng);
             VisMF::Write(rain_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
-		
-			ng = qmoist[lev][9]->nGrowVect();
+
+            ng = qmoist[lev][9]->nGrowVect();
             MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
             MultiFab::Copy(snow_accum,*(qmoist[lev][9]),0,0,nvar,ng);
             VisMF::Write(snow_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "SnowAccum"));
-	
-			ng = qmoist[lev][10]->nGrowVect();
+
+            ng = qmoist[lev][10]->nGrowVect();
             MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
             MultiFab::Copy(graup_accum,*(qmoist[lev][10]),0,0,nvar,ng);
             VisMF::Write(graup_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "GraupAccum"));
-		}
+        }
 
 
 #if defined(ERF_USE_WINDFARM)
@@ -404,19 +404,19 @@ ERF::ReadCheckpointFile ()
             MultiFab::Copy(*(qmoist[lev][4]),moist_vars,0,0,nvar,ng);
         }
 
-		 if (solverChoice.moisture_type == MoistureType::SAM) {
+         if (solverChoice.moisture_type == MoistureType::SAM) {
             ng = qmoist[lev][8]->nGrowVect();
             int nvar = 1;
             MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
             VisMF::Read(rain_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "RainAccum"));
             MultiFab::Copy(*(qmoist[lev][8]),rain_accum,0,0,nvar,ng);
 
-			ng = qmoist[lev][9]->nGrowVect();
+            ng = qmoist[lev][9]->nGrowVect();
             MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
             VisMF::Read(snow_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "SnowAccum"));
             MultiFab::Copy(*(qmoist[lev][9]),snow_accum,0,0,nvar,ng);
 
-			ng = qmoist[lev][10]->nGrowVect();
+            ng = qmoist[lev][10]->nGrowVect();
             MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
             VisMF::Read(graup_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "GraupAccum"));
             MultiFab::Copy(*(qmoist[lev][10]),graup_accum,0,0,nvar,ng);

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -837,7 +837,7 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                 MultiFab::Divide(mf[lev], Sm, Rho_comp  , mf_comp, 1, 0);
                 mf_comp += 1;
             }
-#ifdef ERF_USE_MOISTURE
+
         if(solverChoice.moisture_type == MoistureType::Kessler){
             if (containerHasElement(plot_var_names, "rain_accum"))
             {
@@ -846,28 +846,27 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                 mf_comp += 1;
             }
         }
-		else if(solverChoice.moisture_type == MoistureType::SAM)
+        else if(solverChoice.moisture_type == MoistureType::SAM)
         {
-        	if (containerHasElement(plot_var_names, "rain_accum"))
+            if (containerHasElement(plot_var_names, "rain_accum"))
             {
-            	MultiFab rain_accum_mf(*(qmoist[lev][8]), make_alias, 0, 1);
-            	MultiFab::Copy(mf[lev],rain_accum_mf,0,mf_comp,1,0);
-            	mf_comp += 1;
+                MultiFab rain_accum_mf(*(qmoist[lev][8]), make_alias, 0, 1);
+                MultiFab::Copy(mf[lev],rain_accum_mf,0,mf_comp,1,0);
+                mf_comp += 1;
             }
-			if (containerHasElement(plot_var_names, "snow_accum"))
+            if (containerHasElement(plot_var_names, "snow_accum"))
             {
-            	MultiFab snow_accum_mf(*(qmoist[lev][9]), make_alias, 0, 1);
-            	MultiFab::Copy(mf[lev],snow_accum_mf,0,mf_comp,1,0);
-            	mf_comp += 1;
+                MultiFab snow_accum_mf(*(qmoist[lev][9]), make_alias, 0, 1);
+                MultiFab::Copy(mf[lev],snow_accum_mf,0,mf_comp,1,0);
+                mf_comp += 1;
             }
             if (containerHasElement(plot_var_names, "graup_accum"))
             {
-            	MultiFab graup_accum_mf(*(qmoist[lev][10]), make_alias, 0, 1);
-            	MultiFab::Copy(mf[lev],graup_accum_mf,0,mf_comp,1,0);
-            	mf_comp += 1;
+                MultiFab graup_accum_mf(*(qmoist[lev][10]), make_alias, 0, 1);
+                MultiFab::Copy(mf[lev],graup_accum_mf,0,mf_comp,1,0);
+                mf_comp += 1;
             }
-		}	
-#endif
+        }
         }
 
 #ifdef ERF_USE_PARTICLES

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -837,13 +837,37 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                 MultiFab::Divide(mf[lev], Sm, Rho_comp  , mf_comp, 1, 0);
                 mf_comp += 1;
             }
-
+#ifdef ERF_USE_MOISTURE
+        if(solverChoice.moisture_type == MoistureType::Kessler){
             if (containerHasElement(plot_var_names, "rain_accum"))
             {
-                MultiFab rain_accum_mf(*(qmoist[lev][0]), make_alias, 0, 1);
+                MultiFab rain_accum_mf(*(qmoist[lev][4]), make_alias, 0, 1);
                 MultiFab::Copy(mf[lev],rain_accum_mf,0,mf_comp,1,0);
                 mf_comp += 1;
             }
+        }
+		else if(solverChoice.moisture_type == MoistureType::SAM)
+        {
+        	if (containerHasElement(plot_var_names, "rain_accum"))
+            {
+            	MultiFab rain_accum_mf(*(qmoist[lev][8]), make_alias, 0, 1);
+            	MultiFab::Copy(mf[lev],rain_accum_mf,0,mf_comp,1,0);
+            	mf_comp += 1;
+            }
+			if (containerHasElement(plot_var_names, "snow_accum"))
+            {
+            	MultiFab snow_accum_mf(*(qmoist[lev][9]), make_alias, 0, 1);
+            	MultiFab::Copy(mf[lev],snow_accum_mf,0,mf_comp,1,0);
+            	mf_comp += 1;
+            }
+            if (containerHasElement(plot_var_names, "graup_accum"))
+            {
+            	MultiFab graup_accum_mf(*(qmoist[lev][10]), make_alias, 0, 1);
+            	MultiFab::Copy(mf[lev],graup_accum_mf,0,mf_comp,1,0);
+            	mf_comp += 1;
+            }
+		}	
+#endif
         }
 
 #ifdef ERF_USE_PARTICLES

--- a/Source/Microphysics/SAM/Init_SAM.cpp
+++ b/Source/Microphysics/SAM/Init_SAM.cpp
@@ -34,7 +34,7 @@ void SAM::Init (const MultiFab& cons_in,
 
     MicVarMap.resize(m_qmoist_size);
     MicVarMap = {MicVar::qt, MicVar::qv , MicVar::qcl, MicVar::qci,
-                 MicVar::qp, MicVar::qpr, MicVar::qps, MicVar::qpg};
+                 MicVar::qp, MicVar::qpr, MicVar::qps, MicVar::qpg, MicVar::rain_accum, MicVar::snow_accum, MicVar::graup_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar::NumVars; ++ivar) {

--- a/Source/Microphysics/SAM/PrecipFall.cpp
+++ b/Source/Microphysics/SAM/PrecipFall.cpp
@@ -38,9 +38,9 @@ void SAM::PrecipFall ()
     auto rho   = mic_fab_vars[MicVar::rho];
     auto tabs  = mic_fab_vars[MicVar::tabs];
     auto theta = mic_fab_vars[MicVar::theta];
-	auto rain_accum = mic_fab_vars[MicVar::rain_accum];
-	auto snow_accum = mic_fab_vars[MicVar::snow_accum];
-	auto graup_accum = mic_fab_vars[MicVar::graup_accum];
+    auto rain_accum = mic_fab_vars[MicVar::rain_accum];
+    auto snow_accum = mic_fab_vars[MicVar::snow_accum];
+    auto graup_accum = mic_fab_vars[MicVar::graup_accum];
 
     auto ba    = tabs->boxArray();
     auto dm    = tabs->DistributionMap();
@@ -55,9 +55,9 @@ void SAM::PrecipFall ()
         auto rho_array  = rho->array(mfi);
         auto tabs_array = tabs->array(mfi);
         auto fz_array   = fz.array(mfi);
-		auto rain_accum_array = rain_accum->array(mfi);
-		auto snow_accum_array = snow_accum->array(mfi);
-		auto graup_accum_array = graup_accum->array(mfi);
+        auto rain_accum_array = rain_accum->array(mfi);
+        auto snow_accum_array = snow_accum->array(mfi);
+        auto graup_accum_array = graup_accum->array(mfi);
 
         const auto& box3d = mfi.tilebox();
 
@@ -97,13 +97,13 @@ void SAM::PrecipFall ()
             //       Therefore, we simply end up with a division by detJ when
             //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
             fz_array(i,j,k) = Pprecip * std::sqrt(rho_0/rho_avg);
-		
-			if(k==k_lo){
-				Real omp = std::max(0.0,std::min(1.0,(tab_avg-tprmin)*a_pr));
-				Real omg = std::max(0.0,std::min(1.0,(tab_avg-tgrmin)*a_gr));
-            	rain_accum_array(i,j,k)  = rain_accum_array(i,j,k) +  rho_avg*(omp*qp_avg)*vrain*dtn/rhor*1000.0; // Divide by rho_water and convert to mm
-            	snow_accum_array(i,j,k)  = snow_accum_array(i,j,k) +  rho_avg*(1.0-omp)*(1.0-omg)*qp_avg*vrain*dtn/rhos*1000.0; // Divide by rho_snow and convert to mm
-            	graup_accum_array(i,j,k) = graup_accum_array(i,j,k) + rho_avg*(1.0-omp)*(omg)*qp_avg*vrain*dtn/rhog*1000.0; // Divide by rho_graupel and convert to mm
+
+            if(k==k_lo){
+                Real omp = std::max(0.0,std::min(1.0,(tab_avg-tprmin)*a_pr));
+                Real omg = std::max(0.0,std::min(1.0,(tab_avg-tgrmin)*a_gr));
+                rain_accum_array(i,j,k)  = rain_accum_array(i,j,k) +  rho_avg*(omp*qp_avg)*vrain*dtn/rhor*1000.0; // Divide by rho_water and convert to mm
+                snow_accum_array(i,j,k)  = snow_accum_array(i,j,k) +  rho_avg*(1.0-omp)*(1.0-omg)*qp_avg*vrain*dtn/rhos*1000.0; // Divide by rho_snow and convert to mm
+                graup_accum_array(i,j,k) = graup_accum_array(i,j,k) + rho_avg*(1.0-omp)*(omg)*qp_avg*vrain*dtn/rhog*1000.0; // Divide by rho_graupel and convert to mm
             }
 
         });

--- a/Source/Microphysics/SAM/PrecipFall.cpp
+++ b/Source/Microphysics/SAM/PrecipFall.cpp
@@ -38,6 +38,9 @@ void SAM::PrecipFall ()
     auto rho   = mic_fab_vars[MicVar::rho];
     auto tabs  = mic_fab_vars[MicVar::tabs];
     auto theta = mic_fab_vars[MicVar::theta];
+	auto rain_accum = mic_fab_vars[MicVar::rain_accum];
+	auto snow_accum = mic_fab_vars[MicVar::snow_accum];
+	auto graup_accum = mic_fab_vars[MicVar::graup_accum];
 
     auto ba    = tabs->boxArray();
     auto dm    = tabs->DistributionMap();
@@ -52,6 +55,9 @@ void SAM::PrecipFall ()
         auto rho_array  = rho->array(mfi);
         auto tabs_array = tabs->array(mfi);
         auto fz_array   = fz.array(mfi);
+		auto rain_accum_array = rain_accum->array(mfi);
+		auto snow_accum_array = snow_accum->array(mfi);
+		auto graup_accum_array = graup_accum->array(mfi);
 
         const auto& box3d = mfi.tilebox();
 
@@ -91,6 +97,15 @@ void SAM::PrecipFall ()
             //       Therefore, we simply end up with a division by detJ when
             //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
             fz_array(i,j,k) = Pprecip * std::sqrt(rho_0/rho_avg);
+		
+			if(k==k_lo){
+				Real omp = std::max(0.0,std::min(1.0,(tab_avg-tprmin)*a_pr));
+				Real omg = std::max(0.0,std::min(1.0,(tab_avg-tgrmin)*a_gr));
+            	rain_accum_array(i,j,k)  = rain_accum_array(i,j,k) +  rho_avg*(omp*qp_avg)*vrain*dtn/rhor*1000.0; // Divide by rho_water and convert to mm
+            	snow_accum_array(i,j,k)  = snow_accum_array(i,j,k) +  rho_avg*(1.0-omp)*(1.0-omg)*qp_avg*vrain*dtn/rhos*1000.0; // Divide by rho_snow and convert to mm
+            	graup_accum_array(i,j,k) = graup_accum_array(i,j,k) + rho_avg*(1.0-omp)*(omg)*qp_avg*vrain*dtn/rhog*1000.0; // Divide by rho_graupel and convert to mm
+            }
+
         });
     }
 

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -43,6 +43,9 @@ namespace MicVar {
       qps,   // precip ice
       qpg,   // graupel
       // derived vars
+	  rain_accum,
+	  snow_accum,
+	  graup_accum,
       omega,
       NumVars
   };
@@ -146,7 +149,7 @@ public:
 
 private:
     // Number of qmoist variables (qt, qv, qcl, qci, qp, qpr, qps, qpg)
-    int m_qmoist_size = 8;
+    int m_qmoist_size = 11;
 
     // Number of qmoist variables
     int m_qstate_size = 6;

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -43,9 +43,9 @@ namespace MicVar {
       qps,   // precip ice
       qpg,   // graupel
       // derived vars
-	  rain_accum,
-	  snow_accum,
-	  graup_accum,
+      rain_accum,
+      snow_accum,
+      graup_accum,
       omega,
       NumVars
   };


### PR DESCRIPTION
This PR adds the precipitation accumulation for the SAM microphysics. Rain, snow and graupel are separately accumulated on the ground. The input file can include `rain_accum`, `snow_accum` and `graup_accum` to plot the accumulations in the plotfile. The restart capability is implemented and tested as well.