### PR TITLE
Real BDY Re-factor

### DIFF
--- a/Exec/DevTests/MetGrid/inputs
+++ b/Exec/DevTests/MetGrid/inputs
@@ -7,7 +7,7 @@ amrex.fpe_trap_overflow = 1
 
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  28000 16000 8000
-amr.n_cell           =   140 80 100
+amr.n_cell           =   140     80  100
 
 geometry.is_periodic = 0 0 0
 

--- a/Source/BoundaryConditions/ERF_BoundaryConditions_realbdy.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditions_realbdy.cpp
@@ -29,8 +29,14 @@ ERF::fill_from_realbdy (const Vector<MultiFab*>& mfs,
     Real oma   = 1.0 - alpha;
 
     // Flags for read vars and index mapping
-    Vector<int> cons_read = {1, 1, 0, 0, 0, 1, 0, 0, 0};
-    Vector<int> cons_map = {RealBdyVars::R, RealBdyVars::T, 0, 0, 0, RealBdyVars::QV, 0, 0, 0};
+    Vector<int> cons_read = {0, 1, 0,
+                             0, 0, 1,
+                             0, 0, 0,
+                             0, 0};
+    Vector<int> cons_map = {Rho_comp,    RealBdyVars::T, RhoKE_comp,
+                            RhoQKE_comp, RhoScalar_comp, RealBdyVars::QV,
+                            RhoQ2_comp,  RhoQ3_comp,     RhoQ4_comp,
+                            RhoQ5_comp,  RhoQ6_comp};
 
     Vector<Vector<int>> is_read;
     is_read.push_back( cons_read );
@@ -113,6 +119,7 @@ ERF::fill_from_realbdy (const Vector<MultiFab*>& mfs,
                             jj = std::min(jj, dom_hi.y);
                         dest_arr(i,j,k,comp_idx) = oma   * bdatxlo_n  (ii,jj,k,0)
                                                  + alpha * bdatxlo_np1(ii,jj,k,0);
+                        if (var_idx == Vars::cons) dest_arr(i,j,k,comp_idx) *= dest_arr(i,j,k,Rho_comp);
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
@@ -121,6 +128,7 @@ ERF::fill_from_realbdy (const Vector<MultiFab*>& mfs,
                             jj = std::min(jj, dom_hi.y);
                         dest_arr(i,j,k,comp_idx) = oma   * bdatxhi_n  (ii,jj,k,0)
                                                  + alpha * bdatxhi_np1(ii,jj,k,0);
+                        if (var_idx == Vars::cons) dest_arr(i,j,k,comp_idx) *= dest_arr(i,j,k,Rho_comp);
                     });
 
                     // y-faces (do not include exterior x ghost cells)
@@ -130,12 +138,14 @@ ERF::fill_from_realbdy (const Vector<MultiFab*>& mfs,
                         int jj = std::max(j , dom_lo.y);
                         dest_arr(i,j,k,comp_idx) = oma   * bdatylo_n  (i,jj,k,0)
                                                  + alpha * bdatylo_np1(i,jj,k,0);
+                        if (var_idx == Vars::cons) dest_arr(i,j,k,comp_idx) *= dest_arr(i,j,k,Rho_comp);
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         int jj = std::min(j , dom_hi.y);
                         dest_arr(i,j,k,comp_idx) = oma   * bdatyhi_n  (i,jj,k,0)
                                                  + alpha * bdatyhi_np1(i,jj,k,0);
+                        if (var_idx == Vars::cons) dest_arr(i,j,k,comp_idx) *= dest_arr(i,j,k,Rho_comp);
                     });
                 } // mfi
 

--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -236,7 +236,7 @@ ERF::FillPatch (int lev, Real time,
 #ifdef ERF_USE_NETCDF
     // We call this here because it is an ERF routine
     if (use_real_bcs && (lev==0)) {
-        fill_from_realbdy(mfs_vel,time,false,icomp_cons,ncomp_cons);
+        fill_from_realbdy(mfs_vel,time,cons_only,icomp_cons,ncomp_cons,ngvect_cons,ngvect_vels);
     }
 #endif
 
@@ -504,7 +504,7 @@ ERF::FillIntermediatePatch (int lev, Real time,
 #ifdef ERF_USE_NETCDF
     // We call this here because it is an ERF routine
     if (use_real_bcs && (lev==0)) {
-        fill_from_realbdy(mfs_vel,time,false,icomp_cons,ncomp_cons);
+        fill_from_realbdy(mfs_vel,time,cons_only,icomp_cons,ncomp_cons,ngvect_cons, ngvect_vels);
     }
 #endif
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -399,7 +399,9 @@ public:
                             amrex::Real time,
                             bool cons_only,
                             int icomp_cons,
-                            int ncomp_cons);
+                            int ncomp_cons,
+                            amrex::IntVect ngvect_cons,
+                            amrex::IntVect ngvect_vels);
 #endif
 
 #ifdef ERF_USE_NETCDF

--- a/Source/ERF_IndexDefines.H
+++ b/Source/ERF_IndexDefines.H
@@ -85,9 +85,8 @@ namespace RealBdyVars {
     enum {
         U  = 0,
         V  = 1,
-        R  = 2,
-        T  = 3,
-        QV,
+        T  = 2,
+        QV = 3,
         NumTypes
     };
 }
