### PR TITLE
Release 24.06

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,13 @@
 # 24.05
+    -- AMReX submodule set to 24.06 release hash (f141191)
+
+    -- SAM microphysics corrections (#1634/#1629)
+
+    -- Open boundaries with viscous terms (#1615)
+
+    -- Incompressible pathway (#1612/#1613)
+
+# 24.05
     -- AMReX submodule set to 24.05 release hash (76d09f5)
     
     -- Explict MOST as runtime option (#1605)

--- a/Source/Advection/AdvectionSrcForMom_N.H
+++ b/Source/Advection/AdvectionSrcForMom_N.H
@@ -303,21 +303,25 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
     InterpType_H interp_w_h(w); InterpType_V interp_w_v(w); // Z-MOM
     WallInterpType interp_w_wall(w); // Z-MOM @ wall
 
-    amrex::ParallelFor(bxx, bxy, bxz,
+    amrex::ParallelFor(bxx,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_u_h, interp_u_v,
                                                     upw_frac_h, upw_frac_v,
                                                     cellSizeInv, mf_u_inv, mf_v_inv);
-    },
+    });
+
+    amrex::ParallelFor(bxy,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_v_h, interp_v_v,
                                                     upw_frac_h, upw_frac_v,
                                                     cellSizeInv, mf_u_inv, mf_v_inv);
-    },
+    });
+
+    amrex::ParallelFor(bxz,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom_N(i, j, k, rho_u, rho_v, rho_w, w,

--- a/Source/Advection/AdvectionSrcForMom_T.H
+++ b/Source/Advection/AdvectionSrcForMom_T.H
@@ -380,21 +380,25 @@ AdvectionSrcForMomWrapper (const amrex::Box& bxx, const amrex::Box& bxy, const a
     InterpType_H interp_w_h(w); InterpType_V interp_w_v(w); // Z-MOM
     WallInterpType interp_w_wall(w); // Z-MOM @ wall
 
-    amrex::ParallelFor(bxx, bxy, bxz,
+    amrex::ParallelFor(bxx,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom(i, j, k, rho_u, rho_v, Omega, z_nd, ax, ay, az, detJ,
                                                   interp_u_h, interp_u_v,
                                                   upw_frac_h, upw_frac_v,
                                                     cellSizeInv, mf_u_inv, mf_v_inv);
-    },
+    });
+
+    amrex::ParallelFor(bxy,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom(i, j, k, rho_u, rho_v, Omega, z_nd, ax, ay, az, detJ,
                                                   interp_v_h, interp_v_v,
                                                   upw_frac_h, upw_frac_v,
                                                   cellSizeInv, mf_u_inv, mf_v_inv);
-    },
+    });
+
+    amrex::ParallelFor(bxz,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom(i, j, k, rho_u, rho_v, Omega, w, z_nd, ax, ay, az, detJ,


### PR DESCRIPTION
These changes support release 24.06:

1. Bump AMReX submodule hash to 24.06 release
2. Modify CHANGES file
3. Add Weiqun's code for de-fusing kernels in the advection wrapper (too large of a lambda capture).