### PR TITLE
[WindFarm] Power output for all wind models

### DIFF
--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -97,7 +97,7 @@ ERF::setPlotVariables (const std::string& pp_plot_var_names, Vector<std::string>
     for (int i = 0; i < derived_names.size(); ++i) {
         if ( containerHasElement(plot_var_names, derived_names[i]) ) {
             if(solverChoice.windfarm_type == WindFarmType::Fitch or solverChoice.windfarm_type == WindFarmType::EWP) {
-                if(derived_names[i] == "num_turb") {
+                if(derived_names[i] == "num_turb" or derived_names[i] == "SMark0") {
                     tmp_plot_names.push_back(derived_names[i]);
                 }
             }
@@ -510,7 +510,8 @@ ERF::WritePlotFile (int which, PlotFileType plotfile_type, Vector<std::string> p
         }
 
         if( containerHasElement(plot_var_names, "SMark0") and
-           (solverChoice.windfarm_type == WindFarmType::SimpleAD or solverChoice.windfarm_type == WindFarmType::GeneralAD) ) {
+           (solverChoice.windfarm_type == WindFarmType::Fitch or solverChoice.windfarm_type == WindFarmType::EWP or
+            solverChoice.windfarm_type == WindFarmType::SimpleAD or solverChoice.windfarm_type == WindFarmType::GeneralAD) ) {
              for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 const Box& bx = mfi.tilebox();

--- a/Source/Initialization/ERF_init_windfarm.cpp
+++ b/Source/Initialization/ERF_init_windfarm.cpp
@@ -29,9 +29,18 @@ ERF::init_windfarm (int lev)
                              true, false);
     }
 
-    windfarm->fill_Nturb_multifab(geom[lev], Nturb[lev], z_phys_cc[lev]);
+    windfarm->fill_Nturb_multifab(geom[lev], Nturb[lev], z_phys_nd[lev]);
 
     windfarm->write_turbine_locations_vtk();
+
+
+    if(solverChoice.windfarm_type == WindFarmType::Fitch or
+       solverChoice.windfarm_type == WindFarmType::EWP) {
+        windfarm->fill_SMark_multifab_mesoscale_models(geom[lev],
+                                                       SMark[lev],
+                                                       Nturb[lev],
+                                                       z_phys_nd[lev]);
+    }
 
     if(solverChoice.windfarm_type == WindFarmType::SimpleAD or
        solverChoice.windfarm_type == WindFarmType::GeneralAD) {

--- a/Source/WindFarmParametrization/ERF_WindFarm.H
+++ b/Source/WindFarmParametrization/ERF_WindFarm.H
@@ -72,13 +72,18 @@ public:
 
     void fill_Nturb_multifab (const amrex::Geometry& geom,
                               amrex::MultiFab& mf_Nturb,
-                              std::unique_ptr<amrex::MultiFab>& z_phys_cc);
+                              std::unique_ptr<amrex::MultiFab>& z_phys_nd);
 
     void fill_SMark_multifab (const amrex::Geometry& geom,
                               amrex::MultiFab& mf_SMark,
                               const amrex::Real& sampling_distance_by_D,
                               const amrex::Real& turb_disk_angle,
                               std::unique_ptr<amrex::MultiFab>& z_phys_cc);
+
+    void fill_SMark_multifab_mesoscale_models (const amrex::Geometry& geom,
+                                          amrex::MultiFab& mf_SMark,
+                                          const amrex::MultiFab& mf_Nturb,
+                                          std::unique_ptr<amrex::MultiFab>& z_phys_cc);
 
     void write_turbine_locations_vtk ();
 

--- a/Source/WindFarmParametrization/EWP/ERF_EWP.H
+++ b/Source/WindFarmParametrization/EWP/ERF_EWP.H
@@ -35,8 +35,17 @@ public:
 
     void update (const amrex::Real& dt_advance,
                  amrex::MultiFab& cons_in,
-                 amrex::MultiFab& U_old, amrex::MultiFab& V_old,
+                 amrex::MultiFab& U_old,
+                 amrex::MultiFab& V_old,
                  const amrex::MultiFab& mf_vars_ewp);
+
+    void compute_power_output (const amrex::MultiFab& cons_in,
+                               const amrex::MultiFab& U_old,
+                               const amrex::MultiFab& V_old,
+                                const amrex::MultiFab& W_old,
+                               const amrex::MultiFab& mf_SMark,
+                               const amrex::MultiFab& mf_Nturb,
+                               const amrex::Real& time);
 
 protected:
     amrex::Vector<amrex::Real> xloc, yloc;

--- a/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
+++ b/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
@@ -61,8 +61,8 @@ Fitch::advance (const Geometry& geom,
     AMREX_ALWAYS_ASSERT(time > -1.0);
     source_terms_cellcentered(geom, cons_in, mf_vars_fitch, U_old, V_old, W_old, mf_Nturb);
     update(dt_advance, cons_in, U_old, V_old, mf_vars_fitch);
+    compute_power_output(cons_in, U_old, V_old, mf_SMark, mf_Nturb, time);
 }
-
 
 void
 Fitch::update (const Real& dt_advance,
@@ -95,6 +95,67 @@ Fitch::update (const Real& dt_advance,
         {
             cons_array(i,j,k,RhoKE_comp) = cons_array(i,j,k,RhoKE_comp) + fitch_array(i,j,k,4)*dt_advance;
         });
+    }
+}
+
+void
+Fitch::compute_power_output (const MultiFab& cons_in,
+                             const MultiFab& U_old,
+                             const MultiFab& V_old,
+                             const MultiFab& mf_SMark,
+                             const MultiFab& mf_Nturb,
+                             const Real& time)
+{
+     get_turb_loc(xloc, yloc);
+     get_turb_spec(rotor_rad, hub_height, thrust_coeff_standing,
+                  wind_speed, thrust_coeff, power);
+
+     const int n_spec_table = wind_speed.size();
+
+     Gpu::DeviceVector<Real> d_wind_speed(wind_speed.size());
+     Gpu::DeviceVector<Real> d_power(wind_speed.size());
+     Gpu::copy(Gpu::hostToDevice, wind_speed.begin(), wind_speed.end(), d_wind_speed.begin());
+     Gpu::copy(Gpu::hostToDevice, power.begin(), power.end(), d_power.begin());
+
+    Gpu::DeviceScalar<Real> d_total_power(0.0);
+    Real* d_total_power_ptr = d_total_power.dataPtr();
+
+     const Real* d_wind_speed_ptr  = d_wind_speed.dataPtr();
+     const Real* d_power_ptr  = d_power.dataPtr();
+
+     for ( MFIter mfi(cons_in,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+
+        auto SMark_array    = mf_SMark.array(mfi);
+        auto Nturb_array    = mf_Nturb.array(mfi);
+        auto u_vel          = U_old.array(mfi);
+        auto v_vel          = V_old.array(mfi);
+        Box tbx = mfi.nodaltilebox(0);
+
+        ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+
+            if(SMark_array(i,j,k,0) == 1.0) {
+                Real avg_vel = std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),0.5);
+                Real turb_power = interpolate_1d(d_wind_speed_ptr, d_power_ptr, avg_vel, n_spec_table);
+                turb_power = turb_power*Nturb_array(i,j,k,0);
+                Gpu::Atomic::Add(d_total_power_ptr,turb_power);
+            }
+        });
+    }
+
+    Real h_total_power = 0.0;
+    Gpu::copy(Gpu::deviceToHost, d_total_power.dataPtr(), d_total_power.dataPtr()+1, &h_total_power);
+
+    amrex::ParallelAllReduce::Sum(&h_total_power, 1, amrex::ParallelContext::CommunicatorAll());
+
+    if (ParallelDescriptor::IOProcessor()){
+        static std::ofstream file("power_output_Fitch.txt", std::ios::app);
+        // Check if the file opened successfully
+        if (!file.is_open()) {
+            std::cerr << "Error opening file!" << std::endl;
+            Abort("Could not open file to write power output in ERF_AdvanceSimpleAD.cpp");
+        }
+        file << time << " " << h_total_power << "\n";
+        file.flush();
     }
 }
 

