### PR TITLE
Generalized particle restart to allow restarting other particle containers

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -930,6 +930,10 @@ private:
     /*! Initialize tracer and hydro particles */
     void initializeTracers ( amrex::ParGDBBase*,
                              const amrex::Vector<std::unique_ptr<amrex::MultiFab>>& );
+
+    /*! Restart tracer and hydro particles */
+    void restartTracers ( amrex::ParGDBBase*, const std::string& );
+
     /*! Evolve tracers and hydro particles */
     void evolveTracers( int,
                         amrex::Real,

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -722,6 +722,14 @@ ERF::InitData_post ()
             }
         }
 
+#ifdef ERF_USE_PARTICLES
+        if (Microphysics::modelType(solverChoice.moisture_type) == MoistureModelType::Lagrangian) {
+            for (int lev = 0; lev <= finest_level; lev++) {
+                dynamic_cast<LagrangianMicrophysics&>(*micro).initParticles(z_phys_nd[lev]);
+            }
+        }
+#endif
+
     } else { // Restart from a checkpoint
 
         restart();

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -455,6 +455,9 @@ ERF::ReadCheckpointFile ()
 
 #ifdef ERF_USE_PARTICLES
     restartTracers((ParGDBBase*)GetParGDB(),restart_chkfile);
+    if (Microphysics::modelType(solverChoice.moisture_type) == MoistureModelType::Lagrangian) {
+        dynamic_cast<LagrangianMicrophysics&>(*micro).restartParticles((ParGDBBase*)GetParGDB(),restart_chkfile);
+    }
 #endif
 
 #ifdef ERF_USE_NETCDF

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -454,7 +454,7 @@ ERF::ReadCheckpointFile ()
     }
 
 #ifdef ERF_USE_PARTICLES
-   particleData.Restart((ParGDBBase*)GetParGDB(),restart_chkfile);
+    restartTracers((ParGDBBase*)GetParGDB(),restart_chkfile);
 #endif
 
 #ifdef ERF_USE_NETCDF

--- a/Source/Microphysics/ERF_LagrangianMicrophysics.H
+++ b/Source/Microphysics/ERF_LagrangianMicrophysics.H
@@ -111,6 +111,12 @@ public:
         return m_moist_model->Qstate_Size();
     }
 
+    /*! \brief initialize particles in particle container */
+    inline void initParticles ( std::unique_ptr<amrex::MultiFab>& z_phys_nd /*!< Nodal z heights */ )
+    {
+        m_moist_model->InitParticles(z_phys_nd);
+    }
+
     /*! \brief get the particle container from the moisture model */
     inline ERFPC* getParticleContainer () const
     {

--- a/Source/Microphysics/ERF_LagrangianMicrophysics.H
+++ b/Source/Microphysics/ERF_LagrangianMicrophysics.H
@@ -117,6 +117,12 @@ public:
         m_moist_model->InitParticles(z_phys_nd);
     }
 
+    /*! \brief restart particles in particle container */
+    inline void restartParticles ( amrex::ParGDBBase* a_gdb, const std::string& a_fname)
+    {
+        m_moist_model->RestartParticles(a_gdb, a_fname);
+    }
+
     /*! \brief get the particle container from the moisture model */
     inline ERFPC* getParticleContainer () const
     {

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -25,6 +25,9 @@ public:
                std::unique_ptr<amrex::MultiFab>& /*detJ_cc*/) { }
 
     virtual
+    void InitParticles ( std::unique_ptr<amrex::MultiFab>& ) { }
+
+    virtual
     void
     Advance (const amrex::Real& /*dt_advance*/,
              const SolverChoice& /*solverChoce*/) { }

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -25,9 +25,6 @@ public:
                std::unique_ptr<amrex::MultiFab>& /*detJ_cc*/) { }
 
     virtual
-    void InitParticles ( std::unique_ptr<amrex::MultiFab>& ) { }
-
-    virtual
     void
     Advance (const amrex::Real& /*dt_advance*/,
              const SolverChoice& /*solverChoce*/) { }

