### PR TITLE
Fix ABL tests on GPUs

### DIFF
--- a/Source/BoundaryConditions/MOSTAverage.cpp
+++ b/Source/BoundaryConditions/MOSTAverage.cpp
@@ -850,9 +850,11 @@ MOSTAverage::compute_plane_averages (int lev)
     }
     else // copy temperature
     {
-        int iavg        = m_navg - 2;
-        denom[iavg]     = 1.0 / (Real)ncell_plane[iavg];
-        plane_avg[iavg] = plane_avg[2];
+        int iavg    = m_navg - 2;
+        denom[iavg] = 1.0 / (Real)ncell_plane[iavg];
+        // plane_avg[iavg] = plane_avg[2]
+        Gpu::copy(Gpu::deviceToDevice, pavg.begin() + 2, pavg.begin() + 3,
+                  pavg.begin() + iavg);
     }
 
     //

--- a/Source/Diffusion/DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/DiffusionSrcForState_N.cpp
@@ -667,14 +667,14 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
     if (l_use_QKE && start_comp <= RhoQKE_comp && end_comp >=RhoQKE_comp) {
         int qty_index = RhoQKE_comp;
         auto pbl_mynn_B1_l = turbChoice.pbl_mynn_B1;
-        bool c_ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc].lo(2) == ERFBCType::ext_dir) );
-        bool c_ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc].lo(5) == ERFBCType::ext_dir) );
-        bool u_ext_dir_on_zlo = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir) );
-        bool u_ext_dir_on_zhi = ( (bc_ptr[BCVars::xvel_bc].lo(5) == ERFBCType::ext_dir) );
-        bool v_ext_dir_on_zlo = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir) );
-        bool v_ext_dir_on_zhi = ( (bc_ptr[BCVars::yvel_bc].lo(5) == ERFBCType::ext_dir) );
         ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
+            bool c_ext_dir_on_zlo = ( (bc_ptr[BCVars::cons_bc].lo(2) == ERFBCType::ext_dir) );
+            bool c_ext_dir_on_zhi = ( (bc_ptr[BCVars::cons_bc].lo(5) == ERFBCType::ext_dir) );
+            bool u_ext_dir_on_zlo = ( (bc_ptr[BCVars::xvel_bc].lo(2) == ERFBCType::ext_dir) );
+            bool u_ext_dir_on_zhi = ( (bc_ptr[BCVars::xvel_bc].lo(5) == ERFBCType::ext_dir) );
+            bool v_ext_dir_on_zlo = ( (bc_ptr[BCVars::yvel_bc].lo(2) == ERFBCType::ext_dir) );
+            bool v_ext_dir_on_zhi = ( (bc_ptr[BCVars::yvel_bc].lo(5) == ERFBCType::ext_dir) );
             cell_rhs(i, j, k, qty_index) += ComputeQKESourceTerms(i,j,k,u,v,cell_data,cell_prim,
                                                                   mu_turb,cellSizeInv,domain,
                                                                   pbl_mynn_B1_l,tm_arr(i,j,0),

--- a/Source/TimeIntegration/ERF_advance_dycore.cpp
+++ b/Source/TimeIntegration/ERF_advance_dycore.cpp
@@ -214,7 +214,7 @@ void ERF::advance_dycore(int level,
     if (l_use_kturb)
     {
         // NOTE: state_new transfers to state_old for PBL (due to ptr swap in advance)
-        const BCRec* bc_ptr_d = domain_bcs_type_d.data();
+        const BCRec* bc_ptr_h = domain_bcs_type.data();
         ComputeTurbulentViscosity(xvel_old, yvel_old,
                                   *Tau11_lev[level].get(), *Tau22_lev[level].get(), *Tau33_lev[level].get(),
                                   *Tau12_lev[level].get(), *Tau13_lev[level].get(), *Tau23_lev[level].get(),
@@ -222,7 +222,7 @@ void ERF::advance_dycore(int level,
                                   *eddyDiffs, *Hfx1, *Hfx2, *Hfx3, *Diss, // to be updated
                                   fine_geom, *mapfac_u[level], *mapfac_v[level],
                                   z_phys_nd[level], tc, solverChoice.gravity,
-                                  m_most, exp_most, l_use_moisture, level, bc_ptr_d);
+                                  m_most, exp_most, l_use_moisture, level, bc_ptr_h);
     }
 
     // ***********************************************************************************************


### PR DESCRIPTION
* `ABL_MOST` segfaults on Lassen, not sure why this doesn't happen in the nightly tests

* `ABL_MYNN_PBL` is not in the nightly tests
 
   * The input sounding file is not found because the full file path need to be provided -- add `INPUT_SOUNDING` argument to `add_test_r`
 
  * Segfault in `ComputeTurbulentViscosityPBL` -- pass host version of `domain_bcs_type` (alternatively could move `bool *_ext_dir_on_*` flags in `ComputeTurbulentViscosityPBL` inside `ParallelFor`

  * Segfault in `DiffusionSrcForState_N` -- move `bool *_ext_dir_on_*` flags inside `ParallelFor`

The GPU build of the `ABL_MYNN_PBL` test still fails on Lassen though. Not sure if a new gold file is needed because of the input sounding file problem or if there's another issue. The CPU `fcompre` output is 
```
             variable name            absolute error            relative error
                                         (||A - B||)         (||A - B||/||A||)
  ----------------------------------------------------------------------------
  level = 0
  density                            9.103828802e-15           6.886544933e-15
  rhoQKE                              1.36487488e-11           9.238371606e-12
  x_velocity                         8.153477893e-13           1.019184715e-13
  y_velocity                         7.536262331e-15           2.136273283e-13
  z_velocity                         6.790261835e-14           2.012320074e-08
  theta                              1.818989404e-12           6.788065413e-15
  pressure                           1.164153218e-10           1.155378706e-15
  Kmv                                 2.06592965e-10           1.703209758e-10
  Khv                                 4.44722037e-10           1.960210041e-10
  PLOTFILE AGREE to specified tolerances: absolute = 2e-10 relative = 2e-10
2/3 Test #33: ABL_MYNN_PBL .....................   Passed    7.61 sec
```
while the GPU `fcompare` is
```
             variable name            absolute error            relative error
                                         (||A - B||)         (||A - B||/||A||)
  ----------------------------------------------------------------------------
  level = 0
  density                            6.728311221e-06           5.089596757e-06
  rhoQKE                                0.1082811306             0.07329179669
  x_velocity                           0.01079617625            0.001349522003
  y_velocity                          9.43657388e-05             0.00267494678
  z_velocity                         8.197856447e-06               2.429466123
  theta                               0.001412069874           5.269531892e-06
  pressure                             0.02744788973           2.724100817e-07
  Kmv                                   0.9301580474              0.7668481177
  Khv                                    1.517888149              0.6690425351
2/3 Test #33: ABL_MYNN_PBL .....................***Failed   34.81 sec
```



