### PR TITLE
Fix moisture with bdy forcing.

### DIFF
--- a/Source/SourceTerms/ERF_Src_headers.H
+++ b/Source/SourceTerms/ERF_Src_headers.H
@@ -83,8 +83,8 @@ void add_thin_body_sources (amrex::MultiFab& xmom_source,
 
 #if defined(ERF_USE_NETCDF)
 void
-moist_set_rhs (
-               const amrex::Box& tbx,
+moist_set_rhs (const amrex::Box& tbx,
+               const amrex::Box& gtbx,
                const amrex::Array4<amrex::Real const>& old_cons,
                const amrex::Array4<amrex::Real const>& new_cons,
                const amrex::Array4<amrex::Real      >& cell_rhs,

--- a/Source/SourceTerms/ERF_moist_set_rhs.cpp
+++ b/Source/SourceTerms/ERF_moist_set_rhs.cpp
@@ -12,6 +12,7 @@ using namespace amrex;
 
 void
 moist_set_rhs (const Box& tbx,
+               const Box& gtbx,
                const Array4<Real const>& old_cons,
                const Array4<Real const>& new_cons,
                const Array4<Real      >& cell_rhs,
@@ -95,7 +96,7 @@ moist_set_rhs (const Box& tbx,
     Array4<Real> arr_ylo = QV_ylo.array();  Array4<Real> arr_yhi = QV_yhi.array();
 
     Box tbx_xlo, tbx_xhi, tbx_ylo, tbx_yhi;
-    compute_interior_ghost_bxs_xy(tbx, domain, width, 0,
+    compute_interior_ghost_bxs_xy(gtbx, domain, width, 0,
                                   tbx_xlo, tbx_xhi,
                                   tbx_ylo, tbx_yhi,
                                   ng_vect, true);
@@ -155,6 +156,10 @@ moist_set_rhs (const Box& tbx,
     // Compute RHS in specified region
     //==========================================================
     if (set_width > 0) {
+        compute_interior_ghost_bxs_xy(tbx, domain, width, 0,
+                                      tbx_xlo, tbx_xhi,
+                                      tbx_ylo, tbx_yhi,
+                                      ng_vect, true);
         wrfbdy_set_rhs_in_spec_region(dt, RhoQ1_comp, 1,
                                       width, set_width, dom_lo, dom_hi,
                                       tbx_xlo, tbx_xhi, tbx_ylo, tbx_yhi,

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -436,10 +436,10 @@ void erf_slow_rhs_post (int level, int finest_level,
 #if defined(ERF_USE_NETCDF)
         if (moist_set_rhs_bool)
         {
-            Box tbx_moist  = mfi.tilebox(IntVect(0),IntVect(2,2,0));
+            Box gtbx_moist  = mfi.tilebox(IntVect(0),IntVect(2,2,0));
             const Array4<const Real> & old_cons_const = S_old[IntVars::cons].const_array(mfi);
             const Array4<const Real> & new_cons_const = S_new[IntVars::cons].const_array(mfi);
-            moist_set_rhs(tbx_moist, old_cons_const, new_cons_const, cell_rhs,
+            moist_set_rhs(tbx, gtbx_moist, old_cons_const, new_cons_const, cell_rhs,
                           bdy_time_interval, start_bdy_time, new_stage_time, dt, width, set_width, domain,
                           bdy_data_xlo, bdy_data_xhi, bdy_data_ylo, bdy_data_yhi);
         }


### PR DESCRIPTION
Correct box logic from bdy refactor. Those tests were with null moisture and did not exercise the moist_set_rhs routine. 