@@ -96,8 +95,7 @@ namespace WRFBdyVars {
     enum {
         U  = 0,
         V  = 1,
-        R  = 2,
-        T  = 3,
+        T  = 2,
         QV    , // water vapor
         MU    , // bdy perturbation dry air mass in column (we will get mub from the initial data)
         PC    , // p_s - p_top = dry hydrostatic pressure difference between the surface and the model top
@@ -109,8 +107,7 @@ namespace MetGridBdyVars {
     enum {
         U = 0,
         V = 1,
-        R = 2,
-        T = 3,
+        T = 2,
         QV,
         NumTypes
     };

--- a/Source/IO/ERF_ReadFromWRFBdy.cpp
+++ b/Source/IO/ERF_ReadFromWRFBdy.cpp
@@ -103,7 +103,7 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
     // WRFBdyVars:  U, V, R, T, QV, MU, PC
     // ******************************************************************
     Vector<std::string> nc_var_names;
-    Vector<std::string> nc_var_prefix = {"U","V","R","T","QVAPOR","MU","PC"};
+    Vector<std::string> nc_var_prefix = {"U","V","T","QVAPOR","MU","PC"};
 
     for (int ip = 0; ip < nc_var_prefix.size(); ++ip)
     {
@@ -145,8 +145,6 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
             bdyVarType = WRFBdyVars::U;
         } else if (first1 == "V") {
             bdyVarType = WRFBdyVars::V;
-        } else if (first1 == "R") {
-            bdyVarType = WRFBdyVars::R;
         } else if (first1 == "T") {
             bdyVarType = WRFBdyVars::T;
         } else if (first2 == "QV") {
@@ -182,179 +180,163 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
 
         if (bdyType == WRFBdyTypes::x_lo) {
 
-                // *******************************************************************************
-                // xlo bdy
-                // *******************************************************************************
-                plo[0] = lo[0]        ; plo[1] = lo[1]; plo[2] = lo[2];
-                phi[0] = lo[0]+width-1; phi[1] = hi[1]; phi[2] = hi[2];
-                const Box pbx_xlo(plo, phi);
+            // *******************************************************************************
+            // xlo bdy
+            // *******************************************************************************
+            plo[0] = lo[0]        ; plo[1] = lo[1]; plo[2] = lo[2];
+            phi[0] = lo[0]+width-1; phi[1] = hi[1]; phi[2] = hi[2];
+            const Box pbx_xlo(plo, phi);
 
-                Box xlo_plane_no_stag(pbx_xlo);
-                Box xlo_plane_x_stag = pbx_xlo; xlo_plane_x_stag.shiftHalf(0,-1);
-                Box xlo_plane_y_stag = convert(pbx_xlo, {0, 1, 0});
+            Box xlo_plane_no_stag(pbx_xlo);
+            Box xlo_plane_x_stag = pbx_xlo; xlo_plane_x_stag.shiftHalf(0,-1);
+            Box xlo_plane_y_stag = convert(pbx_xlo, {0, 1, 0});
 
-                Box xlo_line(IntVect(lo[0], lo[1], 0), IntVect(lo[0]+width-1, hi[1], 0));
+            Box xlo_line(IntVect(lo[0], lo[1], 0), IntVect(lo[0]+width-1, hi[1], 0));
 
-                if        (bdyVarType == WRFBdyVars::U) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_x_stag, 1, Arena_Used)); // U
-                    }
-                } else if (bdyVarType == WRFBdyVars::V) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                        bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_y_stag , 1, Arena_Used)); // V
-                    }
-                } else if (bdyVarType == WRFBdyVars::R) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1, Arena_Used)); // R
-                    }
-                } else if (bdyVarType == WRFBdyVars::T) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1, Arena_Used)); // T
-                    }
-                } else if (bdyVarType == WRFBdyVars::QV) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1, Arena_Used)); // QV
-                    }
-                } else if (bdyVarType == WRFBdyVars::MU ||
-                           bdyVarType == WRFBdyVars::PC) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xlo[nt].push_back(FArrayBox(xlo_line, 1, Arena_Used));
-                    }
+            if        (bdyVarType == WRFBdyVars::U) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_x_stag, 1, Arena_Used)); // U
                 }
+            } else if (bdyVarType == WRFBdyVars::V) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_y_stag , 1, Arena_Used)); // V
+                }
+            } else if (bdyVarType == WRFBdyVars::T) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1, Arena_Used)); // T
+                }
+            } else if (bdyVarType == WRFBdyVars::QV) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xlo[nt].push_back(FArrayBox(xlo_plane_no_stag, 1, Arena_Used)); // QV
+                }
+            } else if (bdyVarType == WRFBdyVars::MU ||
+                       bdyVarType == WRFBdyVars::PC) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xlo[nt].push_back(FArrayBox(xlo_line, 1, Arena_Used));
+                }
+            }
 
-            } else if (bdyType == WRFBdyTypes::x_hi) {
+        } else if (bdyType == WRFBdyTypes::x_hi) {
 
-                // *******************************************************************************
-                // xhi bdy
-                // *******************************************************************************
-                plo[0] = hi[0]-width+1; plo[1] = lo[1]; plo[2] = lo[2];
-                phi[0] = hi[0]        ; phi[1] = hi[1]; phi[2] = hi[2];
-                const Box pbx_xhi(plo, phi);
+            // *******************************************************************************
+            // xhi bdy
+            // *******************************************************************************
+            plo[0] = hi[0]-width+1; plo[1] = lo[1]; plo[2] = lo[2];
+            phi[0] = hi[0]        ; phi[1] = hi[1]; phi[2] = hi[2];
+            const Box pbx_xhi(plo, phi);
 
-                Box xhi_plane_no_stag(pbx_xhi);
-                Box xhi_plane_x_stag = pbx_xhi; xhi_plane_x_stag.shiftHalf(0,1);
-                Box xhi_plane_y_stag = convert(pbx_xhi, {0, 1, 0});
+            Box xhi_plane_no_stag(pbx_xhi);
+            Box xhi_plane_x_stag = pbx_xhi; xhi_plane_x_stag.shiftHalf(0,1);
+            Box xhi_plane_y_stag = convert(pbx_xhi, {0, 1, 0});
 
-                Box xhi_line(IntVect(hi[0]-width+1, lo[1], 0), IntVect(hi[0], hi[1], 0));
+            Box xhi_line(IntVect(hi[0]-width+1, lo[1], 0), IntVect(hi[0], hi[1], 0));
 
-                //Print() << "HI XBX NO STAG " << pbx_xhi << std::endl;
-                //Print() << "HI XBX  X STAG " << xhi_plane_x_stag << std::endl;
-                //Print() << "HI XBX  Y STAG " << xhi_plane_y_stag << std::endl;
+            //Print() << "HI XBX NO STAG " << pbx_xhi << std::endl;
+            //Print() << "HI XBX  X STAG " << xhi_plane_x_stag << std::endl;
+            //Print() << "HI XBX  Y STAG " << xhi_plane_y_stag << std::endl;
 
-                if        (bdyVarType == WRFBdyVars::U) {
+            if        (bdyVarType == WRFBdyVars::U) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_x_stag, 1, Arena_Used)); // U
+                }
+            } else if (bdyVarType == WRFBdyVars::V) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_y_stag , 1, Arena_Used)); // V
+                }
+            } else if (bdyVarType == WRFBdyVars::T) {
                     for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_x_stag, 1, Arena_Used)); // U
