### PR TITLE
add density and theta forcing consistent with FastEddy methodology

### DIFF
--- a/Source/SourceTerms/ERF_MakeSources.cpp
+++ b/Source/SourceTerms/ERF_MakeSources.cpp
@@ -38,6 +38,7 @@ void make_sources (int level,
 #ifdef ERF_USE_RRTMGP
                    const MultiFab* qheating_rates,
 #endif
+                          MultiFab* terrain_blank,
                    const Geometry geom,
                    const SolverChoice& solverChoice,
                    std::unique_ptr<MultiFab>& /*mapfac_u*/,
@@ -76,7 +77,7 @@ void make_sources (int level,
     // *****************************************************************************
     Table1D<Real>      dptr_r_plane, dptr_t_plane, dptr_qv_plane, dptr_qc_plane;
     TableData<Real, 1>  r_plane_tab,  t_plane_tab,  qv_plane_tab,  qc_plane_tab;
-    if (dptr_wbar_sub || solverChoice.nudging_from_input_sounding)
+    if (dptr_wbar_sub || solverChoice.nudging_from_input_sounding || solverChoice.terrain_type == TerrainType::ImmersedForcing)
     {
         // Rho
         PlaneAverage r_ave(&(S_data[IntVars::cons]), geom, solverChoice.ave_plane, true);
@@ -168,6 +169,7 @@ void make_sources (int level,
     //    7. sponging
     //    8. turbulent perturbation
     //    9. nudging towards input sounding values (only for theta)
+    //    10. Immersed forcing
     // *****************************************************************************
 
     // ***********************************************************************************************
@@ -186,6 +188,9 @@ void make_sources (int level,
         const Array4<Real>       & cell_src   = source.array(mfi);
 
         const Array4<const Real>& z_cc_arr = (z_phys_cc) ? z_phys_cc->const_array(mfi) : Array4<Real>{};
+
+        const Array4<const Real>& t_blank_arr = (terrain_blank) ? terrain_blank->const_array(mfi) :
+                                                               Array4<const Real>{};
 
 #ifdef ERF_USE_RRTMGP
         // *************************************************************************************
@@ -407,6 +412,23 @@ void make_sources (int level,
                 cell_src(i, j, k, n) += cell_data(i, j, k, nr) * nudge;
             });
         }
+
+        // *************************************************************************************
+        // 10. Add Immersed source terms
+        // *************************************************************************************
+        if (solverChoice.terrain_type == TerrainType::ImmersedForcing) {
+            const Real drag_coefficient = 10.0/dz;
+            const Real CdT = drag_coefficient;
+            const Real U_s  = 1.0;
+            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            {
+                const Real t_blank = t_blank_arr(i, j, k);
+                cell_src(i, j, k, RhoTheta_comp) -= t_blank * CdT * U_s * (cell_data(i,j,k,RhoTheta_comp) - dptr_t_plane(k));
+                cell_src(i, j, k, Rho_comp)      -= t_blank * CdT * U_s * (cell_data(i,j,k,Rho_comp) - dptr_r_plane(k));                 
+            });
+        }
+
+
     } // mfi
     } // OMP
 }

--- a/Source/SourceTerms/ERF_SrcHeaders.H
+++ b/Source/SourceTerms/ERF_SrcHeaders.H
@@ -31,6 +31,7 @@ void make_sources (int level, int nrk,
 #if defined(ERF_USE_RRTMGP)
                    const amrex::MultiFab* qheating_rates,
 #endif
+                   amrex::MultiFab* terrain_blank,
                    const amrex::Geometry geom,
                    const SolverChoice& solverChoice,
                    std::unique_ptr<amrex::MultiFab>& mapfac_u,

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
@@ -49,17 +49,6 @@
         Real* dptr_u_geos = solverChoice.have_geo_wind_profile ? d_u_geos[level].data(): nullptr;
         Real* dptr_v_geos = solverChoice.have_geo_wind_profile ? d_v_geos[level].data(): nullptr;
 
-        // Construct the source terms for the cell-centered (conserved) variables
-        make_sources(level, nrk, slow_dt, old_stage_time, S_data, S_prim, cc_src, z_phys_cc[level],
-#if defined(ERF_USE_RRTMGP)
-                     qheating_rates[level].get(),
-#endif
-                     fine_geom, solverChoice,
-                     mapfac_u[level], mapfac_v[level], mapfac_m[level],
-                     dptr_rhotheta_src, dptr_rhoqt_src,
-                     dptr_wbar_sub, d_rayleigh_ptrs_at_lev,
-                     input_sounding_data, turbPert);
-
         // Canopy data for mom sources
         MultiFab* forest_drag = nullptr;
         if (solverChoice.do_forest_drag) { forest_drag = m_forest_drag[level]->get_drag_field(); }
@@ -68,6 +57,17 @@
         if (solverChoice.terrain_type == TerrainType::ImmersedForcing) {
             terrain_blank = terrain_blanking[level].get();
         }
+
+        // Construct the source terms for the cell-centered (conserved) variables
+        make_sources(level, nrk, slow_dt, old_stage_time, S_data, S_prim, cc_src, z_phys_cc[level],
+#if defined(ERF_USE_RRTMGP)
+                     qheating_rates[level].get(),
+#endif
+                     terrain_blank, fine_geom, solverChoice,
+                     mapfac_u[level], mapfac_v[level], mapfac_m[level],
+                     dptr_rhotheta_src, dptr_rhoqt_src,
+                     dptr_wbar_sub, d_rayleigh_ptrs_at_lev,
+                     input_sounding_data, turbPert);
 
         // Moving terrain
         if ( solverChoice.terrain_type == TerrainType::MovingFittedMesh )
@@ -459,7 +459,7 @@
 #if defined(ERF_USE_RRTMGP)
                      qheating_rates[level].get(),
 #endif
-                     fine_geom, solverChoice,
+                     terrain_blank, fine_geom, solverChoice,
                      mapfac_u[level], mapfac_v[level], mapfac_m[level],
                      dptr_rhotheta_src, dptr_rhoqt_src,
                      dptr_wbar_sub, d_rayleigh_ptrs_at_lev,


### PR DESCRIPTION
This capability forces rho and rhoTheta to a reference value for immersed cells. Currently, the reference value is the planar average of rho or rhoTheta at each k level. In the attached image, the contours of theta within the hill are horizontal indicative that theta is forced towards the planar average as a function of height.

![image (1)](https://github.com/user-attachments/assets/78d486e8-409a-4006-a83e-627149d4a40c)

This follows the methodology in Muñoz-Esparza et al. (2020).

Muñoz-Esparza, D., Sauer, J. A., Shin, H. H., Sharman, R., Kosović, B., Meech, S., et al. (2020). Inclusion of building-resolving capabilities into the FastEddy® GPU-LES model using an immersed body force method. Journal of Advances in Modeling Earth Systems, 12, e2020MS002141. https://doi.org/10.1029/2020MS002141

