### PR TITLE
Adaptive timestep bug fix

### DIFF
--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -207,7 +207,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
 
          // Compressible with or without substepping
          } else {
-             return estdt_comp;
+             return estdt_lowM;
          }
      }
 }


### PR DESCRIPTION
Hi ERF team,

I noticed what I think is unintended behavior when using the adaptive timestep option (fixed_dt = -1) for compressible simulations. 

The issue comes from the output value of the ERF:estTimeStep function, which was recently modified to output the compressible dt for compressible flows with adaptive timestepping and acoustic substepping. But, when acoustic substepping is enabled, this makes it so that the big timestep is equal to the compressible dt which is then further substepped in time. 

I've posted a sample output below for the SquallLine_2D case, with the only modification to the input file is setting fixed_dt = -1. Note that the first timestep only integrates over the compressible dt (0.23 sec) instead of the incompressible dt (17.92 sec).

I've suggested a simple fix, but it might require further discussion of what the compressible simulation without substepping should look like.


Sample output from SquallLine_2D below.
---------------------------------------------------------------------
$ lrun -T 1 ./ERF3d.gnu.TEST.MPI.ex inputs_moisture_SAM 

Initializing AMReX (24.09-11-gc88b2b51c1ce)...
MPI initialized with 1 MPI processes
MPI initialized with thread support level 0
AMReX (24.09-11-gc88b2b51c1ce) initialized
Successfully read inputs file ... 

ERF git hash: e7e76f36
AMReX git hash: 24.09-11-gc88b2b51c

No inflow perturbation method selected
Using dycore_horiz_adv_type: Centered_2nd
Using dycore_vert_adv_type: Centered_2nd
Using dryscal_horiz_adv_type: Centered_2nd
Using dryscal_vert_adv_type: Centered_2nd
Using moistscal_horiz_adv_type: Centered_2nd
Using moistscal_vert_adv_type: Centered_2nd
Using constant kinematic diffusion coefficients
  momentum : 100 m^2/s
  temperature : 100 m^2/s
  scalar : 100 m^2/s
Null land surface model!
SOLVER CHOICE: 
no_substepping              : 0
force_stage1_single_substep : 1
incompressible at level     : 0 is 0
use_coriolis                : 0
use_gravity                 : 1
Using one-way coupling 
Using static terrain 
ABL Driver Type: None
No ABL driver selected 
Buoyancy_type               : 1
Advection Choices: 
dycore_horiz_adv_type       : Centered_2nd
dycore_vert_adv_type        : Centered_2nd
dryscal_horiz_adv_type      : Centered_2nd
dryscal_vert_adv_type       : Centered_2nd
moistscal_horiz_adv_type    : Centered_2nd
moistscal_vert_adv_type     : Centered_2nd
Diffusion choices: 
rho0_trans                  : 1
alpha_T                     : 100
alpha_C                     : 100
dynamicViscosity            : 100
Sponge choices: 
Turbulence Settings at level 0
Using DNS model at level 0
SAM moisture model!
Creating new distribution map on level: 0

TIME= 0     MASS          = 1.911968471e+11
TIME= 0 RHO THETA         = 6.265888142e+13
TIME= 0 RHO SCALAR        = 2222013936
Using cfl = 0.8
Compressible dt at level 0:  0.231703639
Incompressible dt at level 0:  17.92114695
smallest even ratio is: 78
Writing native checkpoint chk00000
Writing native plotfile plt00000

Coarse STEP 1 starts ...
Using cfl = 0.8
Compressible dt at level 0:  0.231703639
Incompressible dt at level 0:  17.92114695
smallest even ratio is: 78
Timestep 0: shrink initial dt at level 0 by 1
[Level 0 step 1] ADVANCE from time = 0 to 0.231703639 with dt = 0.231703639
Making slow rhs at time 0 for fast variables advancing from 0 to 0.07723454634
Calling fast rhs at level 0 with dt = 0.07723454634
Making slow rhs at time 0 for slow variables advancing from 0 to 0.07723454634
Making slow rhs at time 0.07723454634 for fast variables advancing from 0 to 0.1158518195
Calling fast rhs at level 0 with dt = 0.002970559475
Calling fast rhs at level 0 with dt = 0.002970559475
Calling fast rhs at level 0 with dt = 0.002970559475
.
. (clipped for brevity)
. 
Calling fast rhs at level 0 with dt = 0.002970559475
Making slow rhs at time 0.1158518195 for slow variables advancing from 0 to 0.231703639
Done with advance_dycore at level 0
[Level 0 step 1] Advanced 98304 cells
Cloud fraction 0  0
Coarse STEP 1 ends. TIME = 0.231703639 DT = 0.231703639

TIME= 0.231703639     MASS          = 1.91196847e+11
TIME= 0.231703639 RHO THETA         = 6.265888138e+13
TIME= 0.231703639 RHO SCALAR        = 2222013936
