### PR TITLE
SAM only rain option

### DIFF
--- a/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SAM_OnlyRain
+++ b/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SAM_OnlyRain
@@ -1,0 +1,81 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step  = 1000
+stop_time = 3600.0
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_extent = 20000.0 400.0  10000.0
+amr.n_cell           = 200     4      100
+geometry.is_periodic = 0 1 0
+xlo.type = "SlipWall"
+xhi.type = "SlipWall"    
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.fixed_dt = 0.5
+erf.fixed_mri_dt_ratio = 4
+#erf.no_substepping = 1
+#erf.fixed_dt = 0.1
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1       # timesteps between computing mass
+erf.v              = 1       # verbosity in ERF.cpp
+amr.v              = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 100       # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 100        # number of timesteps between plotfiles
+erf.plot_vars_1     = density rhotheta rhoQ1 rhoQ2 rhoadv_0 x_velocity y_velocity z_velocity pressure theta scalar temp pres_hse dens_hse pert_pres pert_dens eq_pot_temp qt qv qc qi qrain qsnow qgraup
+
+# SOLVER CHOICES
+erf.use_gravity          = true
+erf.use_coriolis         = false
+    
+erf.dycore_horiz_adv_type    = "Upwind_3rd"
+erf.dycore_vert_adv_type     = "Upwind_3rd"
+erf.dryscal_horiz_adv_type   = "Upwind_3rd"
+erf.dryscal_vert_adv_type    = "Upwind_3rd"
+erf.moistscal_horiz_adv_type = "Upwind_3rd"
+erf.moistscal_vert_adv_type  = "Upwind_3rd"       
+
+# PHYSICS OPTIONS
+erf.les_type        = "None"
+erf.pbl_type        = "None"
+erf.moisture_model  = "SAM_OnlyRain"
+erf.buoyancy_type   = 1
+erf.use_moist_background = true
+
+erf.molec_diff_type  = "ConstantAlpha"
+erf.rho0_trans       = 1.0 # [kg/m^3], used to convert input diffusivities
+erf.dynamicViscosity = 0.0 # [kg/(m-s)] ==> nu = 75.0 m^2/s
+erf.alpha_T          = 0.0 # [m^2/s]
+erf.alpha_C          = 0.0
+
+# INITIAL CONDITIONS
+#erf.init_type = "input_sounding"
+#erf.input_sounding_file = "BF02_moist_sounding"
+#erf.init_sounding_ideal = true
+
+# PROBLEM PARAMETERS (optional)
+# warm bubble input
+prob.x_c    = 10000.0
+prob.z_c    =  2000.0
+prob.x_r    =  2000.0
+prob.z_r    =  2000.0
+prob.T_0    =   300.0
+
+prob.do_moist_bubble = true
+prob.theta_pert  = 2.0
+prob.qt_init     = 0.02
+prob.eq_pot_temp = 320.0

--- a/Exec/RegTests/Bubble/prob.cpp
+++ b/Exec/RegTests/Bubble/prob.cpp
@@ -366,6 +366,8 @@ Problem::init_custom_pert(
                 moisture_type = 1;
             } else if(sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
                 moisture_type = 2;
+            } else if(sc.moisture_type == MoistureType::SAM_OnlyRain) {
+                moisture_type = 3;
             }
 
             amrex::ParallelFor(bx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k)
