### PR TITLE
Submodules: dependabot updates and shallow clones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,3 @@ updates:
     directory: /
     allow:
       - dependency-name: "Submodules/AMReX"
-      - dependency-name: "Submodules/RRTMGP"
-      - dependency-name: "Submodules/WW3"
-      - dependency-name: "Submodules/YAKL"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: gitsubmodule
+    schedule:
+        interval: "monthly"
+    directory: /
+    allow:
+      - dependency-name: "Submodules/AMReX"
+      - dependency-name: "Submodules/RRTMGP"
+      - dependency-name: "Submodules/WW3"
+      - dependency-name: "Submodules/YAKL"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,16 @@
 [submodule "Submodules/AMReX"]
 	path = Submodules/AMReX
 	url = https://github.com/amrex-codes/amrex.git
+	shallow = true
 [submodule "Submodules/YAKL"]
 	path = Submodules/YAKL
 	url = https://github.com/mrnorman/YAKL
+	shallow = true
 [submodule "Submodules/RRTMGP"]
 	path = Submodules/RRTMGP
 	url = https://github.com/E3SM-Project/rte-rrtmgp
+	shallow = true
 [submodule "Submodules/WW3"]
 	path = Submodules/WW3
 	url = https://github.com/erf-model/WW3
+	shallow = true


### PR DESCRIPTION
This PR does two things. There are plusses and minuses to both so I'm not going to merge just yet:

- Set up dependabot updates for the submodules. Dependabot will automatically create a PR once per month to update each submodule if more recent versions are available. These PRs must still be approved and can be discarded if undesired, and submodules can still be manually updated whenever desired. See amr-wind example: https://github.com/Exawind/amr-wind/pull/1241 (for this to work, a rule exception would have to be added to allow dependabot to create branches in the github repo). This ensures the code stays up to date, but does create extra noise in terms of pull reuqests.

- Recommend shallow clones for submodules. Somewhat reduces the download size of ERF, but not a huge impact because the tip of all active branches still gets cloned for each submodule. Users can unshallow if they desire the full git history, but that does create an extra step.