### PR TITLE
Fixes for RRTMGP

### DIFF
--- a/Exec/Radiation/inputs_radiation
+++ b/Exec/Radiation/inputs_radiation
@@ -38,7 +38,7 @@ amr.check_int       = 10000       # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1         = plt        # root name of plotfile
 erf.plot_int_1          = 1         # number of timesteps between plotfiles
-erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 x_velocity y_velocity z_velocity pressure theta temp qt qp qv qc qi
+erf.plot_vars_1         = density rhotheta rhoQ1 rhoQ2 x_velocity y_velocity z_velocity pressure theta temp qt qp qv qc qi qsrc_sw qsrc_lw
 
 # SOLVER CHOICE
 erf.use_gravity = true

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -885,6 +885,9 @@ private:
                                                     // error vars
                                                     ,"xvel_err", "yvel_err", "zvel_err", "pp_err"
 #endif
+#ifdef ERF_USE_RRTMGP
+                                                    ,"qsrc_sw", "qsrc_lw"
+#endif
                                                    };
 
     // algorithm choices

--- a/Source/IO/Plotfile.cpp
+++ b/Source/IO/Plotfile.cpp
@@ -1247,6 +1247,17 @@ ERF::WritePlotFile (int which, Vector<std::string> plot_var_names)
             mf_comp += 1;
         }
 #endif
+
+#ifdef ERF_USE_RRTMGP
+    if (containerHasElement(plot_var_names, "qsrc_sw")) {
+        MultiFab::Copy(mf[lev], *(qheating_rates[lev]), 0, mf_comp, 1, 0);
+        mf_comp += 1;
+    }
+    if (containerHasElement(plot_var_names, "qsrc_lw")) {
+        MultiFab::Copy(mf[lev], *(qheating_rates[lev]), 1, mf_comp, 1, 0);
+        mf_comp += 1;
+    }
+#endif
     }
 
 #ifdef EB_USE_EB

--- a/Source/Radiation/Aero_rad_props.H
+++ b/Source/Radiation/Aero_rad_props.H
@@ -25,7 +25,7 @@ class AerRadProps {
                     int nswbands_, int nlwbands_,
                     int ncoloum, int nlevel, int num_rh, int top_levels,
                     const std::vector<std::string>& aerosol_names,
-                    const real2d& zint, const real2d& pmiddle, const real2d& pint,
+                    const real2d& zint, const real2d& pmiddle, const real2d& pdel,
                     const real2d& temperature, const real2d& qtotal,
                     const real2d& geom_rad);
 

--- a/Source/Radiation/Aero_rad_props.cpp
+++ b/Source/Radiation/Aero_rad_props.cpp
@@ -13,7 +13,7 @@ void AerRadProps::initialize (int num_gas, int num_modes, int naeroes,
                               int nswbands_, int nlwbands_,
                               int ncoloum, int nlevel, int num_rh, int top_levels,
                               const std::vector<std::string>& aerosol_names,
-                              const real2d& zint, const real2d& pmiddle, const real2d& pint,
+                              const real2d& zint, const real2d& pmiddle, const real2d& pdel,
                               const real2d& temperature, const real2d& qtotal,
                               const real2d& geom_rad)
 {
@@ -32,12 +32,16 @@ void AerRadProps::initialize (int num_gas, int num_modes, int naeroes,
     // NOTE: pmid is absolute pressure but pdeldry is the vertical
     //       change in pressure (analog to mass per area with HSE balance)
     pmid    = pmiddle;
+    pdeldry = pdel;
+    /*
+    // This will overwrite pmid
     pdeldry = pmiddle;
     parallel_for(SimpleBounds<2>(ncol, nlev), YAKL_LAMBDA (int icol, int ilev)
     {
         // Pressure max at bottom of column
         pdeldry(icol,ilev) = pmid(icol,ilev) -  pmid(icol,ilev+1);
     });
+    */
 
     temp = temperature;
     qt   = qtotal;
@@ -91,7 +95,7 @@ void AerRadProps::aer_rad_props_sw (const int& list_idx, const real& dt, const i
         WaterVaporSat::qsat(temp(icol,ilev), pmid(icol,ilev), es, qs);
         rh = qt(icol,ilev)/qs;
         rhtrunc = std::min(rh,1.);
-        krh(icol, ilev) = std::min(std::floor(rhtrunc*nrh )+1, nrh - 1.); // index into rh mesh
+        krh(icol, ilev) = std::min(std::floor(rhtrunc*nrh )+1., nrh - 1.); // index into rh mesh
         wrh(icol, ilev) = rhtrunc*nrh-krh(icol, ilev);       // (-) weighting on left side values
     });
 

--- a/Source/Radiation/Aero_rad_props.cpp
+++ b/Source/Radiation/Aero_rad_props.cpp
@@ -139,7 +139,7 @@ void AerRadProps::aer_rad_props_sw (const int& list_idx, const real& dt, const i
         });
 
         //Quit if tropopause is not found
-        if (yakl::intrinsics::any(trop_level) == -1) {
+        if (yakl::intrinsics::any(yakl::componentwise::operator==(trop_level, -1))) {
             amrex::Print() << "aer_rad_props.F90: subr aer_rad_props_sw: tropopause not found\n";
         }
     }
@@ -413,7 +413,7 @@ void AerRadProps::aer_rad_props_lw (const bool& is_cmip6_volc,
         });
 
         // Quit if tropopause is not found
-        if (yakl::intrinsics::any(trop_level) == -1)
+        if (yakl::intrinsics::any(yakl::componentwise::operator==(trop_level, -1)))
             amrex::Print() << "aer_rad_props_lw: tropopause not found\n";
 
         // If tropopause is found, update taus with 50% contributuions from the volcanic input

