### PR TITLE
fix bug in windspeed calc for ysu

### DIFF
--- a/Source/Diffusion/PBLModels.cpp
+++ b/Source/Diffusion/PBLModels.cpp
@@ -346,7 +346,7 @@ ComputeTurbulentViscosityPBL (const MultiFab& xvel,
                 while (!above_critical and bx.contains(i,j,kpbl+1)) {
                     kpbl += 1;
                     const Real zval = use_terrain ? Compute_Zrel_AtCellCenter(i,j,kpbl,z_nd_arr) : gdata.ProbLo(2) + (kpbl + 0.5)*gdata.CellSize(2);
-                    const Real ws2_level = (uvel(i,j,kpbl)+uvel(i+1,j,kpbl))*(uvel(i,j,kpbl)+uvel(i+1,j,kpbl)) + (vvel(i,j,kpbl)+vvel(i,j+1,kpbl))*(uvel(i,j,kpbl)+uvel(i,j+1,kpbl));
+                    const Real ws2_level = 0.25*((uvel(i,j,kpbl)+uvel(i+1,j,kpbl))*(uvel(i,j,kpbl)+uvel(i+1,j,kpbl)) + (vvel(i,j,kpbl)+vvel(i,j+1,kpbl))*(uvel(i,j,kpbl)+uvel(i,j+1,kpbl)));
                     const Real theta = cell_data(i,j,kpbl,RhoTheta_comp) / cell_data(i,j,kpbl,Rho_comp);
                     Rib_dn = Rib_up;
                     Rib_up = (theta-base_theta)/base_theta * CONST_GRAV * zval / ws2_level;


### PR DESCRIPTION
With this bug fix, the YSU results are now qualitatively reasonable for the GABLS1 case. Agreement can be further improved by setting the critical bulk Richardson number over land to 0.2 from the value in WRF of 0.25. Further testing needed to determine whether the remaining disagreement is due to an outstanding bug, model coefficient tuning, or is merely the expected variation between models.

![windspeed](https://github.com/user-attachments/assets/18455ad7-de20-4908-9b0d-e743aad30e49)

![temperature](https://github.com/user-attachments/assets/3c51db3e-d6dc-4843-aac9-461f5f9c8964)

![fluxes](https://github.com/user-attachments/assets/fcf37637-8970-4c13-b318-482df816d872)
