### PR TITLE
Consolidated Moisture Variables Checkpointing

### DIFF
--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -144,19 +144,19 @@ ERF::WriteCheckpointFile () const
             VisMF::Write(z_height, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "Z_Phys_nd"));
         }
 
-         // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
-         // Write the moisture model restart variables
-         std::vector<int> indices(0);
-         std::vector<std::string> names(0);
-         micro->Get_Qmoist_Restart_Vars(lev, indices, names);
-         int nvar = indices.size();
-         for (int var = 0; var < nvar; var++) {
-            ng = qmoist[lev][indices[var]]->nGrowVect();
-            const int ncomp = 1;
-            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
-            MultiFab::Copy(moist_vars,*(qmoist[lev][indices[var]]),0,0,ncomp,ng);
-            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", names[var]));
-         }
+        // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
+        // Write the moisture model restart variables
+        std::vector<int> indices(0);
+        std::vector<std::string> names(0);
+        micro->Get_Qmoist_Restart_Vars(lev, indices, names);
+        int nvar = indices.size();
+        for (int var = 0; var < nvar; var++) {
+           ng = qmoist[lev][indices[var]]->nGrowVect();
+           const int ncomp = 1;
+           MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
+           MultiFab::Copy(moist_vars,*(qmoist[lev][indices[var]]),0,0,ncomp,ng);
+           VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", names[var]));
+        }
 
 #if defined(ERF_USE_WINDFARM)
         if(solverChoice.windfarm_type == WindFarmType::Fitch or
@@ -168,7 +168,6 @@ ERF::WriteCheckpointFile () const
             VisMF::Write(mf_Nturb, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "NumTurb"));
         }
 #endif