--- a/Source/Radiation/Linear_interpolate.H
+++ b/Source/Radiation/Linear_interpolate.H
@@ -252,6 +252,7 @@ class LinInterp
         parallel_for(SimpleBounds<1>(nout), YAKL_LAMBDA (int j)
         {
             int count = 0;
+            amrex::ignore_unused(count);
             if (interp_wgts.jjm(j) == 0 || interp_wgts.jjp(j) == 0) count +=  1;
             auto frac = interp_wgts.wgts(j) + interp_wgts.wgtn(j);
             if ((frac < 0.9 || frac > 1.1) && extrap_method != 0)

--- a/Source/Radiation/Mam4_aero.H
+++ b/Source/Radiation/Mam4_aero.H
@@ -255,7 +255,7 @@ class Mam4_aer {
 
             // get mode properties
             real dgnum, dgnumhi, dgnumlo, sigmag;
-            mam_consti.get_mode_props(list_idx, n-1, dgnum, dgnumhi, dgnumlo, sigmag=sigmag);
+            mam_consti.get_mode_props(list_idx, n-1, dgnum, dgnumhi, dgnumlo, sigmag);
 
             // get mode number mixing ratio
             mam_consti.rad_cnst_get_mode_num(list_idx, n-1, "a", mode_num);
@@ -335,6 +335,7 @@ class Mam4_aer {
         std::string spectype;          // species type
         real hygro_aer;
         real volf;
+        amrex::ignore_unused(volf);
 
         real2d dgnumwet("dgnumwet", ncol,nlev);     // number mode wet diameter
         real2d qaerwat("qaerwat", ncol,nlev);      // aerosol water (g/g)
@@ -596,6 +597,7 @@ class Mam4_aer {
         constexpr int nerrmax_dopaer=1000;
         int nerr_dopaer = 0;
         real volf;   // volume fraction of insoluble aerosol
+        amrex::ignore_unused(volf);
 
         // initialize output variables
         yakl::memset(tauxar, 0.);

--- a/Source/Radiation/Mam4_constituents.H
+++ b/Source/Radiation/Mam4_constituents.H
@@ -313,8 +313,8 @@ class MamConstituents {
 
     // Return pointer to mass mixing ratio for the gas from the specified
     // climate or diagnostic list.
-    const inline
-    void rad_cnst_get_gas (int list_idx, const std::string& gasname, real2d& mmr)
+    inline
+    void rad_cnst_get_gas (int list_idx, const std::string& gasname, real2d& mmr) const
     {
         gaslist_t list;
         if (list_idx >= 0 && list_idx <= N_DIAG) {
@@ -347,29 +347,25 @@ class MamConstituents {
         //   end select
     }
 
-    const
-    void get_nmodes (int list_idx, int& nmodes)
+    void get_nmodes (int list_idx, int& nmodes) const
     {
         auto m_list = ma_list[list_idx];
         nmodes = m_list.nmodes;
     }
 
-    const
-    void get_ngas (int list_idx, int& ngas)
+    void get_ngas (int list_idx, int& ngas) const
     {
         auto g_list = gaslist[list_idx];
         ngas = g_list.ngas;
     }
 
-    const
-    void get_naero (int list_idx, int& naero)
+    void get_naero (int list_idx, int& naero) const
     {
         auto a_list = aerosollist[list_idx];
         naero = a_list.numaerosols;
     }
 
-    const
-    void get_gas_names (int list_idx, std::vector<std::string>& gasnames, bool use_data_o3=false)
+    void get_gas_names (int list_idx, std::vector<std::string>& gasnames, bool& use_data_o3) const
     {
         auto g_list = gaslist[list_idx];
 
@@ -386,8 +382,7 @@ class MamConstituents {
         if (source == "N") use_data_o3 = true;
     }
 
-    const
-    void get_aero_names (int list_idx, std::vector<std::string>& aernames)
+    void get_aero_names (int list_idx, std::vector<std::string>& aernames) const
     {
         auto a_list = aerosollist[list_idx];
 
@@ -396,8 +391,7 @@ class MamConstituents {
         for(auto i = 0; i < a_list.numaerosols; ++i) aernames[i] = a_list.aer[i].camname;
     }
 
-    const
-    void get_mode_nspec (int list_idx, int m_idx, int& nspec)
+    void get_mode_nspec (int list_idx, int m_idx, int& nspec) const
     {
         auto m_list = ma_list[list_idx];
         auto mm = m_list.idx[m_idx];
@@ -407,10 +401,9 @@ class MamConstituents {
     }
 
     // Return info about modal aerosol list
-    const
     void rad_cnst_get_info_by_mode (int list_idx, int m_idx,
                                     std::string& mode_type, std::string& num_name,
-                                    std::string& num_name_cw, int& nspec)
+                                    std::string& num_name_cw, int& nspec) const
     {
         auto m_list = ma_list[list_idx];
 
@@ -436,10 +429,9 @@ class MamConstituents {
     }
 
     // Return info about modal aerosol lists
-    const
     void rad_cnst_get_info_by_mode_spec (int list_idx, int m_idx, int s_idx,
                                          std::string& spec_type, std::string& spec_name,
-                                         std::string& spec_name_cw)
+                                         std::string& spec_name_cw) const
     {
         auto m_list = ma_list[list_idx];
 
@@ -467,9 +459,8 @@ class MamConstituents {
     }
 
     // Return info about modes in the specified climate/diagnostics list
-    const
     void rad_cnst_get_info_by_spectype (int list_idx, const std::string& spectype,
-                                        int& mode_idx, int& spec_idx)
+                                        int& mode_idx, int& spec_idx) const
     {
         auto m_list = ma_list[list_idx];
 
@@ -504,8 +495,7 @@ class MamConstituents {
         }
     }
 
-    const
-    int rad_cnst_get_mode_idx (int list_idx, const std::string& mode_type)
+    int rad_cnst_get_mode_idx (int list_idx, const std::string& mode_type) const
     {
         // if mode type not found return -1
         int mode_idx = -1;
@@ -530,9 +520,8 @@ class MamConstituents {
         return mode_idx;
     }
 
-    const
     int rad_cnst_get_spec_idx (int list_idx, int mode_idx,
-                               const std::string& spec_type)
+                               const std::string& spec_type) const
     {
         // if specie type not found return -1
         int spec_idx = -1;
@@ -562,11 +551,11 @@ class MamConstituents {
 
     // Output the mass per layer, and total column burdens for gas and aerosol
     // constituents in either the climate or diagnostic lists
-    const
-    void rad_cnst_out (int list_idx)
+    void rad_cnst_out (int list_idx) const
     {
         //int ncol;
         int idx;
+        amrex::ignore_unused(idx);
         std::string name, cbname, source;
 
         aerlist_t aerlist;
@@ -623,8 +612,7 @@ class MamConstituents {
 
     // Return pointer to mass mixing ratio for the aerosol from the specified
     // climate or diagnostic list.
-    const
-    void rad_cnst_get_aer_mmr_by_idx (int list_idx, int aer_idx, real2d& mmr)
+    void rad_cnst_get_aer_mmr_by_idx (int list_idx, int aer_idx, real2d& mmr) const
     {
         aerlist_t aerlist;
 
@@ -648,9 +636,8 @@ class MamConstituents {
 
     // Return pointer to mass mixing ratio for the modal aerosol specie from the specified
     // climate or diagnostic list.
-    const
     void rad_cnst_get_mam_mmr_by_idx (int list_idx, int mode_idx, int spec_idx,
-                                      const std::string& phase, real2d& mmr)
+                                      const std::string& phase, real2d& mmr) const
     {
         //int idx;
         std::string source;
@@ -693,8 +680,7 @@ class MamConstituents {
         }
     }
 
-    const
-    void rad_cnst_get_mam_mmr_idx (int mode_idx, int spec_idx, int& idx)
+    void rad_cnst_get_mam_mmr_idx (int mode_idx, int spec_idx, int& idx) const
     {
         modelist_t mlist;
 
@@ -722,8 +708,7 @@ class MamConstituents {
 
     // Return pointer to number mixing ratio for the aerosol mode from the specified
     // climate or diagnostic list.
-    const
-    void rad_cnst_get_mode_num (int list_idx, int mode_idx, const std::string& phase, real2d& num)
+    void rad_cnst_get_mode_num (int list_idx, int mode_idx, const std::string& phase, real2d& num) const
     {
         modelist_t mlist;
         std::string source;
@@ -765,8 +750,7 @@ class MamConstituents {
     // constituent array inside physics parameterizations that have been passed,
     // and are operating over the entire constituent array.  The interstitial phase
     // is assumed since that's what is contained in the constituent array.
-    const
-    void rad_cnst_get_mode_num_idx (int mode_idx, int& cnst_idx)
+    void rad_cnst_get_mode_num_idx (int mode_idx, int& cnst_idx) const
     {
         modelist_t mlist;
         // assume climate list
@@ -793,8 +777,7 @@ class MamConstituents {
     }
 
     // Return the index of aerosol aer_name in the list specified by list_idx.
-    const
-    int rad_cnst_get_aer_idx (int list_idx, std::string& aer_name)
+    int rad_cnst_get_aer_idx (int list_idx, std::string& aer_name) const
     {
         aerlist_t aerlist;
 
@@ -822,9 +805,8 @@ class MamConstituents {
 
     // Return requested properties for the mode from the specified
     // climate or diagnostic list.
-    const
     void get_mode_props (int list_idx, int mode_idx, real& sigmag,
-                         real& rhcrystal, real& rhdeliques)
+                         real& rhcrystal, real& rhdeliques) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -838,9 +820,8 @@ class MamConstituents {
         prop.get_rhdeliques(id, rhdeliques);
     }
 
-    const
     void get_mode_props (int list_idx, int mode_idx, real& sigmag,
-                         real2d& refrtablw, real2d& refitablw, real4d& absplw)
+                         real2d& refrtablw, real2d& refitablw, real4d& absplw) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -855,9 +836,8 @@ class MamConstituents {
         prop.get_absplw(id, absplw);
     }
 
-    const
     void get_mode_props (int list_idx, int mode_idx, real& sigmag, real2d& refrtabsw,
-                         real2d& refitabsw, real4d& extpsw, real4d& abspsw, real4d& asmpsw)
+                         real2d& refitabsw, real4d& extpsw, real4d& abspsw, real4d& asmpsw) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -874,8 +854,7 @@ class MamConstituents {
         prop.get_asmpsw(id, asmpsw);
     }
 
-    const
-    void get_mode_props (int list_idx, int mode_idx, int& ncoef, int& prefr, int& prefi)
+    void get_mode_props (int list_idx, int mode_idx, int& ncoef, int& prefr, int& prefi) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -889,9 +868,9 @@ class MamConstituents {
         prop.get_prefi(id, prefi);
     }
 
-    const inline
+    inline
     void get_mode_props (int list_idx, int mode_idx, real& dgnum, real& dgnumhi,
-                         real& dgnumlo, real& sigmag)
+                         real& dgnumlo, real& sigmag) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -906,9 +885,9 @@ class MamConstituents {
         prop.get_sigmag(id, sigmag);
     }
 
-    const inline
+    inline
     void get_mam_density_aer (int list_idx, int mode_idx, int spec_idx,
-                              real& density_aer)
+                              real& density_aer) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -920,9 +899,9 @@ class MamConstituents {
         prop.get_density_aer(id, density_aer);
     }
 
-    const inline
+    inline
     void get_mam_hygro_aer (int list_idx, int mode_idx, int spec_idx,
-                            real& hygro_aer)
+                            real& hygro_aer) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -936,10 +915,10 @@ class MamConstituents {
 
     // Return requested properties for the aerosol from the specified
     // climate or diagnostic list.
-    const inline
+    inline
     void get_mam_props (int list_idx, int mode_idx, int spec_idx, real& density_aer,
                         std::string& spectype, real& hygro_aer,
-                        real1d& refindex_real_aer_sw, real1d& refindex_im_aer_sw)
+                        real1d& refindex_real_aer_sw, real1d& refindex_im_aer_sw) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -956,10 +935,10 @@ class MamConstituents {
         spectype = modes.comps[m_idx].type[spec_idx];
     }
 
-    const inline
+    inline
     void get_mam_props_sw (int list_idx, int mode_idx, int spec_idx,
                            real& density_aer, real1d& refindex_real_aer_sw,
-                           real1d& refindex_im_aer_sw)
+                           real1d& refindex_im_aer_sw) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -974,8 +953,8 @@ class MamConstituents {
         prop.get_ref_im_aer_sw(id, refindex_im_aer_sw);
     }
 
-    const inline
-    void get_mam_props (int list_idx, int mode_idx, int spec_idx, real& density_aer)
+    inline
+    void get_mam_props (int list_idx, int mode_idx, int spec_idx, real& density_aer) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -987,11 +966,11 @@ class MamConstituents {
         prop.get_density_aer(id, density_aer);
     }
 
-    const inline
+    inline
     void get_mam_props_lw (int list_idx, int mode_idx, int spec_idx,
                            real& density_aer,
                            real1d& refindex_real_aer_lw,
-                           real1d& refindex_im_aer_lw)
+                           real1d& refindex_im_aer_lw) const
     {
         modelist_t mlist;
         if (list_idx >= 0 && list_idx <= N_DIAG)
@@ -1006,8 +985,8 @@ class MamConstituents {
         prop.get_ref_im_aer_lw(id, refindex_im_aer_lw);
     }
 
-    const inline
-    void get_aer_opticstype (int list_idx, int aer_idx, std::string& opticstype)
+    inline
+    void get_aer_opticstype (int list_idx, int aer_idx, std::string& opticstype) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1015,8 +994,8 @@ class MamConstituents {
         prop.get_opticstype(id, opticstype);
     }
 
-    const inline
-    void get_aer_sw_hygro_ext (int list_idx, int aer_idx, real2d& sw_hygro_ext)
+    inline
+    void get_aer_sw_hygro_ext (int list_idx, int aer_idx, real2d& sw_hygro_ext) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1024,8 +1003,8 @@ class MamConstituents {
         prop.get_sw_hygro_ext(id, sw_hygro_ext);
     }
 
-    const inline
-    void get_aer_sw_hygro_ssa (int list_idx, int aer_idx, real2d& sw_hygro_ssa)
+    inline
+    void get_aer_sw_hygro_ssa (int list_idx, int aer_idx, real2d& sw_hygro_ssa) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1033,8 +1012,8 @@ class MamConstituents {
         prop.get_sw_hygro_ssa(id, sw_hygro_ssa);
     }
 
-    const inline
-    void get_aer_sw_hygro_asm (int list_idx, int aer_idx, real2d& sw_hygro_asm)
+    inline
+    void get_aer_sw_hygro_asm (int list_idx, int aer_idx, real2d& sw_hygro_asm) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1042,8 +1021,8 @@ class MamConstituents {
         prop.get_sw_hygro_asm(id, sw_hygro_asm);
     }
 
-    const inline
-    void get_aer_lw_hygro_abs (int list_idx, int aer_idx, real2d& lw_hygro_abs)
+    inline
+    void get_aer_lw_hygro_abs (int list_idx, int aer_idx, real2d& lw_hygro_abs) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1051,8 +1030,8 @@ class MamConstituents {
         prop.get_lw_hygro_abs(id, lw_hygro_abs);
     }
 
-    const inline
-    void get_aer_sw_nonhygro_ext (int list_idx, int aer_idx, real1d& sw_nonhygro_ext)
+    inline
+    void get_aer_sw_nonhygro_ext (int list_idx, int aer_idx, real1d& sw_nonhygro_ext) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1060,8 +1039,8 @@ class MamConstituents {
         prop.get_sw_nonhygro_ext(id, sw_nonhygro_ext);
     }
 
-    const inline
-    void get_aer_sw_nonhygro_ssa (int list_idx, int aer_idx, real1d& sw_nonhygro_ssa)
+    inline
+    void get_aer_sw_nonhygro_ssa (int list_idx, int aer_idx, real1d& sw_nonhygro_ssa) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1069,8 +1048,8 @@ class MamConstituents {
         prop.get_sw_nonhygro_ssa(id, sw_nonhygro_ssa);
     }
 
-    const inline
-    void get_aer_sw_nonhygro_asm (int list_idx, int aer_idx, real1d& sw_nonhygro_asm)
+    inline
+    void get_aer_sw_nonhygro_asm (int list_idx, int aer_idx, real1d& sw_nonhygro_asm) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1078,8 +1057,8 @@ class MamConstituents {
         prop.get_sw_nonhygro_asm(id, sw_nonhygro_asm);
     }
 
-    const inline
-    void get_aer_sw_nonhygro_scat (int list_idx, int aer_idx, real1d& sw_nonhygro_scat)
+    inline
+    void get_aer_sw_nonhygro_scat (int list_idx, int aer_idx, real1d& sw_nonhygro_scat) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1087,8 +1066,8 @@ class MamConstituents {
         prop.get_sw_nonhygro_scat(id, sw_nonhygro_scat);
     }
 
-    const inline
-    void get_aer_sw_nonhygro_ascat (int list_idx, int aer_idx, real1d& sw_nonhygro_ascat)
+    inline
+    void get_aer_sw_nonhygro_ascat (int list_idx, int aer_idx, real1d& sw_nonhygro_ascat) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1096,8 +1075,8 @@ class MamConstituents {
         prop.get_sw_nonhygro_ascat(id, sw_nonhygro_ascat);
     }
 
-    const inline
-    void get_aer_lw_abs (int list_idx, int aer_idx, real1d& lw_abs)
+    inline
+    void get_aer_lw_abs (int list_idx, int aer_idx, real1d& lw_abs) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1105,10 +1084,10 @@ class MamConstituents {
         prop.get_lw_abs(id, lw_abs);
     }
 
-    const inline
+    inline
     void get_aer_refindex_aer_sw (int list_idx, int aer_idx,
                                   real1d& refindex_real_aer_sw,
-                                  real1d& refindex_im_aer_sw)
+                                  real1d& refindex_im_aer_sw) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1117,10 +1096,10 @@ class MamConstituents {
         prop.get_ref_im_aer_sw(id, refindex_im_aer_sw);
     }
 
-    const inline
+    inline
     void get_aer_refindex_aer_lw (int list_idx, int aer_idx,
                                   real1d& refindex_real_aer_lw,
-                                  real1d& refindex_im_aer_lw)
+                                  real1d& refindex_im_aer_lw) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1129,8 +1108,8 @@ class MamConstituents {
         prop.get_ref_im_aer_lw(id, refindex_im_aer_lw);
     }
 
-    const inline
-    void get_aer_r_sw_ext (int list_idx, int aer_idx, real2d& r_sw_ext)
+    inline
+    void get_aer_r_sw_ext (int list_idx, int aer_idx, real2d& r_sw_ext) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1138,8 +1117,8 @@ class MamConstituents {
         prop.get_r_sw_ext(id, r_sw_ext);
     }
 
-    const inline
-    void get_aer_r_sw_scat (int list_idx, int aer_idx, real2d& r_sw_scat)
+    inline
+    void get_aer_r_sw_scat (int list_idx, int aer_idx, real2d& r_sw_scat) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1147,8 +1126,8 @@ class MamConstituents {
         prop.get_r_sw_scat(id, r_sw_scat);
     }
 
-    const inline
-    void get_aer_r_sw_ascat (int list_idx, int aer_idx, real2d& r_sw_ascat)
+    inline
+    void get_aer_r_sw_ascat (int list_idx, int aer_idx, real2d& r_sw_ascat) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1156,8 +1135,8 @@ class MamConstituents {
         prop.get_r_sw_ascat(id, r_sw_ascat);
     }
 
-    const inline
-    void get_aer_r_lw_abs (int list_idx, int aer_idx, real2d& r_lw_abs)
+    inline
+    void get_aer_r_lw_abs (int list_idx, int aer_idx, real2d& r_lw_abs) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1165,8 +1144,8 @@ class MamConstituents {
         prop.get_r_lw_abs(id, r_lw_abs);
     }
 
-    const inline
-    void get_aer_mu (int list_idx, int aer_idx, real1d& mu)
+    inline
+    void get_aer_mu (int list_idx, int aer_idx, real1d& mu) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1174,8 +1153,8 @@ class MamConstituents {
         prop.get_mu(id, mu);
     }
 
-    const inline
-    void get_aername (int list_idx, int aer_idx, std::string& aername)
+    inline
+    void get_aername (int list_idx, int aer_idx, std::string& aername) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1183,8 +1162,8 @@ class MamConstituents {
         prop.get_aername(id, aername);
     }
 
-    const inline
-    void get_density_aer (int list_idx, int aer_idx, real& density_aer)
+    inline
+    void get_density_aer (int list_idx, int aer_idx, real& density_aer) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1192,8 +1171,8 @@ class MamConstituents {
         prop.get_density_aer(id, density_aer);
     }
 
-    const inline
-    void get_hygro_aer (int list_idx, int aer_idx, real& hygro_aer)
+    inline
+    void get_hygro_aer (int list_idx, int aer_idx, real& hygro_aer) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1201,8 +1180,8 @@ class MamConstituents {
         prop.get_hygro_aer(id, hygro_aer);
     }
 
-    const inline
-    void get_dryrad_aer (int list_idx, int aer_idx, real& dryrad_aer)
+    inline
+    void get_dryrad_aer (int list_idx, int aer_idx, real& dryrad_aer) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1210,8 +1189,8 @@ class MamConstituents {
         prop.get_dryrad_aer(id, dryrad_aer);
     }
 
-    const inline
-    void get_dispersion_aer (int list_idx, int aer_idx, real& dispersion_aer)
+    inline
+    void get_dispersion_aer (int list_idx, int aer_idx, real& dispersion_aer) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;
@@ -1219,8 +1198,8 @@ class MamConstituents {
         prop.get_dispersion_aer(id, dispersion_aer);
     }
 
-    const inline
-    void get_num_to_mass_aer (int list_idx, int aer_idx, real& num_to_mass_aer)
+    inline
+    void get_num_to_mass_aer (int list_idx, int aer_idx, real& num_to_mass_aer) const
     {
         auto aerlist = aerosollist[list_idx];
         auto id = aerlist.aer[aer_idx].physprop_id;

--- a/Source/Radiation/Optics.H
+++ b/Source/Radiation/Optics.H
@@ -76,7 +76,7 @@ class Optics {
                      int nswbands, int nlwbands,
                      int ncol, int nlev, int nrh, int top_lev,
                      const std::vector<std::string>& aero_names,
-                     const real2d& zi, const real2d& pmid, const real2d& pint,
+                     const real2d& zi, const real2d& pmid, const real2d& pdel,
                      const real2d& temp, const real2d& qi,
                      const real2d& geom_radius);
 

--- a/Source/Radiation/Optics.cpp
+++ b/Source/Radiation/Optics.cpp
@@ -13,14 +13,14 @@ void Optics::initialize (int ngas, int nmodes, int num_aeros,
                          int nswbands, int nlwbands,
                          int ncol, int nlev, int nrh, int top_lev,
                          const std::vector<std::string>& aero_names,
-                         const real2d& zi, const real2d& pmid, const real2d& pint,
+                         const real2d& zi, const real2d& pmid, const real2d& pdel,
                          const real2d& temp, const real2d& qi,
                          const real2d& geom_radius)
 {
     cloud_optics.initialize();
     aero_optics.initialize(ngas, nmodes, num_aeros,
                            nswbands, nlwbands, ncol, nlev, nrh, top_lev,
-                           aero_names, zi, pmid, pint, temp, qi, geom_radius);
+                           aero_names, zi, pmid, pdel, temp, qi, geom_radius);
 }
 
 void Optics::finalize ()

--- a/Source/Radiation/Parameterizations.H
+++ b/Source/Radiation/Parameterizations.H
@@ -2,7 +2,7 @@
 // parameterization provides the tracer particle properties
 // that are not provided by the microphysics model
 //
-#ifndef ERF_PARAMETERIZATIONS_H
+#ifndef ERF_PARAMETERIZATIONS_H_
 #define ERF_PARAMETERIZATIONS_H_
 
 #include "rrtmgp_const.h"

--- a/Source/Radiation/Phys_prop.H
+++ b/Source/Radiation/Phys_prop.H
@@ -122,7 +122,7 @@ class PhysProp {
 
     // Look for filename in the global list of unique filenames (module data uniquefilenames).
     // If found, return it's index in the list.  Otherwise return -1.
-    int physprop_get_id (std::string filename)
+    int physprop_get_id (std::string filename) const
     {
         auto physprop_id = -1;
         auto numphysprops = uniquefilenames.size();
@@ -135,308 +135,308 @@ class PhysProp {
         return physprop_id;
     }
 
-    void get_sourcefile (int& id, std::string& sourcefile)
+    void get_sourcefile (int& id, std::string& sourcefile) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sourcefile: illegal ID value %d\n", id);
         sourcefile = physprop[id].sourcefile;
     }
 
-    void get_opticstype (int& id, std::string& opticstype)
+    void get_opticstype (int& id, std::string& opticstype) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_opticstype: illegal ID value %d\n", id);
         opticstype  = physprop[id].opticsmethod;
     }
 
-    void get_sw_hygro_ext (int& id, real2d& sw_hygro_ext)
+    void get_sw_hygro_ext (int& id, real2d& sw_hygro_ext) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_hygro_ext: illegal ID value %d\n", id);
         sw_hygro_ext = physprop[id].sw_hygro_ext;
     }
 
-    void get_sw_hygro_ssa (int& id, real2d& sw_hygro_ssa)
+    void get_sw_hygro_ssa (int& id, real2d& sw_hygro_ssa) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_hygro_ssa: illegal ID value %d\n", id);
         sw_hygro_ssa = physprop[id].sw_hygro_ssa;
     }
 
-    void get_sw_hygro_asm (int& id, real2d& sw_hygro_asm)
+    void get_sw_hygro_asm (int& id, real2d& sw_hygro_asm) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_hygro_asm: illegal ID value %d\n", id);
         sw_hygro_asm = physprop[id].sw_hygro_asm;
     }
 
-    void get_lw_hygro_abs (int& id, real2d& lw_hygro_abs)
+    void get_lw_hygro_abs (int& id, real2d& lw_hygro_abs) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_lw_hygro_abs: illegal ID value %d\n", id);
         lw_hygro_abs = physprop[id].lw_hygro_abs;
     }
 
-    void get_sw_nonhygro_ext (int& id, real1d& sw_nonhygro_ext)
+    void get_sw_nonhygro_ext (int& id, real1d& sw_nonhygro_ext) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_nonhygro_ext: illegal ID value %d\n", id);
         sw_nonhygro_ext = physprop[id].sw_nonhygro_ext;
     }
 
-    void get_sw_nonhygro_ssa (int& id, real1d& sw_nonhygro_ssa)
+    void get_sw_nonhygro_ssa (int& id, real1d& sw_nonhygro_ssa) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_nonhygro_ssa: illegal ID value %d\n", id);
         sw_nonhygro_ssa = physprop[id].sw_nonhygro_ssa;
     }
 
-    void get_sw_nonhygro_asm (int& id, real1d& sw_nonhygro_asm)
+    void get_sw_nonhygro_asm (int& id, real1d& sw_nonhygro_asm) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_nonhygro_asm: illegal ID value %d\n", id);
         sw_nonhygro_asm = physprop[id].sw_nonhygro_asm;
     }
 
-    void get_sw_nonhygro_scat (int& id, real1d& sw_nonhygro_scat)
+    void get_sw_nonhygro_scat (int& id, real1d& sw_nonhygro_scat) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_nonhygro_scat: illegal ID value %d\n", id);
         sw_nonhygro_scat = physprop[id].sw_nonhygro_scat;
     }
 
-    void get_sw_nonhygro_ascat (int& id, real1d& sw_nonhygro_ascat)
+    void get_sw_nonhygro_ascat (int& id, real1d& sw_nonhygro_ascat) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sw_nonhygro_ascat: illegal ID value %d\n", id);
         sw_nonhygro_ascat = physprop[id].sw_nonhygro_ascat;
     }
 
-    void get_lw_abs (int& id, real1d& lw_abs)
+    void get_lw_abs (int& id, real1d& lw_abs) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_lw_abs: illegal ID value %d\n", id);
         lw_abs = physprop[id].lw_abs;
     }
 
-    void get_ref_real_aer_sw (int& id, real1d& ref_real_aer_sw)
+    void get_ref_real_aer_sw (int& id, real1d& ref_real_aer_sw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_ref_real_aer_sw: illegal ID value %d\n", id);
         ref_real_aer_sw = physprop[id].refindex_real_aer_sw;
     }
 
-    void get_ref_real_aer_lw (int& id, real1d& ref_real_aer_lw)
+    void get_ref_real_aer_lw (int& id, real1d& ref_real_aer_lw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_ref_real_aer_lw: illegal ID value %d\n", id);
         ref_real_aer_lw = physprop[id].refindex_real_aer_lw;
     }
 
-    void get_ref_im_aer_sw (int& id, real1d& ref_im_aer_sw)
+    void get_ref_im_aer_sw (int& id, real1d& ref_im_aer_sw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_ref_im_aer_sw: illegal ID value %d\n", id);
         ref_im_aer_sw = physprop[id].refindex_im_aer_sw;
     }
 
-    void get_ref_im_aer_lw (int& id, real1d& ref_im_aer_lw)
+    void get_ref_im_aer_lw (int& id, real1d& ref_im_aer_lw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_ref_im_aer_lw: illegal ID value %d\n", id);
         ref_im_aer_lw = physprop[id].refindex_im_aer_lw;
     }
 
-    void get_r_sw_ext (int& id, real2d& r_sw_ext)
+    void get_r_sw_ext (int& id, real2d& r_sw_ext) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_r_sw_ext: illegal ID value %d\n", id);
         r_sw_ext = physprop[id].r_sw_ext;
     }
 
-    void get_r_sw_scat (int& id, real2d& r_sw_scat)
+    void get_r_sw_scat (int& id, real2d& r_sw_scat) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_r_sw_scat: illegal ID value %d\n", id);
         r_sw_scat = physprop[id].r_sw_scat;
     }
 
-    void get_r_sw_ascat (int& id, real2d& r_sw_ascat)
+    void get_r_sw_ascat (int& id, real2d& r_sw_ascat) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_r_sw_ascat: illegal ID value %d\n", id);
         r_sw_ascat = physprop[id].r_sw_ascat;
     }
 
