### PR TITLE
DO NOT MERGE: Partial sum test for moisture

### DIFF
--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -986,6 +986,10 @@ ERF::WritePlotFile (int which, PlotFileType plotfile_type, Vector<std::string> p
             mf_comp ++;
         }
 
+        // PS may alleviate these issues if we simply launch a kernel
+        // and call the general wrapper function with the associated
+        // index map for the variable we need to plot
+
         // TODO: The size of the q variables can vary with different
         //       moisture models. Therefore, certain components may
         //       reside at different indices. For example, Kessler is

--- a/Source/Microphysics/ERF_EulerianMicrophysics.H
+++ b/Source/Microphysics/ERF_EulerianMicrophysics.H
@@ -108,12 +108,19 @@ public:
 
     /*! \brief get the indices and names of moisture model variables for restart
                at a given level */
-    void Get_Qmoist_Restart_Vars ( const int a_lev, /*!< level */
-                                   const SolverChoice& a_sc, /*!< Solver choice object */
-                                   std::vector<int>& a_idx, /*!< indices */
-                                   std::vector<std::string>& a_names /*!< names */ ) const override
+    void Get_Qmoist_Restart_Vars (const int a_lev, /*!< level */
+                                  const SolverChoice& a_sc, /*!< Solver choice object */
+                                  std::vector<int>& a_idx, /*!< indices */
+                                  std::vector<std::string>& a_names /*!< names */ ) const override
     {
-        m_moist_model[a_lev]->Qmoist_Restart_Vars( a_sc, a_idx, a_names );
+        m_moist_model[a_lev]->Qmoist_Restart_Vars(a_sc, a_idx, a_names);
+    }
+
+    // Wrapper fun
+    int*
+    NonPrecip_Index_Map (int& size) override
+    {
+        return m_moist_model[0]->NonPrecip_Index_Map(size);
     }
 
 protected:

--- a/Source/Microphysics/ERF_Microphysics.H
+++ b/Source/Microphysics/ERF_Microphysics.H
@@ -7,7 +7,7 @@
 
 #include <vector>
 #include <string>
