### PR TITLE
Fix regtests with Real BCs and correct a bug

### DIFF
--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -174,7 +174,7 @@ ERF::FillPatch (int lev, Real time,
 #ifdef ERF_USE_NETCDF
     // We call this here because it is an ERF routine
     if (use_real_bcs && (lev==0)) {
-        fill_from_realbdy(mfs_vel,time,false,0,ncomp_cons);
+        fill_from_realbdy(mfs_vel,time,false,icomp_cons,ncomp_cons);
     }
 #endif
 
@@ -398,7 +398,7 @@ ERF::FillIntermediatePatch (int lev, Real time,
 #ifdef ERF_USE_NETCDF
     // We call this here because it is an ERF routine
     if (use_real_bcs && (lev==0)) {
-        fill_from_realbdy(mfs_vel,time,false,0,ncomp_cons);
+        fill_from_realbdy(mfs_vel,time,false,icomp_cons,ncomp_cons);
     }
 #endif
 

--- a/Source/TimeIntegration/TI_fast_rhs_fun.H
+++ b/Source/TimeIntegration/TI_fast_rhs_fun.H
@@ -172,10 +172,10 @@ auto fast_rhs_fun = [&](int fast_step, int /*n_sub*/, int nrk,
         //       box over which VelocityToMomentum is computed. V2M requires one more ghost cell be
         //       filled for rho than velocity. This logical condition ensures we fill enough ghost cells
         //       when use_NumDiff is true.
-        int ng_cons = S_data[IntVars::cons].nGrowVect().max();
+        int ng_cons = S_data[IntVars::cons].nGrowVect().max() - 1;
         int ng_vel  = S_data[IntVars::xmom].nGrowVect().max();
         if (!solverChoice.use_NumDiff) {
-            ng_cons = 2;
+            ng_cons = 1;
             ng_vel  = 1;
         }
         apply_bcs(S_data, new_substep_time, ng_cons, ng_vel, fast_only=true, vel_and_mom_synced=false);


### PR DESCRIPTION
The previous PR that corrected issues with numerical diffusion provided some conflicts with cases that use Real BCs. The end of the fast integrator will call `apply_bcs` which will fill the fast conserved vars. It will first fill `rho` with `std::max(ng_cons,ng_vel+1)` ghost cells. So this operation will occur over all the `rho` ghost cells. The second call to `FillIntermediatePatch` but uses `ng_cons` directly. By using `ng_cons=ng_cons_tot-1` we have an overhead savings since `rhoTheta` is not needed in the last ghost cell since it is not used to convert `VelocityToMomentum`.

However, numerical diffusion still did not work with the Real BC case after correcting the `ng_cons` size. The root cause of this was found to be a bug in `FillPatchIntermediate` where the `fill_from_realbdy` call was not aware of the starting component `icomp_cons`. Since this value was hard-coded to `0` we always filled `rho` rather than filling `rho` in the first `FillPatchIntermediate` call and then `rhoTheta` in the second. Numerical diffusion now works after this correction. A remake of the benchmarks is expected.