### PR TITLE
Doc: Fix 5th Upw 

### DIFF
--- a/Docs/sphinx_doc/Discretizations.rst
+++ b/Docs/sphinx_doc/Discretizations.rst
@@ -188,7 +188,7 @@ The midpoint values given above :math:`q_{m - \frac{1}{2}}`, where :math:`q` may
     & & \\
    \left. q_{m - \frac{1}{2}} \right|^{3rd} = \left. q_{m - \frac{1}{2}} \right|^{4th}      & \hspace{-5pt} + \beta_{\text{up}}\frac{U_{d}}{\left| U_{d} \right|}\frac{1}{12}\left\lbrack \left( q_{m + 1} - q_{m - 2} \right) \right.\  & \hspace{-5pt} - 3\left. \ \left( q_{m} - q_{m - 1} \right) \right\rbrack \\
     & & \\
-   \left. q_{m - \frac{1}{2}} \right|^{5th} = \left. q_{m - \frac{1}{2}} \right|^{6th}      & \hspace{-5pt} - \beta_{\text{up}}\frac{U_{d}}{\left| U_{d} \right|}\frac{1}{60}\left\lbrack \left( q_{m + 2} - q_{m - 1} \right) \right.\  & \hspace{-5pt} - 5\left( q_{m + 1} - q_{m - 2} \right) + 10\left. \left( q_{m} - q_{m - 1} \right) \right\rbrack
+   \left. q_{m - \frac{1}{2}} \right|^{5th} = \left. q_{m - \frac{1}{2}} \right|^{6th}      & \hspace{-5pt} - \beta_{\text{up}}\frac{U_{d}}{\left| U_{d} \right|}\frac{1}{60}\left\lbrack \left( q_{m + 2} - q_{m - 3} \right) \right.\  & \hspace{-5pt} - 5\left( q_{m + 1} - q_{m - 2} \right) + 10\left. \left( q_{m} - q_{m - 1} \right) \right\rbrack
    \end{array}
 
 An extra blending factor (:math:`\beta_{\text{up}}`) has been added to allow control


### PR DESCRIPTION
The 5th order upwind equation has a typo (see below ARW doc snippet):
![image](https://github.com/user-attachments/assets/340539bb-3d19-4603-a3e7-89af272dad3c)

The actual stencil in ERF follows the image and not the docs so no code change is included.