### PR TITLE
MOST Rotations w/ Terrain

### DIFF
--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -70,6 +70,10 @@ public:
             amrex::Abort("Undefined MOST flux type!");
         }
 
+        // Check if we do stress rotations for terrain
+        pp.query("most.terrain_rotate",m_rotate);
+        if (m_rotate) AMREX_ASSERT_WITH_MESSAGE((z_phys_nd[0].get()), "Stress rotations are only valid with terrain!");
+
         // Get surface temperature
         auto erf_st = pp.query("most.surf_temp", surf_temp);
 
@@ -252,6 +256,7 @@ public:
                      amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
                      amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
                      amrex::MultiFab* heat_flux,
+                     amrex::MultiFab* qv_flux,
                      amrex::MultiFab* z_phys);
 
     template<typename FluxCalc>
@@ -261,6 +266,7 @@ public:
                       amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
                       amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
                       amrex::MultiFab* heat_flux,
+                      amrex::MultiFab* qv_flux,
                       amrex::MultiFab* z_phys,
                       const amrex::Real& dz_no_terrain,
                       const FluxCalc& flux_comp);
@@ -316,6 +322,8 @@ public:
     const amrex::FArrayBox*
     get_z0 (const int& lev) {return &z_0[lev];}
 
+
+
     enum struct FluxCalcType {
         MOENG = 0,      ///< Moeng functional form
         DONELAN,        ///< Donelan functional form
@@ -343,6 +351,7 @@ public:
 private:
     bool use_moisture;
     bool m_exp_most = false;
+    bool m_rotate   = false;
     amrex::Real z0_const{0.1};
     amrex::Real surf_temp;
     amrex::Real surf_heating_rate{0};
@@ -371,6 +380,8 @@ private:
     amrex::Vector<amrex::MultiFab*>  m_Hwave_lev;
     amrex::Vector<amrex::MultiFab*>  m_Lwave_lev;
     amrex::Vector<amrex::MultiFab*>  m_eddyDiffs_lev;
+
+    amrex::Array2D<amrex::Real,0,2,0,2> m_rot_mat;
 };
 
 #endif /* ABLMOST_H */

--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -381,7 +381,7 @@ private:
     amrex::Vector<amrex::MultiFab*>  m_Lwave_lev;
     amrex::Vector<amrex::MultiFab*>  m_eddyDiffs_lev;
 
-    amrex::Array2D<amrex::Real,0,2,0,2> m_rot_mat;
+    //amrex::Array2D<amrex::Real,0,2,0,2> m_rot_mat;
 };
 
 #endif /* ABLMOST_H */

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -420,6 +420,7 @@ ERF::FillIntermediatePatch (int lev, Real time,
                                 Tau13_lev[lev].get(), Tau31_lev[lev].get(),
                                 Tau23_lev[lev].get(), Tau32_lev[lev].get(),
                                 SFS_hfx3_lev[lev].get(),
+                                SFS_q1fx3_lev[lev].get(),
                                 z_phys_nd[lev].get());
     }
 

--- a/Source/BoundaryConditions/MOSTAverage.H
+++ b/Source/BoundaryConditions/MOSTAverage.H
@@ -30,7 +30,7 @@ public:
 
     // Delete the copy constructor
     MOSTAverage (const MOSTAverage& other) = delete;
-    //
+
     // Delete the copy assignment operator
     MOSTAverage& operator=(const MOSTAverage& other) = delete;
 
@@ -39,6 +39,9 @@ public:
                             amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
                             amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
                             amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim);
+
+    // Update the rotated fields
+    void set_rotated_fields (int lev);
 
     // Compute ncells per plane
     void set_plane_normalization ();
@@ -167,10 +170,11 @@ protected:
 
     // General vars for multiple or all policies
     //--------------------------------------------
