### PR TITLE
HOEXTRAP fix

### DIFF
--- a/Exec/SquallLine_2D/inputs_moisture_WRF
+++ b/Exec/SquallLine_2D/inputs_moisture_WRF
@@ -58,12 +58,12 @@ erf.alpha_C = 100.0
 erf.moisture_model = "Kessler"
 erf.use_moist_background = true
 
-erf.dycore_horiz_adv_type    = "Centered_2nd"
-erf.dycore_vert_adv_type     = "Centered_2nd"
-erf.dryscal_horiz_adv_type   = "Centered_2nd"
-erf.dryscal_vert_adv_type    = "Centered_2nd"
-erf.moistscal_horiz_adv_type = "Centered_2nd"
-erf.moistscal_vert_adv_type  = "Centered_2nd"
+erf.dycore_horiz_adv_type    = Upwind_3rd
+erf.dycore_vert_adv_type     = Upwind_3rd 
+erf.dryscal_horiz_adv_type   = Upwind_3rd 
+erf.dryscal_vert_adv_type    = Upwind_3rd 
+erf.moistscal_horiz_adv_type = Upwind_3rd 
+erf.moistscal_vert_adv_type  = Upwind_3rd 
 
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0

--- a/Source/BoundaryConditions/ERF_BoundaryConditions_cons.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditions_cons.cpp
@@ -166,7 +166,8 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrapcc) {
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(dom_lo.x,j,k,dest_comp) - dest_arr(dom_lo.x+1,j,k,dest_comp) ;
+                    Real delta_i = (dom_lo.x - i);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp) ;
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
@@ -183,7 +184,8 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrapcc) {
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(dom_hi.x,j,k,dest_comp) - dest_arr(dom_hi.x-1,j,k,dest_comp) ;
+                    Real delta_i = (i - dom_hi.x);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp) ;
                 }
             }
         );
@@ -213,7 +215,8 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrapcc) {
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(i,dom_lo.y,k,dest_comp) - dest_arr(i,dom_lo.y+1,k,dest_comp) ;
+                    Real delta_j = (dom_lo.y - j);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp) ;
                 }
 
             },
@@ -231,7 +234,8 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrapcc) {
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(i,dom_hi.y,k,dest_comp) - dest_arr(i,dom_hi.y-1,k,dest_comp);
+                    Real delta_j = (j - dom_hi.y);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
                 }
             }
         );
@@ -373,7 +377,8 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                     dest_arr(i,j,k,dest_comp) = dest_arr(i,j,dom_lo.z,dest_comp) -
                         delta_z*l_bc_neumann_vals_d[bc_comp][2]*dest_arr(i,j,dom_lo.z,Rho_comp);
                 } else if (l_bc_type == ERFBCType::hoextrapcc) {
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(i,j,dom_lo.z,dest_comp) - dest_arr(i,j,dom_lo.z+1,dest_comp);
+                    Real delta_k = (dom_lo.z - k);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_k)*dest_arr(i,j,dom_lo.z,dest_comp) - delta_k*dest_arr(i,j,dom_lo.z+1,dest_comp);
                 }
             },
             bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
@@ -402,7 +407,8 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                             delta_z*l_bc_neumann_vals_d[bc_comp][5]*dest_arr(i,j,dom_hi.z,Rho_comp);
                     }
                 } else if (h_bc_type == ERFBCType::hoextrapcc){
-                    dest_arr(i,j,k,dest_comp) = 2.0*dest_arr(i,j,dom_hi.z,dest_comp) - dest_arr(i,j,dom_hi.z-1,dest_comp);
+                    Real delta_k = (k - dom_hi.z);
+                    dest_arr(i,j,k,dest_comp) = (1.0 + delta_k)*dest_arr(i,j,dom_hi.z,dest_comp) - delta_k*dest_arr(i,j,dom_hi.z-1,dest_comp);
                 }
             }
         );


### PR DESCRIPTION
We need to extrapolate the gradient through all the ghost cells with `HOEXTRAP`. This impact higher order advection stencils and keeps the squall line stable with things other than `2nd order`.