-
 
         if (solverChoice.lsm_type != LandSurfaceType::None) {
             for (int mvar(0); mvar<lsm_data[lev].size(); ++mvar) {

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -146,16 +146,16 @@ ERF::WriteCheckpointFile () const
 
         // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
         // Write the moisture model restart variables
-        std::vector<int> indices(0);
-        std::vector<std::string> names(0);
-        micro->Get_Qmoist_Restart_Vars(lev, indices, names);
-        int nvar = indices.size();
-        for (int var = 0; var < nvar; var++) {
-           ng = qmoist[lev][indices[var]]->nGrowVect();
+        std::vector<int> qmoist_indices(0);
+        std::vector<std::string> qmoist_names(0);
+        micro->Get_Qmoist_Restart_Vars(lev, qmoist_indices, qmoist_names);
+        int qmoist_nvar = qmoist_indices.size();
+        for (int var = 0; var < qmoist_nvar; var++) {
+           ng = qmoist[lev][qmoist_indices[var]]->nGrowVect();
            const int ncomp = 1;
            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
-           MultiFab::Copy(moist_vars,*(qmoist[lev][indices[var]]),0,0,ncomp,ng);
-           VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", names[var]));
+           MultiFab::Copy(moist_vars,*(qmoist[lev][qmoist_indices[var]]),0,0,ncomp,ng);
+           VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", qmoist_names[var]));
         }
 
 #if defined(ERF_USE_WINDFARM)
@@ -395,16 +395,16 @@ ERF::ReadCheckpointFile ()
         }
 
         // Read in the moisture model restart variables
-        std::vector<int> indices(0);
-        std::vector<std::string> names(0);
-        micro->Get_Qmoist_Restart_Vars(lev, indices, names);
-        int nvar = indices.size();
-        for (int var = 0; var < nvar; var++) {
-            ng = qmoist[lev][indices[var]]->nGrowVect();
+        std::vector<int> qmoist_indices(0);
+        std::vector<std::string> qmoist_names(0);
+        micro->Get_Qmoist_Restart_Vars(lev, qmoist_indices, qmoist_names);
+        int qmoist_nvar = qmoist_indices.size();
+        for (int var = 0; var < qmoist_nvar; var++) {
+            ng = qmoist[lev][qmoist_indices[var]]->nGrowVect();
             const int ncomp = 1;
             MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
-            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", names[var]));
-            MultiFab::Copy(*(qmoist[lev][indices[var]]),moist_vars,0,0,ncomp,ng);
+            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", qmoist_names[var]));
+            MultiFab::Copy(*(qmoist[lev][qmoist_indices[var]]),moist_vars,0,0,ncomp,ng);
         }
 
 #if defined(ERF_USE_WINDFARM)

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -3,6 +3,8 @@
 
 #include <iostream>
 #include <fstream>
+#include <vector>
+#include <string>
 
 using namespace amrex;
 
@@ -143,33 +145,18 @@ ERF::WriteCheckpointFile () const
         }
 
          // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
-         // Write the precipitation accumulation component only
-        if (solverChoice.moisture_type == MoistureType::Kessler) {
-            ng = qmoist[lev][4]->nGrowVect();
-            int nvar = 1;
-            MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
-            MultiFab::Copy(moist_vars,*(qmoist[lev][4]),0,0,nvar,ng);
-            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
-        }
-
-        if(solverChoice.moisture_type == MoistureType::SAM){
-            ng = qmoist[lev][8]->nGrowVect();
-            int nvar = 1;
-            MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
-            MultiFab::Copy(rain_accum,*(qmoist[lev][8]),0,0,nvar,ng);
-            VisMF::Write(rain_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "RainAccum"));
-
-            ng = qmoist[lev][9]->nGrowVect();
-            MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
-            MultiFab::Copy(snow_accum,*(qmoist[lev][9]),0,0,nvar,ng);
-            VisMF::Write(snow_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "SnowAccum"));
-
-            ng = qmoist[lev][10]->nGrowVect();
-            MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
-            MultiFab::Copy(graup_accum,*(qmoist[lev][10]),0,0,nvar,ng);
-            VisMF::Write(graup_accum, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", "GraupAccum"));
-        }
-
+         // Write the moisture model restart variables
+         std::vector<int> indices(0);
+         std::vector<std::string> names(0);
+         micro->Get_Qmoist_Restart_Vars(lev, indices, names);
+         int nvar = indices.size();
+         for (int var = 0; var < nvar; var++) {
+            ng = qmoist[lev][indices[var]]->nGrowVect();
+            const int ncomp = 1;
+            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
+            MultiFab::Copy(moist_vars,*(qmoist[lev][indices[var]]),0,0,ncomp,ng);
+            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", names[var]));
+         }
 
 #if defined(ERF_USE_WINDFARM)
         if(solverChoice.windfarm_type == WindFarmType::Fitch or
@@ -408,32 +395,17 @@ ERF::ReadCheckpointFile ()
            update_terrain_arrays(lev);
         }
 
-        // Read in the precipitation accumulation component
-        if (solverChoice.moisture_type == MoistureType::Kessler) {
-            ng = qmoist[lev][4]->nGrowVect();
-            int nvar = 1;
-            MultiFab moist_vars(grids[lev],dmap[lev],nvar,ng);
-            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "RainAccum"));
-            MultiFab::Copy(*(qmoist[lev][4]),moist_vars,0,0,nvar,ng);
-        }
-
-         if (solverChoice.moisture_type == MoistureType::SAM) {
-            ng = qmoist[lev][8]->nGrowVect();
-            int nvar = 1;
-            MultiFab rain_accum(grids[lev],dmap[lev],nvar,ng);
-            VisMF::Read(rain_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "RainAccum"));
-            MultiFab::Copy(*(qmoist[lev][8]),rain_accum,0,0,nvar,ng);
-
-            ng = qmoist[lev][9]->nGrowVect();
-            MultiFab snow_accum(grids[lev],dmap[lev],nvar,ng);
-            VisMF::Read(snow_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "SnowAccum"));
-            MultiFab::Copy(*(qmoist[lev][9]),snow_accum,0,0,nvar,ng);
-
-            ng = qmoist[lev][10]->nGrowVect();
-            MultiFab graup_accum(grids[lev],dmap[lev],nvar,ng);
-            VisMF::Read(graup_accum, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "GraupAccum"));
-            MultiFab::Copy(*(qmoist[lev][10]),graup_accum,0,0,nvar,ng);
-
+        // Read in the moisture model restart variables
+        std::vector<int> indices(0);
+        std::vector<std::string> names(0);
+        micro->Get_Qmoist_Restart_Vars(lev, indices, names);
+        int nvar = indices.size();
+        for (int var = 0; var < nvar; var++) {
+            ng = qmoist[lev][indices[var]]->nGrowVect();
+            const int ncomp = 1;
+            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng);
+            VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", names[var]));
+            MultiFab::Copy(*(qmoist[lev][indices[var]]),moist_vars,0,0,ncomp,ng);
         }
 
 #if defined(ERF_USE_WINDFARM)