--- a/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
+++ b/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
@@ -24,6 +24,14 @@ public:
     /*! \brief Default destructor */
     virtual ~NullMoistLagrangian () = default;
 
+    /*! \brief Initialize particles */
+    virtual
+    void InitParticles ( std::unique_ptr<amrex::MultiFab>& ) { }
+
+    /*! \brief Restart particles */
+    virtual
+    void RestartParticles ( amrex::ParGDBBase*, const std::string& ) { }
+
     /*! \brief get the particle container */
     virtual ERFPC* getParticleContainer ()
     {

--- a/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
+++ b/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
@@ -6,6 +6,7 @@
 
 #ifdef ERF_USE_PARTICLES
 
+#include <AMReX_AmrParGDB.H>
 #include "ERF_NullMoist.H"
 
 /* forward declaration */

--- a/Source/Particles/ERFTracers.cpp
+++ b/Source/Particles/ERFTracers.cpp
@@ -62,6 +62,41 @@ void ERF::initializeTracers ( ParGDBBase* a_gdb,
     return;
 }
 
+/*! Restart tracer and hydro particles */
+void ERF::restartTracers ( ParGDBBase* a_gdb,
+                           const std::string& a_fname )
+{
+    auto& namelist_unalloc( particleData.getNamesUnalloc() );
+
+    for (auto it = namelist_unalloc.begin(); it != namelist_unalloc.end(); ++it) {
+
+        std::string species_name( *it );
+
+        if (species_name == ERFParticleNames::tracers) {
+
+            AMREX_ASSERT(m_use_tracer_particles);
+            ERFPC* pc = new ERFPC(a_gdb, ERFParticleNames::tracers);
+            pc->Restart(a_fname, ERFParticleNames::tracers);
+            amrex::Print() << "Restarted " << pc->TotalNumberOfParticles() << " tracer particles.\n";
+            particleData.pushBack(ERFParticleNames::tracers, pc);
+
+        } else if (species_name == ERFParticleNames::hydro) {
+
+            AMREX_ASSERT(m_use_hydro_particles);
+            ERFPC* pc = new ERFPC(a_gdb, ERFParticleNames::hydro);
+            pc->Restart(a_fname, ERFParticleNames::hydro);
+            amrex::Print() << "Restarted " << pc->TotalNumberOfParticles() << " hydro particles.\n";
+            particleData.pushBack(ERFParticleNames::hydro, pc);
+
+        }
+    }
+
+    if (m_use_tracer_particles) namelist_unalloc.remove( ERFParticleNames::tracers );
+    if (m_use_hydro_particles)  namelist_unalloc.remove( ERFParticleNames::hydro );
+
+    return;
+}
+
 /*! Evolve tracers and hydro particles for one time step*/
 void ERF::evolveTracers ( int                                        a_lev,
                           Real                                       a_dt_lev,

--- a/Source/Particles/ERF_ParticleData.H
+++ b/Source/Particles/ERF_ParticleData.H
@@ -79,20 +79,6 @@ class ParticleData
             }
         }
 
-        /*! Read from restart file */
-        void Restart ( amrex::ParGDBBase* a_gdb, const std::string& a_fname )
-        {
-            BL_PROFILE("ParticleData::Restart()");
-            AMREX_ASSERT(isEmpty());
-            for (auto it = m_namelist_unalloc.begin(); it != m_namelist_unalloc.end(); ++it) {
-                std::string species_name( *it );
-                ERFPC* pc = new ERFPC( a_gdb, species_name );
-                pc->Restart(a_fname, species_name );
-                pushBack( species_name, pc );
-            }
-            m_namelist_unalloc.clear();
-        }
-
         /*! Get mesh plot quantities from each particle container */
         void GetMeshPlotVarNames ( amrex::Vector<std::string>& a_names ) const
         {


### PR DESCRIPTION
+ Removed the `Restart` function from `ERF::particleData`; instead, letting individual particle-based pieces to restart their particle containers themselves. This is needed because the particle container-type may differ.

+ Created the interface to restart Lagrangian microphysics particle containers

+ Lagrangian microphysics has separate `Init` and `InitParticles` because initializing particles in the former will not work for restart.