### PR TITLE
Allowing non zero problo for sponge

### DIFF
--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
@@ -59,9 +59,9 @@ ApplySpongeZoneBCsForCC (
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
         int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
-        Real x = (ii+0.5) * dx[0];
-        Real y = (jj+0.5) * dx[1];
-        Real z = (kk+0.5) * dx[2];
+        Real x = ProbLoArr[0] + (ii+0.5) * dx[0];
+        Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
+        Real z = ProbLoArr[2] + (kk+0.5) * dx[2];
 
         // x left sponge
         if(use_xlo_sponge_damping){
@@ -171,9 +171,9 @@ ApplySpongeZoneBCsForMom (
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
         int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
-        Real x = ii * dx[0];
-        Real y = (jj+0.5) * dx[1];
-        Real z = (kk+0.5) * dx[2];
+        Real x = ProbLoArr[0] + ii * dx[0];
+        Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
+        Real z = ProbLoArr[2] + (kk+0.5) * dx[2];
 
         // x lo sponge
         if(use_xlo_sponge_damping){
@@ -230,9 +230,9 @@ ApplySpongeZoneBCsForMom (
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
         int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
-        Real x = (ii+0.5) * dx[0];
-        Real y = jj * dx[1];
-        Real z = (kk+0.5) * dx[2];
+        Real x = ProbLoArr[0] + (ii+0.5) * dx[0];
+        Real y = ProbLoArr[1] + jj * dx[1];
+        Real z = ProbLoArr[2] + (kk+0.5) * dx[2];
 
         // x lo sponge
         if(use_xlo_sponge_damping){
@@ -289,9 +289,9 @@ ApplySpongeZoneBCsForMom (
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
         int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
-        Real x = (ii+0.5) * dx[0];
-        Real y = (jj+0.5) * dx[1];
-        Real z = kk * dx[2];
+        Real x = ProbLoArr[0] + (ii+0.5) * dx[0];
+        Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
+        Real z = ProbLoArr[2] + kk * dx[2];
 
         // x left sponge
         if(use_xlo_sponge_damping){


### PR DESCRIPTION
This PR allows for non zero domain extents for sponges. Have verified the working with negative problo in the x direction for the 2d cylinder regtest (attached image). Works fine. Thanks @asalmgren for pointing out this bug.

![Sponge_NonZero_ProbLo](https://github.com/erf-model/ERF/assets/34353555/2dc57cd7-2bad-476b-b7ba-c7c46994f64a)
