### PR TITLE
Add option to set a different gold file directory in CMake

### DIFF
--- a/.gitlab/LC/.gitlab-ci.yml
+++ b/.gitlab/LC/.gitlab-ci.yml
@@ -15,6 +15,10 @@ variables:
 
   TEST_SCRIPT: .gitlab/LC/gitlab_test.sh
 
+  # Update to checkout a different git reference (branch name, tag, hash, etc.)
+  # in the gold file repo
+  CI_GOLD_FILES_GIT_REF: main
+
   # Uncomment to disable testing on particular system
   #ON_LASSEN: "OFF"
   #ON_DANE: "OFF"

--- a/.gitlab/LC/gitlab_test.sh
+++ b/.gitlab/LC/gitlab_test.sh
@@ -21,6 +21,7 @@ host=$(hostname)
 build_type=${BUILD_TYPE:-"Debug"}
 
 ERF_ENABLE_CUDA=${ERF_ENABLE_CUDA:-"OFF"}
+ERF_ENABLE_HIP=${ERF_ENABLE_HIP:-"OFF"}
 
 basehost=${host//[[:digit:]]/}
 
@@ -69,6 +70,33 @@ then
     echo "====================================================="
 fi
 
+# Clone LC gold files repo -- note that we need to grant this repo job
+# token permissions to the gold file repo
+rm -rf erf-llnl-gold-files
+git clone \
+    --branch ${CI_GOLD_FILES_GIT_REF:-"main"} --depth 1 \
+    https://gitlab-ci-token:${CI_JOB_TOKEN}@lc.llnl.gov/gitlab/erf-model/erf-llnl-gold-files.git
+cd erf-llnl-gold-files
+git log -1
+if [[ -d ${CI_MACHINE} ]]
+then
+    ERF_TEST_GOLD_FILES_DIRECTORY="$(pwd)/${CI_MACHINE}"
+    if [[ "${ERF_ENABLE_CUDA}" == "ON" || "${ERF_ENABLE_HIP}" == "ON" ]]
+    then
+        if [[ -d "${CI_MACHINE}/gpu" ]]; then
+            ERF_TEST_GOLD_FILES_DIRECTORY+="/gpu"
+        fi
+    else
+        if [[ -d "${CI_MACHINE}/cpu" ]]; then
+            ERF_TEST_GOLD_FILES_DIRECTORY+="/cpu"
+        fi
+    fi
+    echo "====================================================="
+    echo "Using gold files at: ${ERF_TEST_GOLD_FILES_DIRECTORY}"
+    echo "====================================================="
+fi
+cd -
+
 mkdir ${build_dir}
 cd ${build_dir}
 pwd
@@ -91,6 +119,7 @@ cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
       -DERF_ENABLE_FCOMPARE:BOOL=ON \
       -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
       -DFCOMPARE_EXE="${FCOMPARE_EXE:-"$(pwd)/Submodules/AMReX/Tools/Plotfile/amrex_fcompare"}" \
+      -DERF_TEST_GOLD_FILES_DIRECTORY="${ERF_TEST_GOLD_FILES_DIRECTORY:-"$(pwd)/../Tests/ERFGoldFiles"}" \
       -DERF_TEST_FCOMPARE_RTOL="${ERF_TEST_FCOMPARE_RTOL:-"5.0e-9"}" \
       -DERF_TEST_FCOMPARE_ATOL="${ERF_TEST_FCOMPARE_ATOL:-"2.0e-10"}" \
       -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \

--- a/.gitlab/LC/runners/dane.yml
+++ b/.gitlab/LC/runners/dane.yml
@@ -13,6 +13,8 @@
   rules:
     - if: '$ON_DANE == "OFF"'
       when: never
+    # test the default branch
+    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     # test the upstream branch
     - if: $CI_COMMIT_BRANCH == 'development'
     # branches starting with "gitlab"
@@ -20,7 +22,6 @@
     - if: $CI_PIPELINE_SOURCE == "push"
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     - if: '$CI_JOB_NAME =~ /release_resources_dane/'
       when: always
     - when: on_success
@@ -50,6 +51,7 @@ release_resources_dane:
   stage: build
   needs: ["allocate_resources_dane"]
   variables:
+    CI_MACHINE: dane
     MPIEXEC_EXECUTABLE: srun
     MPIEXEC_PREFLAGS: "--cpu-bind=cores -v"
   script:

--- a/.gitlab/LC/runners/lassen.yml
+++ b/.gitlab/LC/runners/lassen.yml
@@ -13,6 +13,8 @@
   rules:
     - if: '$ON_LASSEN == "OFF"'
       when: never
+    # test the default branch
+    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     # test the upstream branch
     - if: $CI_COMMIT_BRANCH == 'development'
     # branches starting with "gitlab"
@@ -20,7 +22,6 @@
     - if: $CI_PIPELINE_SOURCE == "push"
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     - when: on_success
 
 .job_on_lassen:
@@ -28,6 +29,7 @@
   stage: build
   needs: []
   variables:
+    CI_MACHINE: lassen
     MPIEXEC_EXECUTABLE: jsrun
     MPIEXEC_PREFLAGS: "-a 1 -c 1 -g 1"
   script:

--- a/.gitlab/LC/runners/tioga.yml
+++ b/.gitlab/LC/runners/tioga.yml
@@ -13,6 +13,8 @@
   rules:
     - if: '$ON_TIOGA == "OFF"'
       when: never
+    # test the default branch
+    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     # test the upstream branch
     - if: $CI_COMMIT_BRANCH == 'development'
     # branches starting with "gitlab"
@@ -20,7 +22,6 @@
     - if: $CI_PIPELINE_SOURCE == "push"
       when: never
     - if: $CI_PIPELINE_SOURCE == "merge_request_event"
-    - if: $CI_COMMIT_BRANCH == $DEFAULT_BRANCH
     - if: '$CI_JOB_NAME =~ /release_resources_tioga/'
       when: always
     - when: on_success
@@ -50,6 +51,7 @@ release_resources_tioga:
   stage: build
   needs: ["allocate_resources_tioga"]
   variables:
+    CI_MACHINE: tioga
     # Note: "flux" gets expanded to "flux run" inside build script
     MPIEXEC_EXECUTABLE: flux
     MPIEXEC_PREFLAGS: "-c 1 -g 1 -o mpi-spectrum -o cpu-affinity=per-task -o gpu-affinity=per-task -vv"

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -2,11 +2,13 @@
 set(ERF_TEST_NRANKS 2 CACHE STRING  "Number of MPI ranks to use for each test")
 set(ERF_TEST_FCOMPARE_RTOL "2.0e-10" CACHE STRING "fcompare relative tolerance")
 set(ERF_TEST_FCOMPARE_ATOL "2.0e-10" CACHE STRING "fcompare absolute tolerance")
+set(ERF_TEST_GOLD_FILES_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ERFGoldFiles" CACHE PATH "Path to ERF gold files")
 
 message(STATUS "ERF testing configuration summary:")
 message(STATUS "   Number of ranks               = ${ERF_TEST_NRANKS}")
 message(STATUS "   fcompare executable           = ${FCOMPARE_EXE}")
 message(STATUS "   comparison relative tolerance = ${ERF_TEST_FCOMPARE_RTOL}")
 message(STATUS "   comparison absolute tolerance = ${ERF_TEST_FCOMPARE_ATOL}")
+message(STATUS "   Gold file directory           = ${ERF_TEST_GOLD_FILES_DIRECTORY}")
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/CTestList.cmake)

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -2,15 +2,13 @@
 include(ProcessorCount)
 ProcessorCount(PROCESSES)
 
-set(FCOMPARE_GOLD_FILES_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ERFGoldFiles)
-
 #=============================================================================
 # Functions for adding tests / Categories of tests
 #=============================================================================
 macro(setup_test)
     set(CURRENT_TEST_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test_files/${TEST_NAME})
     set(CURRENT_TEST_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/test_files/${TEST_NAME})
-    set(PLOT_GOLD ${FCOMPARE_GOLD_FILES_DIRECTORY}/${TEST_NAME})
+    set(PLOT_GOLD ${ERF_TEST_GOLD_FILES_DIRECTORY}/${TEST_NAME})
 
     file(MAKE_DIRECTORY ${CURRENT_TEST_BINARY_DIR})
     file(GLOB TEST_FILES "${CURRENT_TEST_SOURCE_DIR}/*")


### PR DESCRIPTION
* Add `ERF_TEST_GOLD_FILES_DIRECTORY` option for gold file directory. Defaults to the gold file directory in the ERF repo. 
* Corresponding update to LC GitLab CI files to use machine-specific gold files.