-#include "ERF_DataStruct.H"
+#include <ERF_DataStruct.H>
 
 /*! \brief Base class for microphysics interface */
 class Microphysics {
@@ -58,7 +58,17 @@ public:
 
     /*! \brief get the indices and names of moisture model variables for restart
                at a given level */
-    virtual void Get_Qmoist_Restart_Vars ( int, const SolverChoice&, std::vector<int>&, std::vector<std::string>& ) const = 0;
+    virtual void Get_Qmoist_Restart_Vars (int,
+                                          const SolverChoice&,
+                                          std::vector<int>&,
+                                          std::vector<std::string>& ) const = 0;
+    // Wrapper fun
+    virtual int*
+    NonPrecip_Index_Map (int& size)
+    {
+        size = 0;
+        return nullptr;
+    }
 
     /*! \brief query if a specified moisture model is Eulerian or Lagrangian */
     static MoistureModelType modelType (const MoistureType a_moisture_type)

--- a/Source/Microphysics/Kessler/ERF_Init_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Init_Kessler.cpp
@@ -36,6 +36,13 @@ void Kessler::Init (const MultiFab& cons_in,
     MicVarMap.resize(m_qmoist_size);
     MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp, MicVar_Kess::rain_accum};
 
+    // Test micro partial sum
+    NP_map_size = 2;
+    Vector<int> NP_map;
+    NP_map.resize(NP_map_size); NP_map_d.resize(NP_map_size);
+    NP_map = {0, 1}; // THESE ARE OFFSETS!!!! (qv, qc)
+    Gpu::copy(Gpu::hostToDevice, NP_map.begin(), NP_map.end(), NP_map_d.begin());
+
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Kess::NumVars; ++ivar) {
         mic_fab_vars[ivar] = std::make_shared<MultiFab>(cons_in.boxArray(), cons_in.DistributionMap(),

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -125,15 +125,22 @@ public:
     Qstate_Size () override { return Kessler::m_qstate_size; }
 
     void
-    Qmoist_Restart_Vars ( const SolverChoice& a_sc,
-                          std::vector<int>& a_idx,
-                          std::vector<std::string>& a_names) const override
+    Qmoist_Restart_Vars (const SolverChoice& a_sc,
+                         std::vector<int>& a_idx,
+                         std::vector<std::string>& a_names) const override
     {
         a_idx.clear();
         a_names.clear();
         if (a_sc.moisture_type == MoistureType::Kessler) {
             a_idx.push_back(4); a_names.push_back("RainAccum");
         }
+    }
+
+    int*
+    NonPrecip_Index_Map (int& size) override
+    {
+        size = NP_map_size;
+        return NP_map_d.data();
     }
 
 private:
@@ -145,6 +152,10 @@ private:
 
     // CFL MAX for vertical advection
     static constexpr amrex::Real CFL_MAX = 0.5;
+
+    // Nonprecip ind map
+    int NP_map_size;
+    amrex::Gpu::DeviceVector<int> NP_map_d;
 
     // MicVar map (Qmoist indices -> MicVar enum)
     amrex::Vector<int> MicVarMap;

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -59,10 +59,20 @@ public:
 
     virtual
     void
-    Qmoist_Restart_Vars ( const SolverChoice&, std::vector<int>& a_idx, std::vector<std::string>& a_names) const
+    Qmoist_Restart_Vars (const SolverChoice&,
+                         std::vector<int>& a_idx,
+                         std::vector<std::string>& a_names) const
     {
         a_idx.clear();
         a_names.clear();
+    }
+
+    virtual
+    int*
+    NonPrecip_Index_Map (int& size)
+    {
+        size = 0;
+        return nullptr;
     }
 
 private:

--- a/Source/Microphysics/SAM/ERF_Init_SAM.cpp
+++ b/Source/Microphysics/SAM/ERF_Init_SAM.cpp
@@ -37,6 +37,13 @@ SAM::Init (const MultiFab& cons_in,
     MicVarMap = {MicVar::qt, MicVar::qv , MicVar::qcl, MicVar::qci,
                  MicVar::qp, MicVar::qpr, MicVar::qps, MicVar::qpg, MicVar::rain_accum, MicVar::snow_accum, MicVar::graup_accum};
 
+    // Test micro partial sum
+    NP_map_size = 3;
+    Vector<int> NP_map;
+    NP_map.resize(NP_map_size); NP_map_d.resize(NP_map_size);
+    NP_map = {0, 1, 2}; // THESE ARE OFFSETS!!!! (qv, qc, qi)
+    Gpu::copy(Gpu::hostToDevice, NP_map.begin(), NP_map.end(), NP_map_d.begin());
+
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar::NumVars; ++ivar) {
         mic_fab_vars[ivar] = std::make_shared<MultiFab>(cons_in.boxArray(), cons_in.DistributionMap(),

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -264,9 +264,9 @@ public:
     }
 
     void
-    Qmoist_Restart_Vars ( const SolverChoice& a_sc,
-                          std::vector<int>& a_idx,
-                          std::vector<std::string>& a_names) const override
+    Qmoist_Restart_Vars (const SolverChoice& a_sc,
+                         std::vector<int>& a_idx,
+                         std::vector<std::string>& a_names) const override
     {
         a_idx.clear();
         a_names.clear();
@@ -279,6 +279,13 @@ public:
         }
     }
 
+    int*
+    NonPrecip_Index_Map (int& size) override
+    {
+        size = NP_map_size;
+        return NP_map_d.data();
+    }
+
 private:
     // Number of qmoist variables (qt, qv, qcl, qci, qp, qpr, qps, qpg)
     int m_qmoist_size = 11;
@@ -288,6 +295,10 @@ private:
 
     // CFL MAX for vertical advection
     static constexpr amrex::Real CFL_MAX = 0.5;
+
+    // Nonprecip ind map
+    int NP_map_size;
+    amrex::Gpu::DeviceVector<int> NP_map_d;
 
     // MicVar map (Qmoist indices -> MicVar enum)
     amrex::Vector<int> MicVarMap;

--- a/Source/SourceTerms/ERF_buoyancy_utils.H
+++ b/Source/SourceTerms/ERF_buoyancy_utils.H
@@ -40,9 +40,9 @@ buoyancy_moist_anelastic (int& i, int& j, int& k,
                           const amrex::Array4<const amrex::Real>& cell_data)
 {
     amrex::Real theta_d_lo = cell_data(i,j,k-1,RhoTheta_comp)/r0_arr(i,j,k-1);
-    amrex::Real qv_lo      = cell_data(i,j,k-1,RhoQ1_comp)   /r0_arr(i,j,k-1);
-    amrex::Real qc_lo      = cell_data(i,j,k-1,RhoQ2_comp)   /r0_arr(i,j,k-1);
-    amrex::Real qt_lo      = qv_lo + qc_lo;
+    amrex::Real qv_lo      = cell_data(i,j,k-1,RhoQ1_comp)   /r0_arr(i,j,k-1); // PS?
+    amrex::Real qc_lo      = cell_data(i,j,k-1,RhoQ2_comp)   /r0_arr(i,j,k-1); // PS
+    amrex::Real qt_lo      = qv_lo + qc_lo;                                    // PS (could include ice etc.)
     amrex::Real theta_v_lo = theta_d_lo * (1.0 - (1.0 - rv_over_rd)*qt_lo - rv_over_rd*qc_lo);
 
     amrex::Real theta_d_hi = cell_data(i,j,k,RhoTheta_comp)/r0_arr(i,j,k);
@@ -97,7 +97,7 @@ buoyancy_rhopert (int& i, int& j, int& k,
 {
     amrex::Real rhop_hi = cell_data(i,j,k  ,Rho_comp) - r0_arr(i,j,k  );
     amrex::Real rhop_lo = cell_data(i,j,k-1,Rho_comp) - r0_arr(i,j,k-1);
-    for (int q_offset(0); q_offset<n_qstate; ++q_offset) {
+    for (int q_offset(0); q_offset<n_qstate; ++q_offset) { // PS (we would replace this)
         rhop_hi += cell_data(i,j,k  ,RhoQ1_comp+q_offset);
         rhop_lo += cell_data(i,j,k-1,RhoQ1_comp+q_offset);
     }
@@ -124,19 +124,19 @@ buoyancy_type2 (int& i, int& j, int& k,
 
     amrex::Real tempp3d  = getTgivenRandRTh(cell_data(i,j,k  ,Rho_comp),
                                             cell_data(i,j,k  ,RhoTheta_comp),
-                                            cell_data(i,j,k  ,RhoQ1_comp)/cell_data(i,j,k  ,Rho_comp));
+                                            cell_data(i,j,k  ,RhoQ1_comp)/cell_data(i,j,k  ,Rho_comp)); // PS?
     amrex::Real tempm3d  = getTgivenRandRTh(cell_data(i,j,k-1,Rho_comp),
                                             cell_data(i,j,k-1,RhoTheta_comp),
-                                            cell_data(i,j,k-1,RhoQ1_comp)/cell_data(i,j,k-1,Rho_comp));
+                                            cell_data(i,j,k-1,RhoQ1_comp)/cell_data(i,j,k-1,Rho_comp)); // PS?
 
-    amrex::Real qv_plus  = (n_qstate >= 1) ? cell_prim(i,j,k  ,PrimQ1_comp) : 0.0;
-    amrex::Real qv_minus = (n_qstate >= 1) ? cell_prim(i,j,k-1,PrimQ1_comp) : 0.0;
+    amrex::Real qv_plus  = (n_qstate >= 1) ? cell_prim(i,j,k  ,PrimQ1_comp) : 0.0; // PS?
+    amrex::Real qv_minus = (n_qstate >= 1) ? cell_prim(i,j,k-1,PrimQ1_comp) : 0.0; // PS?
 
-    amrex::Real qc_plus  = (n_qstate >= 2) ? cell_prim(i,j,k  ,PrimQ2_comp) : 0.0;
-    amrex::Real qc_minus = (n_qstate >= 2) ? cell_prim(i,j,k-1,PrimQ2_comp) : 0.0;
+    amrex::Real qc_plus  = (n_qstate >= 2) ? cell_prim(i,j,k  ,PrimQ2_comp) : 0.0; // PS
+    amrex::Real qc_minus = (n_qstate >= 2) ? cell_prim(i,j,k-1,PrimQ2_comp) : 0.0; // PS
 
-    amrex::Real qp_plus  = (n_qstate >= 3) ? cell_prim(i,j,k  ,PrimQ3_comp) : 0.0;
-    amrex::Real qp_minus = (n_qstate >= 3) ? cell_prim(i,j,k-1,PrimQ3_comp) : 0.0;
+    amrex::Real qp_plus  = (n_qstate >= 3) ? cell_prim(i,j,k  ,PrimQ3_comp) : 0.0; // PS
+    amrex::Real qp_minus = (n_qstate >= 3) ? cell_prim(i,j,k-1,PrimQ3_comp) : 0.0; // PS
 
     amrex::Real qplus  = 0.61 * ( qv_plus - qv_d_ptr[k] ) -
                                 ( qc_plus - qc_d_ptr[k]   +

--- a/Source/TimeIntegration/ERF_advance_microphysics.cpp
+++ b/Source/TimeIntegration/ERF_advance_microphysics.cpp
@@ -1,4 +1,5 @@
 #include <ERF.H>
+#include <ERF_ParFunctions.H>
 
 using namespace amrex;
 
@@ -9,6 +10,29 @@ void ERF::advance_microphysics (int lev,
                                 const Real& time )
 {
     if (solverChoice.moisture_type != MoistureType::None) {
+
+        // Test the PS interface.
+        // These type of ops need to be done on GPU
+        // but outside the micro class. Note, we can't
+        // operate through the class pointers on GPU.
+        int size(0);
+        int* ind_map = micro->NonPrecip_Index_Map(size);
+        Print() << "CHECK: " << size << ' '
+                << (ind_map==nullptr) << "\n";
+        for (MFIter mfi(cons); mfi.isValid(); ++mfi) {
+            const auto& tbx  = mfi.tilebox();
+            const auto& data = cons.const_array(mfi);
+            ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                Real partial_sum = comp_partial_sum (i, j, k,
+                                                     size, ind_map, data);
+                if (i==0 && j==0) {
+                    printf("Partial Micro Sum: %i %e\n",k,partial_sum);
+                }
+            });
+        }
+
+
         micro->Update_Micro_Vars_Lev(lev, cons);
         micro->Advance(lev, dt_advance, iteration, time, solverChoice, vars_new, z_phys_nd);
         micro->Update_State_Vars_Lev(lev, cons);

--- a/Source/TimeIntegration/ERF_slow_rhs_post.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_post.cpp
@@ -271,10 +271,12 @@ void erf_slow_rhs_post (int level, int finest_level,
         const Array4<const Real> & u = xvel.array(mfi);
         const Array4<const Real> & v = yvel.array(mfi);
 
-        const Array4<Real const>& mu_turb = l_use_turb ? eddyDiffs->const_array(mfi) : Array4<const Real>{};
-
-        const Array4<const Real>& z_nd         = l_use_terrain    ? z_phys_nd->const_array(mfi) : Array4<const Real>{};
-        const Array4<const Real>& detJ_new_arr = l_moving_terrain ? detJ_new->const_array(mfi)    : Array4<const Real>{};
+        const Array4<Real const>& mu_turb      = l_use_turb       ? eddyDiffs->const_array(mfi) :
+                                                                    Array4<const Real>{};
+        const Array4<const Real>& z_nd         = l_use_terrain    ? z_phys_nd->const_array(mfi) :
+                                                                    Array4<const Real>{};
+        const Array4<const Real>& detJ_new_arr = l_moving_terrain ? detJ_new->const_array(mfi) :
+                                                                    Array4<const Real>{};
 
         // Map factors
         const Array4<const Real>& mf_m = mapfac_m->const_array(mfi);
@@ -282,7 +284,8 @@ void erf_slow_rhs_post (int level, int finest_level,
         const Array4<const Real>& mf_v = mapfac_v->const_array(mfi);
 
         // SmnSmn for KE src with Deardorff
-        const Array4<const Real>& SmnSmn_a = l_use_ddorf ? SmnSmn->const_array(mfi) : Array4<const Real>{};
+        const Array4<const Real>& SmnSmn_a = l_use_ddorf ? SmnSmn->const_array(mfi) :
+                                                           Array4<const Real>{};
 
         // **************************************************************************
         // Here we fill the "current" data with "new" data because that is the result of the previous RK stage
@@ -408,7 +411,8 @@ void erf_slow_rhs_post (int level, int finest_level,
                 }
 
                 if (l_use_diff) {
-                    const Array4<const Real> tm_arr = t_mean_mf ? t_mean_mf->const_array(mfi) : Array4<const Real>{};
+                    const Array4<const Real> tm_arr = t_mean_mf ? t_mean_mf->const_array(mfi) :
+                                                                  Array4<const Real>{};
                     if (l_use_terrain) {
                         DiffusionSrcForState_T(tbx, domain, start_comp, num_comp, exp_most, rot_most, u, v,
                                                new_cons, cur_prim, cell_rhs,

--- a/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
+++ b/Source/TimeIntegration/ERF_slow_rhs_pre.cpp
@@ -351,7 +351,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
                     amrex::Abort("Bad theta in ERF_slow_rhs_pre");
                 }
 #endif
-                Real qv_for_p = (l_use_moisture) ? cell_data(i,j,k,RhoQ1_comp)/cell_data(i,j,k,Rho_comp) : 0.0;
+                Real qv_for_p = (l_use_moisture) ? cell_data(i,j,k,RhoQ1_comp)/cell_data(i,j,k,Rho_comp) : 0.0; // PS?
                 pptemp_arr(i,j,k) = getPgivenRTh(cell_data(i,j,k,RhoTheta_comp),qv_for_p) - p0_arr(i,j,k);
             });
         }
@@ -624,7 +624,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
             Real q = 0.0;
             if (l_use_moisture) {
                 q = 0.5 * ( cell_prim(i,j,k,PrimQ1_comp) + cell_prim(i-1,j,k,PrimQ1_comp)
-                           +cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i-1,j,k,PrimQ2_comp) );
+                          + cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i-1,j,k,PrimQ2_comp) ); // PS
             }
 
             rho_u_rhs(i, j, k) += (-gpx - abl_pressure_grad[0]) / (1.0 + q)
@@ -673,7 +673,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
             Real q = 0.0;
             if (l_use_moisture) {
                 q = 0.5 * ( cell_prim(i,j,k,PrimQ1_comp) + cell_prim(i,j-1,k,PrimQ1_comp)
-                           +cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i,j-1,k,PrimQ2_comp) );
+                          + cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i,j-1,k,PrimQ2_comp) ); // PS
             }
 
             rho_v_rhs(i, j, k) += (-gpy - abl_pressure_grad[1]) / (1.0_rt + q) + ymom_src_arr(i,j,k);
@@ -734,7 +734,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
             Real q = 0.0;
             if (l_use_moisture) {
                 q = 0.5 * ( cell_prim(i,j,k,PrimQ1_comp) + cell_prim(i,j,k-1,PrimQ1_comp)
-                           +cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i,j,k-1,PrimQ2_comp) );
+                          + cell_prim(i,j,k,PrimQ2_comp) + cell_prim(i,j,k-1,PrimQ2_comp) ); // PS
             }
             rho_w_rhs(i, j, k) += (zmom_src_arr(i,j,k) - gpz - abl_pressure_grad[2]) / (1.0_rt + q);
 