-    int m_nvar{4};                                                   // 4 fields for U/V/T/Qv
-    int m_navg{5};                                                   // 5 averages for U/V/T/Qv/Umag
-    int m_maxlev{0};                                                 // Total number of levels
-    int m_policy{0};                                                 // Policy for type of averaging
+    int  m_nvar{5};                                                  // 5 fields for U/V/T/Qv/W
+    int  m_navg{5};                                                  // 5 averages for U/V/T/Qv/Umag
+    int  m_maxlev{0};                                                // Total number of levels
+    int  m_policy{0};                                                // Policy for type of averaging
+    bool m_rotate{false};                                            // Do vector rotations for terrain?
     amrex::Real m_zref{10.0};                                        // Height above surface for MOST BC
     std::string m_pp_prefix {"erf"};                                 // ParmParse prefix
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_x_pos;         // Ptr to 2D mf to hold x position (maxlev)
@@ -180,6 +184,7 @@ protected:
     amrex::Vector<std::unique_ptr<amrex::iMultiFab>> m_j_indx;       // Ptr to 2D imf to hold j indices (maxlev)
     amrex::Vector<std::unique_ptr<amrex::iMultiFab>> m_k_indx;       // Ptr to 2D imf to hold k indices (maxlev)
     amrex::Vector<amrex::Vector<std::unique_ptr<amrex::MultiFab>>> m_averages; // Ptr to 2D mf to hold averages (maxlev,navg)
+    amrex::Vector<amrex::Vector<std::unique_ptr<amrex::MultiFab>>> m_rot_fields; // Rotated field data
 
     // Vars for planar average policy
     //--------------------------------------------

--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -24,18 +24,21 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
     ParmParse pp(m_pp_prefix);
     pp.query("most.radius",m_radius);
     pp.query("most.time_average",m_t_avg);
+    pp.query("most.terrain_rotate",m_rotate);
     pp.query("most.average_policy",m_policy);
     pp.query("most.use_interpolation",m_interp);
     pp.query("most.use_normal_vector",m_norm_vec);
 
     AMREX_ASSERT_WITH_MESSAGE(m_radius<=2, "Radius must be less than nGhost=3!");
     if (m_interp) AMREX_ASSERT_WITH_MESSAGE((z_phys_nd[0].get()), "Interpolation only implemented with terrain!");
+    if (m_rotate) AMREX_ASSERT_WITH_MESSAGE((z_phys_nd[0].get()), "Stress rotations are only valid with terrain!");
 
     // Set up fields and 2D MF/iMFs for averages
     //--------------------------------------------------------
     m_maxlev = m_geom.size();
 
     m_fields.resize(m_maxlev);
+    m_rot_fields.resize(m_maxlev);
     m_averages.resize(m_maxlev);
     m_z_phys_nd.resize(m_maxlev);
 
@@ -52,48 +55,61 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
 
     for (int lev(0); lev < m_maxlev; lev++) {
       m_fields[lev].resize(m_nvar);
+      m_rot_fields[lev].resize(m_nvar-1);
       m_averages[lev].resize(m_navg);
       m_z_phys_nd[lev] = z_phys_nd[lev].get();
       { // Nodal in x
-        auto& mf  = vars_old[lev][Vars::xvel];
-        // Create a 2D ba, dm, & ghost cells
-        const BoxArray& ba  = mf.boxArray();
-        BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) b.setRange(2,0);
-        BoxArray ba2d(std::move(bl2d));
-        const DistributionMapping& dm = mf.DistributionMap();
-        const int ncomp   = 1;
-        IntVect ng = mf.nGrowVect(); ng[2]=0;
+          auto& mf = vars_old[lev][Vars::xvel];
+          // Create a 2D ba, dm, & ghost cells
+          const BoxArray& ba = mf.boxArray();
+          BoxList bl2d = ba.boxList();
+          for (auto& b : bl2d) b.setRange(2,0);
+          BoxArray ba2d(std::move(bl2d));
+          const DistributionMapping& dm = mf.DistributionMap();
+          const int ncomp = 1;
+          IntVect ng = mf.nGrowVect(); ng[2]=0;
 
-          m_fields[lev][0]   = &vars_old[lev][Vars::xvel];
+            m_fields[lev][0] = &vars_old[lev][Vars::xvel];
           m_averages[lev][0] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
-        m_averages[lev][0]->setVal(1.E34);
+          m_averages[lev][0]->setVal(1.E34);
+          if (m_rotate) {
+              m_rot_fields[lev][0] = std::make_unique<MultiFab>(ba,dm,ncomp,ng);
+              MultiFab::Copy(*m_rot_fields[lev][0],vars_old[lev][Vars::xvel],0,0,1,ng);
+          } else {
+              m_rot_fields[lev][0] = nullptr;
+          }
       }
       { // Nodal in y
-        auto& mf  = vars_old[lev][Vars::yvel];
-        // Create a 2D ba, dm, & ghost cells
-        const BoxArray& ba  = mf.boxArray();
-        BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) b.setRange(2,0);
-        BoxArray ba2d(std::move(bl2d));
-        const DistributionMapping& dm = mf.DistributionMap();
-        const int ncomp   = 1;
-        IntVect ng = mf.nGrowVect(); ng[2]=0;
+          auto& mf  = vars_old[lev][Vars::yvel];
+          // Create a 2D ba, dm, & ghost cells
+          const BoxArray& ba = mf.boxArray();
+          BoxList bl2d = ba.boxList();
+          for (auto& b : bl2d) b.setRange(2,0);
+          BoxArray ba2d(std::move(bl2d));
+          const DistributionMapping& dm = mf.DistributionMap();
+          const int ncomp = 1;
+          IntVect ng = mf.nGrowVect(); ng[2]=0;
 