-    void get_r_lw_abs (int& id, real2d& r_lw_abs)
+    void get_r_lw_abs (int& id, real2d& r_lw_abs) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_r_lw_abs: illegal ID value %d\n", id);
         r_lw_abs = physprop[id].r_lw_abs;
     }
 
-    void get_mu (int& id, real1d& mu)
+    void get_mu (int& id, real1d& mu) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_mu: illegal ID value %d\n", id);
         mu = physprop[id].mu;
     }
 
-    void get_extpsw (int& id, real4d& extpsw)
+    void get_extpsw (int& id, real4d& extpsw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_expsw: illegal ID value %d\n", id);
         extpsw = physprop[id].extpsw;
     }
 
-    void get_abspsw (int& id, real4d& abspsw)
+    void get_abspsw (int& id, real4d& abspsw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_abspsw: illegal ID value %d\n", id);
         abspsw = physprop[id].abspsw;
     }
 
-    void get_asmpsw (int& id, real4d& asmpsw)
+    void get_asmpsw (int& id, real4d& asmpsw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_asmpsw: illegal ID value %d\n", id);
         asmpsw = physprop[id].asmpsw;
     }
 
-    void get_absplw (int& id, real4d& absplw)
+    void get_absplw (int& id, real4d& absplw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_absplw: illegal ID value %d\n", id);
         absplw = physprop[id].absplw;
     }
 