+                        bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_no_stag, 1, Arena_Used)); // T
                     }
-                } else if (bdyVarType == WRFBdyVars::V) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_y_stag , 1, Arena_Used)); // V
-                    }
-                } else if (bdyVarType == WRFBdyVars::R) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_no_stag, 1, Arena_Used)); // R
-                    }
-                } else if (bdyVarType == WRFBdyVars::T) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_no_stag, 1, Arena_Used)); // T
-                    }
-                } else if (bdyVarType == WRFBdyVars::QV) {
-                    for (int nt(0); nt < ntimes; ++nt) {
+            } else if (bdyVarType == WRFBdyVars::QV) {
+                for (int nt(0); nt < ntimes; ++nt) {
                       bdy_data_xhi[nt].push_back(FArrayBox(xhi_plane_no_stag, 1, Arena_Used)); // QV
-                    }
-                } else if (bdyVarType == WRFBdyVars::MU ||
-                           bdyVarType == WRFBdyVars::PC) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_xhi[nt].push_back(FArrayBox(xhi_line, 1, Arena_Used)); // MU
-                    }
                 }
-
-            } else if (bdyType == WRFBdyTypes::y_lo) {
-
-                // *******************************************************************************
-                // ylo bdy
-                // *******************************************************************************
-                plo[1] = lo[1]        ; plo[0] = lo[0]; plo[2] = lo[2];
-                phi[1] = lo[1]+width-1; phi[0] = hi[0]; phi[2] = hi[2];
-                const Box pbx_ylo(plo, phi);
-
-                Box ylo_plane_no_stag(pbx_ylo);
-                Box ylo_plane_x_stag = convert(pbx_ylo, {1, 0, 0});
-                Box ylo_plane_y_stag = pbx_ylo; ylo_plane_y_stag.shiftHalf(1,-1);
-
-                Box ylo_line(IntVect(lo[0], lo[1], 0), IntVect(hi[0], lo[1]+width-1, 0));
-
-                if        (bdyVarType == WRFBdyVars::U) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_x_stag , 1, Arena_Used)); // U
-                    }
-                } else if (bdyVarType == WRFBdyVars::V) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_y_stag, 1, Arena_Used)); // V
-                    }
-                } else if (bdyVarType == WRFBdyVars::R) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1, Arena_Used)); // R
-                    }
-                } else if (bdyVarType == WRFBdyVars::T) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1, Arena_Used)); // T
-                    }
-                } else if (bdyVarType == WRFBdyVars::QV) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1, Arena_Used)); // QV
-                    }
-                } else if (bdyVarType == WRFBdyVars::MU ||
-                           bdyVarType == WRFBdyVars::PC) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_ylo[nt].push_back(FArrayBox(ylo_line, 1, Arena_Used)); // PC
-                    }
+            } else if (bdyVarType == WRFBdyVars::MU ||
+                       bdyVarType == WRFBdyVars::PC) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_xhi[nt].push_back(FArrayBox(xhi_line, 1, Arena_Used)); // MU
                 }
+            }
 
-            } else if (bdyType == WRFBdyTypes::y_hi) {
+        } else if (bdyType == WRFBdyTypes::y_lo) {
 
-                // *******************************************************************************
-                // yhi bdy
-                // *******************************************************************************
-                plo[1] = hi[1]-width+1; plo[0] = lo[0]; plo[2] = lo[2];
-                phi[1] = hi[1]        ; phi[0] = hi[0]; phi[2] = hi[2];
-                const Box pbx_yhi(plo, phi);
+            // *******************************************************************************
+            // ylo bdy
+            // *******************************************************************************
+            plo[1] = lo[1]        ; plo[0] = lo[0]; plo[2] = lo[2];
+            phi[1] = lo[1]+width-1; phi[0] = hi[0]; phi[2] = hi[2];
+            const Box pbx_ylo(plo, phi);
 
-                Box yhi_plane_no_stag(pbx_yhi);
-                Box yhi_plane_x_stag = convert(pbx_yhi, {1, 0, 0});
-                Box yhi_plane_y_stag = pbx_yhi; yhi_plane_y_stag.shiftHalf(1,1);
+            Box ylo_plane_no_stag(pbx_ylo);
+            Box ylo_plane_x_stag = convert(pbx_ylo, {1, 0, 0});
+            Box ylo_plane_y_stag = pbx_ylo; ylo_plane_y_stag.shiftHalf(1,-1);
 
-                Box yhi_line(IntVect(lo[0], hi[1]-width+1, 0), IntVect(hi[0], hi[1], 0));
+            Box ylo_line(IntVect(lo[0], lo[1], 0), IntVect(hi[0], lo[1]+width-1, 0));
 
-                //Print() << "HI YBX NO STAG " << pbx_yhi << std::endl;
-                //Print() << "HI YBX  X STAG " << yhi_plane_x_stag << std::endl;
-                //Print() << "HI YBX  Y STAG " << yhi_plane_y_stag << std::endl;
-
-                if        (bdyVarType == WRFBdyVars::U) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_x_stag , 1, Arena_Used)); // U
-                    }
-                } else if (bdyVarType == WRFBdyVars::V) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_y_stag, 1, Arena_Used)); // V
-                    }
-                } else if (bdyVarType == WRFBdyVars::R) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1, Arena_Used)); // R
-                    }
-                } else if (bdyVarType == WRFBdyVars::T) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1, Arena_Used)); // T
-                    }
-                } else if (bdyVarType == WRFBdyVars::QV) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1, Arena_Used)); // QV
-                    }
-                } else if (bdyVarType == WRFBdyVars::MU ||
-                           bdyVarType == WRFBdyVars::PC) {
-                    for (int nt(0); nt < ntimes; ++nt) {
-                      bdy_data_yhi[nt].push_back(FArrayBox(yhi_line, 1, Arena_Used)); // PC
-                    }
+            if        (bdyVarType == WRFBdyVars::U) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_x_stag , 1, Arena_Used)); // U
                 }
