### PR TITLE
Rad pressure units

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -77,6 +77,7 @@ function(build_erf_lib erf_lib_name)
 
   if(ERF_ENABLE_RRTMGP)
     target_sources(${erf_lib_name} PRIVATE
+                   ${SRC_DIR}/Utils/Orbit.cpp
                    ${SRC_DIR}/Radiation/Init_rrtmgp.cpp
                    ${SRC_DIR}/Radiation/Finalize_rrtmgp.cpp
                    ${SRC_DIR}/Radiation/Run_longwave_rrtmgp.cpp

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -273,6 +273,11 @@ ERF::ERF ()
     // Size lat long arrays if using netcdf
     lat_m.resize(nlevs_max);
     lon_m.resize(nlevs_max);
+    for (int lev = 0; lev < max_level; ++lev)
+    {
+        lat_m[lev] = nullptr;
+        lon_m[lev] = nullptr;
+    }
 #endif
 
     // Initialize tagging criteria for mesh refinement

--- a/Source/Radiation/Radiation.H
+++ b/Source/Radiation/Radiation.H
@@ -45,6 +45,8 @@ class Radiation {
     // init
     void initialize (const amrex::MultiFab& cons_in,
                      amrex::MultiFab* qheating_rates,
+                     amrex::MultiFab* lat,
+                     amrex::MultiFab* lon,
                      amrex::Vector<amrex::MultiFab*> qmoist,
                      const amrex::BoxArray& grids,
                      const amrex::Geometry& geom,
@@ -97,6 +99,19 @@ class Radiation {
     // Pointer to the radiation source terms
     amrex::MultiFab* qrad_src;
 
+    // Pointer to latitude and longitude
+    amrex::MultiFab* m_lat = nullptr;
+    amrex::MultiFab* m_lon = nullptr;
+
+    // Specified uniform angle for radiation
+    amrex::Real uniform_angle = 78.463;
+
+    // Orbital properties (constant for now)
+    static constexpr amrex::Real eccen  =   0.0;                   // Earth's eccentricity factor (unitless) (typically 0 to 0.1)
+    static constexpr amrex::Real obliqr =  23.0 * PI / 180.0;      // Earth's obliquity in radians
+    static constexpr amrex::Real mvelpp = 103.0 * PI / 180.0 + PI; // Earth's moving vernal equinox longitude of perihelion plus pi (radians)
+    static constexpr amrex::Real lambm0 = -3.2503635878519378e-2;  // Mean longitude of perihelion at the vernal equinox (radians)
+
     // number of vertical levels
     int nlev, zlo, zhi;
 
@@ -145,7 +160,7 @@ class Radiation {
     // radiation data
     const std::vector<std::string> active_gases = {
                                                    "H2O", "CO2", "O3", "N2O",
-                                                   "CO", "CH4", "O2", "N2" };
+                                                   "CO" , "CH4", "O2", "N2" };
 
     bool spectralflux  = false;  // calculate fluxes (up and down) per band.
 

--- a/Source/Radiation/Radiation.cpp
+++ b/Source/Radiation/Radiation.cpp
@@ -195,8 +195,8 @@ void Radiation::initialize (const MultiFab& cons_in,
             qi(icol,ilev)   = (qi_array) ? qi_array(i,j,k): 0.0;
             qn(icol,ilev)   = qc(icol,ilev) + qi(icol,ilev);
             tmid(icol,ilev) = getTgivenRandRTh(states_array(i,j,k,Rho_comp),states_array(i,j,k,RhoTheta_comp),qv);
-            // NOTE: RRTMGP code expects pressure in mb so we convert it here
-            pmid(icol,ilev) = getPgivenRTh(states_array(i,j,k,RhoTheta_comp),qv) * 1.0e-2;
+            // NOTE: RRTMGP code expects pressure in pa
+            pmid(icol,ilev) = getPgivenRTh(states_array(i,j,k,RhoTheta_comp),qv);// * 1.0e-2;
         });
     }
 
@@ -889,12 +889,11 @@ void Radiation::calculate_heating_rate (const real2d& flux_up,
                                         const real2d& pint,
                                         const real2d& heating_rate)
 {
-    // NOTE: The pressure is in [mb] for RRTMGP to use.
+    // NOTE: The pressure is in [pa] for RRTMGP to use.
     //       The fluxes are in [W/m^2] and gravity is [m/s^2].
-    //       We need to convert pressure from [mb] -> [Pa] and divide by Cp [J/kg*K]
     //       The heating rate is {dF/dP * g / Cp} with units [K/s]
     real1d heatfac("heatfac",1);
-    yakl::memset(heatfac, 1.0e-2/Cp_d);
+    yakl::memset(heatfac, 1.0/Cp_d);//1.0e-2/Cp_d);
     parallel_for(SimpleBounds<2>(ncol, nlev), YAKL_LAMBDA (int icol, int ilev)
     {
         heating_rate(icol,ilev) = heatfac(1) * ( (flux_up(icol,ilev+1) - flux_dn(icol,ilev+1))

--- a/Source/Radiation/Radiation.cpp
+++ b/Source/Radiation/Radiation.cpp
@@ -27,6 +27,7 @@
 #include "DataStruct.H"
 #include "EOS.H"
 #include "TileNoZ.H"
+#include "Orbit.H"
 
 using namespace amrex;
 using yakl::intrinsics::size;
@@ -99,6 +100,8 @@ namespace internal {
 // init
 void Radiation::initialize (const MultiFab& cons_in,
                             MultiFab* qheating_rates,
+                            MultiFab* lat,
+                            MultiFab* lon,
                             Vector<MultiFab*> qmoist,
                             const BoxArray& grids,
                             const Geometry& geom,
@@ -125,14 +128,19 @@ void Radiation::initialize (const MultiFab& cons_in,
     do_snow_optics    = do_snow_opt;
     is_cmip6_volc     = is_cmip6_volcano;
 
+    m_lat = lat;
+    m_lon = lon;
+
     rrtmgp_data_path = getRadiationDataDir() + "/";
     rrtmgp_coefficients_file_sw = rrtmgp_data_path + rrtmgp_coefficients_file_name_sw;
     rrtmgp_coefficients_file_lw = rrtmgp_data_path + rrtmgp_coefficients_file_name_lw;
 
+    ParmParse pp("erf");
+    pp.query("fixed_total_solar_irradiance", fixed_total_solar_irradiance);
+    pp.query("radiation_uniform_angle"     , uniform_angle);
+
     for ( MFIter mfi(cons_in, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-
         const auto& box3d = mfi.tilebox();
-
         nlev = box3d.length(2);
         ncol = box3d.length(0)*box3d.length(1);
     }
@@ -174,18 +182,27 @@ void Radiation::initialize (const MultiFab& cons_in,
     zi   = real2d("zi", ncol, nlev);
 
     // Get the temperature, density, theta, qt and qp from input
-    for ( MFIter mfi(cons_in, false); mfi.isValid(); ++mfi) {
+    for (MFIter mfi(cons_in); mfi.isValid(); ++mfi) {
+        const auto& box3d = mfi.tilebox();
+        auto nx = box3d.length(0);
+
         auto states_array = cons_in.array(mfi);
+        /*
         auto qt_array = (qmoist[0]) ? qmoist[0]->array(mfi) : Array4<Real> {};
         auto qv_array = (qmoist[1]) ? qmoist[1]->array(mfi) : Array4<Real> {};
         auto qc_array = (qmoist[2]) ? qmoist[2]->array(mfi) : Array4<Real> {};
         auto qi_array = (qmoist.size()>=8) ? qmoist[3]->array(mfi) : Array4<Real> {};
+        */
 
-        const auto& box3d = mfi.tilebox();
-        auto nx = box3d.length(0);
-        //auto ny = box3d.length(1);
+        // DEBUG: delete and uncomment  when done
+        // NOTE : SW crashes with moisture but runs without it (pressure unit issue?!)
+        auto qt_array = (false) ? qmoist[0]->array(mfi) : Array4<Real> {};
+        auto qv_array = (false) ? qmoist[1]->array(mfi) : Array4<Real> {};
+        auto qc_array = (false) ? qmoist[2]->array(mfi) : Array4<Real> {};
+        auto qi_array = (false) ? qmoist[3]->array(mfi) : Array4<Real> {};
+
         // Get pressure, theta, temperature, density, and qt, qp
-        amrex::ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             auto icol = j*nx+i+1;
             auto ilev = k+1;
@@ -196,23 +213,19 @@ void Radiation::initialize (const MultiFab& cons_in,
             qn(icol,ilev)   = qc(icol,ilev) + qi(icol,ilev);
             tmid(icol,ilev) = getTgivenRandRTh(states_array(i,j,k,Rho_comp),states_array(i,j,k,RhoTheta_comp),qv);
             // NOTE: RRTMGP code expects pressure in pa
-            pmid(icol,ilev) = getPgivenRTh(states_array(i,j,k,RhoTheta_comp),qv);// * 1.0e-2;
+            pmid(icol,ilev) = getPgivenRTh(states_array(i,j,k,RhoTheta_comp),qv);
         });
     }
 
     parallel_for(SimpleBounds<2>(ncol, nlev+1), YAKL_LAMBDA (int icol, int ilev)
     {
         if (ilev == 1) {
-            //pint(icol, 1) = 2.*pmid(icol, 2) - pmid(icol, 1);
-            //tint(icol, 1) = 2.*tmid(icol, 2) - tmid(icol, 1);
             pint(icol, 1) = -0.5*pmid(icol, 2) + 1.5*pmid(icol, 1);
             tint(icol, 1) = -0.5*tmid(icol, 2) + 1.5*tmid(icol, 1);
         } else if (ilev <= nlev) {
             pint(icol, ilev) = 0.5*(pmid(icol, ilev-1) + pmid(icol, ilev));
             tint(icol, ilev) = 0.5*(tmid(icol, ilev-1) + tmid(icol, ilev));
         } else {
-            //pint(icol, nlev+1) = 2.*pmid(icol, nlev-1) - pmid(icol, nlev);
-            //tint(icol, nlev+1) = 2.*tmid(icol, nlev-1) - tmid(icol, nlev);
             pint(icol, nlev+1) = -0.5*pmid(icol, nlev-1) + 1.5*pmid(icol, nlev);
             tint(icol, nlev+1) = -0.5*tmid(icol, nlev-1) + 1.5*tmid(icol, nlev);
         }
@@ -323,9 +336,16 @@ void Radiation::run ()
         internal::initial_fluxes(ncol, nlev+1, nswbands, fluxes_allsky);
         internal::initial_fluxes(ncol, nlev+1, nswbands, fluxes_clrsky);
 
-        // Get cosine solar zenith angle for current time step. ( still NOT YET implemented here)
-        //      set_cosine_solar_zenith_angle(state, dt_avg, coszrs(1:ncol))
-        yakl::memset(coszrs, 0.2);  // we set constant value here to avoid numerical overflow.
+        // TODO: Integrate calendar day computation
+        int calday = 1;
+        // Get cosine solar zenith angle for current time step.
+        if (m_lat) {
+            zenith(calday, m_lat, m_lon, coszrs, ncol,
+                   eccen,  mvelpp, lambm0, obliqr);
+        } else {
+            zenith(calday, m_lat, m_lon, coszrs, ncol,
+                   eccen,  mvelpp, lambm0, obliqr, uniform_angle);
+        }
 
         // Get albedo. This uses CAM routines internally and just provides a
         // wrapper to improve readability of the code here.
@@ -580,10 +600,13 @@ void Radiation::radiation_driver_sw (int ncol, const real3d& gas_vmr,
     // eccentricity, and could be used to scale total sky irradiance for different
     // climates as well (i.e., paleoclimate simulations)
     real tsi_scaling;
+    real solar_declination;
 
     if (fixed_total_solar_irradiance<0) {
+        // TODO: Integrate calendar day computation
+        int calday = 1;
         // Get orbital eccentricity factor to scale total sky irradiance
-        tsi_scaling = 1.0e-3; //get_eccentricity_factor();
+        shr_orb_decl(calday, eccen, mvelpp, lambm0, obliqr, solar_declination, tsi_scaling);
     } else {
         // For fixed TSI we divide by the default solar constant of 1360.9
         // At some point we will want to replace this with a method that
@@ -785,13 +808,14 @@ void Radiation::get_gas_vmr (const std::vector<std::string>& gas_names, const re
 {
     // Mass mixing ratio
     real2d mmr("mmr", ncol, nlev);
+
     // Gases and molecular weights. Note that we do NOT have CFCs yet (I think
     // this is coming soon in RRTMGP). RRTMGP also allows for absorption due to
     // CO and N2, which RRTMG did not have.
     const std::vector<std::string> gas_species = {"H2O", "CO2", "O3", "N2O",
-                                                  "CO", "CH4", "O2", "N2"};
-    const std::vector<real> mol_weight_gas = {18.01528, 44.0095, 47.9982, 44.0128,
-                                              28.0101, 16.04246, 31.998, 28.0134}; // g/mol
+                                                  "CO" , "CH4", "O2", "N2"};
+    const std::vector<real> mol_weight_gas = {18.01528, 44.00950, 47.9982, 44.0128,
+                                              28.01010, 16.04246, 31.9980, 28.0134}; // g/mol
     // Molar weight of air
     //const real mol_weight_air = 28.97; // g/mol
     // Defaults for gases that are not available (TODO: is this still accurate?)
@@ -893,7 +917,7 @@ void Radiation::calculate_heating_rate (const real2d& flux_up,
     //       The fluxes are in [W/m^2] and gravity is [m/s^2].
     //       The heating rate is {dF/dP * g / Cp} with units [K/s]
     real1d heatfac("heatfac",1);
-    yakl::memset(heatfac, 1.0/Cp_d);//1.0e-2/Cp_d);
+    yakl::memset(heatfac, 1.0/Cp_d);
     parallel_for(SimpleBounds<2>(ncol, nlev), YAKL_LAMBDA (int icol, int ilev)
     {
         heating_rate(icol,ilev) = heatfac(1) * ( (flux_up(icol,ilev+1) - flux_dn(icol,ilev+1))

--- a/Source/Radiation/Run_longwave_rrtmgp.cpp
+++ b/Source/Radiation/Run_longwave_rrtmgp.cpp
@@ -69,7 +69,7 @@ void Rrtmgp::run_longwave_rrtmgp (int ngas, int ncol, int nlay,
     parallel_for(SimpleBounds<1>(ncol), YAKL_LAMBDA (int icol)
     {
         t_sfc(icol) = tint(icol,nlay+1);
-        top_at_1_g(1) = pmid(1, 1) < pmid (1, 2);
+        top_at_1_g(1) = pmid(1, 1) < pmid (1, nlay);
     });
     top_at_1_g.deep_copy_to(top_at_1_h);
     top_at_1 = top_at_1_h(1);

--- a/Source/Radiation/Run_shortwave_rrtmgp.cpp
+++ b/Source/Radiation/Run_shortwave_rrtmgp.cpp
@@ -34,8 +34,8 @@ void Rrtmgp::run_shortwave_rrtmgp (int ngas, int ncol, int nlay,
     bool1d top_at_1_g("top_at_1_g",1);
     boolHost1d top_at_1_h("top_at_1_h",1);
     bool top_at_1;
-    parallel_for(SimpleBounds<1>(1), YAKL_LAMBDA (int icol) { // HACK: Single loop kernel is not efficient
-       top_at_1_g(1) = pmid(1, 1) < pmid (1, 2);
+    parallel_for(SimpleBounds<1>(1), YAKL_LAMBDA (int ilay) { // HACK: Single loop kernel is not efficient
+       top_at_1_g(1) = pmid(1, 1) < pmid (1, nlay);
     });
     top_at_1_g.deep_copy_to(top_at_1_h);
     top_at_1 = top_at_1_h(1);

--- a/Source/TimeIntegration/ERF_advance_radiation.cpp
+++ b/Source/TimeIntegration/ERF_advance_radiation.cpp
@@ -15,6 +15,8 @@ void ERF::advance_radiation (int lev,
 
     rad.initialize(cons,
                    qheating_rates[lev].get(),
+                   lat_m[lev].get(),
+                   lon_m[lev].get(),
                    qmoist[lev],
                    grids[lev],
                    Geom(lev),

--- a/Source/Utils/Orbit.H
+++ b/Source/Utils/Orbit.H
@@ -1,0 +1,100 @@
+#ifndef _ORBIT_H_
+#define _ORBIT_H_
+
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <Rrtmgp.H>
+#include <ERF_Constants.H>
+
+void
+zenith (int& calday,
+        amrex::MultiFab* clat,
+        amrex::MultiFab* clon,
+        real1d& coszrs,
+        int& ncol,
+        const amrex::Real& eccen,
+        const amrex::Real& mvelpp,
+        const amrex::Real& lambm0,
+        const amrex::Real& obliqr,
+        amrex::Real uniform_angle=-1.0);
+
+
+AMREX_GPU_HOST
+AMREX_FORCE_INLINE
+amrex::Real
+shr_orb_cosz (const amrex::Real& jday,
+              const amrex::Real& lat,
+              const amrex::Real& lon,
+              const amrex::Real& declin,
+              amrex::Real uniform_angle)
+{
+    amrex::Real cos_sol_zen_ang;
+
+    // If uniform angle is specified we use that.
+    // NOTE: uniform angle is in degrees
+    if (uniform_angle>0.0) {
+        cos_sol_zen_ang = std::cos(uniform_angle * PI/180.0);
+    }
+    // Default method
+    else {
+        cos_sol_zen_ang = std::sin(lat)*std::sin(declin) - std::cos(lat)*std::cos(declin) *
+                          std::cos((jday-std::floor(jday))*2.0*PI + lon);
+    }
+
+    return cos_sol_zen_ang;
+}
+
+
+AMREX_GPU_HOST
+AMREX_FORCE_INLINE
+void
+shr_orb_decl (const amrex::Real& calday,
+              const amrex::Real& eccen ,
+              const amrex::Real& mvelpp,
+              const amrex::Real& lambm0,
+              const amrex::Real& obliqr,
+              amrex::Real& delta,
+              amrex::Real& eccf)
+{
+
+    static constexpr amrex::Real day_p_yr = 365.0;
+    static constexpr amrex::Real ve = 80.5;
+
+    // Compute eccentricity factor and solar declination using
+    // day value where a round day (such as 213.0) refers to 0z at
+    // Greenwich longitude.
+
+    // Use formulas from Berger, Andre 1978: Long-Term Variations of Daily
+    // Insolation and Quaternary Climatic Changes. J. of the Atmo. Sci.
+    // 35:2362-2367.
+
+    // To get the earths true longitude (position in orbit; lambda in Berger
+    // 1978) which is necessary to find the eccentricity factor and declination,
+    // must first calculate the mean longitude (lambda m in Berger 1978) at
+    // the present day.  This is done by adding to lambm0 (the mean longitude
+    // at the vernal equinox, set as March 21 at noon, when lambda=0; in radians)
+    // an increment (delta lambda m in Berger 1978) that is the number of
+    // days past or before (a negative increment) the vernal equinox divided by
+    // the days in a model year times the 2*pi radians in a complete orbit.
+    amrex::Real lambm = lambm0 + (calday - ve)*2.0*PI/day_p_yr;
+    amrex::Real lmm   = lambm  - mvelpp;
+
+    // The earths true longitude, in radians, is then found from
+    // the formula in Berger 1978:
+    amrex::Real sinl  = std::sin(lmm);
+    amrex::Real lamb  = lambm  + eccen*(2.0*sinl + eccen*(1.25*sin(2.0*lmm)
+                               + eccen*((13.0/12.0)*sin(3.0*lmm) - 0.25*sinl)));
+
+
+    // Using the obliquity, eccentricity, moving vernal equinox longitude of
+    // perihelion (plus), and earths true longitude, the declination (delta)
+    // and the normalized earth/sun distance (rho in Berger 1978; actually inverse
+    // rho will be used), and thus the eccentricity factor (eccf), can be
+    // calculated from formulas given in Berger 1978.
+    amrex::Real invrho = (1.0 + eccen*std::cos(lamb - mvelpp)) / (1.0 - eccen*eccen);
+
+    // Set solar declination and eccentricity factor
+    delta  = std::asin(std::sin(obliqr)*std::sin(lamb));
+    eccf   = invrho*invrho;
+}
+#endif

--- a/Source/Utils/Orbit.cpp
+++ b/Source/Utils/Orbit.cpp
@@ -1,0 +1,47 @@
+#include <Orbit.H>
+
+using namespace amrex;
+
+void
+zenith (int& calday,
+        amrex::MultiFab* clat,
+        amrex::MultiFab* clon,
+        real1d& coszrs,
+        int& ncol,
+        const Real& eccen,
+        const Real& mvelpp,
+        const Real& lambm0,
+        const Real& obliqr,
+        amrex::Real uniform_angle)
+{
+    Real delta;    // Solar declination angle  in radians
+    Real eccf;     // Earth orbit eccentricity factor
+
+    // Populate delta & eccf
+    shr_orb_decl(calday, eccen, mvelpp, lambm0, obliqr, delta, eccf);
+
+    // If we have a valid pointer, go through the whole machinery
+    if (clat) {
+        for (MFIter mfi(*clat); mfi.isValid(); ++mfi) {
+            const auto& tbx = mfi.tilebox();
+            auto nx = tbx.length(0);
+
+            auto lat_array = clat->array(mfi);
+            auto lon_array = clon->array(mfi);
+
+            // NOTE: lat/lon are 2D multifabs!
+            ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
+            {
+                auto icol = j*nx+i+1;
+                coszrs(icol) = shr_orb_cosz(calday, lat_array(i,j,0), lon_array(i,j,0), delta, uniform_angle);
+            });
+       }
+    }
+    // Use constant value near center of USA or the uniform angle
+    else {
+        Real cons_lat = 40.0;
+        Real cons_lon = 100.0;
+        Real val = shr_orb_cosz(calday, cons_lat, cons_lon, delta, uniform_angle);
+        yakl::memset(coszrs, val);
+    }
+}


### PR DESCRIPTION
Use pressure units of `Pa` since RRTMGP converts for us. See [E3SM-Project/rte-rrtmgp minor](https://github.com/E3SM-Project/rte-rrtmgp/blob/ddf82a25a3a59a8f0fe904b69181cb7bd99881fb/cpp/rrtmgp/kernels/mo_gas_optics_kernels.cpp#L263). The long wavelength [example case](https://github.com/E3SM-Project/rte-rrtmgp/blob/ddf82a25a3a59a8f0fe904b69181cb7bd99881fb/examples/rfmip-clear-sky/rrtmgp_rfmip_lw.F90#L266) was used to verify this through print statements. Note that in the example case the state (pressure, temp, composition) is read in from a netCDF file `multiple_input4MIPs_radiation_RFMIP_UColorado-RFMIP-1-2_none.nc` and `ncdump` also confirms the units of pressure are `Pa`. Finally, hacking the ERF code and example case allows the long wavelength results to agree well between the two codes. Short wavelength still needs to be addressed.