### PR TITLE
Add `erf.substepping_cfl` param

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -432,10 +432,12 @@ List of Parameters
 | **erf.no_substepping**     | Should we turn off   | int (0 or 1)   | 0                 |
 |                            | substepping in time? |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
-| **erf.cfl**                | CFL number for       | Real > 0 and   | 0.8               |
-|                            | hydro                | <= 1           |                   |
-|                            |                      |                |                   |
-|                            |                      |                |                   |
+| **erf.cfl**                | CFL number used to   | Real > 0 and   | 0.8               |
+|                            | compute level 0 dt   | <= 1           |                   |
++----------------------------+----------------------+----------------+-------------------+
+| **erf.substepping_cfl**    | CFL number used to   | Real > 0 and   | 1.0               |
+|                            | compute the number   | <= 1           |                   |
+|                            | of substeps          |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
 | **erf.fixed_dt**           | set level 0 dt       | Real > 0       | unused if not     |
 |                            | as this value        |                | set               |

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -922,6 +922,7 @@ private:
 
     // Time step controls
     static amrex::Real cfl;
+    static amrex::Real sub_cfl;
     static amrex::Real init_shrink;
     static amrex::Real change_max;
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -26,6 +26,7 @@ SolverChoice ERF::solverChoice;
 
 // Time step control
 Real ERF::cfl           =  0.8;
+Real ERF::sub_cfl       =  1.0;
 Real ERF::init_shrink   =  1.0;
 Real ERF::change_max    =  1.1;
 int  ERF::fixed_mri_dt_ratio = 0;
@@ -1455,6 +1456,7 @@ ERF::ReadParameters ()
 
         // Time step controls
         pp.query("cfl", cfl);
+        pp.query("substepping_cfl", sub_cfl);
         pp.query("init_shrink", init_shrink);
         pp.query("change_max", change_max);
 

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -202,8 +202,9 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
          if (fixed_dt[level] > 0. && fixed_fast_dt[level] > 0.) {
              dt_fast_ratio = static_cast<long>( fixed_dt[level] / fixed_fast_dt[level] );
          } else if (fixed_dt[level] > 0.) {
-             // Max CFL_c = 1.0 for substeps, but we enforce a min of 4 substeps
-             auto dt_sub_max = (estdt_comp/cfl);
+             // Max CFL_c = 1.0 for substeps by default, but we enforce a min of 4 substeps
+             auto dt_sub_max = (estdt_comp/cfl * sub_cfl);
+             Print() << "fixed_dt="<<fixed_dt[level] << " dt_sub_max="<<dt_sub_max << std::endl;
              dt_fast_ratio = static_cast<long>( std::max(fixed_dt[level]/dt_sub_max,4.) );
          }
 


### PR DESCRIPTION
Previously, we exactly follow WRF and select the number of substeps based on CFL~1 (i.e., dt/nsubs ~ dt_comp) with a minimum number of substeps = 4. The `erf.cfl` parameter is ONLY used for estimating the level-0 timestep if `erf.fixed_dt` is not given, which may be confusing to users expecting that are using substepping and expect the CFL to be lower than the input value. 

The `erf.substepping_cfl` input gives users an option to more aggressively substep (by decreasing the effective CFL < 1) without knowing the number of substeps needed a priori. 