+            } else if (bdyVarType == WRFBdyVars::V) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_y_stag, 1, Arena_Used)); // V
+                }
+            } else if (bdyVarType == WRFBdyVars::T) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1, Arena_Used)); // T
+                }
+            } else if (bdyVarType == WRFBdyVars::QV) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_ylo[nt].push_back(FArrayBox(ylo_plane_no_stag, 1, Arena_Used)); // QV
+                }
+            } else if (bdyVarType == WRFBdyVars::MU ||
+                       bdyVarType == WRFBdyVars::PC) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_ylo[nt].push_back(FArrayBox(ylo_line, 1, Arena_Used)); // PC
+                }
+            }
+
+        } else if (bdyType == WRFBdyTypes::y_hi) {
+
+            // *******************************************************************************
+            // yhi bdy
+            // *******************************************************************************
+            plo[1] = hi[1]-width+1; plo[0] = lo[0]; plo[2] = lo[2];
+            phi[1] = hi[1]        ; phi[0] = hi[0]; phi[2] = hi[2];
+            const Box pbx_yhi(plo, phi);
+
+            Box yhi_plane_no_stag(pbx_yhi);
+            Box yhi_plane_x_stag = convert(pbx_yhi, {1, 0, 0});
+            Box yhi_plane_y_stag = pbx_yhi; yhi_plane_y_stag.shiftHalf(1,1);
+
+            Box yhi_line(IntVect(lo[0], hi[1]-width+1, 0), IntVect(hi[0], hi[1], 0));
+
+            //Print() << "HI YBX NO STAG " << pbx_yhi << std::endl;
+            //Print() << "HI YBX  X STAG " << yhi_plane_x_stag << std::endl;
+            //Print() << "HI YBX  Y STAG " << yhi_plane_y_stag << std::endl;
+
+            if        (bdyVarType == WRFBdyVars::U) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_x_stag , 1, Arena_Used)); // U
+                }
+            } else if (bdyVarType == WRFBdyVars::V) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_y_stag, 1, Arena_Used)); // V
+                }
+            } else if (bdyVarType == WRFBdyVars::T) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1, Arena_Used)); // T
+                }
+            } else if (bdyVarType == WRFBdyVars::QV) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_yhi[nt].push_back(FArrayBox(yhi_plane_no_stag, 1, Arena_Used)); // QV
+                }
+            } else if (bdyVarType == WRFBdyVars::MU ||
+                       bdyVarType == WRFBdyVars::PC) {
+                for (int nt(0); nt < ntimes; ++nt) {
+                    bdy_data_yhi[nt].push_back(FArrayBox(yhi_line, 1, Arena_Used)); // PC
+                }
+            }
         }
 
         long num_pts;
@@ -369,8 +351,7 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
 
             Array4<Real> fab_arr;
             if (bdyVarType == WRFBdyVars::U || bdyVarType == WRFBdyVars::V ||
-                bdyVarType == WRFBdyVars::R || bdyVarType == WRFBdyVars::T ||
-                bdyVarType == WRFBdyVars::QV)
+                bdyVarType == WRFBdyVars::T || bdyVarType == WRFBdyVars::QV)
             {
                 int ns2 = arrays[iv].get_vshape()[2];
                 int ns3 = arrays[iv].get_vshape()[3];
@@ -529,13 +510,17 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
 }
 
 void
-convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
+convert_wrfbdy_data (const Box& domain,
+                     Vector<Vector<FArrayBox>>& bdy_data,
                      const FArrayBox& NC_MUB_fab,
-                     const FArrayBox& NC_PH_fab, const FArrayBox& NC_PHB_fab,
-                     const FArrayBox& NC_C1H_fab, const FArrayBox& NC_C2H_fab,
+                     const FArrayBox& NC_PH_fab,
+                     const FArrayBox& NC_PHB_fab,
+                     const FArrayBox& NC_C1H_fab,
+                     const FArrayBox& NC_C2H_fab,
                      const FArrayBox& NC_RDNW_fab,
-                     const FArrayBox& NC_xvel_fab, const FArrayBox& NC_yvel_fab,
-                     const FArrayBox& NC_rho_fab, const FArrayBox& NC_rhotheta_fab,
+                     const FArrayBox& NC_xvel_fab,
+                     const FArrayBox& NC_yvel_fab,
+                     const FArrayBox& NC_theta_fab,
                      const FArrayBox& NC_QVAPOR_fab)
 {
     // These were filled from wrfinput
@@ -552,7 +537,6 @@ convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
     {
         Array4<Real> bdy_u_arr  = bdy_data[nt][WRFBdyVars::U].array();  // This is face-centered
         Array4<Real> bdy_v_arr  = bdy_data[nt][WRFBdyVars::V].array();
-        Array4<Real> bdy_r_arr  = bdy_data[nt][WRFBdyVars::R].array();
         Array4<Real> bdy_t_arr  = bdy_data[nt][WRFBdyVars::T].array();
         Array4<Real> bdy_qv_arr = bdy_data[nt][WRFBdyVars::QV].array();
         Array4<Real> mu_arr     = bdy_data[nt][WRFBdyVars::MU].array(); // This is cell-centered
@@ -563,12 +547,10 @@ convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
         int jhi  = domain.bigEnd()[1];
 
         if (nt==0) {
-            bdy_data[0][WRFBdyVars::U].template copy<RunOn::Device>(NC_xvel_fab);
-            bdy_data[0][WRFBdyVars::V].template copy<RunOn::Device>(NC_yvel_fab);
-            bdy_data[0][WRFBdyVars::R].template copy<RunOn::Device>(NC_rho_fab);
-            bdy_data[0][WRFBdyVars::T].template copy<RunOn::Device>(NC_rhotheta_fab);
+            bdy_data[0][WRFBdyVars::U].template  copy<RunOn::Device>(NC_xvel_fab);
+            bdy_data[0][WRFBdyVars::V].template  copy<RunOn::Device>(NC_yvel_fab);
+            bdy_data[0][WRFBdyVars::T].template  copy<RunOn::Device>(NC_theta_fab);
             bdy_data[0][WRFBdyVars::QV].template copy<RunOn::Device>(NC_QVAPOR_fab);
-            bdy_data[0][WRFBdyVars::QV].template mult<RunOn::Device>(NC_rho_fab);
         } else {
             // Define u velocity
             const auto & bx_u  = bdy_data[0][WRFBdyVars::U].box();
@@ -606,21 +588,9 @@ convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
                 bdy_v_arr(i,j,k) = new_bdy;
             });
 
-            // Define density
-            const auto & bx_t = bdy_data[0][WRFBdyVars::T].box(); // Note this is currently "THM" aka the perturbational moist pot. temp.
-            ParallelFor(bx_t, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
-                Real xmu  = c1h_arr(0,0,k) * (mu_arr(i,j,0) + mub_arr(i,j,0)) + c2h_arr(0,0,k);
-                Real dpht = (ph_arr(i,j,k+1) + phb_arr(i,j,k+1)) - (ph_arr(i,j,k) + phb_arr(i,j,k));
-                bdy_r_arr(i,j,k) = -xmu / ( dpht * rdnw_arr(0,0,k) );
-                //if (nt == 0 and std::abs(r_arr(i,j,k) - bdy_r_arr(i,j,k)) > 0.) {
-                //    Print() << "INIT VS BDY DEN " << IntVect(i,j,k) << " " << r_arr(i,j,k) << " " << bdy_r_arr(i,j,k) <<
-                //        " " << std::abs(r_arr(i,j,k) - bdy_r_arr(i,j,k)) << std::endl;
-                //}
-            });
-
             // Define theta
             Real theta_ref = 300.;
