### PR TITLE
use perl instead of sed for style checks for portability for Mac

### DIFF
--- a/.github/workflows/style/check_tabs.sh
+++ b/.github/workflows/style/check_tabs.sh
@@ -21,7 +21,7 @@ find . -type d \( -name .git \
                     -a ! -name "*.lex.h" -a ! -name "*.lex.cpp" \) \
                \) \
     -exec grep -Iq . {} \; \
-    -exec sed -i 's/\t/\ \ \ \ /g' {} +
+    -exec perl -i -pe's/\t/\ \ \ \ /g' {} +
 
 gitdiff=`git diff`
 

--- a/.github/workflows/style/check_trailing_whitespaces.sh
+++ b/.github/workflows/style/check_trailing_whitespaces.sh
@@ -21,7 +21,7 @@ find . -type d \( -name .git \
                     -a ! -name "*.lex.h" -a ! -name "*.lex.cpp" \) \
                \) \
     -exec grep -Iq . {} \; \
-    -exec sed -i 's/[[:blank:]]\+$//g' {} +
+    -exec perl -i -pe's/[[:blank:]]+$//g' {} +
 
 gitdiff=`git diff`
 


### PR DESCRIPTION
Same change as: https://github.com/AMReX-Codes/amrex/pull/4127

BSD and GNU sed have different interfaces, so use perl instead.