-    void get_refrtabsw (int& id, real2d& refrtabsw)
+    void get_refrtabsw (int& id, real2d& refrtabsw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_refrtabsw: illegal ID value %d\n", id);
         refrtabsw = physprop[id].refrtabsw;
     }
 
-    void get_refitabsw (int& id, real2d& refitabsw)
+    void get_refitabsw (int& id, real2d& refitabsw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_refitabsw: illegal ID value %d\n", id);
         refitabsw = physprop[id].refitabsw;
     }
 
-    void get_refrtablw (int& id, real2d& refrtablw)
+    void get_refrtablw (int& id, real2d& refrtablw) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_refrtablw: illegal ID value %d\n", id);
         refrtablw = physprop[id].refrtablw;
     }
 
-    void get_refitablw (int& id, real2d& refitablw)
+    void get_refitablw (int& id, real2d& refitablw) const
     {
         if (id < 0 || id > physprop.size())
             printf("ger_refitablw: illegal ID value %d\n", id);
         refitablw = physprop[id].refitablw;
     }
 
-    void get_aername(int& id, std::string& aername)
+    void get_aername(int& id, std::string& aername) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_aername: illegal ID value %d\n", id);
         aername = physprop[id].aername;
     }
 
-    void get_density_aer(int& id, real& density_aer)
+    void get_density_aer(int& id, real& density_aer) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_density_aer: illegal ID value %d\n", id);
         density_aer = physprop[id].density_aer;
     }
 