+            const auto & bx_t = bdy_data[0][WRFBdyVars::T].box(); // Note this is currently "THM" aka the perturbational moist pot. temp.
             ParallelFor(bx_t, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 Real xmu  = (mu_arr(i,j,0) + mub_arr(i,j,0));
@@ -628,7 +598,7 @@ convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
                 Real new_bdy_Th = bdy_t_arr(i,j,k) / xmu_mult + theta_ref;
                 Real qv_fac = (1. + bdy_qv_arr(i,j,k) / 0.622 / xmu_mult);
                 new_bdy_Th /= qv_fac;
-                bdy_t_arr(i,j,k) = new_bdy_Th * bdy_r_arr(i,j,k);
+                bdy_t_arr(i,j,k) = new_bdy_Th;
                 //if (nt == 0 and std::abs(rth_arr(i,j,k) - bdy_t_arr(i,j,k)) > 0.) {
                 //    Print() << "INIT VS BDY TH " << IntVect(i,j,k) << " " << rth_arr(i,j,k) << " " << bdy_t_arr(i,j,k) <<
                 //             " " << std::abs(th_arr(i,j,k) - bdy_t_arr(i,j,k)) << std::endl;
@@ -642,7 +612,7 @@ convert_wrfbdy_data (const Box& domain, Vector<Vector<FArrayBox>>& bdy_data,
                 Real xmu  = (mu_arr(i,j,0) + mub_arr(i,j,0));
                 Real xmu_mult = c1h_arr(0,0,k) * xmu + c2h_arr(0,0,k);
                 Real new_bdy_QV = bdy_qv_arr(i,j,k) / xmu_mult;
-                bdy_qv_arr(i,j,k) = new_bdy_QV * bdy_r_arr(i,j,k);
+                bdy_qv_arr(i,j,k) = new_bdy_QV;
             });
 
         } // nt ==0

--- a/Source/IO/ERF_ReadFromWRFInput.cpp
+++ b/Source/IO/ERF_ReadFromWRFInput.cpp
@@ -158,8 +158,5 @@ read_from_wrfinput (int lev,
 
     const Real theta_ref = 300.0;
     NC_rhotheta_fab.template plus<RunOn::Device>(theta_ref);
-
-    // Now multiply by rho to get (rho theta) instead of theta
-    NC_rhotheta_fab.template mult<RunOn::Device>(NC_rho_fab,0,0,1);
 }
 #endif // ERF_USE_NETCDF

--- a/Source/Initialization/ERF_Metgrid_utils.H
+++ b/Source/Initialization/ERF_Metgrid_utils.H
@@ -97,8 +97,7 @@ init_base_state_from_metgrid (const bool use_moisture,
                               amrex::FArrayBox& z_phys_cc_fab,
                               const amrex::Vector<amrex::FArrayBox>& NC_ght_fab,
                               const amrex::Vector<amrex::FArrayBox>& NC_psfc_fab,
-                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& fabs_for_bcs,
-                              const amrex::Array4<const int>& mask_c_arr);
+                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& fabs_for_bcs);
 
 AMREX_FORCE_INLINE
 AMREX_GPU_DEVICE
