### PR TITLE
Fix NumDiff with substepping and add a vertical option.

### DIFF
--- a/Source/SourceTerms/NumericalDiffusion.H
+++ b/Source/SourceTerms/NumericalDiffusion.H
@@ -16,4 +16,12 @@ void NumericalDiffusion (const amrex::Box& bx,
                          const amrex::Array4<const amrex::Real>& mf_y,
                          const bool avg_mf_x_y,
                          const bool avg_mf_y_x);
+
+void NumericalDiffusionVert (const amrex::Box& bx,
+                             const int start_comp,
+                             const int num_comp,
+                             const amrex::Real dt,
+                             const amrex::Real num_diff_coeff,
+                             const amrex::Array4<const amrex::Real>& data,
+                             const amrex::Array4<      amrex::Real>& rhs);
 #endif

--- a/Source/TimeIntegration/TI_fast_rhs_fun.H
+++ b/Source/TimeIntegration/TI_fast_rhs_fun.H
@@ -167,7 +167,16 @@ auto fast_rhs_fun = [&](int fast_step, int /*n_sub*/, int nrk,
 
         // Even if we update all the conserved variables we don't need
         // to fillpatch the slow ones every acoustic substep
-        int ng_cons    = 1;
-        int ng_vel     = 1;
+
+        // NOTE: Numerical diffusion is tested on in FillPatchIntermediate and dictates the size of the
+        //       box over which VelocityToMomentum is computed. V2M requires one more ghost cell be
+        //       filled for rho than velocity. This logical condition ensures we fill enough ghost cells
+        //       when use_NumDiff is true.
+        int ng_cons = S_data[IntVars::cons].nGrowVect().max();
+        int ng_vel  = S_data[IntVars::xmom].nGrowVect().max();
+        if (!solverChoice.use_NumDiff) {
+            ng_cons = 2;
+            ng_vel  = 1;
+        }
         apply_bcs(S_data, new_substep_time, ng_cons, ng_vel, fast_only=true, vel_and_mom_synced=false);
     };


### PR DESCRIPTION
The numerical diffusion option did not work with substepping due to an erroneous arithmetic operation. The root cause of the issue was an inconsistency between the number of ghost cells filled after the fast integrator and the number of ghost cells operated on by `VelocityToMomentum`. This PR corrects that issue (tested in DEBUG with `Exec/ABL/inputs_numdiff`. Additionally, a vertical numerical diffusion function was added for potential testing with the BOMEX simulation (no direct plugin yet).  