### PR TITLE
Most Rotation Intermediate Clean Up

### DIFF
--- a/Source/BoundaryConditions/ABLMost.H
+++ b/Source/BoundaryConditions/ABLMost.H
@@ -31,6 +31,7 @@ public:
     // Constructor
     explicit ABLMost (const amrex::Vector<amrex::Geometry>& geom,
                       bool& use_exp_most,
+                      bool& use_rot_most,
                       amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
                       amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
                       amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim,
@@ -45,6 +46,7 @@ public:
                       amrex::Real start_bdy_time = 0.0,
                       amrex::Real bdy_time_interval = 0.0)
     : m_exp_most(use_exp_most),
+      m_rotate(use_rot_most),
       m_start_bdy_time(start_bdy_time),
       m_bdy_time_interval(bdy_time_interval),
       m_geom(geom),
@@ -69,10 +71,6 @@ public:
         } else {
             amrex::Abort("Undefined MOST flux type!");
         }
-
-        // Check if we do stress rotations for terrain
-        pp.query("most.terrain_rotate",m_rotate);
-        if (m_rotate) AMREX_ASSERT_WITH_MESSAGE((z_phys_nd[0].get()), "Stress rotations are only valid with terrain!");
 
         // Get surface temperature
         auto erf_st = pp.query("most.surf_temp", surf_temp);
