### PR TITLE
Fixes for Intel "Erroneous arithmetic operation" with compiler optimization

### DIFF
--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -189,7 +189,7 @@ void ComputeTurbulentViscosityLES (const MultiFab& Tau11, const MultiFab& Tau22,
                                       - cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dzInv;
                 }
                 Real E              = amrex::max(cell_data(i,j,k,RhoKE_comp)/cell_data(i,j,k,Rho_comp),Real(0.0));
-                Real stratification = l_abs_g * dtheta_dz * l_inv_theta0; // stratification
+                volatile Real stratification = l_abs_g * dtheta_dz * l_inv_theta0;
                 Real length;
                 if (stratification <= eps) {
                     length = DeltaMsf;

--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
@@ -27,6 +27,13 @@ ApplySpongeZoneBCsForCC (
     const int use_yhi_sponge_damping = spongeChoice.use_yhi_sponge_damping;
     const int use_zlo_sponge_damping = spongeChoice.use_zlo_sponge_damping;
     const int use_zhi_sponge_damping = spongeChoice.use_zhi_sponge_damping;
+    if (!use_xlo_sponge_damping &&
+        !use_xhi_sponge_damping &&
+        !use_ylo_sponge_damping &&
+        !use_yhi_sponge_damping &&
+        !use_zlo_sponge_damping &&
+        !use_zhi_sponge_damping)
+        return;
 
     const Real xlo_sponge_end   = spongeChoice.xlo_sponge_end;
     const Real xhi_sponge_start = spongeChoice.xhi_sponge_start;
@@ -136,6 +143,13 @@ ApplySpongeZoneBCsForMom (
     const int use_yhi_sponge_damping = spongeChoice.use_yhi_sponge_damping;
     const int use_zlo_sponge_damping = spongeChoice.use_zlo_sponge_damping;
     const int use_zhi_sponge_damping = spongeChoice.use_zhi_sponge_damping;
+    if (!use_xlo_sponge_damping &&
+        !use_xhi_sponge_damping &&
+        !use_ylo_sponge_damping &&
+        !use_yhi_sponge_damping &&
+        !use_zlo_sponge_damping &&
+        !use_zhi_sponge_damping)
+        return;
 
     const Real xlo_sponge_end   = spongeChoice.xlo_sponge_end;
     const Real xhi_sponge_start = spongeChoice.xhi_sponge_start;


### PR DESCRIPTION
Deal with issues on Kestrel when compiling with Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0 (2023.2.0.20230622). Issues were discovered by @rthedin. Before this fix, this test problem would only run without any optimization (or with GNU compilers).

Not sure if there a better way to implement and maintain these types of workarounds...

Test files: [test.tar.gz](https://github.com/user-attachments/files/17859454/test.tar.gz)