-    void get_hygro_aer (int& id, real& hygro_aer)
+    void get_hygro_aer (int& id, real& hygro_aer) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_hygro_aer: illegal ID value %d\n", id);
         hygro_aer = physprop[id].hygro_aer;
     }
 
-    void get_dryrad_aer (int& id, real& dryrad_aer)
+    void get_dryrad_aer (int& id, real& dryrad_aer) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_dryrad_aer: illegal ID value %d\n", id);
         dryrad_aer = physprop[id].dryrad_aer;
     }
 
-    void get_dispersion_aer (int& id, real& dispersion_aer)
+    void get_dispersion_aer (int& id, real& dispersion_aer) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_dispersion_aer: illegal ID value %d\n", id);
         dispersion_aer = physprop[id].dispersion_aer;
     }
 
-    void get_num_to_mass_aer (int& id, real& num_to_mass_aer)
+    void get_num_to_mass_aer (int& id, real& num_to_mass_aer) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_num_to_mass_aer: illegal ID value %d\n", id);
         num_to_mass_aer = physprop[id].num_to_mass_aer;
     }
 
-    void get_ncoef (int& id, int& ncoef)
+    void get_ncoef (int& id, int& ncoef) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_ncoef: illegal ID value %d\n", id);
         ncoef = physprop[id].ncoef;
     }
 