@@ -253,6 +251,10 @@ public:
     void
     impose_most_bcs (const int& lev,
                      const amrex::Vector<amrex::MultiFab*>& mfs,
+                     amrex::MultiFab* xxmom_flux,
+                     amrex::MultiFab* yymom_flux,
+                     amrex::MultiFab* zzmom_flux,
+                     amrex::MultiFab* xymom_flux, amrex::MultiFab* yxmom_flux,
                      amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
                      amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
                      amrex::MultiFab* heat_flux,
@@ -263,6 +265,10 @@ public:
     void
     compute_most_bcs (const int& lev,
                       const amrex::Vector<amrex::MultiFab*>& mfs,
+                      amrex::MultiFab* xxmom_flux,
+                      amrex::MultiFab* yymom_flux,
+                      amrex::MultiFab* zzmom_flux,
+                      amrex::MultiFab* xymom_flux, amrex::MultiFab* yxmom_flux,
                       amrex::MultiFab* xzmom_flux, amrex::MultiFab* zxmom_flux,
                       amrex::MultiFab* yzmom_flux, amrex::MultiFab* zymom_flux,
                       amrex::MultiFab* heat_flux,

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -417,6 +417,10 @@ ERF::FillIntermediatePatch (int lev, Real time,
     // MOST boundary conditions
     if (!(cons_only && ncomp_cons == 1) && m_most && allow_most_bcs) {
         m_most->impose_most_bcs(lev,mfs_vel,
+                                Tau11_lev[lev].get(),
+                                Tau22_lev[lev].get(),
+                                Tau33_lev[lev].get(),
+                                Tau12_lev[lev].get(), Tau21_lev[lev].get(),
                                 Tau13_lev[lev].get(), Tau31_lev[lev].get(),
                                 Tau23_lev[lev].get(), Tau32_lev[lev].get(),
                                 SFS_hfx3_lev[lev].get(),

--- a/Source/BoundaryConditions/MOSTStress.H
+++ b/Source/BoundaryConditions/MOSTStress.H
@@ -850,7 +850,7 @@ struct moeng_flux
                     const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
                     const amrex::Array4<amrex::Real>& dest_arr) const
     {
-        amrex::Real rho, eta, qv;
+        amrex::Real rho, eta;
 
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
@@ -859,17 +859,17 @@ struct moeng_flux
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
         rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        qv    = cons_arr(ic,jc,zlo,RhoQ1_comp) / rho;
 
         // TODO: Integrate MOST with moisture and MOENG FLUX type
-        amrex::Real moflux  = 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<q'w'> = -K dqdz
+        amrex::Real moflux  = 0.0;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
-                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+            amrex::Real rqvgrad = (cons_arr(ic,jc,zlo+1,RhoQ1_comp) - cons_arr(ic,jc,zlo  ,RhoQ1_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rqvgrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -878,7 +878,7 @@ struct moeng_flux
             je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
             eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -938,14 +938,16 @@ struct moeng_flux
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real num1    = wsp * (theta_mean-theta_surf);
         amrex::Real num2    = wsp_mean * (theta-theta_mean);
-        amrex::Real moflux  = (std::abs(tstar) > eps) ?
-                              -tstar*ustar*(num1+num2)/((theta_mean-theta_surf)*wsp_mean) : 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<T'w'> = -K dTdz
+        amrex::Real moflux  = (std::abs(tstar) > eps) ?
+                              -rho*tstar*ustar*(num1+num2)/((theta_mean-theta_surf)*wsp_mean) : 0.0;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real thetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - thetagrad * deltaz;
+            amrex::Real rthetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - rthetagrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -957,7 +959,7 @@ struct moeng_flux
             // Note: Kh = eta/rho
             //      hfx = -Kh dT/dz  ==> +ve hfx corresponds to heating from the surface
             // Extrapolate from klo to ghost cell a distance of -deltaz; negative signs cancel
-            dest_arr(i,j,k,icomp+n) = rho*(theta + moflux*rho/eta*deltaz);
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -1013,8 +1015,10 @@ struct moeng_flux
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real num1    = wsp * umean;
         amrex::Real num2    = wsp_mean * (velx-umean);
-        amrex::Real stressx = rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<u'w'> = -K dudz
+        amrex::Real stressx = -rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1029,7 +1033,7 @@ struct moeng_flux
             eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
                           + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressx/eta*deltaz;
         }
 
         return stressx;
@@ -1085,8 +1089,10 @@ struct moeng_flux
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
         amrex::Real num1    = wsp * vmean;
         amrex::Real num2    = wsp_mean * (vely-vmean);
-        amrex::Real stressy = rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<v'w'> = -K dvdz
+        amrex::Real stressy = -rho*ustar*ustar * (num1+num2)/(wsp_mean*wsp_mean);
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1101,7 +1107,7 @@ struct moeng_flux
             eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
                          + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressy/eta*deltaz;
         }
 
         return stressy;
@@ -1145,7 +1151,7 @@ struct donelan_flux
                     const amrex::Array4<const amrex::Real>& /*t_surf_arr*/,
                     const amrex::Array4<amrex::Real>& dest_arr) const
     {
-        amrex::Real rho, eta, qv;
+        amrex::Real rho, eta;
 
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
@@ -1154,17 +1160,17 @@ struct donelan_flux
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
         rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        qv    = cons_arr(ic,jc,zlo,RhoQ1_comp) / rho;
 
         // TODO: Integrate MOST with moisture and DONELAN FLUX type
-        amrex::Real moflux  = 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<q'w'> = -K dqdz
+        amrex::Real moflux  = 0.0;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
-                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+            amrex::Real rqvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp) - cons_arr(ic,jc,zlo  ,RhoQ1_comp) ) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rqvgrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -1173,7 +1179,7 @@ struct donelan_flux
             je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
             eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp+n) = rho*(qv - moflux*rho/eta*deltaz);
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -1201,7 +1207,7 @@ struct donelan_flux
                     const amrex::Array4<const amrex::Real>& t_surf_arr,
                     const amrex::Array4<amrex::Real>& dest_arr) const
     {
-        amrex::Real rho, theta, eta;
+        amrex::Real rho, eta;
 
         int ic, jc;
         ic = i  < lbound(cons_arr).x ? lbound(cons_arr).x : i;
@@ -1210,19 +1216,20 @@ struct donelan_flux
         jc = jc > ubound(cons_arr).y ? ubound(cons_arr).y : jc;
 
         rho   = cons_arr(ic,jc,zlo,Rho_comp);
-        theta = cons_arr(ic,jc,zlo,RhoTheta_comp) / rho;
 
-        amrex::Real Cd = 0.0012;
+        amrex::Real Ch = 0.0012;
         amrex::Real wsp_mean    = umm_arr(ic,jc,zlo);
         amrex::Real theta_surf  = t_surf_arr(ic,jc,zlo);
         amrex::Real theta_mean  = tm_arr(ic,jc,zlo);
-        amrex::Real moflux      = Cd * wsp_mean * (theta_surf - theta_mean);
         amrex::Real deltaz      = dz * (zlo - k);
+
+        // NOTE: this is rho*<T'w'> = -K dTdz
+        amrex::Real moflux      = -rho * Ch * wsp_mean * (theta_mean - theta_surf);
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real thetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - thetagrad * deltaz;
+            amrex::Real rthetagrad = (cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo,RhoTheta_comp)) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - rthetagrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -1234,7 +1241,7 @@ struct donelan_flux
             // Note: Kh = eta/rho
             //      hfx = -Kh dT/dz  ==> +ve hfx corresponds to heating from the surface
             // Extrapolate from klo to ghost cell a distance of -deltaz; negative signs cancel
-            dest_arr(i,j,k,icomp+n) = rho*(theta + moflux*rho/eta*deltaz);
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -1290,8 +1297,10 @@ struct donelan_flux
         } else {
             Cd = 0.0024;
         }
