### PR TITLE
Adding control of adaptive time-stepping.

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -456,10 +456,13 @@ List of Parameters
 |                            | to shrink the        | <= 1           |                   |
 |                            | initial dt           |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
-| **erf.change_max**         | factor by which      | Real >= 1      | 1.1               |
-|                            | dt can grow          |                |                   |
-|                            | in subsequent        |                |                   |
-|                            | steps                |                |                   |
+| **erf.dt_max**             | maximum adaptive     | Real > 0       | 1e9               |
+|                            | timestep             |                |                   |  
+|                            | alllowed by time     |                |                   |
+|                            | stepping             |                |                   |
++----------------------------+----------------------+----------------+-------------------+
+| **erf.dt_max_initial**     | maximum initial      | Real > 0       | 1.0               |
+|                            | timestep             |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
 
 Notes

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -456,9 +456,14 @@ List of Parameters
 |                            | to shrink the        | <= 1           |                   |
 |                            | initial dt           |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
+| **erf.change_max**         | factor by which      | Real >= 1      | 1.1               |
+|                            | dt can grow          |                |                   |
+|                            | in subsequent        |                |                   |
+|                            | steps                |                |                   |
++----------------------------+----------------------+----------------+-------------------+
 | **erf.dt_max**             | maximum adaptive     | Real > 0       | 1e9               |
-|                            | timestep             |                |                   |  
-|                            | alllowed by time     |                |                   |
+|                            | timestep             |                |                   |
+|                            | allowed by time     |                |                   |
 |                            | stepping             |                |                   |
 +----------------------------+----------------------+----------------+-------------------+
 | **erf.dt_max_initial**     | maximum initial      | Real > 0       | 1.0               |

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -926,6 +926,8 @@ private:
     static amrex::Real sub_cfl;
     static amrex::Real init_shrink;
     static amrex::Real change_max;
+    static amrex::Real dt_max_initial;
+    static amrex::Real dt_max;
 
     // Fixed dt for level 0 timesteps (only used if positive)
     amrex::Vector<amrex::Real> fixed_dt;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -29,6 +29,8 @@ Real ERF::cfl           =  0.8;
 Real ERF::sub_cfl       =  1.0;
 Real ERF::init_shrink   =  1.0;
 Real ERF::change_max    =  1.1;
+Real ERF::dt_max_initial = 1.0;
+Real ERF:: dt_max = 1e9;
 int  ERF::fixed_mri_dt_ratio = 0;
 
 // Dictate verbosity in screen output
@@ -1443,6 +1445,8 @@ ERF::ReadParameters ()
         pp.query("substepping_cfl", sub_cfl);
         pp.query("init_shrink", init_shrink);
         pp.query("change_max", change_max);
+        pp.query("dt_max_initial", dt_max_initial);
+        pp.query("dt_max", dt_max);
 
         fixed_dt.resize(max_level+1,-1.);
         fixed_fast_dt.resize(max_level+1,-1.);

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -32,7 +32,6 @@ ERF::ComputeDt (int step)
             }
         }
     }
-
     // Limit dt's by the value of stop_time.
     const Real eps = 1.e-3*dt_0;
     if (t_new[0] + dt_0 > stop_time - eps) {
@@ -279,7 +278,18 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
      } else {
          // Anelastic (substepping is not allowed)
          if (l_anelastic) {
+
+            // Make sure that timestep is less than the dt_max
+            estdt_lowM = amrex::min(estdt_lowM, dt_max);
+
+            // On the first timestep enforce dt_max_initial
+            if(istep[level] == 0){
+                return amrex::min(dt_max_initial, estdt_lowM);
+             }
+            else{
              return estdt_lowM;
+            }
+
 
          // Compressible with or without substepping
          } else {


### PR DESCRIPTION
This PR is meant to address an issue in which adaptive time-stepping computes an erroneously large time-step `dt` when using the anelasitc solver under low (no) windspeed conditions. The fix is to limit the length of the initial time-step and subsequent time-steps, which are controllable though the input file variables  `erf.dt_max_initial` and erf.dt_max` respectively.