### PR TITLE
Fix regtest failures.

### DIFF
--- a/Exec/DevTests/MetGrid/inputs
+++ b/Exec/DevTests/MetGrid/inputs
@@ -44,7 +44,7 @@ erf.check_int       = 100        # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
 erf.plot_int_1      = 10          # number of timesteps between plotfiles
-erf.plot_vars_1     = lat_m lon_m density dens_hse rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta z_phys mapfac pres_hse pert_pres 
+erf.plot_vars_1     = density dens_hse rhoadv_0 x_velocity y_velocity z_velocity pressure temp theta z_phys mapfac pres_hse pert_pres 
 
 # SOLVER CHOICE
 erf.alpha_T = 1.0

--- a/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
+++ b/Exec/RegTests/WPS_Test/inputs_real_ChisholmView
@@ -39,7 +39,7 @@ erf.check_int       = -100    # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt     # prefix of plotfile name
 erf.plot_int_1      = 1       # number of timesteps between plotfiles
-erf.plot_vars_1     = lat_m lon_m density rhoQ1 x_velocity y_velocity z_velocity pressure temp theta pres_hse z_phys qt qp qv qc
+erf.plot_vars_1     = density rhoQ1 x_velocity y_velocity z_velocity pressure temp theta pres_hse z_phys qt qp qv qc
 
 # SOLVER CHOICE
 erf.alpha_T = 0.0

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -270,11 +270,9 @@ ERF::ERF ()
     t_avg_cnt.resize(nlevs_max);
 
 #ifdef ERF_USE_NETCDF
-    // Longitude and latitude (only filled for use_real_bcs==True)
-    if (use_real_bcs) {
-        lat_m.resize(nlevs_max);
-        lon_m.resize(nlevs_max);
-    }
+    // Size lat long arrays if using netcdf
+    lat_m.resize(nlevs_max);
+    lon_m.resize(nlevs_max);
 #endif
 
     // Initialize tagging criteria for mesh refinement


### PR DESCRIPTION
Fixes issues with lat/lon reading.

1. Ekman spiral uses netcdf and tries to read the lat/lon since it goes into init from wrf. However, it doesn't use real bcs. We size the lat/lon vector now only if using netcdf.

2. The WPS and metgrid inputs have lat/lon as plotfile outputs. This will require a benchmark remake that is not necessary. Furthermore, WPS has a restart test and we need to read/write lat/lon from checkfiles in order to successfully restart a simulation and then plot lat/lon (work to be done).
