### PR TITLE
Add eff rad approximation.

### DIFF
--- a/Source/Radiation/ERF_Radiation.cpp
+++ b/Source/Radiation/ERF_Radiation.cpp
@@ -452,6 +452,10 @@ Radiation::mf_to_yakl_buffers ()
             lwp(icol,ilay) = 0.0;
             iwp(icol,ilay) = 0.0;
 
+            // NOTE: These would be populated from P3 (we use the constants in p3_main_impl.hpp)
+            eff_radius_qc(icol,ilay) = (qc>1.0e-12) ? 10.0e-6 : 0.0;
+            eff_radius_qi(icol,ilay) = (qi>1.0e-12) ? 25.0e-6 : 0.0;
+
             // Buffers on z-faces (nlay+1)
             p_lev(icol,ilay) = getPgivenRTh(rt_avg, qv_avg);
             t_lev(icol,ilay) = getTgivenRandRTh(r_avg, rt_avg, qv_avg);
@@ -479,9 +483,6 @@ Radiation::mf_to_yakl_buffers ()
     parallel_for(SimpleBounds<2>(ncol, nlay), YAKL_LAMBDA (int icol, int ilay)
     {
         p_del(icol,ilay)  = p_lev(icol,ilay+1) - p_lev(icol,ilay);
-        // TODO: How to compute these?
-        eff_radius_qc(icol,ilay) = 0.0;
-        eff_radius_qi(icol,ilay) = 0.0;
     });
 
     // TODO: Fill properly


### PR DESCRIPTION
The effective radius would come from something like a P3 microphysics scheme. For now, we approximate the quantity with a scalar value from [here](https://github.com/E3SM-Project/E3SM/blob/63caa550131d95fb6e0980ce1795140726ff3f7c/components/eamxx/src/physics/p3/impl/p3_main_impl.hpp#L56) only if there is finite `cloud` or `ice` in the cell.