### PR TITLE
Nscalar Bounds Fix

### DIFF
--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -72,26 +72,31 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
+
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int l_bc_type = bc_ptr[n].lo(0);
 
                 if (l_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][0];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][0];
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_lo.x,j,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][0];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][0];
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int h_bc_type = bc_ptr[n].hi(0);
 
                 if (h_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][3];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][3];
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_hi.x,j,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][3];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][3];
                 }
             }
         );
@@ -105,23 +110,27 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int l_bc_type = bc_ptr[n].lo(1);
                 if (l_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][1];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][1];
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_lo.y,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][1];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][1];
                 }
             },
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int h_bc_type = bc_ptr[n].hi(1);
                 if (h_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][4];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][4];
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_hi.y,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][4];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][4];
                 }
             }
         );
@@ -304,25 +313,29 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
             bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int l_bc_type = bc_ptr[n].lo(2);
 
                 if (l_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][2];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][2];
 
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,j,dom_lo.z,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][2];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][2];
                 }
             },
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                                 BCVars::RhoScalar_bc_comp : dest_comp;
                 int h_bc_type = bc_ptr[n].hi(2);
                 if (h_bc_type == ERFBCType::ext_dir) {
-                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[n][5];
+                    dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][5];
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,j,dom_hi.z,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[n][5];
+                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][5];
                 }
 
             }

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -72,10 +72,10 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         ParallelFor(
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
-
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int l_bc_type = bc_ptr[n].lo(0);
 
                 if (l_bc_type == ERFBCType::ext_dir) {
@@ -88,8 +88,9 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int h_bc_type = bc_ptr[n].hi(0);
 
                 if (h_bc_type == ERFBCType::ext_dir) {
@@ -105,13 +106,15 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
     if (!is_periodic_in_y)
     {
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
-        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
+        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_
+                                         hi.y+1);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int l_bc_type = bc_ptr[n].lo(1);
                 if (l_bc_type == ERFBCType::ext_dir) {
                     dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][1];
@@ -123,8 +126,9 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int h_bc_type = bc_ptr[n].hi(1);
                 if (h_bc_type == ERFBCType::ext_dir) {
                     dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][4];
@@ -313,10 +317,10 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
             bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int l_bc_type = bc_ptr[n].lo(2);
-
                 if (l_bc_type == ERFBCType::ext_dir) {
                     dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][2];
 
@@ -328,8 +332,9 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
-                int bc_comp   = (icomp+nc >= RhoScalar_comp && icomp+nc < RhoScalar_comp+NSCALARS) ?
+                int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
+                if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int h_bc_type = bc_ptr[n].hi(2);
                 if (h_bc_type == ERFBCType::ext_dir) {
                     dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][5];

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -52,7 +52,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         }
 
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++) {
-            l_bc_extdir_vals_d[nc][ori]  = m_bc_extdir_vals[bc_comp][ori];
+            l_bc_extdir_vals_d[bc_comp][ori]  = m_bc_extdir_vals[bc_comp][ori];
         }
     }
 
@@ -288,8 +288,8 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
         }
 
         for (int ori = 0; ori < 2*AMREX_SPACEDIM; ori++) {
-            l_bc_extdir_vals_d[nc][ori]  = m_bc_extdir_vals[bc_comp][ori];
-            l_bc_neumann_vals_d[nc][ori] = m_bc_neumann_vals[bc_comp][ori];
+            l_bc_extdir_vals_d[bc_comp][ori]  = m_bc_extdir_vals[bc_comp][ori];
+            l_bc_neumann_vals_d[bc_comp][ori] = m_bc_neumann_vals[bc_comp][ori];
         }
     }
 

