### PR TITLE
More warning checking in CI

### DIFF
--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -64,10 +64,20 @@ jobs:
             -DERF_ENABLE_MPI:BOOL=ON \
             -DERF_ENABLE_CUDA:BOOL=ON \
             -DERF_ENABLE_REGRESSION_TESTS_ONLY:BOOL=ON .
-          cmake --build build-${{matrix.cuda_pkg}} -- -j $(nproc)
+          cmake --build build-${{matrix.cuda_pkg}} -- -j $(nproc) \
+          2>&1 | tee -a ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output.txt;
 
           ccache -s
           du -hs ~/.cache/ccache
+
+      - name: Report
+        run: |
+          egrep "warning:|error:" ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output.txt \
+            | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+            | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output-warnings.txt
+          cat ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output-warnings.txt
+          export return=$(tail -n 1 ${{runner.workspace}}/build-${{matrix.cuda_pkg}}-output-warnings.txt | awk '{print $2}')
+          exit ${return}
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -51,10 +51,20 @@ jobs:
         export CCACHE_MAXSIZE=300M
         ccache -z
 
-        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose
+        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose \
+        2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache
+
+    - name: Report
+      run: |
+        egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
+          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-output-warnings.txt
+        cat ${{runner.workspace}}/build-output-warnings.txt
+        export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
+        exit ${return}
 
     - name: CMake Tests # see file ERF/Tests/CTestList.cmake
       run: |

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -96,10 +96,19 @@ jobs:
 
         pushd ${{runner.workspace}}/ERF/build-${{matrix.os}};
         # make -j ${{env.NPROCS}};
-        make -j 2;
+        make -j 2 2>&1 | tee -a ${{runner.workspace}}/build-${{matrix.os}}-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache
+
+    - name: Report
+      run: |
+        egrep "warning:|error:" ${{runner.workspace}}/build-${{matrix.os}}-output.txt \
+          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-${{matrix.os}}-output-warnings.txt
+        cat ${{runner.workspace}}/build-${{matrix.os}}-output-warnings.txt
+        export return=$(tail -n 1 ${{runner.workspace}}/build-${{matrix.os}}-output-warnings.txt | awk '{print $2}')
+        exit ${return}
 
     # - name: Regression Tests
     #   run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -50,10 +50,20 @@ jobs:
         export CCACHE_SLOPPINESS=time_macros
         ccache -z
 
-        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose
+        cmake --build ${{runner.workspace}}/ERF/build --parallel 2 --verbose \
+        2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         du -hs ~/Library/Caches/ccache
         ccache -s
+
+    - name: Report
+      run: |
+        egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
+          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-output-warnings.txt
+        cat ${{runner.workspace}}/build-output-warnings.txt
+        export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
+        exit ${return}
 
     - name: CMake Tests # see file ERF/Tests/CTestList.cmake
       run: |

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -65,10 +65,19 @@ jobs:
           -DCMAKE_C_COMPILER=$(which icx) \
           -DCMAKE_CXX_COMPILER=$(which icpx) \
           -DCMAKE_CXX_STANDARD=17
-        make -j 2
+        make -j 2 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache
+
+    - name: Report
+      run: |
+        egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
+          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-output-warnings.txt
+        cat ${{runner.workspace}}/build-output-warnings.txt
+        export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
+        exit ${return}
 
   save_pr_number:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,16 +29,7 @@ jobs:
 
     - name: Compile and Link
       run: |
-        cmake --build build --parallel 2 --verbose 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
-
-    - name: Report
-      run: |
-        egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
-          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
-          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-output-warnings.txt
-        cat ${{runner.workspace}}/build-output-warnings.txt
-        export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
-        exit ${return}
+        cmake --build build --parallel 2 --verbose
 
     - name: CMake Tests # see file ERF/Tests/CTestList.cmake
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,7 +29,17 @@ jobs:
 
     - name: Compile and Link
       run: |
