### PR TITLE
lon and lat for real data cases

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -251,6 +251,14 @@ Output Options
 |                             |                  |
 |                             |                  |
 +-----------------------------+------------------+
+| **lat_m**                   | Latitude at mass |
+|                             | points           |
+|                             |                  |
++-----------------------------+------------------+
+| **lon_m**                   | Longitude at     |
+|                             | mass points      |
+|                             |                  |
++-----------------------------+------------------+
 | **Kmv**                     | Vertical         |
 |                             | Eddy Diffusivity |
 |                             | of Momentum      |

--- a/Exec/DevTests/MetGrid/inputs
+++ b/Exec/DevTests/MetGrid/inputs
@@ -44,7 +44,7 @@ erf.check_int       = 100        # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
 erf.plot_int_1      = 10          # number of timesteps between plotfiles
-erf.plot_vars_1     = density dens_hse rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta z_phys mapfac pres_hse pert_pres 
+erf.plot_vars_1     = lat_m lon_m density dens_hse rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta z_phys mapfac pres_hse pert_pres 
 
 # SOLVER CHOICE
 erf.alpha_T = 1.0

--- a/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
+++ b/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
@@ -39,7 +39,7 @@ erf.check_int       = -100    # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt     # prefix of plotfile name
 erf.plot_int_1      = 1       # number of timesteps between plotfiles
-erf.plot_vars_1     = density rhoQ1 x_velocity y_velocity z_velocity pressure temp theta pres_hse z_phys qt qp qv qc
+erf.plot_vars_1     = lat_m lon_m density rhoQ1 x_velocity y_velocity z_velocity pressure temp theta pres_hse z_phys qt qp qv qc
 
 # SOLVER CHOICE
 erf.alpha_T = 0.0

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -528,6 +528,7 @@ private:
     amrex::Vector<amrex::Vector<amrex::FArrayBox>> bdy_data_yhi;
 
     amrex::Real bdy_time_interval;
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> lat_m, lon_m;
     amrex::Real Latitude;
     amrex::Real Longitude;
 #endif // ERF_USE_NETCDF
@@ -780,7 +781,7 @@ private:
                                                     "magvel", "divU",
                                                     "pres_hse", "dens_hse", "pressure", "pert_pres", "pert_dens", "eq_pot_temp", "num_turb",
                                                     "dpdx", "dpdy", "pres_hse_x", "pres_hse_y",
-                                                    "z_phys", "detJ" , "mapfac",
+                                                    "z_phys", "detJ" , "mapfac", "lat_m", "lon_m",
                                                     // Time averaged velocity
                                                     "u_t_avg", "v_t_avg", "w_t_avg", "umag_t_avg",
                                                     // eddy viscosity

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -266,6 +266,10 @@ ERF::ERF ()
     vel_t_avg.resize(nlevs_max);
     t_avg_cnt.resize(nlevs_max);
 
+    // Longitude and latitude (only filled for use_real_bcs==True)
+    lat_m.resize(nlevs_max);
+    lon_m.resize(nlevs_max);
+
     // Initialize tagging criteria for mesh refinement
     refinement_criteria_setup();
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -266,9 +266,13 @@ ERF::ERF ()
     vel_t_avg.resize(nlevs_max);
     t_avg_cnt.resize(nlevs_max);
 
+#ifdef ERF_USE_NETCDF
     // Longitude and latitude (only filled for use_real_bcs==True)
-    lat_m.resize(nlevs_max);
-    lon_m.resize(nlevs_max);
+    if (use_real_bcs) {
+        lat_m.resize(nlevs_max);
+        lon_m.resize(nlevs_max);
+    }
+#endif
 
     // Initialize tagging criteria for mesh refinement
     refinement_criteria_setup();

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -767,8 +767,6 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                     });
                 }
                 mf_comp ++;
-//                MultiFab::Copy(mf[lev],lat_m[lev],0,mf_comp,1,0);
-//                mf_comp += 1;
             }
             if (containerHasElement(plot_var_names, "lon_m")) {
 #ifdef _OPENMP

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -752,6 +752,7 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             mf_comp ++;
         }
 
+#ifdef ERF_USE_NETCDF
         if (use_real_bcs) {
             if (containerHasElement(plot_var_names, "lat_m")) {
 #ifdef _OPENMP
@@ -767,7 +768,7 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                     });
                 }
                 mf_comp ++;
-            }
+            } // lat_m
             if (containerHasElement(plot_var_names, "lon_m")) {
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -782,8 +783,9 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
                     });
                 }
                 mf_comp ++;
-            }
-        }
+            } // lon_m
+        } // use_real_bcs
+#endif
 
 
         if (solverChoice.time_avg_vel) {

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -87,6 +87,9 @@ ERF::setPlotVariables (const std::string& pp_plot_var_names, Vector<std::string>
 #endif
 
     plot_var_names = tmp_plot_names;
+
+    for (int i=0; i<plot_var_names.size(); i++) {
+    }
 }
 
 void
@@ -748,6 +751,42 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             }
             mf_comp ++;
         }
+
+        if (use_real_bcs) {
+            if (containerHasElement(plot_var_names, "lat_m")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const Array4<Real>& derdat = mf[lev].array(mfi);
+                    const Array4<Real>& data   = lat_m[lev]->array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = data(i,j,0);
+                    });
+                }
+                mf_comp ++;
+//                MultiFab::Copy(mf[lev],lat_m[lev],0,mf_comp,1,0);
+//                mf_comp += 1;
+            }
+            if (containerHasElement(plot_var_names, "lon_m")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const Array4<Real>& derdat = mf[lev].array(mfi);
+                    const Array4<Real>& data   = lon_m[lev]->array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = data(i,j,0);
+                    });
+                }
+                mf_comp ++;
+            }
+        }
+
 
         if (solverChoice.time_avg_vel) {
             if (containerHasElement(plot_var_names, "u_t_avg")) {


### PR DESCRIPTION
Reads in latitude and longitude at mass points for real data cases (init_type of "metgrid" or "real"). These longitude and latitude arrays can be saved in the plotfiles by adding lat_m and lon_m to plot_vars_1 in inputs.