### PR TITLE
Correction to Fitch source terms

### DIFF
--- a/Source/WindFarmParametrization/Fitch/AdvanceFitch.cpp
+++ b/Source/WindFarmParametrization/Fitch/AdvanceFitch.cpp
@@ -139,13 +139,13 @@ void fitch_source_terms_cellcentered (const Geometry& geom,
 
                  Real Vabs = std::pow(u_vel(i,j,k)*u_vel(i,j,k) +
                                       v_vel(i,j,k)*v_vel(i,j,k) +
-                                      w_vel(i,j,k)*w_vel(i,j,k), 0.5);
+                                      w_vel(i,j,kk)*w_vel(i,j,kk), 0.5);
 
                  fitch_array(i,j,k,0) = Vabs;
-                 fitch_array(i,j,k,1) =  -0.5*Nturb_array(i,j,k)*C_T*Vabs*Vabs*A_ijk/(z_kp1 - z_k);
+                 fitch_array(i,j,k,1) =  -0.5*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_T*Vabs*Vabs*A_ijk/(z_kp1 - z_k);
                  fitch_array(i,j,k,2) = u_vel(i,j,k)/Vabs*fitch_array(i,j,k,1);
                  fitch_array(i,j,k,3) = v_vel(i,j,k)/Vabs*fitch_array(i,j,k,1);
-                 fitch_array(i,j,k,4) = 0.5*Nturb_array(i,j,k)*C_TKE*std::pow(Vabs,3)*A_ijk/(z_kp1 - z_k);
+                 fitch_array(i,j,k,4) = 0.5*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_TKE*std::pow(Vabs,3)*A_ijk/(z_kp1 - z_k);
 
                  //amrex::Gpu::Atomic::Add(sum_area, A_ijk);
           });


### PR DESCRIPTION
This PR corrects the Fitch source terms. 
The `N_ij` variable in the Fitch formulation refers to the number density of the turbines - ie. number of turbines per unit area in a mesh cell. This correction makes the Fitch and EWP results look very similar for a configuration of 49 wind turbines with one turbine in each cell. The velocity deficit is still smaller than expected, but both models give similar results, which is encouraging. More testing in progress. Figure attached of wind turbine locations, and velocity magnitude contours for the Fitch and EWP models. 

![WindFarm](https://github.com/erf-model/ERF/assets/34353555/0afec6ac-4391-4ed1-9cea-1afecddd9545)

<img width="998" alt="Screen Shot 2024-04-30 at 2 41 00 AM" src="https://github.com/erf-model/ERF/assets/34353555/3f70f617-6ee0-455f-990e-78a8669009de">