@@ -117,7 +116,7 @@ calc_rho_p (const int& kmax,
             amrex::Real* Pm_vec)
 {
     const int maxiter = 10;
-    const amrex::Real tol = 1.0e-12;
+    const amrex::Real tol = 1.0e-10;
 
     // Calculate or use moist pressure at the surface.
     amrex::Real Psurf;

--- a/Source/Initialization/ERF_init_from_wrfinput.cpp
+++ b/Source/Initialization/ERF_init_from_wrfinput.cpp
@@ -17,7 +17,7 @@ void
 read_from_wrfinput (int lev, const Box& domain, const std::string& fname,
                     FArrayBox& NC_xvel_fab, FArrayBox& NC_yvel_fab,
                     FArrayBox& NC_zvel_fab, FArrayBox& NC_rho_fab,
-                    FArrayBox& NC_rhop_fab, FArrayBox& NC_rhotheta_fab,
+                    FArrayBox& NC_rhop_fab, FArrayBox& NC_theta_fab,
                     FArrayBox& NC_MUB_fab ,
                     FArrayBox& NC_MSFU_fab, FArrayBox& NC_MSFV_fab,
                     FArrayBox& NC_MSFM_fab, FArrayBox& NC_SST_fab,
@@ -58,8 +58,7 @@ convert_wrfbdy_data (const Box& domain,
                      const FArrayBox& NC_RDNW_fab,
                      const FArrayBox& NC_xvel_fab,
                      const FArrayBox& NC_yvel_fab,
-                     const FArrayBox& NC_rho_fab,
-                     const FArrayBox& NC_rhoth_fab,
+                     const FArrayBox& NC_theta_fab,
                      const FArrayBox& NC_QVAPOR_fab);
 
 void
@@ -75,7 +74,7 @@ init_state_from_wrfinput (int lev,
                           const Vector<FArrayBox>& NC_yvel_fab,
                           const Vector<FArrayBox>& NC_zvel_fab,
                           const Vector<FArrayBox>& NC_rho_fab,
-                          const Vector<FArrayBox>& NC_rhotheta_fab,
+                          const Vector<FArrayBox>& NC_theta_fab,
                           const int n_qstate,
                           const int RhoQr_comp);
 
@@ -126,7 +125,7 @@ ERF::init_from_wrfinput (int lev)
     Vector<FArrayBox> NC_zvel_fab;   NC_zvel_fab.resize(num_boxes_at_level[lev]);
     Vector<FArrayBox> NC_rho_fab;    NC_rho_fab.resize(num_boxes_at_level[lev]);
     Vector<FArrayBox> NC_rhop_fab;   NC_rhop_fab.resize(num_boxes_at_level[lev]);
-    Vector<FArrayBox> NC_rhoth_fab;  NC_rhoth_fab.resize(num_boxes_at_level[lev]);
+    Vector<FArrayBox> NC_theta_fab;  NC_theta_fab.resize(num_boxes_at_level[lev]);
     Vector<FArrayBox> NC_MUB_fab;    NC_MUB_fab.resize(num_boxes_at_level[lev]);
     Vector<FArrayBox> NC_MSFU_fab;   NC_MSFU_fab.resize(num_boxes_at_level[lev]);
     Vector<FArrayBox> NC_MSFV_fab;   NC_MSFV_fab.resize(num_boxes_at_level[lev]);
@@ -154,15 +153,15 @@ ERF::init_from_wrfinput (int lev)
     for (int idx = 0; idx < num_boxes_at_level[lev]; idx++)
     {
         read_from_wrfinput(lev, boxes_at_level[lev][idx], nc_init_file[lev][idx],
-                           NC_xvel_fab[idx]  , NC_yvel_fab[idx]  , NC_zvel_fab[idx] , NC_rho_fab[idx],
-                           NC_rhop_fab[idx]  , NC_rhoth_fab[idx] , NC_MUB_fab[idx]  ,
-                           NC_MSFU_fab[idx]  , NC_MSFV_fab[idx]  , NC_MSFM_fab[idx] ,
-                           NC_SST_fab[idx]   , NC_LANDMSK_fab[idx], NC_C1H_fab[idx] ,
-                           NC_C2H_fab[idx]  , NC_RDNW_fab[idx],
-                           NC_QVAPOR_fab[idx], NC_QCLOUD_fab[idx], NC_QRAIN_fab[idx],
-                           NC_PH_fab[idx]    , NC_P_fab[idx]     , NC_PHB_fab[idx]  ,
-                           NC_ALB_fab[idx]   , NC_PB_fab[idx]    ,
-                           NC_LAT_fab[idx]   , NC_LON_fab[idx],
+                           NC_xvel_fab[idx]  , NC_yvel_fab[idx]   , NC_zvel_fab[idx] , NC_rho_fab[idx],
+                           NC_rhop_fab[idx]  , NC_theta_fab[idx]  , NC_MUB_fab[idx]  ,
+                           NC_MSFU_fab[idx]  , NC_MSFV_fab[idx]   , NC_MSFM_fab[idx] ,
+                           NC_SST_fab[idx]   , NC_LANDMSK_fab[idx], NC_C1H_fab[idx]  ,
+                           NC_C2H_fab[idx]   , NC_RDNW_fab[idx]   ,
+                           NC_QVAPOR_fab[idx], NC_QCLOUD_fab[idx] , NC_QRAIN_fab[idx],
+                           NC_PH_fab[idx]    , NC_P_fab[idx]      , NC_PHB_fab[idx]  ,
+                           NC_ALB_fab[idx]   , NC_PB_fab[idx]     ,
+                           NC_LAT_fab[idx]   , NC_LON_fab[idx]    ,
                            solverChoice.moisture_type, Latitude, Longitude, geom[lev]);
     }
 
@@ -184,7 +183,7 @@ ERF::init_from_wrfinput (int lev)
         init_state_from_wrfinput(lev, cons_fab, xvel_fab, yvel_fab, zvel_fab,
                                  NC_QVAPOR_fab, NC_QCLOUD_fab, NC_QRAIN_fab,
                                  NC_xvel_fab, NC_yvel_fab, NC_zvel_fab,
-                                 NC_rho_fab, NC_rhoth_fab,
+                                 NC_rho_fab, NC_theta_fab,
                                  n_qstate, solverChoice.RhoQr_comp);
     } // mf
 
@@ -312,21 +311,21 @@ ERF::init_from_wrfinput (int lev)
                 << " and relaxation width: " << real_width - real_set_width << std::endl;
 
         convert_wrfbdy_data(domain,bdy_data_xlo,
-                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0] ,
-                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0],
-                            NC_xvel_fab[0], NC_yvel_fab[0], NC_rho_fab[0] , NC_rhoth_fab[0], NC_QVAPOR_fab[0]);
+                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0]  ,
+                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0] ,
+                            NC_xvel_fab[0], NC_yvel_fab[0], NC_theta_fab[0], NC_QVAPOR_fab[0]);
         convert_wrfbdy_data(domain,bdy_data_xhi,
-                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0] ,
-                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0],
-                            NC_xvel_fab[0], NC_yvel_fab[0], NC_rho_fab[0] , NC_rhoth_fab[0], NC_QVAPOR_fab[0]);
+                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0]  ,
+                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0] ,
+                            NC_xvel_fab[0], NC_yvel_fab[0], NC_theta_fab[0], NC_QVAPOR_fab[0]);
         convert_wrfbdy_data(domain,bdy_data_ylo,
-                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0] ,
-                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0],
-                            NC_xvel_fab[0], NC_yvel_fab[0], NC_rho_fab[0] , NC_rhoth_fab[0], NC_QVAPOR_fab[0]);
+                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0]  ,
+                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0] ,
+                            NC_xvel_fab[0], NC_yvel_fab[0], NC_theta_fab[0], NC_QVAPOR_fab[0]);
         convert_wrfbdy_data(domain,bdy_data_yhi,
-                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0] ,
-                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0],
-                            NC_xvel_fab[0], NC_yvel_fab[0], NC_rho_fab[0] , NC_rhoth_fab[0], NC_QVAPOR_fab[0]);
+                            NC_MUB_fab[0] , NC_PH_fab[0]  , NC_PHB_fab[0]  ,
+                            NC_C1H_fab[0] , NC_C2H_fab[0] , NC_RDNW_fab[0] ,
+                            NC_xvel_fab[0], NC_yvel_fab[0], NC_theta_fab[0], NC_QVAPOR_fab[0]);
     }
 
     // Start at the earliest time (read_from_wrfbdy)