-        amrex::Real stressx = rho * Cd * velx * wsp;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<u'w'> = -K dudz
+        amrex::Real stressx = -rho * Cd * velx * wsp;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1306,7 +1315,7 @@ struct donelan_flux
             eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
                           + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressx/eta*deltaz;
         }
 
         return stressx;
@@ -1362,8 +1371,10 @@ struct donelan_flux
         } else {
             Cd = 0.0024;
         }
-        amrex::Real stressy = rho * Cd * vely * wsp;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<v'w'> = -K dvdz
+        amrex::Real stressy = -rho * Cd * vely * wsp;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1378,7 +1389,7 @@ struct donelan_flux
             eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
                          + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressy/eta*deltaz;
         }
 
         return stressy;
@@ -1432,14 +1443,15 @@ struct custom_flux
         rho   = cons_arr(ic,jc,zlo,Rho_comp);
 
         amrex::Real qstar   = q_star_arr(ic,jc,zlo);
-        amrex::Real moflux  = (std::abs(qstar) > eps) ? -rho * qstar : 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<q'w'> = -K dqdz
+        amrex::Real moflux  = (std::abs(qstar) > eps) ? rho * qstar : 0.0;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real qvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
-                                 - cons_arr(ic,jc,zlo  ,RhoQ1_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rho*qvgrad * deltaz;
+            amrex::Real rqvgrad = ( cons_arr(ic,jc,zlo+1,RhoQ1_comp) - cons_arr(ic,jc,zlo  ,RhoQ1_comp) ) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoQ1_comp) - rqvgrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -1448,7 +1460,7 @@ struct custom_flux
             je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
             eta   = eta_arr(ie,je,zlo,EddyDiff::Q_v); // == rho * alpha [kg/m^3 * m^2/s]
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) - moflux*rho/eta*deltaz;
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -1487,14 +1499,15 @@ struct custom_flux
         rho   = cons_arr(ic,jc,zlo,Rho_comp);
 
         amrex::Real tstar   = t_star_arr(ic,jc,zlo);
