### PR TITLE
WW3 Z0 limiters

### DIFF
--- a/Source/BoundaryConditions/MOSTStress.H
+++ b/Source/BoundaryConditions/MOSTStress.H
@@ -256,8 +256,8 @@ struct adiabatic_wave_coupled
         u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0_arr(i,j,k));
         do {
             ustar = u_star_arr(i,j,k);
-            z0    = 1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/Lwave_arr(i,j,k), 4.5 )
-                  + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar;
+            z0    = std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
+                             + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps);
             u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
@@ -271,6 +271,8 @@ private:
     most_data mdata;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
+    const amrex::Real eps = 1e-15;
+    const amrex::Real z0_eps = 1.0e-6;
 };
 
 
@@ -513,8 +515,8 @@ struct surface_flux_wave_coupled
         u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0_arr(i,j,k));
         do {
             ustar = u_star_arr(i,j,k);
-            z0    = 1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/Lwave_arr(i,j,k), 4.5 )
-                  + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar;
+            z0    = std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
+                             + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps);
             Olen = -ustar * ustar * ustar * tm_arr(i,j,k) /
                    (mdata.kappa * mdata.gravity * mdata.surf_temp_flux);
             zeta  = mdata.zref / Olen;
@@ -535,6 +537,8 @@ private:
     most_data mdata;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
+    const amrex::Real eps = 1e-15;
+    const amrex::Real z0_eps = 1.0e-6;
 };
 
 
@@ -784,8 +788,8 @@ struct surface_temp_wave_coupled
         u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0_arr(i,j,k));
         do {
             ustar = u_star_arr(i,j,k);
-            z0    = 1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/Lwave_arr(i,j,k), 4.5 )
-                  + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar;
+            z0    = std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
+                             + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps);
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h);
             Olen = -ustar * ustar * ustar * tm_arr(i,j,k) /
@@ -807,6 +811,8 @@ private:
     most_data mdata;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
+    const amrex::Real eps = 1e-15;
+    const amrex::Real z0_eps = 1.0e-6;
 };
 
 


### PR DESCRIPTION
Protect against divide by `0` case and ensure that `z0` never goes below a threshold value.