### PR TITLE
Radiation model fix for MPI

### DIFF
--- a/Source/Radiation/ERF_Radiation.H
+++ b/Source/Radiation/ERF_Radiation.H
@@ -121,6 +121,8 @@ class Radiation {
     std::string moisture_type = "None";
     bool has_qmoist;
 
+    amrex::Vector<int> rank_offsets;
+
     // Specified uniform angle for radiation
     amrex::Real uniform_angle = 78.463;
 

--- a/Source/Utils/ERF_Orbit.H
+++ b/Source/Utils/ERF_Orbit.H
@@ -10,6 +10,7 @@ void
 zenith (int& calday,
         amrex::MultiFab* clat,
         amrex::MultiFab* clon,
+        const amrex::Vector<int> &rank_offsets,
         real1d& coszrs,
         int& ncol,
         const amrex::Real& eccen,

--- a/Source/Utils/ERF_Orbit.cpp
+++ b/Source/Utils/ERF_Orbit.cpp
@@ -6,6 +6,7 @@ void
 zenith (int& calday,
         amrex::MultiFab* clat,
         amrex::MultiFab* clon,
+        const amrex::Vector<int> &rank_offsets,
         real1d& coszrs,
         int& ncol,
         const Real& eccen,
@@ -29,10 +30,12 @@ zenith (int& calday,
             auto lat_array = clat->array(mfi);
             auto lon_array = clon->array(mfi);
 
+            const int offset = rank_offsets[mfi.LocalIndex()];
+
             // NOTE: lat/lon are 2D multifabs!
             ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
             {
-                auto icol = j*nx+i+1;
+                auto icol = (j-tbx.smallEnd(1))*nx + (i-tbx.smallEnd(0)) + 1 + offset;
                 coszrs(icol) = shr_orb_cosz(calday, lat_array(i,j,0), lon_array(i,j,0), delta, uniform_angle);
             });
        }


### PR DESCRIPTION
This updates the index mapping in the RRTMGP interface to handle multiple MPI ranks. Each rank determines the total `ncol` from the distribution mapping and uses an offset to map from RRTMGP column index to MultiFab `i,j,k`.

This also fixes an indexing issue with `gas_vmr` for both shortwave and longwave radiation.