-        amrex::Real moflux  = (std::abs(tstar) > eps) ? -rho * tstar : 0.0;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<T'w'> = -K dTdz
+        amrex::Real moflux  = (std::abs(tstar) > eps) ? rho * tstar : 0.0;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
-            amrex::Real thetagrad = ( cons_arr(ic,jc,zlo+1,RhoTheta_comp)/cons_arr(ic,jc,zlo+1,Rho_comp)
-                                    - cons_arr(ic,jc,zlo  ,RhoTheta_comp)/cons_arr(ic,jc,zlo  ,Rho_comp)) / (0.5*(dz+dz1));
-            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - rho*thetagrad * deltaz;
+            amrex::Real rthetagrad = ( cons_arr(ic,jc,zlo+1,RhoTheta_comp) - cons_arr(ic,jc,zlo  ,RhoTheta_comp) ) / (0.5*(dz+dz1));
+            dest_arr(i,j,k,icomp+n) = cons_arr(ic,jc,zlo,RhoTheta_comp) - rthetagrad * deltaz;
         } else {
             int ie, je;
             ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
@@ -1503,7 +1516,7 @@ struct custom_flux
             je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
             eta   = eta_arr(ie,je,zlo,EddyDiff::Theta_v); // == rho * alpha [kg/m^3 * m^2/s]
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) - moflux*rho/eta*deltaz;
+            dest_arr(i,j,k,icomp+n) = dest_arr(i,j,zlo,icomp+n) + moflux*rho/eta*deltaz;
         }
 
         return moflux;
@@ -1550,8 +1563,10 @@ struct custom_flux
 
         amrex::Real ustar   = 0.5 * ( u_star_arr(ic-1,jc,zlo) + u_star_arr(ic,jc,zlo) );
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
-        amrex::Real stressx = rho * ustar * ustar * velx / wsp;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<u'w'> = -K dudz
+        amrex::Real stressx = -rho * ustar * ustar * velx / wsp;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1566,7 +1581,7 @@ struct custom_flux
             eta   = 0.5 *(  eta_arr(ie-1,je,zlo,EddyDiff::Mom_v)
                           + eta_arr(ie  ,je,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressx/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressx/eta*deltaz;
         }
 
         return stressx;
@@ -1613,8 +1628,10 @@ struct custom_flux
 
         amrex::Real ustar   = 0.5 * ( u_star_arr(ic,jc-1,zlo) + u_star_arr(ic,jc,zlo) );
         amrex::Real wsp     = sqrt(velx*velx+vely*vely);
-        amrex::Real stressy = rho * ustar * ustar * vely / wsp;
         amrex::Real deltaz  = dz * (zlo - k);
+
+        // NOTE: this is rho*<v'w'> = -K dvdz
+        amrex::Real stressy = -rho * ustar * ustar * vely / wsp;
 
         if (exp_most) {
             // surface gradient equal to gradient at first zface
@@ -1629,7 +1646,7 @@ struct custom_flux
             eta   = 0.5*(  eta_arr(ie,je-1,zlo,EddyDiff::Mom_v)
                          + eta_arr(ie,je  ,zlo,EddyDiff::Mom_v) );
             eta   = amrex::max(eta,eta_eps);
-            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) - stressy/eta*deltaz;
+            dest_arr(i,j,k,icomp) = dest_arr(i,j,zlo,icomp) + stressy/eta*deltaz;
         }
 
         return stressy;

--- a/Source/DataStructs/DataStruct.H
+++ b/Source/DataStructs/DataStruct.H
@@ -224,6 +224,13 @@ struct SolverChoice {
         // Flag to do explicit MOST formulation
         pp.query("use_explicit_most",use_explicit_most);
 
+        // Flag to do MOST rotations with terrain
+        pp.query("use_rotate_most",use_rotate_most);
+        if (use_rotate_most) {
+            AMREX_ASSERT_WITH_MESSAGE(use_terrain,"MOST stress rotations are only valid with terrain!");
+            AMREX_ASSERT_WITH_MESSAGE(use_explicit_most, "MOST Stress rotations are only valid with explicit MOST!");
+        }
+
         // Which external forcings?
         static std::string abl_driver_type_string = "None";
         pp.query("abl_driver_type",abl_driver_type_string);
@@ -527,6 +534,9 @@ struct SolverChoice {
 
     // User specified MOST BC type
     bool use_explicit_most = false;
+
+    // MOST stress rotations
+    bool use_rotate_most = false;
 
     // User wishes to output time averaged velocity fields
     bool time_avg_vel = false;

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -202,7 +202,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             rhoAlpha += 0.5 * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
                               + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_index]) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