-          m_fields[lev][1] = &vars_old[lev][Vars::yvel];
-        m_averages[lev][1] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
-        m_averages[lev][1]->setVal(1.E34);
+            m_fields[lev][1] = &vars_old[lev][Vars::yvel];
+          m_averages[lev][1] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
+          m_averages[lev][1]->setVal(1.E34);
+          if (m_rotate) {
+              m_rot_fields[lev][1] = std::make_unique<MultiFab>(ba,dm,ncomp,ng);
+              MultiFab::Copy(*m_rot_fields[lev][1],vars_old[lev][Vars::yvel],0,0,1,ng);
+          } else {
+              m_rot_fields[lev][1] = nullptr;
+          }
       }
       { // CC vars
         auto& mf  = *Theta_prim[lev];
         // Create a 2D ba, dm, & ghost cells
-        const BoxArray& ba  = mf.boxArray();
+        const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
         for (auto& b : bl2d) b.setRange(2,0);
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
-        const int ncomp   = 1;
-        const int incomp  = 1;
+        const int ncomp  = 1;
+        const int incomp = 1;
         IntVect ng = mf.nGrowVect(); ng[2]=0;
 
           m_fields[lev][2] = Theta_prim[lev].get();
@@ -106,6 +122,16 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
 
         m_averages[lev][4] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
         m_averages[lev][4]->setVal(1.E34);
+
+        if (m_rotate) {
+            m_rot_fields[lev][2] = std::make_unique<MultiFab>(ba,dm,ncomp,ng);
+            m_rot_fields[lev][3] = std::make_unique<MultiFab>(ba,dm,ncomp,ng);
+            MultiFab::Copy(*m_rot_fields[lev][2],*Theta_prim[lev],0,0,1,ng);
+            if (Qv_prim[lev]) MultiFab::Copy(*m_rot_fields[lev][3],   *Qv_prim[lev],0,0,1,ng);
+        } else {
+            m_rot_fields[lev][2] = nullptr;
+            m_rot_fields[lev][3] = nullptr;
+        }
 
         if (m_z_phys_nd[0] && m_norm_vec && m_interp) {
             m_x_pos[lev] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
@@ -123,6 +149,8 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
             m_k_indx[lev] = std::make_unique<iMultiFab>(ba2d,dm,incomp,ng);
         }
       }
+      // Nodal in z (only used with terrain stress rotations)
+      m_fields[lev][4] = &vars_old[lev][Vars::zvel];
     } // lev
 
     // Setup auxiliary data for spatial configuration & policy
@@ -178,24 +206,84 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
  * @param[in] Theta_prim Primitive theta component at each level
  */
 void
-MOSTAverage::update_field_ptrs(int lev,
-                               Vector<Vector<MultiFab>>& vars_old,
-                               Vector<std::unique_ptr<MultiFab>>& Theta_prim,
-                               Vector<std::unique_ptr<MultiFab>>& Qv_prim)
+MOSTAverage::update_field_ptrs (int lev,
+                                Vector<Vector<MultiFab>>& vars_old,
+                                Vector<std::unique_ptr<MultiFab>>& Theta_prim,
+                                Vector<std::unique_ptr<MultiFab>>& Qv_prim)
 {
     m_fields[lev][0] = &vars_old[lev][Vars::xvel];
     m_fields[lev][1] = &vars_old[lev][Vars::yvel];
     m_fields[lev][2] = Theta_prim[lev].get();
     m_fields[lev][3] = Qv_prim[lev].get();
+    m_fields[lev][4] = &vars_old[lev][Vars::zvel];
 }
 