--- a/Source/BoundaryConditions/BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/BoundaryConditions_cons.cpp
@@ -106,8 +106,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
     if (!is_periodic_in_y)
     {
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
-        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_
-                                         hi.y+1);
+        Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
         ParallelFor(
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -63,7 +63,7 @@ function(add_test_d TEST_NAME TEST_EXE PLTFILE)
     setup_test()
 
     set(TEST_EXE ${CMAKE_BINARY_DIR}/Exec/${TEST_EXE})
-    set(FCOMPARE_TOLERANCE "-r 2.0e-9 --abs_tol 2.0e-9")
+    set(FCOMPARE_TOLERANCE "-r 3.0e-9 --abs_tol 3.0e-9")
     set(FCOMPARE_FLAGS "--abort_if_not_all_found -a ${FCOMPARE_TOLERANCE}")
     set(test_command sh -c "${MPI_COMMANDS} ${TEST_EXE} ${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i > ${TEST_NAME}.log && ${MPI_FCOMP_COMMANDS} ${FCOMPARE_EXE} ${FCOMPARE_FLAGS} ${PLOT_GOLD} ${CURRENT_TEST_BINARY_DIR}/${PLTFILE}")
 
@@ -135,7 +135,7 @@ add_test_r(TaylorGreenAdvectingDiffusing     "RegTests/TaylorGreenVortex/*/erf_t
 add_test_r(MSF_NoSub_IsentropicVortexAdv     "RegTests/IsentropicVortex/*/erf_isentropic_vortex.exe" "plt00010")
 add_test_r(MSF_Sub_IsentropicVortexAdv       "RegTests/IsentropicVortex/*/erf_isentropic_vortex.exe" "plt00010")
 add_test_r(ABL_MOST                          "ABL/*/erf_abl.exe" "plt00010")
-add_test_r(ABL_MYNN_PBL                      "ABL/*/erf_abl.exe" "plt00100" INPUT_SOUNDING "input_sounding_GABLS1")
+add_test_d(ABL_MYNN_PBL                      "ABL/*/erf_abl.exe" "plt00100" INPUT_SOUNDING "input_sounding_GABLS1")
 add_test_r(ABL_InflowFile                    "ABL/*/erf_abl.exe" "plt00010")
 add_test_r(MoistBubble                       "RegTests/Bubble/*/erf_bubble.exe" "plt00010")
 
@@ -175,7 +175,7 @@ add_test_r(TaylorGreenAdvectingDiffusing     "RegTests/TaylorGreenVortex/erf_tay
 add_test_r(MSF_NoSub_IsentropicVortexAdv     "RegTests/IsentropicVortex/erf_isentropic_vortex" "plt00010")
 add_test_r(MSF_Sub_IsentropicVortexAdv       "RegTests/IsentropicVortex/erf_isentropic_vortex" "plt00010")
 add_test_r(ABL_MOST                          "ABL/erf_abl" "plt00010")
-add_test_r(ABL_MYNN_PBL                      "ABL/erf_abl" "plt00100" INPUT_SOUNDING "input_sounding_GABLS1")
+add_test_d(ABL_MYNN_PBL                      "ABL/erf_abl" "plt00100" INPUT_SOUNDING "input_sounding_GABLS1")
 add_test_r(ABL_InflowFile                    "ABL/erf_abl" "plt00010")
 add_test_r(MoistBubble                       "RegTests/Bubble/erf_bubble" "plt00010")
 


### PR DESCRIPTION
With the generalization to allow for `NSCALARS` we have a copy that occurs in the `BoundaryConditions_cons.cpp` file into the variable [l_bc_extdir_vals_d](https://github.com/AMLattanzi/ERF/blob/751d5d4e39c97f23de84da30db486dd919ea5663/Source/BoundaryConditions/BoundaryConditions_cons.cpp#L35). This variable is allocated with `NBCVAR_max = NDRY + 1 + MOIST_max`. However, we try to access it over the for loop iterator `nc \in [icomp ncomp]`. Since `nc` will loop at most from `[0 NSCALAR + NDRY + 1]` we have a bounds access issue. We need to protect against this by using `bc_comp` likes is done for `m_bc_extdir_vals_d`.