### PR TITLE
Rad PdelDry 

### DIFF
--- a/Source/Radiation/Aero_rad_props.H
+++ b/Source/Radiation/Aero_rad_props.H
@@ -25,8 +25,9 @@ class AerRadProps {
                     int nswbands_, int nlwbands_,
                     int ncoloum, int nlevel, int num_rh, int top_levels,
                     const std::vector<std::string>& aerosol_names,
-                    const real2d& zint, const real2d& pmiddle, const real2d& temperature,
-                    const real2d& qtotal, const real2d& geom_rad);
+                    const real2d& zint, const real2d& pmiddle, const real2d& pint,
+                    const real2d& temperature, const real2d& qtotal,
+                    const real2d& geom_rad);
 
    void aer_rad_props_sw (const int& list_idx,
                           const real& dt,

--- a/Source/Radiation/Optics.H
+++ b/Source/Radiation/Optics.H
@@ -76,8 +76,9 @@ class Optics {
                      int nswbands, int nlwbands,
                      int ncol, int nlev, int nrh, int top_lev,
                      const std::vector<std::string>& aero_names,
-                     const real2d& zi, const real2d& pmid, const real2d& temp,
-                     const real2d& qi, const real2d& geom_radius);
+                     const real2d& zi, const real2d& pmid, const real2d& pint,
+                     const real2d& temp, const real2d& qi,
+                     const real2d& geom_radius);
 
     // finalize/clean up
     void finalize ();

--- a/Source/Radiation/Optics.cpp
+++ b/Source/Radiation/Optics.cpp
@@ -13,13 +13,14 @@ void Optics::initialize (int ngas, int nmodes, int num_aeros,
                          int nswbands, int nlwbands,
                          int ncol, int nlev, int nrh, int top_lev,
                          const std::vector<std::string>& aero_names,
-                         const real2d& zi, const real2d& pmid, const real2d& temp,
-                         const real2d& qi, const real2d& geom_radius)
+                         const real2d& zi, const real2d& pmid, const real2d& pint,
+                         const real2d& temp, const real2d& qi,
+                         const real2d& geom_radius)
 {
     cloud_optics.initialize();
     aero_optics.initialize(ngas, nmodes, num_aeros,
                            nswbands, nlwbands, ncol, nlev, nrh, top_lev,
-                           aero_names, zi, pmid, temp, qi, geom_radius);
+                           aero_names, zi, pmid, pint, temp, qi, geom_radius);
 }
 
 void Optics::finalize ()

--- a/Source/Radiation/Radiation.H
+++ b/Source/Radiation/Radiation.H
@@ -89,6 +89,12 @@ class Radiation {
                                  const real2d& flux_dn,
                                  const real2d& pint,
                                  const real2d& heating_rate);
+#if 0
+    void
+    export_surface_fluxes(FluxesByband& fluxes,
+                          std::string band);
+#endif
+
   private:
     // geometry
     amrex::Geometry m_geom;

--- a/Source/Radiation/Radiation.cpp
+++ b/Source/Radiation/Radiation.cpp
@@ -249,7 +249,7 @@ void Radiation::initialize (const MultiFab& cons_in,
 
     optics.initialize(ngas, nmodes, naer, nswbands, nlwbands,
                       ncol, nlev, nrh, top_lev, aero_names, zi,
-                      pmid, tmid, qt, geom_radius);
+                      pmid, pint, tmid, qt, geom_radius);
 
     amrex::Print() << "LW coefficents file: " << rrtmgp_coefficients_file_lw
                    << "\nSW coefficents file: " << rrtmgp_coefficients_file_sw
@@ -477,6 +477,12 @@ void Radiation::run ()
                              aer_tau_bnd_sw, aer_ssa_bnd_sw, aer_asm_bnd_sw,
                              fluxes_allsky, fluxes_clrsky, qrs, qrsc);
         }