--- a/Source/WindFarmParametrization/Fitch/ERF_Fitch.H
+++ b/Source/WindFarmParametrization/Fitch/ERF_Fitch.H
@@ -38,7 +38,15 @@ public:
                   amrex::MultiFab& U_old, amrex::MultiFab& V_old,
                   const amrex::MultiFab& mf_vars_fitch);
 
+    void compute_power_output (const amrex::MultiFab& cons_in,
+                               const amrex::MultiFab& U_old,
+                               const amrex::MultiFab& V_old,
+                               const amrex::MultiFab& mf_SMark,
+                               const amrex::MultiFab& mf_Nturb,
+                               const amrex::Real& time);
+
 protected:
+    amrex::Vector<amrex::Real> hub_height_velocity;
     amrex::Vector<amrex::Real> xloc, yloc;
     amrex::Real hub_height, rotor_rad, thrust_coeff_standing, nominal_power;
     amrex::Vector<amrex::Real> wind_speed, thrust_coeff, power;

--- a/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_GeneralAD.H
+++ b/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_GeneralAD.H
@@ -41,6 +41,8 @@ public:
                  amrex::MultiFab& W_old,
                  const amrex::MultiFab& mf_vars);
 
+    void compute_power_output (const amrex::Real& time);
+
 protected:
     amrex::Vector<amrex::Real> xloc, yloc;
     amrex::Real turb_disk_angle;

--- a/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
+++ b/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
@@ -35,7 +35,7 @@ SimpleAD::compute_power_output (const Real& time)
   // Compute power based on the look-up table
 
     if (ParallelDescriptor::IOProcessor()){
-        static std::ofstream file("power_output.txt", std::ios::app);
+        static std::ofstream file("power_output_SimpleAD.txt", std::ios::app);
         // Check if the file opened successfully
         if (!file.is_open()) {
             std::cerr << "Error opening file!" << std::endl;


### PR DESCRIPTION
This PR has the routines to compute the power output for all wind models. Fig. 1 show the idealized run (inflow of 10 m/s at 45 deg to the horinzontal) hub-height horizontal velocity contours for all the wind models at `t=1 hr`. The total power output is shown in Fig. 2.

The simple and general actuator disk models are within 3% of each other. 
The Fitch model is about 5-10% less compared to the actuator disk models, and EWP is 5-10% higher compared to actuator disk models. 
From the lower resolution of the mesoscale models (500 m in the horizontal compared to 20 m for the actuator disks), such discrepancies are expected.

<img width="748" alt="Screen Shot 2024-12-02 at 2 26 02 PM" src="https://github.com/user-attachments/assets/54a3ecb3-9137-40ce-917d-ef49c2efa923">

![PowerOutput](https://github.com/user-attachments/assets/b58c6739-1107-44aa-941f-f19b97e3b2ea)