-    void get_prefr (int& id, int& prefr)
+    void get_prefr (int& id, int& prefr) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_prefr: illegal ID value %d\n", id);
         prefr = physprop[id].prefr;
     }
 
-    void get_prefi (int& id, int& prefi)
+    void get_prefi (int& id, int& prefi) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_prefi: illegal ID value %d\n", id);
         prefi = physprop[id].prefi;
     }
 
-    void get_sigmag (int& id, real& sigmag)
+    void get_sigmag (int& id, real& sigmag) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_sigmag: illegal ID value %d\n", id);
         sigmag = physprop[id].sigmag;
     }
 
-    void get_dgnum (int& id, real& dgnum)
+    void get_dgnum (int& id, real& dgnum) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_dgnum: illegal ID value %d\n", id);
         dgnum = physprop[id].dgnum;
     }
 
-    void get_dgnumlo (int& id, real& dgnumlo)
+    void get_dgnumlo (int& id, real& dgnumlo) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_dgnumlo: illegal ID value %d\n", id);
         dgnumlo = physprop[id].dgnumlo;
     }
 
-    void get_dgnumhi (int& id, real& dgnumhi)
+    void get_dgnumhi (int& id, real& dgnumhi) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_dgnumhi: illegal ID value %d\n", id);
         dgnumhi = physprop[id].dgnumhi;
     }
 
