### PR TITLE
SAM Newton Iters

### DIFF
--- a/Source/Microphysics/SAM/Cloud_SAM.cpp
+++ b/Source/Microphysics/SAM/Cloud_SAM.cpp
@@ -190,7 +190,34 @@ void SAM::Cloud () {
                 // Pressure unit conversion
                 pres_array(i,j,k) /= 100.0;
 
-            } // qt > qsat
+            }
+            // We cannot blindly relax to qsat, but we can convert qc/qi -> qv
+            else {
+                // Changes in each component
+                delta_qv =  qcl_array(i,j,k) + qci_array(i,j,k);
+                delta_qc = -qcl_array(i,j,k);
+                delta_qi = -qci_array(i,j,k);
+
+                // Partition the change in non-precipitating q
+                 qv_array(i,j,k) += delta_qv;
+                qcl_array(i,j,k)  = 0.0;
+                qci_array(i,j,k)  = 0.0;
+                 qn_array(i,j,k)  = 0.0;
+                 qt_array(i,j,k)  = qv_array(i,j,k);
+
+                // Update temperature (endothermic since we evap/sublime)
+                tabs_array(i,j,k) -= fac_fus * delta_qc + fac_sub * delta_qi;
+
+                // Update pressure
+                pres_array(i,j,k) = rho_array(i,j,k) * R_d * tabs_array(i,j,k)
+                                    * (1.0 + R_v/R_d * qv_array(i,j,k));
+
+                // Update theta from temperature
+                theta_array(i,j,k) = getThgivenPandT(tabs_array(i,j,k), pres_array(i,j,k), rdOcp);
+
+                // Pressure unit conversion
+                pres_array(i,j,k) /= 100.0;
+            }
         });
     } // mfi
 }


### PR DESCRIPTION
Computation of `qsat` depends upon pressure and temperature. This PR updates pressure in the Newton iterations (in addition to temperature) for more consistency. This showed modest increases in the amount of Qc evaporated to Qv.

Additionally, this PR adds logical conditions to address the case that `qt<qsat` and thus we cannot use Newton iterations to drive `qv->qsat` since we do not have enough moisture to reach `qsat`. This condition leaves us with a conversion of all the cloud and ice back to vapor.