--- a/Source/Utils/ERF_ParFunctions.H
+++ b/Source/Utils/ERF_ParFunctions.H
@@ -23,4 +23,23 @@ void reduce_to_max_per_height (amrex::Vector<amrex::Real>& v,
     amrex::ParallelDescriptor::ReduceRealMax(v.data(), v.size());
 }
 
+// Partial Sum over specific components.
+// This is an interface for the micro models.
+AMREX_FORCE_INLINE
+AMREX_GPU_HOST_DEVICE
+amrex::Real
+comp_partial_sum (const int& i,
+                  const int& j,
+                  const int& k,
+                  const int& nsize,
+                  const int* ind_map,
+                  const amrex::Array4<const amrex::Real>& data)
+{
+    amrex::Real partial_sum = 0.0;
+    for (int n(0); n<nsize; ++n) {
+        int ind = RhoQ1_comp + ind_map[n];
+        partial_sum += data(i,j,k,ind);
+    }
+    return partial_sum;
+}
 #endif /* ERF_ParFunctions.H */


### PR DESCRIPTION
This is just a test of a code pathway for computing partial sums of moisture variables where the moisture model alone knows the index mapping. This has application to micro models with 1000s of `q` variables. Under such cases, we need to compute partial sums over specific indices OUTSIDE the micro class.