-        cmake --build build --parallel 2 --verbose
+        cmake --build build --parallel 2 --verbose \
+        2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
+
+    - name: Report
+      run: |
+        egrep "warning:|error:" ${{runner.workspace}}/build-output.txt \
+          | egrep -v "Submodules/amrex" | egrep -v "lto-wrapper: warning:" | sort | uniq \
+          | awk 'BEGIN{i=0}{print $0}{i++}END{print "Warnings: "i}' > ${{runner.workspace}}/build-output-warnings.txt
+        cat ${{runner.workspace}}/build-output-warnings.txt
+        export return=$(tail -n 1 ${{runner.workspace}}/build-output-warnings.txt | awk '{print $2}')
+        exit ${return}
 
     - name: CMake Tests # see file ERF/Tests/CTestList.cmake
       run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,8 +29,7 @@ jobs:
 
     - name: Compile and Link
       run: |
-        cmake --build build --parallel 2 --verbose \
-        2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
+        cmake --build build --parallel 2 --verbose 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
     - name: Report
       run: |

--- a/Exec/ABL/prob.cpp
+++ b/Exec/ABL/prob.cpp
@@ -98,7 +98,7 @@ Problem::init_custom_pert(
         }
     }
 
-  ParallelForRNG(bx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(bx, [=, d_parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     // Geometry
     const Real* prob_lo = geomdata.ProbLo();
     const Real* prob_hi = geomdata.ProbHi();
@@ -115,36 +115,36 @@ Problem::init_custom_pert(
     const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
     // Add temperature perturbations
-    if ((z <= parms.pert_ref_height) && (parms.T_0_Pert_Mag != 0.0)) {
+    if ((z <= d_parms.pert_ref_height) && (d_parms.T_0_Pert_Mag != 0.0)) {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        state_pert(i, j, k, RhoTheta_comp) = (rand_double*2.0 - 1.0)*parms.T_0_Pert_Mag;
-        if (!parms.pert_rhotheta) {
+        state_pert(i, j, k, RhoTheta_comp) = (rand_double*2.0 - 1.0)*d_parms.T_0_Pert_Mag;
+        if (!d_parms.pert_rhotheta) {
             // we're perturbing theta, not rho*theta
             state_pert(i, j, k, RhoTheta_comp) *= r_hse(i,j,k);
         }
     }
 
     // Set scalar = A_0*exp(-10r^2), where r is distance from center of domain
-    state_pert(i, j, k, RhoScalar_comp) = parms.A_0 * exp(-10.*r*r);
+    state_pert(i, j, k, RhoScalar_comp) = d_parms.A_0 * exp(-10.*r*r);
 
     // Set an initial value for SGS KE
     if (state_pert.nComp() > RhoKE_comp) {
         // Deardorff
-        state_pert(i, j, k, RhoKE_comp) = r_hse(i,j,k) * parms.KE_0;
-        if (parms.KE_decay_height > 0) {
+        state_pert(i, j, k, RhoKE_comp) = r_hse(i,j,k) * d_parms.KE_0;
+        if (d_parms.KE_decay_height > 0) {
             // scale initial SGS kinetic energy with height
             state_pert(i, j, k, RhoKE_comp) *= max(
-                std::pow(1 - min(z/parms.KE_decay_height,1.0), parms.KE_decay_order),
+                std::pow(1 - min(z/d_parms.KE_decay_height,1.0), d_parms.KE_decay_order),
                 1e-12);
         }
     }
     if (state_pert.nComp() > RhoQKE_comp) {
         // PBL
-        state_pert(i, j, k, RhoQKE_comp) = r_hse(i,j,k) * parms.QKE_0;
-        if (parms.KE_decay_height > 0) {
+        state_pert(i, j, k, RhoQKE_comp) = r_hse(i,j,k) * d_parms.QKE_0;
+        if (d_parms.KE_decay_height > 0) {
             // scale initial SGS kinetic energy with height
             state_pert(i, j, k, RhoQKE_comp) *= max(
-                std::pow(1 - min(z/parms.KE_decay_height,1.0), parms.KE_decay_order),
+                std::pow(1 - min(z/d_parms.KE_decay_height,1.0), d_parms.KE_decay_order),
                 1e-12);
         }
     }
@@ -156,7 +156,7 @@ Problem::init_custom_pert(
   });
 
   // Set the x-velocity
-  ParallelForRNG(xbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(xbx, [=, d_parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
     const Real y = prob_lo[1] + (j + 0.5) * dx[1];
@@ -165,24 +165,24 @@ Problem::init_custom_pert(
                                : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the x-velocity
-    x_vel_pert(i, j, k) = parms.U_0;
-    if ((z <= parms.pert_ref_height) && (parms.U_0_Pert_Mag != 0.0))
+    x_vel_pert(i, j, k) = d_parms.U_0;
+    if ((z <= d_parms.pert_ref_height) && (d_parms.U_0_Pert_Mag != 0.0))
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real x_vel_prime = (rand_double*2.0 - 1.0)*parms.U_0_Pert_Mag;
+        Real x_vel_prime = (rand_double*2.0 - 1.0)*d_parms.U_0_Pert_Mag;
         x_vel_pert(i, j, k) += x_vel_prime;
     }
-    if (parms.pert_deltaU != 0.0)
+    if (d_parms.pert_deltaU != 0.0)
     {
         const amrex::Real yl = y - prob_lo[1];
-        const amrex::Real zl = z / parms.pert_ref_height;
+        const amrex::Real zl = z / d_parms.pert_ref_height;
         const amrex::Real damp = std::exp(-0.5 * zl * zl);
-        x_vel_pert(i, j, k) += parms.ufac * damp * z * std::cos(parms.aval * yl);
+        x_vel_pert(i, j, k) += d_parms.ufac * damp * z * std::cos(d_parms.aval * yl);
     }
   });
 
   // Set the y-velocity
-  ParallelForRNG(ybx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(ybx, [=, d_parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
     const Real x = prob_lo[0] + (i + 0.5) * dx[0];
@@ -191,24 +191,24 @@ Problem::init_custom_pert(
                                : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the y-velocity
-    y_vel_pert(i, j, k) = parms.V_0;
-    if ((z <= parms.pert_ref_height) && (parms.V_0_Pert_Mag != 0.0))
+    y_vel_pert(i, j, k) = d_parms.V_0;
+    if ((z <= d_parms.pert_ref_height) && (d_parms.V_0_Pert_Mag != 0.0))
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real y_vel_prime = (rand_double*2.0 - 1.0)*parms.V_0_Pert_Mag;
+        Real y_vel_prime = (rand_double*2.0 - 1.0)*d_parms.V_0_Pert_Mag;
         y_vel_pert(i, j, k) += y_vel_prime;
     }
-    if (parms.pert_deltaV != 0.0)
+    if (d_parms.pert_deltaV != 0.0)
     {
         const amrex::Real xl = x - prob_lo[0];
-        const amrex::Real zl = z / parms.pert_ref_height;
+        const amrex::Real zl = z / d_parms.pert_ref_height;
         const amrex::Real damp = std::exp(-0.5 * zl * zl);
-        y_vel_pert(i, j, k) += parms.vfac * damp * z * std::cos(parms.bval * xl);
+        y_vel_pert(i, j, k) += d_parms.vfac * damp * z * std::cos(d_parms.bval * xl);
     }
   });
 
   // Set the z-velocity
-  ParallelForRNG(zbx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(zbx, [=, d_parms=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const int dom_lo_z = geomdata.Domain().smallEnd()[2];
     const int dom_hi_z = geomdata.Domain().bigEnd()[2];
 
@@ -217,11 +217,11 @@ Problem::init_custom_pert(
     {
         z_vel_pert(i, j, k) = 0.0;
     }
-    else if (parms.W_0_Pert_Mag != 0.0)
+    else if (d_parms.W_0_Pert_Mag != 0.0)
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real z_vel_prime = (rand_double*2.0 - 1.0)*parms.W_0_Pert_Mag;
-        z_vel_pert(i, j, k) = parms.W_0 + z_vel_prime;
+        Real z_vel_prime = (rand_double*2.0 - 1.0)*d_parms.W_0_Pert_Mag;
+        z_vel_pert(i, j, k) = d_parms.W_0 + z_vel_prime;
     }
   });
 }

--- a/Exec/RegTests/Bubble/prob.cpp
+++ b/Exec/RegTests/Bubble/prob.cpp
@@ -424,6 +424,9 @@ Problem::init_custom_pert(
                         omn = std::max(0.0,std::min(1.0,(T-tbgmin)*a_bg));
                     } else if(moisture_type == 2) {
                         omn = 1.0;
+                    } else {
+                        omn = 0.0;
+                        Abort("Bubble/prob.cpp: invalid moisture type specified");
                     }
                     Real qn  = state_pert(i, j, k, RhoQ2_comp);
                     state_pert(i, j, k, RhoQ2_comp) = qn * omn;

--- a/Exec/RegTests/WitchOfAgnesi/prob.cpp
+++ b/Exec/RegTests/WitchOfAgnesi/prob.cpp
@@ -51,7 +51,7 @@ Problem::init_custom_pert (
 
     AMREX_ALWAYS_ASSERT(bx.length()[2] == khi+1);
 
-    amrex::ParallelFor(bx, [=, parms=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Set scalar = 0 everywhere
         state_pert(i, j, k, RhoScalar_comp) = 0.0;

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -408,6 +408,7 @@ MOSTAverage::set_norm_indices_T()
                     if (z_target > z_lo && z_target < z_hi){
                         AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
                                                   "K index must be larger than averaging radius!");
+                        amrex::ignore_unused(d_radius);
                         k_arr(i,j,k) = lk;
                         break;
                     }

--- a/Source/Microphysics/SAM/Precip.cpp
+++ b/Source/Microphysics/SAM/Precip.cpp
@@ -48,7 +48,6 @@ SAM::Precip (const SolverChoice& sc)
 
     // get the temperature, dentisy, theta, qt and qp from input
     for ( MFIter mfi(*(mic_fab_vars[MicVar::tabs]),TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        auto rho_array   = mic_fab_vars[MicVar::rho]->array(mfi);
         auto theta_array = mic_fab_vars[MicVar::theta]->array(mfi);
         auto tabs_array  = mic_fab_vars[MicVar::tabs]->array(mfi);
         auto pres_array  = mic_fab_vars[MicVar::pres]->array(mfi);
@@ -235,5 +234,3 @@ SAM::Precip (const SolverChoice& sc)
         });
     }
 }
-
-

--- a/Source/SourceTerms/ERF_make_sources.cpp
+++ b/Source/SourceTerms/ERF_make_sources.cpp
@@ -70,8 +70,8 @@ void make_sources (int level,
     // *****************************************************************************
     // Planar averages for subsidence terms
     // *****************************************************************************
-    Table1D<Real>      dptr_r_plane, dptr_t_plane, dptr_qv_plane, dptr_qc_plane;
-    TableData<Real, 1>  r_plane_tab,  t_plane_tab,  qv_plane_tab,  qc_plane_tab;
+    Table1D<Real>      dptr_r_plane, dptr_t_plane, dptr_qv_plane;
+    TableData<Real, 1>  r_plane_tab,  t_plane_tab,  qv_plane_tab;
     if (dptr_wbar_sub)
     {
         // Rho

--- a/Source/prob_common.H
+++ b/Source/prob_common.H
@@ -398,6 +398,7 @@ public:
                     }
                 }
                 AMREX_ASSERT_WITH_MESSAGE(found, "Location read from terrain file does not match the grid!");
+                amrex::ignore_unused(found);
                 z_arr(i,j,klo) = zloc;
             });
         }


### PR DESCRIPTION
Follow up from #1685. Extends warnings checks to all CI workflows except windows (due to some annoyances there),

HIP test will fail until changes in [e1200d0](https://github.com/erf-model/ERF/pull/1687/commits/e1200d059675c3376484b88f22e0fb5efc715963) are extended to all prob files.