### PR TITLE
Minor changes for deterministic simulations with particles

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -10,6 +10,7 @@
 #include <ERF_EOS.H>
 #include <ERF.H>
 #include <AMReX_buildInfo.H>
+#include <AMReX_Random.H>
 #include <ERF_Utils.H>
 #include <ERF_TerrainMetrics.H>
 #include <memory>
@@ -84,6 +85,15 @@ Vector<std::string> BCNames = {"xlo", "ylo", "zlo", "xhi", "yhi", "zhi"};
 //             - initializes BCRec boundary condition object
 ERF::ERF ()
 {
+    int fix_random_seed = 0;
+    ParmParse pp("erf"); pp.query("fix_random_seed", fix_random_seed);
+    // Note that the value of 1024UL is not significant -- the point here is just to set the
+    // same seed for all MPI processes for the purpose of regression testing
+    if (fix_random_seed) {
+        Print() << "Fixing the random seed" << std::endl;
+        InitRandom(1024UL);
+    }
+
     ERF_shared();
 }
 

--- a/Source/Initialization/ERF_InitCustom.cpp
+++ b/Source/Initialization/ERF_InitCustom.cpp
@@ -42,15 +42,6 @@ ERF::init_custom (int lev)
     yvel_pert.setVal(0.);
     zvel_pert.setVal(0.);
 
-    int fix_random_seed = 0;
-    ParmParse pp("erf"); pp.query("fix_random_seed", fix_random_seed);
-    // Note that the value of 1024UL is not significant -- the point here is just to set the
-    //     same seed for all MPI processes for the purpose of regression testing
-    if (fix_random_seed) {
-        Print() << "Fixing the random seed" << std::endl;
-        InitRandom(1024UL);
-    }
-
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif

--- a/Source/Particles/ERFPC.H
+++ b/Source/Particles/ERFPC.H
@@ -223,6 +223,8 @@ class ERFPC : public amrex::ParticleContainer<  ERFParticlesRealIdxAoS::ncomps, 
         std::string m_initialization_type;  /*!< initial particle distribution type */
         int m_ppc_init;                     /*!< initial number of particles per cell */
 
+        bool m_stable_redistribute;         /*!< use stable redistribute for deterministic simulations */
+
         /*! read inputs from file */
         virtual void readInputs ();
 

--- a/Source/Particles/ERFPCInitializations.cpp
+++ b/Source/Particles/ERFPCInitializations.cpp
@@ -49,6 +49,14 @@ void ERFPC::readInputs ()
     m_advect_w_gravity = (m_name == ERFParticleNames::hydro ? true : false);
     pp.query("advect_with_gravity", m_advect_w_gravity);
 
+    m_stable_redistribute = false;
+    pp.query("stable_redistribute", m_stable_redistribute);
+
+    if (m_stable_redistribute) {
+        Print() << "Note: using stable Redistribute() for particle container " << m_name << ".\n";
+    }
+    setStableRedistribute(m_stable_redistribute);
+
     return;
 }
 
@@ -65,6 +73,7 @@ void ERFPC::InitializeParticles (const std::unique_ptr<MultiFab>& a_height_ptr)
                 << m_name << " particle species.\n";
         Error("See error message!");
     }
+
     return;
 }
 


### PR DESCRIPTION
- Added an input parameter to choose "stable" `Redistribute()` for GPU sims (use [this](https://github.com/AMReX-Codes/amrex/pull/4200)).
- Moved the fixing of random seed to the beginning of the ERF constructor so that it is set before anything else (eg. particle initialization).