+            xflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -214,7 +214,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             rhoAlpha += 0.5 * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
                               + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_index]) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
+            yflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -236,31 +236,31 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                   (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
                                                           - 3. * cell_prim(i, j, k-1, prim_index)
                                                      + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * qfx1_z(i,j,0);
+                zflux(i,j,k,qty_index) = qfx1_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+                zflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
 
             if (qty_index == RhoTheta_comp) {
                 if (!most_on_zlo) {
-                    hfx_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    hfx_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ1_comp) {
                 if (!most_on_zlo) {
-                    qfx1_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    qfx1_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ2_comp) {
-                qfx2_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                qfx2_z(i,j,k) = zflux(i,j,k,qty_index);
             }
         });
     } else if (l_turb) {
@@ -274,7 +274,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             rhoAlpha += 0.5 * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
                               + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_index]) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
+            xflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -285,14 +285,13 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             rhoAlpha += 0.5 * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
                               + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_index]) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
+            yflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
-            Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = d_alpha_eff[prim_index];
             rhoAlpha += 0.5 * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                               + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
@@ -307,31 +306,31 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                   (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
                                                           - 3. * cell_prim(i, j, k-1, prim_index)
                                                      + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * qfx1_z(i,j,0);
+                zflux(i,j,k,qty_index) = qfx1_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+                zflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
 
             if (qty_index == RhoTheta_comp) {
                 if (!most_on_zlo) {
-                    hfx_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    hfx_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ1_comp) {
                 if (!most_on_zlo) {
-                    qfx1_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    qfx1_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ2_comp) {
-                qfx2_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                qfx2_z(i,j,k) = zflux(i,j,k,qty_index);
             }
         });
     } else if(l_consA) {
@@ -344,7 +343,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
-            xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
+            xflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -354,7 +353,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
-            yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
+            yflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -374,31 +373,31 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                   (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
                                                           - 3. * cell_prim(i, j, k-1, prim_index)
                                                      + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * qfx1_z(i,j,0);
+                zflux(i,j,k,qty_index) = qfx1_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+                zflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
 
             if (qty_index == RhoTheta_comp) {
                 if (!most_on_zlo) {
-                    hfx_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    hfx_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ1_comp) {
                 if (!most_on_zlo) {
-                    qfx1_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    qfx1_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ2_comp) {
-                qfx2_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                qfx2_z(i,j,k) = zflux(i,j,k,qty_index);
             }
         });
     } else {
@@ -411,7 +410,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             Real rhoAlpha = d_alpha_eff[prim_index];
 
-            xflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
+            xflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i-1, j, k, prim_index)) * dx_inv * mf_u(i,j,0);
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -420,14 +419,13 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             Real rhoAlpha = d_alpha_eff[prim_index];
 
-            yflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
+            yflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_v(i,j,0);
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int  qty_index = start_comp + n;
             const int prim_index = qty_index - qty_offset;
 
-            Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = d_alpha_eff[prim_index];
 
             bool ext_dir_on_zlo = ( ((bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::ext_dir) ||
@@ -440,31 +438,31 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
                                   (bc_ptr[BCVars::cons_bc+qty_index].lo(2) == ERFBCType::foextrap) && k == 0);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k,qty_index) = rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * ( -(8./3.) * cell_prim(i, j, k-1, prim_index)
                                                           + 3. * cell_prim(i, j, k  , prim_index)
                                                      - (1./3.) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k,qty_index) = rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