@@ -421,7 +423,7 @@ Problem::init_custom_pert(
                     Real omn;
                     if(moisture_type == 1) {
                         omn = std::max(0.0,std::min(1.0,(T-tbgmin)*a_bg));
-                    } else if(moisture_type == 2) {
+                    } else if(moisture_type == 2 or moisture_type == 3) {
                         omn = 1.0;
                     }
                     Real qn  = state_pert(i, j, k, RhoQ2_comp);

--- a/Source/DataStructs/DataStruct.H
+++ b/Source/DataStructs/DataStruct.H
@@ -33,7 +33,7 @@ enum struct MoistureModelType{
 };
 
 enum struct MoistureType {
-    Kessler, SAM, SAM_NoPrecip_NoIce, Kessler_NoRain, None
+    Kessler, SAM, SAM_NoPrecip_NoIce, SAM_OnlyRain, Kessler_NoRain, None
 };
 
 enum struct WindFarmType {
@@ -97,6 +97,8 @@ struct SolverChoice {
             moisture_type = MoistureType::SAM;
         } else if (moisture_model_string == "SAM_NoPrecip_NoIce") {
             moisture_type = MoistureType::SAM_NoPrecip_NoIce;
+        } else if (moisture_model_string == "SAM_OnlyRain") {
+            moisture_type = MoistureType::SAM_OnlyRain;
         } else if (moisture_model_string == "Kessler") {
             moisture_type = MoistureType::Kessler;
         }else if (moisture_model_string == "Kessler_NoRain") {
@@ -110,7 +112,8 @@ struct SolverChoice {
         if (moisture_type != MoistureType::None) {
             if (moisture_type == MoistureType::Kessler_NoRain ||
                 moisture_type == MoistureType::SAM ||
-                moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
+                moisture_type == MoistureType::SAM_NoPrecip_NoIce ||
+                moisture_type == MoistureType::SAM_OnlyRain) {
                 buoyancy_type = 1; // asserted in make buoyancy
             } else {
                 buoyancy_type = 2; // uses Tprime

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -77,7 +77,7 @@ ERF::setPlotVariables (const std::string& pp_plot_var_names, Vector<std::string>
     for (int i = 0; i < derived_names.size(); ++i) {
         if ( containerHasElement(plot_var_names, derived_names[i]) ) {
             if (solverChoice.use_terrain || (derived_names[i] != "z_phys" && derived_names[i] != "detJ") ) {
-                if ( (solverChoice.moisture_type == MoistureType::SAM) || (derived_names[i] != "qi" &&
+                if ( (solverChoice.moisture_type == MoistureType::SAM || solverChoice.moisture_type == MoistureType::SAM_OnlyRain) || (derived_names[i] != "qi" &&
                                                                            derived_names[i] != "qsnow" &&
                                                                            derived_names[i] != "qgraup" &&
                                                                            derived_names[i] != "snow_accum" &&

--- a/Source/Microphysics/EulerianMicrophysics.H
+++ b/Source/Microphysics/EulerianMicrophysics.H
@@ -28,7 +28,8 @@ public:
         AMREX_ASSERT( Microphysics::modelType(a_model_type) == MoistureModelType::Eulerian );
         m_moist_model.resize(nlev);
         if (a_model_type == MoistureType::SAM or
-            a_model_type == MoistureType::SAM_NoPrecip_NoIce) {
+            a_model_type == MoistureType::SAM_NoPrecip_NoIce or
+            a_model_type == MoistureType::SAM_OnlyRain) {
             SetModel<SAM>();
             amrex::Print() << "SAM moisture model!\n";
         } else if (a_model_type == MoistureType::Kessler or

--- a/Source/Microphysics/Microphysics.H
+++ b/Source/Microphysics/Microphysics.H
@@ -59,6 +59,7 @@ public:
     {
         if (    (a_moisture_type == MoistureType::SAM)
              || (a_moisture_type == MoistureType::SAM_NoPrecip_NoIce)
+             || (a_moisture_type == MoistureType::SAM_OnlyRain)
              || (a_moisture_type == MoistureType::Kessler)
              || (a_moisture_type == MoistureType::Kessler_NoRain)
              || (a_moisture_type == MoistureType::None) ) {

--- a/Source/Microphysics/SAM/Cloud_SAM.cpp
+++ b/Source/Microphysics/SAM/Cloud_SAM.cpp
@@ -24,6 +24,8 @@ void SAM::Cloud (const SolverChoice& solverChoice) {
         SAM_moisture_type = 1;
     } else if(solverChoice.moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
         SAM_moisture_type = 2;
+    } else if(solverChoice.moisture_type == MoistureType::SAM_OnlyRain) {
+        SAM_moisture_type = 3;
     }
 
     for ( MFIter mfi(*(mic_fab_vars[MicVar::tabs]), TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Microphysics/SAM/Cloud_SAM.cpp
+++ b/Source/Microphysics/SAM/Cloud_SAM.cpp
@@ -18,8 +18,6 @@ void SAM::Cloud (const SolverChoice& solverChoice) {
     Real fac_fus  = m_fac_fus;
     Real rdOcp    = m_rdOcp;
 
-    SolverChoice sc = solverChoice;
-
     int SAM_moisture_type = 1;
 
     if(solverChoice.moisture_type == MoistureType::SAM) {

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -222,7 +222,7 @@ public:
                     omn   = an*tabs-bn;
                     domn  = an;
                 }
-            } else if (SAM_moisture_type == 2) {
+            } else if (SAM_moisture_type == 2 or SAM_moisture_type == 3) {
                 omn  = 1.0;
                 domn = 0.0;
             }

--- a/Source/Microphysics/SAM/SAM.H
+++ b/Source/Microphysics/SAM/SAM.H
@@ -69,10 +69,10 @@ public:
     void IceFall ();
 
     // precip
-    void Precip ();
+    void Precip (const SolverChoice& sc);
 
     // precip fall
-    void PrecipFall ();
+    void PrecipFall (const SolverChoice& sc);
 
     // Set up for first time
     void
@@ -128,8 +128,11 @@ public:
         this->Cloud(sc);
         if(sc.moisture_type == MoistureType::SAM) {
             this->IceFall();
-            this->Precip();
-            this->PrecipFall();
+        }
+        if(sc.moisture_type == MoistureType::SAM or
+           sc.moisture_type == MoistureType::SAM_OnlyRain) {
+            this->Precip(sc);
+            this->PrecipFall(sc);
         }
     }
 

--- a/Source/SourceTerms/ERF_make_buoyancy.cpp
+++ b/Source/SourceTerms/ERF_make_buoyancy.cpp
@@ -136,7 +136,9 @@ void make_buoyancy (Vector<MultiFab>& S_data,
             AMREX_ALWAYS_ASSERT(solverChoice.buoyancy_type == 1);
         }
 
-        if (solverChoice.moisture_type == MoistureType::SAM or solverChoice.moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
+        if (solverChoice.moisture_type == MoistureType::SAM or
+            solverChoice.moisture_type == MoistureType::SAM_NoPrecip_NoIce or
+            solverChoice.moisture_type == MoistureType::SAM_OnlyRain) {
             AMREX_ALWAYS_ASSERT(solverChoice.buoyancy_type == 1);
         }
 


### PR DESCRIPTION
This PR adds an option `SAM_OnlyRain` which implements the `SAM` microphysics model with only cloud water and rain ie. no ice, snow and graupel. 

An input file - `inputs_BF02_moist_bubble_SAM_OnlyRain` is added to `RegTests/Bubble` for the moist bubble test case with `SAM_OnlyRain`.

The gif shows the comparison of the rain for `Kessler` and `SAM_OnlyRain`. The contour min/max, though not exactly same, is comparable for both the models. The difference is because the rain parametrization is different for `Kessler` and `SAM` models.

![MoistBubble_Kessler_SAM_Rain-ezgif com-video-to-gif-converter](https://github.com/erf-model/ERF/assets/34353555/2e3b8bbb-1420-4759-8690-30161b9a34fa)
