### PR TITLE
Bndry Plane Scalars

### DIFF
--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -172,10 +172,10 @@ ReadBndryPlanes::ReadBndryPlanes (const Geometry& geom, const Real& rdOcp_in)
             if (m_var_names[i] == "temperature")  is_temperature_read = 1;
             if (m_var_names[i] == "theta")        is_theta_read = 1;
             if (m_var_names[i] == "scalar")       is_scalar_read = 1;
-            if (m_var_names[i] == "qt")           is_q1_read = 1;
-            if (m_var_names[i] == "qp")           is_q2_read = 1;
-            if (m_var_names[i] == "KE")           is_KE_read = 1;
-            if (m_var_names[i] == "QKE")          is_QKE_read = 1;
+            if (m_var_names[i] == "qv")           is_q1_read = 1;
+            if (m_var_names[i] == "qc")           is_q2_read = 1;
+            if (m_var_names[i] == "ke")           is_KE_read = 1;
+            if (m_var_names[i] == "qke")          is_QKE_read = 1;
         }
     }
 
@@ -414,11 +414,11 @@ void ReadBndryPlanes::read_file (const int idx,
         if (var_name == "density")     n_offset = BCVars::Rho_bc_comp;
         if (var_name == "theta")       n_offset = BCVars::RhoTheta_bc_comp;
         if (var_name == "temperature") n_offset = BCVars::RhoTheta_bc_comp;
-        if (var_name == "KE")          n_offset = BCVars::RhoKE_bc_comp;
-        if (var_name == "QKE")         n_offset = BCVars::RhoQKE_bc_comp;
+        if (var_name == "ke")          n_offset = BCVars::RhoKE_bc_comp;
+        if (var_name == "qke")         n_offset = BCVars::RhoQKE_bc_comp;
         if (var_name == "scalar")      n_offset = BCVars::RhoScalar_bc_comp;
-        if (var_name == "qt")          n_offset = BCVars::RhoQ1_bc_comp;
-        if (var_name == "qp")          n_offset = BCVars::RhoQ2_bc_comp;
+        if (var_name == "qv")          n_offset = BCVars::RhoQ1_bc_comp;
+        if (var_name == "qc")          n_offset = BCVars::RhoQ2_bc_comp;
         if (var_name == "velocity")    n_offset = BCVars::xvel_bc;
 
         // Print() << "Reading " << chkname1 << " for variable " << var_name << " with n_offset == " << n_offset << std::endl;
@@ -479,12 +479,12 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = 0.5 * (R1*Th1 + R2*Th2);
                         });
-                  } else if (var_name == "scalar" || var_name == "qt" || var_name == "qp" ||
-                             var_name == "KE" || var_name == "QKE") {
+                  } else if (var_name == "scalar" || var_name == "qv" || var_name == "qc" ||
+                             var_name == "ke"     || var_name == "qke") {
                     ParallelFor(
                         bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1 =  bndry_read_r_arr(i, j, k, 0);
-                             Real R2 =  bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2],n_for_density);
+                             Real R2 =  bndry_read_r_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2],0);
                              bndry_mf_arr(i, j, k, 0) = 0.5 *
                                   ( R1 * bndry_read_arr(i, j, k, 0) +
                                     R2 * bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2], 0));
@@ -509,8 +509,8 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = 0.5 * (R1*Th1 + R2*Th2);
                         });
-                  } else if (var_name == "scalar" || var_name == "qt" || var_name == "qp" ||
-                             var_name == "KE" || var_name == "QKE") {
+                  } else if (var_name == "scalar" || var_name == "qv" || var_name == "qc" ||
+                             var_name == "ke"     || var_name == "qke") {
                       ParallelFor(
                         bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];

--- a/Source/IO/ERF_WriteBndryPlanes.cpp
+++ b/Source/IO/ERF_WriteBndryPlanes.cpp
@@ -171,14 +171,60 @@ void WriteBndryPlanes::write_planes (const int t_step, const Real time,
                 derived::erf_dertemp(bx, Temp[mfi], 0, 1, S[mfi], m_geom[bndry_lev], time, nullptr, bndry_lev);
             }
             bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+        } else if (var_name == "scalar") {
 
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+            for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoKE_comp);
+            }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+
+        } else if (var_name == "ke") {
+
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+            for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoKE_comp);
+            }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+
+        } else if (var_name == "qke") {
+
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+            for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoQKE_comp);
+            }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+
+        } else if (var_name == "qv") {
+            if (S.nComp() > RhoQ2_comp) {
+                MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+                for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoQ1_comp);
+                }
+                bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+            }
+        } else if (var_name == "qc") {
+            if (S.nComp() > RhoQ2_comp) {
+                MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+                for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoQ2_comp);
+                }
+                bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+            }
         } else if (var_name == "velocity") {
-
             MultiFab Vel(S.boxArray(), S.DistributionMap(), 3, m_out_rad);
             average_face_to_cellcenter(Vel,0,Array<const MultiFab*,3>{&xvel,&yvel,&zvel});
-
             bndry.copyFrom(Vel, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
-
         } else {
             //Print() << "Trying to write planar output for " << var_name << std::endl;
             Error("Don't know how to output this variable");

--- a/Source/Initialization/ERF_init_bcs.cpp
+++ b/Source/Initialization/ERF_init_bcs.cpp
@@ -121,19 +121,19 @@ void ERF::init_bcs ()
             }
 
             if (solverChoice.moisture_type != MoistureType::None) {
-                Real qt_in = 0.;
+                Real qv_in = 0.;
                 if (input_bndry_planes && m_r2d->ingested_q1()) {
                     m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = 0.;
                 } else {
-                    if (pp.query("qt", qt_in))
-                    m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = rho_in*qt_in;
+                    if (pp.query("qv", qv_in))
+                    m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = rho_in*qv_in;
                 }
-                Real qp_in = 0.;
+                Real qc_in = 0.;
                 if (input_bndry_planes && m_r2d->ingested_q2()) {
                     m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = 0.;
                 } else {
-                    if (pp.query("qp", qp_in))
-                    m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = rho_in*qp_in;
+                    if (pp.query("qc", qc_in))
+                    m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = rho_in*qc_in;
                 }
             }
 


### PR DESCRIPTION
This allows a user to read and write other scalars to the boundary plane files. We now supports `scalar, ke, qke, qv, qc` for this functionality.