+
+/**
+ * Function to set the rotated velocities.
+ *
+ */
+void
+MOSTAverage::set_rotated_fields (int lev)
+{
+    // Peel back the level
+    auto& fields     = m_fields[lev];
+    auto& rot_fields = m_rot_fields[lev];
+    auto  z_phys_nd  = m_z_phys_nd[lev];
+
+    // Inverse grid size
+    const auto dxInv = m_geom[lev].InvCellSizeArray();
+
+    // Single MFIter over CC data
+    int imf_cc = 2;
+
+    // Populate rotated U & V for terrain
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(*fields[imf_cc], TileNoZ()); mfi.isValid(); ++mfi) {
+        Box ubx = mfi.tilebox(IntVect(1,0,0));
+        Box vbx = mfi.tilebox(IntVect(0,1,0));
+
+        const Array4<const Real>& z_phys_arr = z_phys_nd->const_array(mfi);
+
+        const Array4<const Real>& u_arr = fields[0]->const_array(mfi);
+        const Array4<const Real>& v_arr = fields[1]->const_array(mfi);
+        const Array4<const Real>& w_arr = fields[4]->const_array(mfi);
+
+        const Array4<Real>& u_rot_arr = rot_fields[0]->array(mfi);
+        const Array4<Real>& v_rot_arr = rot_fields[1]->array(mfi);
+
+        // U rotated magnitude
+        ParallelFor(ubx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            // Elements of first tangent vector
+            Real met_h_xi    = Compute_h_xi_AtIface(i,j,k,dxInv,z_phys_arr);
+            u_rot_arr(i,j,k) = (u_arr(i,j,k) + met_h_xi*w_arr(i,j,k))
+                             / std::sqrt(met_h_xi*met_h_xi + 1.0);
+        });
+
+        // V rotated magnitude
+        ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            // Elements of second tangent vector
+            Real met_h_eta   = Compute_h_eta_AtJface(i,j,k,dxInv,z_phys_arr);
+            v_rot_arr(i,j,k) = (v_arr(i,j,k) + met_h_eta*w_arr(i,j,k))
+                             / std::sqrt(met_h_eta*met_h_eta + 1.0);
+        });
+    }
+
+    // Direct copy of other scalar variables
+    MultiFab::Copy(*rot_fields[2],*fields[2],0,0,1,rot_fields[2]->nGrowVect());
+    if (fields[3]) MultiFab::Copy(*rot_fields[3],*fields[3],0,0,1,rot_fields[3]->nGrowVect());
+}
 
 /**
  * Function to compute normalization for plane average.
  *
  */
 void