+
+#if 0
+        // Set surface fluxes that are used by the land model
+        export_surface_fluxes(fluxes_allsky, "shortwave");
+#endif
+
     } else {
         // Conserve energy
         if (conserve_energy) {
@@ -519,6 +525,12 @@ void Radiation::run ()
         // Call the longwave radiation driver to calculate fluxes and heating rates
         radiation_driver_lw(ncol, nlev, gas_vmr, pmid, pint, tmid, tint, cld_tau_gpt_lw, aer_tau_bnd_lw,
                             fluxes_allsky, fluxes_clrsky, qrl, qrlc);
+
+#if 0
+        // Set surface fluxes that are used by the land model
+        export_surface_fluxes(fluxes_allsky, "longwave");
+#endif
+
     }
     else {
         // Conserve energy (what does this mean exactly?)
@@ -540,6 +552,9 @@ void Radiation::run ()
             // Map (col,lev) to (i,j,k)
             auto icol = j*nx+i+1;
             auto ilev = k+1;
+
+            // TODO: We do not include the cloud source term qrsc/qrlc.
+            //       Do these simply sum for a net source or do we pick one?
 
             // SW and LW sources
             qrad_src_array(i,j,k,0) = qrs(icol,ilev);
@@ -920,6 +935,8 @@ void Radiation::calculate_heating_rate (const real2d& flux_up,
                            << heating_rate(icol,ilev) << ' '
                            << (flux_up(icol,ilev+1) - flux_dn(icol,ilev+1)) << ' '
                            << (flux_up(icol,ilev  ) - flux_dn(icol,ilev  )) << ' '
+                           << flux_up(icol,ilev+1) << ' '
+                           << flux_dn(icol,ilev+1) << ' '
                            << (flux_up(icol,ilev+1) - flux_dn(icol,ilev+1))
                             - (flux_up(icol,ilev  ) - flux_dn(icol,ilev  )) << ' '
                            << (pint(icol,ilev+1)-pint(icol,ilev)) << ' '
@@ -928,6 +945,85 @@ void Radiation::calculate_heating_rate (const real2d& flux_up,
         */
     });
 }
+
+#if 0
+void
+export_surface_fluxes(FluxesByband& fluxes,
+                      std::string band)
+{
+    if (band == "shortwave") {
+        real3d flux_dn_diffuse("flux_dn_diffuse", ncol, nlev+1, nswbands);
+
+        // Calculate diffuse flux from total and direct
+        // This only occurs at the bottom level (k index)
+        parallel_for (SimpleBounds<3>(ncol, 1, nswbands), YAKL_LAMBDA (int icol, int ilev, int ibnd)
+        {
+            flux_dn_diffuse(icol,ilev,ibnd) = fluxes.bnd_flux_dn(icol,ilev,ibnd)
+                                            - fluxes.bnd_flux_dn_dir(icol,ilev,ibnd);
+        });
+
+        // Populate the LSM data structure (this is a 2D MF)
+        for (MFIter mfi(*(m_lsm_ptr)); mfi.isValid(); ++mfi) {
+            auto lsm_array = m_lsm_ptr->array(mfi);
+            const auto& box3d = mfi.tilebox();
+            auto nx = box3d.length(0);
+            amrex::ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Map (col,lev) to (i,j,k)
+                auto icol = j*nx+i+1;
+                auto ilev = k+1;
+
+                // Direct fluxes
+                Real sum1(0.0), sum2(0.0);
+                for (int ibnd(1); ibnd<=9; ++ibnd) {
+                    sum1 += fluxes.bnd_flux_dn_dir(icol,ilev,ibnd);
+                }
+                for (int ibnd(11); ibnd<=14; ++ibnd) {
+                    sum2 += fluxes.bnd_flux_dn_dir(icol,ilev,ibnd);
+                }
+                sum1 += 0.5 * fluxes.bnd_flux_dn_dir(icol,ilev,10);
+                sum2 += 0.5 * fluxes.bnd_flux_dn_dir(icol,ilev,10);
+                lsm_array(i,j,k,0) = sum1;
+                lsm_array(i,j,k,1) = sum2;
+
+                // Diffuse fluxes
+                sum1=0.0; sum2=0.0;
+                for (int ibnd(1); ibnd<=9; ++ibnd) {
+                    sum1 += flux_dn_diffuse(icol,ilev,ibnd);
+                }
+                for (int ibnd(11); ibnd<=14; ++ibnd) {
+                    sum2 += flux_dn_diffuse(icol,ilev,ibnd);
+                }
+                sum1 += 0.5 * flux_dn_diffuse(icol,ilev,10);
+                sum2 += 0.5 * flux_dn_diffuse(icol,ilev,10);
+                lsm_array(i,j,k,2) = sum1;
+                lsm_array(i,j,k,3) = sum2;
+
+                // Net fluxes
+                lsm_array(i,j,k,4) = fluxes.flux_net(icol,ilev);
+            });
+        }
+    } else if (band == "longwave") {
+        // Populate the LSM data structure (this is a 2D MF)
+        for (MFIter mfi(*(m_lsm_ptr)); mfi.isValid(); ++mfi) {
+            auto lsm_array = m_lsm_ptr->array(mfi);
+            const auto& box3d = mfi.tilebox();
+            auto nx = box3d.length(0);
+            amrex::ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Map (col,lev) to (i,j,k)
+                auto icol = j*nx+i+1;
+                auto ilev = k+1;
+
+                // Net fluxes
+                lsm_array(i,j,k,5) = fluxes.flux_dn(icol,ilev);
+            });
+        }
+    } else {
+         amrex::Abort("Unknown radiation band type!");
+    }
+}
+#endif
 
 // call back
 void Radiation::on_complete () { }

--- a/Source/Radiation/Run_shortwave_rrtmgp.cpp
+++ b/Source/Radiation/Run_shortwave_rrtmgp.cpp
@@ -103,6 +103,10 @@ void Rrtmgp::run_shortwave_rrtmgp (int ngas, int ncol, int nlay,
 
     cloud_optics.delta_scale();
 
+    // TODO: Sort through cloud optics, this increment does not
+    //       modify the optical properties (tau/ssa/g) so we get
+    //       the same fluxes and heating rate.
+
     // NOTE: See above and here we again have matching gpt sizes
     cloud_optics.increment(combined_optics);
 


### PR DESCRIPTION
This modifies the `pdeldry` to be the vertical change in pressure, this is following discussions with the E3SM developers. The plugin for LSM data transfer is also included but commented out. Once the data structures are available, the ptrs can be stored in the radiation class and populated.