### PR TITLE
Diffusion stencil w/ Dirichlet BC

### DIFF
--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -236,9 +236,9 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                                          - 3. * cell_prim(i, j, k  , prim_index)
-                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                                          - 3. * cell_prim(i, j, k-1, prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
@@ -303,9 +303,9 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                                          - 3. * cell_prim(i, j, k  , prim_index)
-                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                                          - 3. * cell_prim(i, j, k-1, prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
@@ -366,9 +366,9 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                                          - 3. * cell_prim(i, j, k  , prim_index)
-                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                                          - 3. * cell_prim(i, j, k-1, prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
@@ -428,9 +428,9 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                                          - 3. * cell_prim(i, j, k  , prim_index)
-                                                     + (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                                          - 3. * cell_prim(i, j, k-1, prim_index)
+                                                     + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -262,9 +262,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                         + 3. * cell_prim(i, j, k  , prim_index)
                                    - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                        - 3. * cell_prim(i, j, k  , prim_index)
-                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                        - 3. * cell_prim(i, j, k-1, prim_index)
+                                   + (1./3.) * cell_prim(i, j, k-2, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -337,9 +337,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                         + 3. * cell_prim(i, j, k  , prim_index)
                                    - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                        - 3. * cell_prim(i, j, k  , prim_index)
-                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                        - 3. * cell_prim(i, j, k-1, prim_index)
+                                   + (1./3.) * cell_prim(i, j, k-2, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -409,9 +409,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                         + 3. * cell_prim(i, j, k  , prim_index)
                                    - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                        - 3. * cell_prim(i, j, k  , prim_index)
-                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                        - 3. * cell_prim(i, j, k-1, prim_index)
+                                   + (1./3.) * cell_prim(i, j, k-2, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -480,9 +480,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                         + 3. * cell_prim(i, j, k  , prim_index)
                                    - (1./3.) * cell_prim(i, j, k+1, prim_index) );
             } else if (ext_dir_on_zhi) {
-                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k-1, prim_index)
-                                        - 3. * cell_prim(i, j, k  , prim_index)
-                                   + (1./3.) * cell_prim(i, j, k+1, prim_index) );
+                GradCz = dz_inv * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                                        - 3. * cell_prim(i, j, k-1, prim_index)
+                                   + (1./3.) * cell_prim(i, j, k-2, prim_index) );
             } else {
                 GradCz = dz_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }


### PR DESCRIPTION
This PR fixes the special diffusion stencil when a Dirichlet boundary is present. The original code correctly flipped the sign of the stencil weights but it did not shift the indexing of the data appropriately. The full derivation for the `zhi` case is given below and shows that when we are at the `zhi face` we should be using the `k, k-1, and k-2` data, where the `k` data technically lives `1/2 dz` above the top boundary but we use it as if it lives right at the face.
![image](https://github.com/user-attachments/assets/99ea7001-550c-4921-a223-bea8bfdecd43)