-    void get_rhcrystal (int& id, real& rhcrystal)
+    void get_rhcrystal (int& id, real& rhcrystal) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_rhcrystal: illegal ID value %d\n", id);
         rhcrystal = physprop[id].rhcrystal;
     }
 
-    void get_rhdeliques (int& id, real& rhdeliques)
+    void get_rhdeliques (int& id, real& rhdeliques) const
     {
         if (id < 0 || id > physprop.size())
             printf("get_rhdeliques: illegal ID value %d\n", id);

--- a/Source/Radiation/Rad_constants.H
+++ b/Source/Radiation/Rad_constants.H
@@ -141,7 +141,7 @@ class RadConstants {
 
     // number of solar (shortwave) bands in the rrtmg code
     inline
-    static void get_number_sw_bands (int number_of_bands)
+    static void get_number_sw_bands (int& number_of_bands)
     {
         number_of_bands = nswbands;
     }
@@ -257,7 +257,8 @@ class RadConstants {
         for(auto igas = 0; igas < nradgas; ++igas) {
             if (gaslist[igas] == gasname) return igas;
         }
-        amrex::Print() << "rad_gas_index: can not find gas with name" << gasname << std::endl;
+        amrex::Abort("rad_gas_index: can not find gas with name " + gasname);
+        return -1;
     }
 };
 #endif

--- a/Source/Radiation/Radiation.H
+++ b/Source/Radiation/Radiation.H
@@ -113,6 +113,9 @@ class Radiation {
     amrex::MultiFab* m_lsm_fluxes = nullptr;
     amrex::MultiFab* m_lsm_zenith = nullptr;
 
+    std::string moisture_type = "None";
+    bool has_qmoist;
+
     // Specified uniform angle for radiation
     amrex::Real uniform_angle = 78.463;
 

--- a/Source/Radiation/Run_shortwave_rrtmgp.cpp
+++ b/Source/Radiation/Run_shortwave_rrtmgp.cpp
@@ -1,4 +1,5 @@
 #include "Rrtmgp.H"
+#include <AMReX_BLassert.H>
 
 void Rrtmgp::run_shortwave_rrtmgp (int ngas, int ncol, int nlay,
                                    const real3d& gas_vmr, const real2d& pmid      , const real2d& tmid      , const real2d& pint,
@@ -40,6 +41,18 @@ void Rrtmgp::run_shortwave_rrtmgp (int ngas, int ncol, int nlay,
     top_at_1_g.deep_copy_to(top_at_1_h);
     top_at_1 = top_at_1_h(1);
     real2d toa_flux("toa_flux", ncol, nswgpts);
+
+#ifdef AMREX_DEBUG
+    // print extra info from RRTMGP
+    k_dist_sw.print_norms();
+
+    // check pressure is within bounds
+    real pint_min = yakl::intrinsics::minval<real>(pint);
+    real pint_max = yakl::intrinsics::maxval<real>(pint);
+    AMREX_ASSERT(pint_max < k_dist_sw.get_press_max());
+    AMREX_ASSERT(pint_min > k_dist_sw.get_press_min());
+#endif
+
     k_dist_sw.gas_optics(ncol, nlay, top_at_1, pmid, pint, tmid, gas_concs, combined_optics, toa_flux);
 
     // Apply TOA flux scaling

--- a/Source/Utils/Sat_methods.H
+++ b/Source/Utils/Sat_methods.H
@@ -49,7 +49,7 @@ public:
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static void wv_sat_qsat_water (const amrex::Real& t, const amrex::Real& p,
-                                   amrex::Real es, amrex::Real qs, const int idx = 1) {
+                                   amrex::Real &es, amrex::Real &qs, const int idx = 1) {
         // Purpose:
         //   Calculate SVP over water at a given temperature, and then
         //   calculate and return saturation specific humidity.
@@ -64,7 +64,7 @@ public:
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static void wv_sat_qsat_ice (const amrex::Real& t, const amrex::Real& p,
-                                 amrex::Real es, amrex::Real qs, const int idx = 1) {
+                                 amrex::Real &es, amrex::Real &qs, const int idx = 1) {
         // Purpose:
         //   Calculate SVP over ice at a given temperature, and then
         //   calculate and return saturation specific humidity.
@@ -79,7 +79,7 @@ public:
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static void wv_sat_qsat_trans (const amrex::Real& t, const amrex::Real& p,
-                                   amrex::Real es, amrex::Real qs, const int idx = 1) {
+                                   amrex::Real &es, amrex::Real &qs, const int idx = 1) {
         // Purpose:
         //   Calculate SVP over ice at a given temperature, and then
         //   calculate and return saturation specific humidity.

--- a/Source/Utils/Water_vapor_saturation.H
+++ b/Source/Utils/Water_vapor_saturation.H
@@ -74,7 +74,7 @@ public:
     // LATENT HEAT OF VAPORIZATION CORRECTIONS
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static void no_ip_hltalt (const amrex::Real& t,
-                              amrex::Real hltalt) {
+                              amrex::Real& hltalt) {
         hltalt = lat_vap;
         // Account for change of lat_vap with t above freezing where
         // constant slope is given by -2369 j/(kg c) = cpv - cw
@@ -88,8 +88,8 @@ public:
     //  d(es)/dT within the water-ice transition range.
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     static void calc_hltalt (const amrex::Real& t,
-                             amrex::Real hltalt,
-                             amrex::Real tterm = 0.) {
+                             amrex::Real& hltalt,
+                             amrex::Real* tterm = nullptr) {
         amrex::Real tc, weight;
         no_ip_hltalt(t, hltalt);
         if (t < tmelt) {
@@ -103,8 +103,11 @@ public:
                 // ttrice is 40): required for accurate estimate of es
                 // derivative in transition range from ice to water
 
-                for(auto i = npcf-1; i > 0;  --i) tterm = pcf[i] + tc*tterm;
-                tterm = tterm/ttrice;
+                if (tterm)
+                {
+                    for(auto i = npcf-1; i > 0;  --i) *tterm = pcf[i] + tc*(*tterm);
+                    *tterm = *tterm/ttrice;
+                }
             }
             else {
                 weight = 1.0;
@@ -150,12 +153,12 @@ public:
                       const amrex::Real& p,
                       amrex::Real& es,
                       amrex::Real& qs,
-                      amrex::Real gam = 0.,
-                      amrex::Real dqsdt = 0. ,
-                      amrex::Real enthalpy = 0.) {
+                      amrex::Real* gam = nullptr,
+                      amrex::Real* dqsdt = nullptr,
+                      amrex::Real* enthalpy = nullptr) {
         // Local variables
         amrex::Real hltalt;       // Modified latent heat for T derivatives
-        amrex::Real tterm;        // Account for d(es)/dT in transition region
+        amrex::Real tterm = 0.0;        // Account for d(es)/dT in transition region
 
         es = svp_trans(t); //estblf(t);
 
@@ -167,11 +170,17 @@ public:
         // Calculate optional arguments.
         // "generalized" analytic expression for t derivative of es
         // accurate to within 1 percent for 173.16 < t < 373.16
-        calc_hltalt(t, hltalt, tterm);
+        calc_hltalt(t, hltalt, &tterm);
 
-        enthalpy = tq_enthalpy(t, qs, hltalt);
+        if (enthalpy)
+        {
+            *enthalpy = tq_enthalpy(t, qs, hltalt);
+        }
 
-        deriv_outputs(t, p, es, qs, hltalt, tterm, gam, dqsdt);
+        if (gam && dqsdt)
+        {
+            deriv_outputs(t, p, es, qs, hltalt, tterm, *gam, *dqsdt);
+        }
     }
 
     // Calculate SVP over water at a given temperature, and then
@@ -183,9 +192,9 @@ public:
                             const amrex::Real& p,
                             amrex::Real& es,
                             amrex::Real& qs,
-                            amrex::Real gam = 0.,
-                            amrex::Real dqsdt = 0.,
-                            amrex::Real enthalpy = 0.) {
+                            amrex::Real* gam = nullptr,
+                            amrex::Real* dqsdt = nullptr,
+                            amrex::Real* enthalpy = nullptr) {
         // Local variables
         amrex::Real hltalt;       // Modified latent heat for T derivatives
 
@@ -196,10 +205,16 @@ public:
 
         no_ip_hltalt(t, hltalt);
 
-        enthalpy = tq_enthalpy(t, qs, hltalt);
+        if (enthalpy)
+        {
+            *enthalpy = tq_enthalpy(t, qs, hltalt);
+        }
 
-        // For pure water/ice transition term is 0.
-        deriv_outputs(t, p, es, qs, hltalt, 0., gam, dqsdt);
+        if (gam && dqsdt)
+        {
+            // For pure water/ice transition term is 0.
+            deriv_outputs(t, p, es, qs, hltalt, 0., *gam, *dqsdt);
+        }
     }
 
     //  Calculate SVP over ice at a given temperature, and then
@@ -313,9 +328,9 @@ public:
 
         // Generate qsp, gam, and enout from tsp.
         if (use_ice)
-            qsat(tsp, p, es, qsp, gam, enout);
+            qsat(tsp, p, es, qsp, &gam, &enout);
         else
-            qsat_water(tsp, p, es, qsp, gam, enout);
+            qsat_water(tsp, p, es, qsp, &gam, &enout);
 
         // iterate on first guess
         for(auto l = 1; l < iter; ++l) {
@@ -346,9 +361,9 @@ public:
 
             // Re-generate qsp, gam, and enout from new tsp.
             if (use_ice)
-                qsat(tsp, p, es, q1, gam, enout);
+                qsat(tsp, p, es, q1, &gam, &enout);
             else
-                qsat_water(tsp, p, es, q1, gam, enout);
+                qsat_water(tsp, p, es, q1, &gam, &enout);
 
             dq = abs(q1 - qsp)/std::max(q1,1.e-12);
             qsp = q1;


### PR DESCRIPTION
This fixes a few bugs found in the RRTMGP interface and adds plotfile output to the qsrc terms.
- Fix crash if running radiation model without any moisture model
- Fix number of day and night columns, add checks to ensure they sum to total ncols
- Fix indexing of some variables when compressing to daytime-only arrays
- Fix issue where `pint_day` was not set at `nlev+1`
- Add debug check to make sure column pressures are within model bounds
- Add model output heating source terms `qsrc_sw` and `qsrc_lw` to Plotfile
- Update how Aero_rad_props was setting pdel. `pdeldry` was previously set to `pmiddle` causing `pmiddle` to be overwritten and `pdeldry` to be 0.
- Fix water sat util functions to return calculated values
- Temporarily disable `do_aerosol_rad` option since model crashes if enabled.

More work still needs to be done to verify the radiation model is working as expected. There are still issues when `do_aerosol_rad = true` and if the model is run in parallel.