+                zflux(i,j,k,qty_index) = -rhoAlpha * (  (8./3.) * cell_prim(i, j, k  , prim_index)
                                                           - 3. * cell_prim(i, j, k-1, prim_index)
                                                      + (1./3.) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (most_on_zlo && (qty_index == RhoTheta_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else if (most_on_zlo && (qty_index == RhoQ1_comp)) {
-                zflux(i,j,k,qty_index) = -rhoFace * qfx1_z(i,j,0);
+                zflux(i,j,k,qty_index) = qfx1_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
+                zflux(i,j,k,qty_index) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
             }
 
             if (qty_index == RhoTheta_comp) {
                 if (!most_on_zlo) {
-                    hfx_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    hfx_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ1_comp) {
                 if (!most_on_zlo) {
-                    qfx1_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                    qfx1_z(i,j,k) = zflux(i,j,k,qty_index);
                 }
             } else  if (qty_index == RhoQ2_comp) {
-                qfx2_z(i,j,k) = -zflux(i,j,k,qty_index) / rhoFace;
+                qfx2_z(i,j,k) = zflux(i,j,k,qty_index);
             }
         });
     }
@@ -476,7 +474,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
         ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
 
-            cell_rhs(i,j,k,qty_index) += (xflux(i+1,j  ,k  ,qty_index) - xflux(i, j, k, qty_index)) * dx_inv * mf_m(i,j,0)  // Diffusive flux in x-dir
+            cell_rhs(i,j,k,qty_index) -= (xflux(i+1,j  ,k  ,qty_index) - xflux(i, j, k, qty_index)) * dx_inv * mf_m(i,j,0)  // Diffusive flux in x-dir
                                         +(yflux(i  ,j+1,k  ,qty_index) - yflux(i, j, k, qty_index)) * dy_inv * mf_m(i,j,0)  // Diffusive flux in y-dir
                                         +(zflux(i  ,j  ,k+1,qty_index) - zflux(i, j, k, qty_index)) * dz_inv;               // Diffusive flux in z-dir
         });

--- a/Source/Diffusion/DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_T.cpp
@@ -218,7 +218,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i-1, j, k-1, prim_index) );
             Real GradCx =        dx_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i-1, j, k  , prim_index) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
+            xflux(i,j,k,qty_index) = -rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -237,7 +237,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i, j-1, k-1, prim_index) );
             Real GradCy =        dy_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i, j-1, k  , prim_index) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
+            yflux(i,j,k,qty_index) = -rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -275,9 +275,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 // set the exact value from MOST, don't need finite diff
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * GradCz / met_h_zeta;
+                zflux(i,j,k,qty_index) = -rhoAlpha * GradCz / met_h_zeta;
             }
         });
     // Constant rho*alpha & Turb model
@@ -298,7 +298,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i-1, j, k-1, prim_index) );
             Real GradCx =        dx_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i-1, j, k  , prim_index) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
+            xflux(i,j,k,qty_index) = -rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -316,7 +316,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i, j-1, k-1, prim_index) );
             Real GradCy =        dy_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i, j-1, k  , prim_index) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
+            yflux(i,j,k,qty_index) = -rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -354,10 +354,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 // set the exact value from MOST, don't need finite diff
-                Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * GradCz / met_h_zeta;
+                zflux(i,j,k,qty_index) = -rhoAlpha * GradCz / met_h_zeta;
             }
         });
     // Constant alpha & no LES/PBL model
@@ -377,7 +376,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i-1, j, k-1, prim_index) );
             Real GradCx =        dx_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i-1, j, k  , prim_index) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
+            xflux(i,j,k,qty_index) = -rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -394,7 +393,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i, j-1, k-1, prim_index) );
             Real GradCy =        dy_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i, j-1, k  , prim_index) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
+            yflux(i,j,k,qty_index) = -rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -430,9 +429,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 // set the exact value from MOST, don't need finite diff
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * GradCz / met_h_zeta;
+                zflux(i,j,k,qty_index) = -rhoAlpha * GradCz / met_h_zeta;
             }
         });
     // Constant rho*alpha & no LES/PBL model
@@ -452,7 +451,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i-1, j, k-1, prim_index) );
             Real GradCx =        dx_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i-1, j, k  , prim_index) );
 
