### PR TITLE
Fix for Mac

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         cmake \
           -B${{runner.workspace}}/ERF/build \
-          -DBUILD_SHARED_LIBS:BOOL=TRUE \
+          -DBUILD_SHARED_LIBS:BOOL=FALSE \
           -DCMAKE_CXX_COMPILER_LAUNCHER=$(which ccache) \
           -DCMAKE_BUILD_TYPE:STRING=Debug \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \

--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -136,6 +136,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/Diffusion/ERF_ComputeStrain_N.cpp
        ${SRC_DIR}/Diffusion/ERF_ComputeStrain_T.cpp
        ${SRC_DIR}/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+       ${SRC_DIR}/Initialization/ERF_init_bcs.cpp
        ${SRC_DIR}/Initialization/ERF_init_custom.cpp
        ${SRC_DIR}/Initialization/ERF_init_from_hse.cpp
        ${SRC_DIR}/Initialization/ERF_init_from_input_sounding.cpp
@@ -296,11 +297,6 @@ function(build_erf_exe erf_exe_name)
   include(${CMAKE_SOURCE_DIR}/CMake/SetERFCompileFlags.cmake)
   set_erf_compile_flags(${erf_exe_name})
 
-  target_sources(${erf_exe_name}
-     PRIVATE
-       ${SRC_DIR}/Initialization/ERF_init_bcs.cpp
-
-  )
   if(ERF_ENABLE_CUDA)
     set(pctargets "${erf_exe_name}")
     foreach(tgt IN LISTS pctargets)

--- a/Source/ERF_prob_common.H
+++ b/Source/ERF_prob_common.H
@@ -485,7 +485,7 @@ protected:
  * Function to init the physical bounds of the domain
  * and instantiate a Problem derived from ProblemBase
 */
-std::unique_ptr<ProblemBase> amrex_probinit (const amrex_real* problo,
-                                             const amrex_real* probhi);
+extern std::unique_ptr<ProblemBase> amrex_probinit (const amrex_real* problo,
+                                                    const amrex_real* probhi) AMREX_ATTRIBUTE_WEAK;
 
 #endif


### PR DESCRIPTION
amrex_probinit is marked as weak attribute.

Note that amrex_probinit is not an amrex function. So it should be renamed in the future.