### PR TITLE
Bomex GPU

### DIFF
--- a/Source/Advection/Advection.H
+++ b/Source/Advection/Advection.H
@@ -49,6 +49,7 @@ void AdvectionSrcForScalars (const amrex::Real& dt,
                              const AdvType horiz_adv_type, const AdvType vert_adv_type,
                              const amrex::Real horiz_upw_frac, const amrex::Real vert_upw_frac,
                              const amrex::GpuArray<const amrex::Array4<amrex::Real>, AMREX_SPACEDIM>& flx_arr,
+                             const amrex::GpuArray<      amrex::Array4<amrex::Real>, AMREX_SPACEDIM>& flx_tmp_arr,
                              const amrex::Box& domain,
                              const amrex::BCRec* bc_ptr_h);
 


### PR DESCRIPTION
This PR attempts to remove the GPU race condition for Bomex with `mon_adv` by creating a temporary flux array. We then check if the flux should be modified by using `flx_arr` by write into `flx_tmp_arr`. The expense is some two local copies.