### PR TITLE
Lmask with MetGrid

### DIFF
--- a/Source/Initialization/ERF_init_from_metgrid.cpp
+++ b/Source/Initialization/ERF_init_from_metgrid.cpp
@@ -172,6 +172,7 @@ ERF::init_from_metgrid (int lev)
     } else {
         for (int it = 0; it < ntimes; ++it) sst_lev[lev][it] = nullptr;
     }
+
     if (flag_lmask[0]) {
         for (int it = 0; it < ntimes; ++it) {
             lmask_lev[lev][it] = std::make_unique<iMultiFab>(ba2d,dm,1,ngv);
@@ -190,9 +191,7 @@ ERF::init_from_metgrid (int lev)
             }
             lmask_lev[lev][it]->FillBoundary(geom[lev].periodicity());
         }
-    } else {
-        for (int it = 0; it < ntimes; ++it) lmask_lev[lev][it] = nullptr;
-    }
+
     lat_m[lev] = std::make_unique<MultiFab>(ba2d,dm,1,ngv);
     for ( MFIter mfi(*(lat_m[lev]), TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         Box gtbx = mfi.growntilebox();
@@ -207,6 +206,7 @@ ERF::init_from_metgrid (int lev)
             dst_arr(i,j,0) = src_arr(li,lj,0);
         });
     }
+
     lon_m[lev] = std::make_unique<MultiFab>(ba2d,dm,1,ngv);
     for ( MFIter mfi(*(lon_m[lev]), TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
         Box gtbx = mfi.growntilebox();


### PR DESCRIPTION
Lmask is defaulted to 1 now in `make_array`, do not overwrite the ptr to this data since it will break MOST.