@@ -346,7 +345,7 @@ ERF::init_from_wrfinput (int lev)
  * @param NC_yvel_fab Vector of FArrayBox objects with the WRF dataset specifying y-velocity
  * @param NC_zvel_fab Vector of FArrayBox objects with the WRF dataset specifying z-velocity
  * @param NC_rho_fab Vector of FArrayBox objects with the WRF dataset specifying density
- * @param NC_rhotheta_fab Vector of FArrayBox objects with the WRF dataset specifying density*(potential temperature)
+ * @param NC_theta_fab Vector of FArrayBox objects with the WRF dataset specifying density*(potential temperature)
  */
 void
 init_state_from_wrfinput (int /*lev*/,
@@ -361,7 +360,7 @@ init_state_from_wrfinput (int /*lev*/,
                           const Vector<FArrayBox>& NC_yvel_fab,
                           const Vector<FArrayBox>& NC_zvel_fab,
                           const Vector<FArrayBox>& NC_rho_fab,
-                          const Vector<FArrayBox>& NC_rhotheta_fab,
+                          const Vector<FArrayBox>& NC_theta_fab,
                           const int n_qstate,
                           const int RhoQr_comp)
 {
@@ -386,8 +385,10 @@ init_state_from_wrfinput (int /*lev*/,
 
         // This copies the density
         state_fab.template copy<RunOn::Device>(NC_rho_fab[idx], 0, Rho_comp, 1);
+
         // This copies (rho*theta)
-        state_fab.template copy<RunOn::Device>(NC_rhotheta_fab[idx], 0, RhoTheta_comp, 1);
+        state_fab.template copy<RunOn::Device>(NC_theta_fab[idx], 0, RhoTheta_comp, 1);
+        state_fab.template mult<RunOn::Device>(NC_rho_fab[idx]  , 0, RhoTheta_comp, 1);
 
         if (n_qstate >= 1) {
           state_fab.template copy<RunOn::Device>(NC_QVAPOR_fab[idx], 0, RhoQ1_comp, 1);

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
@@ -249,12 +249,12 @@
         // Populate RHS for relaxation zones if using real bcs
         if (use_real_bcs && (level == 0)) {
             if (real_width>0) {
-                    realbdy_compute_interior_ghost_rhs(init_type,
-                                                       bdy_time_interval, start_bdy_time, new_stage_time, slow_dt,
-                                                       real_width, real_set_width, fine_geom,
-                                                       S_rhs, S_old, S_data,
-                                                       bdy_data_xlo, bdy_data_xhi,
-                                                       bdy_data_ylo, bdy_data_yhi);
+                realbdy_compute_interior_ghost_rhs(init_type,
+                                                   bdy_time_interval, start_bdy_time, new_stage_time, slow_dt,
+                                                   real_width, real_set_width, fine_geom,
+                                                   S_rhs, S_old, S_data,
+                                                   bdy_data_xlo, bdy_data_xhi,
+                                                   bdy_data_ylo, bdy_data_yhi);
             }
         }
 #endif

--- a/Source/TimeIntegration/ERF_TI_utils.H
+++ b/Source/TimeIntegration/ERF_TI_utils.H
@@ -130,7 +130,8 @@
         cons_only = false;
         FillIntermediatePatch(level, time_for_fp,
                               {&S_data[IntVars::cons], &xvel_new, &yvel_new, &zvel_new},
-                              {&S_data[IntVars::cons], &S_data[IntVars::xmom], &S_data[IntVars::ymom], &S_data[IntVars::zmom]},
+                              {&S_data[IntVars::cons], &S_data[IntVars::xmom],
+                               &S_data[IntVars::ymom], &S_data[IntVars::zmom]},
                               ng_cons_to_use, ng_vel, cons_only, scomp_cons, ncomp_cons,
                               allow_most_bcs);
     };

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -436,9 +436,10 @@ void erf_slow_rhs_post (int level, int finest_level,
 #if defined(ERF_USE_NETCDF)
         if (moist_set_rhs_bool)
         {
+            Box tbx_moist  = mfi.tilebox(IntVect(0),IntVect(2,2,0));
             const Array4<const Real> & old_cons_const = S_old[IntVars::cons].const_array(mfi);
             const Array4<const Real> & new_cons_const = S_new[IntVars::cons].const_array(mfi);
-            moist_set_rhs(tbx, old_cons_const, new_cons_const, cell_rhs,
+            moist_set_rhs(tbx_moist, old_cons_const, new_cons_const, cell_rhs,
                           bdy_time_interval, start_bdy_time, new_stage_time, dt, width, set_width, domain,
                           bdy_data_xlo, bdy_data_xhi, bdy_data_ylo, bdy_data_yhi);
         }

--- a/Source/Utils/ERF_HSE_utils.H
+++ b/Source/Utils/ERF_HSE_utils.H
@@ -45,6 +45,7 @@ namespace HSEutils
                         Real& F)
     {
         int iter=0;
+        int max_iter=30;
         Real eps  = 1.0e-6;
         Real ieps = 1.0e6;
         do {
@@ -62,8 +63,11 @@ namespace HSEutils
             F = P + 0.5*r_tot*g*dz + C;
             ++iter;
         }
-        while (std::abs(F)>m_tol && iter<25);
-        if (iter>=25) printf("WARNING: HSE Newton iterations did not converge to tolerance!\n");
+        while (std::abs(F)>m_tol && iter<max_iter);
+        if (iter>=max_iter) {
+            printf("WARNING: HSE Newton iterations did not converge to tolerance!\n");
+            printf("HSE Newton tol: %e %e\n",F,m_tol);
+        }
     }
 
 

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -177,9 +177,9 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
         domain.convert(S_cur_data[var_idx].boxArray().ixType());
 
         // Grown domain to get the 4 halo boxes w/ ghost cells
-        // NOTE: 1 ghost cells needed here for Laplacian
+        // NOTE: 2 ghost cells needed here for Laplacian
         //       halo cell.
-        IntVect ng_vect{1,1,0};
+        IntVect ng_vect{2,2,0};
         Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
         compute_interior_ghost_bxs_xy(gdom, domain, width, 0,
@@ -214,9 +214,9 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
         const auto& dom_lo = lbound(domain);
         const auto& dom_hi = ubound(domain);
 
-        // NOTE: 1 ghost cells needed here for Laplacian
+        // NOTE: 2 ghost cells needed here for Laplacian
         //       halo cell.
-        IntVect ng_vect{1,1,0};
+        IntVect ng_vect{2,2,0};
         Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
         compute_interior_ghost_bxs_xy(gdom, domain, width, 0,
@@ -314,11 +314,9 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
 #endif
         for ( MFIter mfi(S_cur_data[ivar_idx],TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
-            // NOTE: 1 ghost cell needed here. This first
-            //       ghost cell is to access the Laplacian
-            //       halo cell. We will touch the second ghost
-            //       cell when averaging u -> rho*u.
-            IntVect ng_vect{1,1,0};
+            // NOTE: 2 ghost cells needed here for Laplacian
+            //       halo cell.
+            IntVect ng_vect{2,2,0};
             Box tbx = mfi.tilebox(ixtype.toIntVect(),ng_vect);
             Box tbx_xlo, tbx_xhi, tbx_ylo, tbx_yhi;
             compute_interior_ghost_bxs_xy(tbx, domain, width, 0,

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -158,7 +158,7 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
     Vector<int> ivar_map = {IntVars::xmom, IntVars::ymom, IntVars::cons, IntVars::cons};
 
     // Variable icomp map
-    Vector<int> comp_map = {0, 0, Rho_comp, RhoTheta_comp};
+    Vector<int> comp_map = {0, 0, RhoTheta_comp};
 
     // Indices
     int  ivarU = RealBdyVars::U;
@@ -177,8 +177,9 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
         domain.convert(S_cur_data[var_idx].boxArray().ixType());
 
         // Grown domain to get the 4 halo boxes w/ ghost cells
-        // NOTE: 2 ghost cells needed for U -> rho*U
-        IntVect ng_vect{2,2,0};
+        // NOTE: 1 ghost cells needed here for Laplacian
+        //       halo cell.
+        IntVect ng_vect{1,1,0};
         Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
         compute_interior_ghost_bxs_xy(gdom, domain, width, 0,
@@ -213,11 +214,9 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
         const auto& dom_lo = lbound(domain);
         const auto& dom_hi = ubound(domain);
 
-        // NOTE: 2 ghost cells needed here. The first
-        //       ghost cell is to access the Laplacian
-        //       halo cell. The second ghost cell is
-        //       for averaging u -> rho*u.
-        IntVect ng_vect{2,2,0};
+        // NOTE: 1 ghost cells needed here for Laplacian
+        //       halo cell.
+        IntVect ng_vect{1,1,0};
         Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
         compute_interior_ghost_bxs_xy(gdom, domain, width, 0,

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -260,7 +260,7 @@ realbdy_compute_interior_ghost_rhs (const std::string& /*init_type*/,
             const auto& bdatyhi_n   = bdy_data_yhi[n_time  ][ivar].const_array();
             const auto& bdatyhi_np1 = bdy_data_yhi[n_time+1][ivar].const_array();
 
-            // Current density to conver to conserved vars
+            // Current density to convert to conserved vars
             Array4<Real> r_arr = S_cur_data[IntVars::cons].array(mfi);
 
             // NOTE: width is now one less than the total bndy width

--- a/Source/Utils/ERF_Utils.H
+++ b/Source/Utils/ERF_Utils.H
@@ -253,7 +253,7 @@ wrfbdy_compute_laplacian_relaxation (const int& icomp,
     int Relax_z = width - Spec_z + 1;
     amrex::Real num     = amrex::Real(Spec_z + Relax_z);
     amrex::Real denom   = amrex::Real(Relax_z - 1);
-    amrex::Real SpecExp = -std::log(0.01) / amrex::Real(width - Spec_z);
+    amrex::Real SpecExp = -std::log(0.1) / amrex::Real(width - Spec_z);
     amrex::ParallelFor(bx_xlo, num_var, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
         // Corners with x boxes


### PR DESCRIPTION
This code refactors the BDY set and nudging based upon a simplified test case with constant `theta=300` and `u=10` in the BDY region but `theta=300` and `u=v=w=0` in the IC region. The flow should propagate into the domain with the advective velocity. The changes made herein allow that to occur by NOT setting `rho` but allowing it to evolve by the continuity equation. Other set/nudge vars are augmented with the `primitive` vars from metgrid or WRF. The test case result is much better now, but more vetting is needed:
![image (7)](https://github.com/user-attachments/assets/e187fdf9-a7a5-4ed4-af8c-785287754e67)