-            xflux(i,j,k,qty_index) = rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
+            xflux(i,j,k,qty_index) = -rhoAlpha * mf_u(i,j,0) * ( GradCx - (met_h_xi/met_h_zeta)*GradCz );
         });
         ParallelFor(ybx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -469,7 +468,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                                           - cell_prim(i, j, k-1, prim_index) - cell_prim(i, j-1, k-1, prim_index) );
             Real GradCy =        dy_inv * ( cell_prim(i, j, k  , prim_index) - cell_prim(i, j-1, k  , prim_index) );
 
-            yflux(i,j,k,qty_index) = rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
+            yflux(i,j,k,qty_index) = -rhoAlpha * mf_v(i,j,0) * ( GradCy - (met_h_eta/met_h_zeta)*GradCz );
         });
         ParallelFor(zbx, num_comp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
@@ -505,10 +504,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             if (most_on_zlo && (qty_index == RhoTheta_comp)) {
                 // set the exact value from MOST, don't need finite diff
-                Real rhoFace  = 0.5 * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
-                zflux(i,j,k,qty_index) = -rhoFace * hfx_z(i,j,0);
+                zflux(i,j,k,qty_index) = hfx_z(i,j,0);
             } else {
-                zflux(i,j,k,qty_index) = rhoAlpha * GradCz / met_h_zeta;
+                zflux(i,j,k,qty_index) = -rhoAlpha * GradCz / met_h_zeta;
             }
         });
     }
@@ -600,7 +598,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             stateContrib /= detJ(i,j,k);
 
-            cell_rhs(i,j,k,qty_index) += stateContrib;
+            cell_rhs(i,j,k,qty_index) -= stateContrib;
         });
     }
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -947,11 +947,16 @@ ERF::InitData ()
     if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::MOST)
     {
         bool use_exp_most = solverChoice.use_explicit_most;
+        bool use_rot_most = solverChoice.use_rotate_most;
         if (use_exp_most) {
             Print() << "Using MOST with explicitly included surface stresses" << std::endl;
+            if (use_rot_most) {
+                Print() << "Using MOST with surface stress rotations" << std::endl;
+            }
         }
 
-        m_most = std::make_unique<ABLMost>(geom, use_exp_most, vars_old, Theta_prim, Qv_prim, z_phys_nd,
+        m_most = std::make_unique<ABLMost>(geom, use_exp_most, use_rot_most,
+                                           vars_old, Theta_prim, Qv_prim, z_phys_nd,
                                            sst_lev, lmask_lev, lsm_data, lsm_flux, Hwave, Lwave, eddyDiffs_lev
 #ifdef ERF_USE_NETCDF
                                            ,start_bdy_time, bdy_time_interval

--- a/Source/TimeIntegration/ERF_make_tau_terms.cpp
+++ b/Source/TimeIntegration/ERF_make_tau_terms.cpp
@@ -53,6 +53,7 @@ void erf_make_tau_terms (int level, int nrk,
 
     const bool use_most     = (most != nullptr);
     const bool exp_most     = (solverChoice.use_explicit_most);
+    const bool rot_most     = (solverChoice.use_rotate_most);
 
     const Box& domain = geom.Domain();
     const int domlo_z = domain.smallEnd(2);
@@ -246,6 +247,10 @@ void erf_make_tau_terms (int level, int nrk,
                     // Don't overwrite modeled total stress value at boundary
                     tbxxz.setSmall(2,1);
                     tbxyz.setSmall(2,1);
+                    if (rot_most) {
+                        bxcc.setSmall(2,1);
+                        tbxxy.setSmall(2,1);
+                    }
                 }
 
                 // *****************************************************************************


### PR DESCRIPTION
Before completing the MOST stress rotations, this PR passes all the stress tensor components into the `impost_most_bcs` routine and unifies the definition of the diffusive flux. More specifically, we now include the negative sign: `tau = -k d \phi d x_{i}`. Prior to this PR, the negative was only done for the momentum stress tensor components while the scalars did not have the negative sign. This change impacts the MOST BCs routines, the stored fluxes `hfx & qfx`, and the diffusion source term. Finally, note that the output SGS fluxes `hfx3 & qfx3` will be `-k d \phi dz`.