### PR TITLE
Use ubuntu-22.04 in GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ${{matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         include:
-        - os: ubuntu-latest
+        - os: ubuntu-22.04
           install_deps: sudo apt-get install mpich libmpich-dev
           comp: gnu
           procs: $(nproc)


### PR DESCRIPTION
Testing if the migration of `ubuntu-lastest` from `22.04` to `24.04` is causing GitHub CI failures. 