--- a/Source/Microphysics/ERF_EulerianMicrophysics.H
+++ b/Source/Microphysics/ERF_EulerianMicrophysics.H
@@ -109,6 +109,15 @@ public:
         return m_moist_model[0]->Qstate_Size();
     }
 
+    /*! \brief get the indices and names of moisture model variables for restart
+               at a given level */
+    void Get_Qmoist_Restart_Vars ( const int a_lev, /*!< level */
+                                   std::vector<int>& a_idx, /*!< indices */
+                                   std::vector<std::string>& a_names /*!< names */ ) const override
+    {
+        m_moist_model[a_lev]->Qmoist_Restart_Vars( a_idx, a_names );
+    }
+
 protected:
 
     /*! \brief Create and set the specified moisture model */

--- a/Source/Microphysics/ERF_LagrangianMicrophysics.H
+++ b/Source/Microphysics/ERF_LagrangianMicrophysics.H
@@ -123,6 +123,20 @@ public:
         return m_moist_model->getName();
     }
 
+    /*! \brief get the indices and names of moisture model variables for restart
+               at a given level */
+    void Get_Qmoist_Restart_Vars ( const int a_lev, /*!< level */
+                                   std::vector<int>& a_idx, /*!< indices */
+                                   std::vector<std::string>& a_names /*!< names */ ) const override
+    {
+        if (a_lev == 0) {
+            m_moist_model->Qmoist_Restart_Vars( a_idx, a_names );
+        } else {
+            a_idx.clear();
+            a_names.clear();
+        }
+    }
+
 protected:
 
     /*! \brief Create and set the specified moisture model */

--- a/Source/Microphysics/ERF_Microphysics.H
+++ b/Source/Microphysics/ERF_Microphysics.H
@@ -5,6 +5,8 @@
 #ifndef ERF_MICROPHYSICS_H
 #define ERF_MICROPHYSICS_H
 
+#include <vector>
+#include <string>
 #include "ERF_DataStruct.H"
 
 /*! \brief Base class for microphysics interface */
@@ -53,6 +55,10 @@ public:
 
     /*! \brief get the number of moisture-model-related conserved state variables */
     virtual int Get_Qstate_Size () = 0;
+
+    /*! \brief get the indices and names of moisture model variables for restart
+               at a given level */
+    virtual void Get_Qmoist_Restart_Vars ( int, std::vector<int>&, std::vector<std::string>& ) const = 0;
 
     /*! \brief query if a specified moisture model is Eulerian or Lagrangian */
     static MoistureModelType modelType (const MoistureType a_moisture_type)

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -124,6 +124,15 @@ public:
     int
     Qstate_Size () override { return Kessler::m_qstate_size; }
 
+    void
+    Qmoist_Restart_Vars ( std::vector<int>& a_idx,
+                          std::vector<std::string>& a_names) const override
+    {
+        a_idx.clear();
+        a_names.clear();
+        a_idx.push_back(4); a_names.push_back("RainAccum");
+    }
+
 private:
     // Number of qmoist variables (qt, qv, qcl, qp)
     int m_qmoist_size = 5;

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -57,6 +57,14 @@ public:
     int
     Qstate_Size () { return NullMoist::m_qstate_size; }
 
+    virtual
+    void
+    Qmoist_Restart_Vars ( std::vector<int>& a_idx, std::vector<std::string>& a_names) const
+    {
+        a_idx.clear();
+        a_names.clear();
+    }
+
 private:
     int m_qmoist_size = 1;
     int m_qstate_size = 0;

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -263,6 +263,17 @@ public:
         return tabs;
     }
 
+    void
+    Qmoist_Restart_Vars ( std::vector<int>& a_idx,
+                          std::vector<std::string>& a_names) const override
+    {
+        a_idx.clear();
+        a_names.clear();
+        a_idx.push_back( 8); a_names.push_back("RainAccum");
+        a_idx.push_back( 9); a_names.push_back("SnowAccum");
+        a_idx.push_back(10); a_names.push_back("GraupAccum");
+    }
+
 private:
     // Number of qmoist variables (qt, qv, qcl, qci, qp, qpr, qps, qpg)
     int m_qmoist_size = 11;


### PR DESCRIPTION
Microphysics (and consequently, the moisture model) is asked for a list of `qmoist` variables that participate in restart, and ERF reads/writes these variables from/to checkpoint files.