### PR TITLE
Fix Deardorff for BOMEX.

### DIFF
--- a/Exec/DevTests/Bomex/input_Kessler
+++ b/Exec/DevTests/Bomex/input_Kessler
@@ -22,7 +22,7 @@ erf.most.zref   = 20.0
 
 # NOTE: This should have a qv grad too (use hoextrapcc?!)
 zhi.type = "SlipWall"
-zhi.theta_grad = 0.00365
+#zhi.theta_grad = 0.00365
     
 # TIME STEP CONTROL
 erf.fixed_dt       = 0.5 # fixed time step depending on grid resolution
@@ -51,8 +51,8 @@ erf.alpha_T = 0.0
 erf.alpha_C = 0.0
 erf.use_gravity = true
 
-erf.dycore_horiz_adv_type    = Upwind_5th
-erf.dycore_vert_adv_type     = Upwind_5th
+erf.dycore_horiz_adv_type    = Upwind_3rd
+erf.dycore_vert_adv_type     = Upwind_3rd
 erf.dryscal_horiz_adv_type   = WENOZ5
 erf.dryscal_vert_adv_type    = WENOZ5
 erf.moistscal_horiz_adv_type = WENOZ5
@@ -61,8 +61,15 @@ erf.moistscal_vert_adv_type  = WENOZ5
 erf.moisture_model  = "Kessler"
 
 erf.molec_diff_type = "None"
+
 erf.les_type        = "Smagorinsky"
 erf.Cs              = 0.17
+
+#erf.les_type = "Deardorff"
+#erf.Ck       = 0.1
+#erf.sigma_k  = 1.0
+#erf.Ce       = 0.1
+
 erf.Pr_t            = 0.333333
 erf.Sc_t            = 0.333333
 

--- a/Exec/DevTests/Bomex/input_SAM
+++ b/Exec/DevTests/Bomex/input_SAM
@@ -22,7 +22,7 @@ erf.most.zref   = 20.0
 
 # NOTE: This should have a qv grad too (use hoextrapcc?!)
 zhi.type = "SlipWall"
-zhi.theta_grad = 0.00365
+#zhi.theta_grad = 0.00365
     
 # TIME STEP CONTROL
 erf.fixed_dt       = 0.5 # fixed time step depending on grid resolution
@@ -51,8 +51,8 @@ erf.alpha_T = 0.0
 erf.alpha_C = 0.0
 erf.use_gravity = true
 
-erf.dycore_horiz_adv_type    = Upwind_5th
-erf.dycore_vert_adv_type     = Upwind_5th
+erf.dycore_horiz_adv_type    = Upwind_3rd
+erf.dycore_vert_adv_type     = Upwind_3rd
 erf.dryscal_horiz_adv_type   = WENOZ5
 erf.dryscal_vert_adv_type    = WENOZ5
 erf.moistscal_horiz_adv_type = WENOZ5
@@ -61,8 +61,15 @@ erf.moistscal_vert_adv_type  = WENOZ5
 erf.moisture_model  = "SAM"
 
 erf.molec_diff_type = "None"
+
 erf.les_type        = "Smagorinsky"
 erf.Cs              = 0.17
+
+#erf.les_type = "Deardorff"
+#erf.Ck       = 0.1
+#erf.sigma_k  = 1.0
+#erf.Ce       = 0.1
+
 erf.Pr_t            = 0.333333
 erf.Sc_t            = 0.333333
 

--- a/Exec/DevTests/Bomex/prob.H
+++ b/Exec/DevTests/Bomex/prob.H
@@ -11,7 +11,7 @@ struct ProbParm : ProbParmDefaults {
     amrex::Real rho_0 = 0.0;
     amrex::Real T_0   = 0.0;
     amrex::Real A_0   = 1.0;
-    amrex::Real QKE_0 = 0.1;
+    amrex::Real KE_0 = 0.1;
 
     amrex::Real U_0 = 0.0;
     amrex::Real V_0 = 0.0;

--- a/Exec/DevTests/Bomex/prob.cpp
+++ b/Exec/DevTests/Bomex/prob.cpp
@@ -17,7 +17,7 @@ Problem::Problem (const Real* problo, const Real* probhi)
     pp.query("rho_0", parms.rho_0);
     pp.query("T_0", parms.T_0);
     pp.query("A_0", parms.A_0);
-    pp.query("QKE_0", parms.QKE_0);
+    pp.query("QKE_0", parms.KE_0);
 
     pp.query("U_0", parms.U_0);
     pp.query("V_0", parms.V_0);
@@ -71,7 +71,7 @@ Problem::init_custom_pert (
     Array4<Real      > const& x_vel_pert,
     Array4<Real      > const& y_vel_pert,
     Array4<Real      > const& z_vel_pert,
-    Array4<Real      > const& /*r_hse*/,
+    Array4<Real      > const& r_hse,
     Array4<Real      > const& /*p_hse*/,
     Array4<Real const> const& /*z_nd*/,
     Array4<Real const> const& /*z_cc*/,
@@ -111,9 +111,10 @@ Problem::init_custom_pert (
 
         // Set an initial value for QKE
         if (parms.custom_TKE) {
-            state_pert(i, j, k, RhoQKE_comp) = 1.0 - zc/3000.0; //*state_pert(i, j, k, Rho_comp);
+            state_pert(i, j, k, RhoKE_comp) = (1.0 - z/prob_hi[2]) * r_hse(i,j,k);
+        } else {
+            state_pert(i, j, k, RhoKE_comp) = parms.KE_0;
         }
-        else state_pert(i, j, k, RhoQKE_comp) = parms.QKE_0;
 
         if (use_moisture) {
             state_pert(i, j, k, RhoQ1_comp) = 0.0;


### PR DESCRIPTION
The initialization of `KE` for the Deardorff model was incorrect in the profile and the index being populated. This PR corrects that and adds inputs the BOMEX case for this turbulence model for ease of use.