-MOSTAverage::set_plane_normalization()
+MOSTAverage::set_plane_normalization ()
 {
     // Cells per plane and temp avg storage
     m_ncell_plane.resize(m_maxlev);
@@ -240,7 +328,7 @@ MOSTAverage::set_plane_normalization()
  *
  */
 void
-MOSTAverage::set_k_indices_N()
+MOSTAverage::set_k_indices_N ()
 {
     ParmParse pp(m_pp_prefix);
     auto read_z = pp.query("most.zref",m_zref);
@@ -299,7 +387,7 @@ MOSTAverage::set_k_indices_N()
  *
  */
 void
-MOSTAverage::set_k_indices_T()
+MOSTAverage::set_k_indices_T ()
 {
     ParmParse pp(m_pp_prefix);
     auto read_z = pp.query("most.zref",m_zref);
@@ -356,7 +444,7 @@ MOSTAverage::set_k_indices_T()
  *
  */
 void
-MOSTAverage::set_norm_indices_T()
+MOSTAverage::set_norm_indices_T ()
 {
     ParmParse pp(m_pp_prefix);
     pp.get("most.zref",m_zref);
@@ -429,7 +517,7 @@ MOSTAverage::set_norm_indices_T()
  *
  */
 void
-MOSTAverage::set_z_positions_T()
+MOSTAverage::set_z_positions_T ()
 {
     ParmParse pp(m_pp_prefix);
     pp.get("most.zref",m_zref);
@@ -475,7 +563,7 @@ MOSTAverage::set_z_positions_T()
  *
  */
 void
-MOSTAverage::set_norm_positions_T()
+MOSTAverage::set_norm_positions_T ()
 {
     ParmParse pp(m_pp_prefix);
     pp.get("most.zref",m_zref);
@@ -537,8 +625,10 @@ MOSTAverage::set_norm_positions_T()
  * @param[in] lev Current level
  */
 void
-MOSTAverage::compute_averages(int lev)
+MOSTAverage::compute_averages (int lev)
 {
+    if (m_rotate) set_rotated_fields(lev);
+
     switch(m_policy) {
     case 0: // Standard plane average
         compute_plane_averages(lev);
@@ -561,11 +651,12 @@ MOSTAverage::compute_averages(int lev)
  * @param[in] lev Current level
  */
 void
-MOSTAverage::compute_plane_averages(int lev)
+MOSTAverage::compute_plane_averages (int lev)
 {
     // Peel back the level
-    auto& fields   = m_fields[lev];
-    auto& averages = m_averages[lev];
+    auto& fields      = m_fields[lev];
+    auto& rot_fields  = m_rot_fields[lev];
+    auto& averages    = m_averages[lev];
     const auto & geom = m_geom[lev];
 
     auto& z_phys   = m_z_phys_nd[lev];
@@ -607,7 +698,7 @@ MOSTAverage::compute_plane_averages(int lev)
         if (geom.isPeriodic(idim)) is_per[idim] = 1;
     }
 
-    for (int imf(0); imf < m_nvar; ++imf) {
+    for (int imf(0); imf < (m_nvar-1); ++imf) {
 
         // Continue if no valid Qv pointer
         if (!fields[imf]) continue;
@@ -635,7 +726,8 @@ MOSTAverage::compute_plane_averages(int lev)
                 }
             }
 
-            auto mf_arr = fields[imf]->const_array(mfi);
+            auto mf_arr = (m_rotate) ? rot_fields[imf]->const_array(mfi) :
+                                           fields[imf]->const_array(mfi);
 
             if (m_interp) {
                 const auto plo   = geom.ProbLoArray();
@@ -691,8 +783,10 @@ MOSTAverage::compute_plane_averages(int lev)
             pbx.setSmall(2,0); pbx.setBig(2,0);
 
             // Last element is Umag and always cell centered
-            auto u_mf_arr = fields[imf  ]->const_array(mfi);
-            auto v_mf_arr = fields[imf+1]->const_array(mfi);
+            auto u_mf_arr = (m_rotate) ? rot_fields[imf  ]->const_array(mfi) :
+                                             fields[imf  ]->const_array(mfi);
+            auto v_mf_arr = (m_rotate) ? rot_fields[imf+1]->const_array(mfi) :
+                                             fields[imf+1]->const_array(mfi);
 
             if (m_interp) {
                 const auto plo   = m_geom[lev].ProbLoArray();
@@ -751,12 +845,13 @@ MOSTAverage::compute_plane_averages(int lev)
  * @param[in] lev Current level
  */
 void
-MOSTAverage::compute_region_averages(int lev)
+MOSTAverage::compute_region_averages (int lev)
 {
     // Peel back the level
-    auto& fields   = m_fields[lev];
-    auto& averages = m_averages[lev];
-    const auto & geom     = m_geom[lev];
+    auto& fields      = m_fields[lev];
+    auto& rot_fields  = m_rot_fields[lev];
+    auto& averages    = m_averages[lev];
+    const auto & geom = m_geom[lev];
 
     auto& z_phys   = m_z_phys_nd[lev];
     auto& x_pos    = m_x_pos[lev];
@@ -785,7 +880,7 @@ MOSTAverage::compute_region_averages(int lev)
 
     // Averages over all the fields
     //----------------------------------------------------------
-    for (int imf(0); imf < m_nvar; ++imf) {
+    for (int imf(0); imf < (m_nvar-1); ++imf) {
 
         // Continue if no valid Qv pointer
         if (!fields[imf]) continue;
@@ -796,7 +891,8 @@ MOSTAverage::compute_region_averages(int lev)
         for (MFIter mfi(*fields[imf], TileNoZ()); mfi.isValid(); ++mfi) {
             Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
 
-            auto mf_arr = fields[imf]->const_array(mfi);
+            auto mf_arr = (m_rotate) ? rot_fields[imf]->const_array(mfi) :
+                                           fields[imf]->const_array(mfi);
             auto ma_arr = averages[imf]->array(mfi);
 
             if (m_interp) {
@@ -866,8 +962,10 @@ MOSTAverage::compute_region_averages(int lev)
         for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi) {
             Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
 
-            auto u_mf_arr = fields[imf]->const_array(mfi);
-            auto v_mf_arr = fields[imf+1]->const_array(mfi);
+            auto u_mf_arr = (m_rotate) ? rot_fields[imf  ]->const_array(mfi) :
+                                             fields[imf  ]->const_array(mfi);
+            auto v_mf_arr = (m_rotate) ? rot_fields[imf+1]->const_array(mfi) :
+                                             fields[imf+1]->const_array(mfi);
             auto ma_arr   = averages[iavg]->array(mfi);
 
             if (m_interp) {
@@ -975,7 +1073,7 @@ MOSTAverage::compute_region_averages(int lev)
  * @param[in] lev Current level
  */
 void
-MOSTAverage::write_k_indices(int lev)
+MOSTAverage::write_k_indices (int lev)
 {
     // Peel back the level
     auto& averages = m_averages[lev];
@@ -1014,7 +1112,7 @@ MOSTAverage::write_k_indices(int lev)
  * @param[in] lev Current level
  */
 void
-MOSTAverage::write_norm_indices(int lev)
+MOSTAverage::write_norm_indices (int lev)
 {
     // Peel back the level
     auto& averages = m_averages[lev];
@@ -1063,7 +1161,7 @@ MOSTAverage::write_norm_indices(int lev)
  * @param[in] j Index in y-dir
  */
 void
-MOSTAverage::write_xz_positions(int lev, int j)
+MOSTAverage::write_xz_positions (int lev, int j)
 {
     // Peel back the level
     auto& x_pos_mf  = m_x_pos[lev];
@@ -1093,7 +1191,7 @@ MOSTAverage::write_xz_positions(int lev, int j)
  * @param[in] lev Current level
  */
 void
-MOSTAverage::write_averages(int lev)
+MOSTAverage::write_averages (int lev)
 {
     // Peel back the level
     auto& averages = m_averages[lev];

--- a/Source/BoundaryConditions/MOSTStress.H
+++ b/Source/BoundaryConditions/MOSTStress.H
@@ -837,7 +837,7 @@ struct moeng_flux
                     const int& n,
                     const int& icomp,
                     const amrex::Real& dz,
-                    const amrex::Real& /*dz1*/,
+                    const amrex::Real& dz1,
                     const bool& exp_most,
                     const amrex::Array4<const amrex::Real>& eta_arr,
                     const amrex::Array4<const amrex::Real>& cons_arr,
@@ -865,16 +865,21 @@ struct moeng_flux
         amrex::Real moflux  = 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
 
-        if (exp_most) amrex::Abort("Explicit MOST stress not implemented for Moeng moisture flux");
-
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+        if (exp_most) {
+            // surface gradient equal to gradient at first zface
+            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
+                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+        } else {
+            int ie, je;
+            ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
+            je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
+            ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
+            je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
+            eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
+            eta   = amrex::max(eta,eta_eps);
+            dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+        }
 
         return moflux;
     }
@@ -1127,7 +1132,7 @@ struct donelan_flux
                     const int& n,
                     const int& icomp,
                     const amrex::Real& dz,
-                    const amrex::Real& /*dz1*/,
+                    const amrex::Real& dz1,
                     const bool& exp_most,
                     const amrex::Array4<const amrex::Real>& eta_arr,
                     const amrex::Array4<const amrex::Real>& cons_arr,
@@ -1155,16 +1160,21 @@ struct donelan_flux
         amrex::Real moflux  = 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
 
-        if (exp_most) amrex::Abort("Explicit MOST stress not implemented for Donelan moisture flux");
-
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+        if (exp_most) {
+            // surface gradient equal to gradient at first zface
+            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
+                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+        } else {
+            int ie, je;
+            ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
+            je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
+            ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
+            je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
+            eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
+            eta   = amrex::max(eta,eta_eps);
+            dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+        }
 
         return moflux;
     }
@@ -1398,7 +1408,7 @@ struct custom_flux
                     const int& n,
                     const int& icomp,
                     const amrex::Real& dz,
-                    const amrex::Real& /*dz1*/,
+                    const amrex::Real& dz1,
                     const bool& exp_most,
                     const amrex::Array4<const amrex::Real>& eta_arr,
                     const amrex::Array4<const amrex::Real>& cons_arr,
@@ -1425,16 +1435,21 @@ struct custom_flux
         amrex::Real moflux  = (std::abs(qstar) > eps) ? -rho * qstar : 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
 
-        if (exp_most) amrex::Abort("Explicit MOST stress not implemented for custom moisture flux");
-
-        int ie, je;
-        ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
-        je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
-        ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
-        je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-        eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
-        eta   = amrex::max(eta,eta_eps);
-        dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) - moflux*rho/eta*deltaz;
+        if (exp_most) {
+            // surface gradient equal to gradient at first zface
+            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
+                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+        } else {
+            int ie, je;
+            ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
+            je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
+            ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
+            je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
+            eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
+            eta   = amrex::max(eta,eta_eps);
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) - moflux*rho/eta*deltaz;
+        }
 
         return moflux;
     }

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -988,7 +988,7 @@ private:
                                 amrex::Gpu::DeviceVector<amrex::Real>& u_geos_d,
                                 amrex::Vector<amrex::Real>& v_geos,
                                 amrex::Gpu::DeviceVector<amrex::Real>& v_geos_d,
-                                const amrex::Geometry& geom,
+                                const amrex::Geometry& lgeom,
                                 const amrex::Vector<amrex::Real>& zlev_stag);
 
     // This is a vector over levels of vectors across quantities of Vectors

--- a/Source/Initialization/ERF_init1d.cpp
+++ b/Source/Initialization/ERF_init1d.cpp
@@ -411,16 +411,16 @@ void ERF::init_geo_wind_profile(const std::string input_file,
                                 Gpu::DeviceVector<Real>& u_geos_d,
                                 Vector<Real>& v_geos,
                                 Gpu::DeviceVector<Real>& v_geos_d,
-                                const Geometry& geom,
+                                const Geometry& lgeom,
                                 const Vector<Real>& zlev_stag)
 {
     const int klo = 0;
-    const int khi = geom.Domain().bigEnd()[AMREX_SPACEDIM-1];
-    const amrex::Real dz = geom.CellSize()[AMREX_SPACEDIM-1];
+    const int khi = lgeom.Domain().bigEnd()[AMREX_SPACEDIM-1];
+    const amrex::Real dz = lgeom.CellSize()[AMREX_SPACEDIM-1];
 
     const bool grid_stretch = (zlev_stag.size() > 0);
-    const Real zbot = (grid_stretch) ? zlev_stag[klo]   : geom.ProbLo(AMREX_SPACEDIM-1);
-    const Real ztop = (grid_stretch) ? zlev_stag[khi+1] : geom.ProbHi(AMREX_SPACEDIM-1);
+    const Real zbot = (grid_stretch) ? zlev_stag[klo]   : lgeom.ProbLo(AMREX_SPACEDIM-1);
+    const Real ztop = (grid_stretch) ? zlev_stag[khi+1] : lgeom.ProbHi(AMREX_SPACEDIM-1);
 
     amrex::Print() << "Reading geostrophic wind profile from " << input_file << std::endl;
     std::ifstream profile_reader(input_file);


### PR DESCRIPTION
This PR is a first pass at rotating vectors for MOST with terrain. The major change is to create `MultiFabs` in the MOSTAverage class and populate them with the magnitudes that lie in the first and second tangent plane. We then average those values to end up with wind means that are inherently tangent to the surface. The implement of the stress rotations still needs to occur in ABLMost.cpp (this moves stresses from the body-fixed coordinate to the global coordinate).

![image](https://github.com/user-attachments/assets/b490819b-4ffd-443a-b637-527a3c9487a7)
