### PR TITLE
SAM coeff bounding

### DIFF
--- a/Source/Microphysics/Kessler/ERF_Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Init_Kessler.cpp
@@ -93,7 +93,7 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
             tabs_array(i,j,k)  = getTgivenRandRTh(states_array(i,j,k,Rho_comp),
                                                   states_array(i,j,k,RhoTheta_comp),
                                                   qv_array(i,j,k));
-            pres_array(i,j,k)  = getPgivenRTh(states_array(i,j,k,RhoTheta_comp), qv_array(i,j,k))/100.;
+            pres_array(i,j,k)  = getPgivenRTh(states_array(i,j,k,RhoTheta_comp), qv_array(i,j,k)) * 0.01;
         });
     }
 }

--- a/Source/Microphysics/SAM/ERF_Init_SAM.cpp
+++ b/Source/Microphysics/SAM/ERF_Init_SAM.cpp
@@ -204,8 +204,12 @@ void SAM::Compute_Coefficients ()
         Real RhoTheta = rho_dptr[k]*theta_dptr[k];
         Real pressure = getPgivenRTh(RhoTheta, qv_dptr[k]);
         rho1d_t(k)    = rho_dptr[k];
-        pres1d_t(k)   = pressure/100.;
-        tabs1d_t(k)   = getTgivenRandRTh(rho_dptr[k], RhoTheta, qv_dptr[k]);
+        pres1d_t(k)   = pressure*0.01;
+        // NOTE: Limit the temperature to the melting point of ice to avoid a divide by
+        //       0 condition when computing the cold evaporation coefficients. This should
+        //       not affect results since evporation requires snow/graupel to be present
+        //       and thus T<273.16
+        tabs1d_t(k)   = std::min(getTgivenRandRTh(rho_dptr[k], RhoTheta, qv_dptr[k]),273.16);
         zmid_t(k)     = lowz + (k+0.5)*dz;
         gamaz_t(k)    = gOcp*zmid_t(k);
     });


### PR DESCRIPTION
This PR prevents a divide by 0 case with the SAM microphysics. Namely, the coefficients of evaporation for snow/graupel depend upon the vapor pressure of ice (`erf_esati`). When `T>273.16`, the ice melts and thus its vapor pressure is 0. To alleviate this issue, we limit the temperature in the SAM initialization so that `esati` is computed at `T=273.16` if `T>273.16`. This keeps the coefficients bounded and should not affect evaporation rates since that process requires finite `q_{s/g}` and that condition requires `T<273.16`.