### PR TITLE
Clean up advection scheme blending

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -866,6 +866,10 @@ The allowed advection types for the dry and moist scalars are
 "Centered_6th" and in addition,
 "WENO3", "WENOZ3", "WENOMZQ3", "WENO5", "WENOZ5", "WENO7", and "WENOZ7."
 
+To use the blended schemes, ``erf.[vartype]_[horiz|vert]_upw_frac`` for the corresponding
+``erf.[vartype]_[horiz|vert]_adv_type`` should be set to a scalar between 0 and 1, where 1 is fully
+upwind and 0 is fully central.
+
 Note: if using WENO schemes, the horizontal and vertical advection types must be set to
 the same string.
 

--- a/Docs/sphinx_doc/building.rst
+++ b/Docs/sphinx_doc/building.rst
@@ -202,6 +202,8 @@ Mac with CMake
 ~~~~~~~~~~~~~~
 Tested with macOS 12.7 (Monterey) using cmake (3.27.8), open-mpi (5.0.0), and
 pkg-config (0.29.2) installed with the homebrew package manager.
+(Note: The homebrew openmpi library was "poured from bottle," not installed
+with the ``--build-from-source`` option.)
 NetCDF will be compiled from source. The instructions below should be version
 agnostic.
 

--- a/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
@@ -54,9 +54,14 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
 {
     BL_PROFILE_VAR("AdvectionSrcForMom_ConstantDz", AdvectionSrcForMom_ConstantDz);
 
+    AMREX_ALWAYS_ASSERT(bxz.smallEnd(2) > 0);
+
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    AMREX_ALWAYS_ASSERT(bxz.smallEnd(2) > 0);
+    const bool use_terrain_fitted_coords = ( terrain_type == TerrainType::StaticFittedMesh ||
+                                             terrain_type == TerrainType::MovingFittedMesh);
+
+    AMREX_ALWAYS_ASSERT(!use_terrain_fitted_coords && (terrain_type != TerrainType::EB));
 
     // compute mapfactor inverses
     Box box2d_u(bxx);   box2d_u.setRange(2,0);   box2d_u.grow({3,3,0});
@@ -65,11 +70,6 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
     FArrayBox mf_v_invFAB(box2d_v,1,The_Async_Arena());
     const Array4<Real>& mf_u_inv = mf_u_invFAB.array();
     const Array4<Real>& mf_v_inv = mf_v_invFAB.array();
-
-    const bool use_terrain_fitted_coords = ( terrain_type == TerrainType::StaticFittedMesh ||
-                                             terrain_type == TerrainType::MovingFittedMesh);
-
-    AMREX_ALWAYS_ASSERT(!use_terrain_fitted_coords && (terrain_type != TerrainType::EB));
 
     ParallelFor(box2d_u, box2d_v,
     [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
@@ -146,12 +146,12 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
     } else {
         if (horiz_adv_type == AdvType::Centered_2nd) {
                 AdvectionSrcForMomVert_N<CENTERED2>(bxx, bxy, bxz,
-                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                  rho_u, rho_v, omega, u, v, w,
-                                                  cellSizeInv, stretched_dz_d, mf_m,
-                                                  mf_u_inv, mf_v_inv,
-                                                  horiz_upw_frac, vert_upw_frac,
-                                                  vert_adv_type, lo_z_face, hi_z_face);
+                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                    rho_u, rho_v, omega, u, v, w,
+                                                    cellSizeInv, stretched_dz_d, mf_m,
+                                                    mf_u_inv, mf_v_inv,
+                                                    horiz_upw_frac, vert_upw_frac,
+                                                    vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Upwind_3rd) {
                 AdvectionSrcForMomVert_N<UPWIND3>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
@@ -162,12 +162,12 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Centered_4th) {
                 AdvectionSrcForMomVert_N<CENTERED4>(bxx, bxy, bxz,
-                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                  rho_u, rho_v, omega, u, v, w,
-                                                  cellSizeInv, stretched_dz_d, mf_m,
-                                                  mf_u_inv, mf_v_inv,
-                                                  horiz_upw_frac, vert_upw_frac,
-                                                  vert_adv_type, lo_z_face, hi_z_face);
+                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                    rho_u, rho_v, omega, u, v, w,
+                                                    cellSizeInv, stretched_dz_d, mf_m,
+                                                    mf_u_inv, mf_v_inv,
+                                                    horiz_upw_frac, vert_upw_frac,
+                                                    vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Upwind_5th) {
                 AdvectionSrcForMomVert_N<UPWIND5>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
@@ -178,12 +178,12 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Centered_6th) {
                 AdvectionSrcForMomVert_N<CENTERED6>(bxx, bxy, bxz,
-                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                  rho_u, rho_v, omega, u, v, w,
-                                                  cellSizeInv, stretched_dz_d, mf_m,
-                                                  mf_u_inv, mf_v_inv,
-                                                  horiz_upw_frac, vert_upw_frac,
-                                                  vert_adv_type, lo_z_face, hi_z_face);
+                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                    rho_u, rho_v, omega, u, v, w,
+                                                    cellSizeInv, stretched_dz_d, mf_m,
+                                                    mf_u_inv, mf_v_inv,
+                                                    horiz_upw_frac, vert_upw_frac,
+                                                    vert_adv_type, lo_z_face, hi_z_face);
         } else {
             AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
         }

--- a/Source/Advection/ERF_AdvectionSrcForMom_N.H
+++ b/Source/Advection/ERF_AdvectionSrcForMom_N.H
@@ -24,8 +24,6 @@ AdvectionSrcForXMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& rho_w,
                        InterpType_H interp_u_h,
                        InterpType_V interp_u_v,
-                       const amrex::Real upw_frac_h,
-                       const amrex::Real upw_frac_v,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv,
                        const amrex::Real dxInv, const amrex::Real dyInv, const amrex::Real dzInv)
@@ -43,27 +41,27 @@ AdvectionSrcForXMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j,0) + rho_u(i, j, k) * mf_u_inv(i,j,0));
-    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
+    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i-1, j, k) * mf_u_inv(i-1,j,0) + rho_u(i, j, k) * mf_u_inv(i,j,0));
-    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) * mf_v_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_v_inv(i-1,j+1,0));
-    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
+    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) * mf_v_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_v_inv(i-1,j  ,0));
-    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     rho_w_avg_hi = 0.5 * (rho_w(i, j, k+1) + rho_w(i-1, j, k+1));
-    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
+    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
     zflux_hi = rho_w_avg_hi * interp_hi;
 
     rho_w_avg_lo = 0.5 * (rho_w(i, j, k  ) + rho_w(i-1, j, k  ));
-    interp_u_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v);
+    interp_u_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo);
     zflux_lo = rho_w_avg_lo * interp_lo;
 
     amrex::Real mfsq = 1 / (mf_u_inv(i,j,0) * mf_u_inv(i,j,0));
@@ -98,8 +96,6 @@ AdvectionSrcForYMom_N (int i, int j, int k,
                        const amrex::Array4<const amrex::Real>& rho_w,
                        InterpType_H interp_v_h,
                        InterpType_V interp_v_v,
-                       const amrex::Real upw_frac_h,
-                       const amrex::Real upw_frac_v,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv,
                        const amrex::Real dxInv, const amrex::Real dyInv, const amrex::Real dzInv)
@@ -117,27 +113,27 @@ AdvectionSrcForYMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j  ,0) + rho_u(i+1, j-1, k) * mf_u_inv(i+1,j-1,0));
-    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
+    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) * mf_u_inv(i  ,j  ,0) + rho_u(i  , j-1, k) * mf_u_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_v_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j+1, k) * mf_v_inv(i  ,j+1,0));
-    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
+    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j, k) * mf_v_inv(i  ,j  ,0) + rho_v(i, j-1, k) * mf_v_inv(i  ,j-1,0));
-    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_v_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     rho_w_avg_hi = 0.5 * (rho_w(i, j, k+1) + rho_w(i, j-1, k+1));
-    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
+    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
     zflux_hi = rho_w_avg_hi * interp_hi;
 
     rho_w_avg_lo = 0.5 * (rho_w(i, j, k  ) + rho_w(i, j-1, k  ));
-    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,rho_w_avg_lo,upw_frac_v);
+    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,rho_w_avg_lo);
     zflux_lo = rho_w_avg_lo * interp_lo;
 
     amrex::Real mfsq = 1 / (mf_v_inv(i,j,0) * mf_v_inv(i,j,0));
@@ -176,8 +172,6 @@ AdvectionSrcForZMom_N (int i, int j, int k,
                        InterpType_H   interp_w_h,
                        InterpType_V   interp_w_v,
                        WallInterpType interp_w_wall,
-                       const amrex::Real upw_frac_h,
-                       const amrex::Real upw_frac_v,
                        const amrex::Array4<const amrex::Real>& mf_m,
                        const amrex::Array4<const amrex::Real>& mf_u_inv,
                        const amrex::Array4<const amrex::Real>& mf_v_inv,
@@ -199,19 +193,19 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     amrex::Real interp_hi(0.), interp_lo(0.);
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv(i+1,j  ,0);
-    interp_w_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
+    interp_w_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
     xflux_hi = rho_u_avg_hi * interp_hi;
 
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv(i  ,j  ,0);
-    interp_w_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_w_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
     xflux_lo = rho_u_avg_lo * interp_lo;
 
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv(i  ,j+1,0);
-    interp_w_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
+    interp_w_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
     yflux_hi = rho_v_avg_hi * interp_hi;
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv(i  ,j  ,0);
-    interp_w_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_w_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
     yflux_lo = rho_v_avg_lo * interp_lo;
 
     // int l_spatial_order_hi = std::min(std::min(vert_spatial_order, 2*(hi_z_face-k)), 2*(k+1));
@@ -225,15 +219,15 @@ AdvectionSrcForZMom_N (int i, int j, int k,
         rho_w_avg_hi = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k+1));
         if (k == hi_z_face-1)
         {
-            interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,0,AdvType::Centered_2nd);
+            interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,AdvType::Centered_2nd);
         } else if (k == hi_z_face-2 || k == lo_z_face+1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,0,AdvType::Centered_4th);
+               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,AdvType::Centered_4th);
             } else {
-               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v,vert_adv_type);
+               interp_w_wall.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,vert_adv_type);
             }
         } else {
-            interp_w_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi,upw_frac_v);
+            interp_w_v.InterpolateInZ(i,j,k+1,0,interp_hi,rho_w_avg_hi);
         }
         zflux_hi = rho_w_avg_hi * interp_hi;
     }
@@ -248,15 +242,15 @@ AdvectionSrcForZMom_N (int i, int j, int k,
     } else {
         rho_w_avg_lo = 0.5 * (rho_w(i,j,k) + rho_w(i,j,k-1));
         if (k == lo_z_face+1) {
-            interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,0,AdvType::Centered_2nd);
+            interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,AdvType::Centered_2nd);
         } else if (k == lo_z_face+2 || k == hi_z_face-1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,0,AdvType::Centered_4th);
+                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,AdvType::Centered_4th);
             } else {
-                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v,vert_adv_type);
+                interp_w_wall.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,vert_adv_type);
             }
         } else {
-            interp_w_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo,upw_frac_v);
+            interp_w_v.InterpolateInZ(i,j,k,0,interp_lo,rho_w_avg_lo);
         }
         zflux_lo = rho_w_avg_lo * interp_lo;
     }
@@ -296,10 +290,10 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
                              const int lo_z_face, const int hi_z_face)
 {
     // Instantiate the appropriate structs
-    InterpType_H interp_u_h(u); InterpType_V interp_u_v(u); // X-MOM
-    InterpType_H interp_v_h(v); InterpType_V interp_v_v(v); // Y-MOM
-    InterpType_H interp_w_h(w); InterpType_V interp_w_v(w); // Z-MOM
-    WallInterpType interp_w_wall(w); // Z-MOM @ wall
+    InterpType_H interp_u_h(u, upw_frac_h); InterpType_V interp_u_v(u, upw_frac_v); // X-MOM
+    InterpType_H interp_v_h(v, upw_frac_h); InterpType_V interp_v_v(v, upw_frac_v); // Y-MOM
+    InterpType_H interp_w_h(w, upw_frac_h); InterpType_V interp_w_v(w, upw_frac_v); // Z-MOM
+    WallInterpType interp_w_wall(w, upw_frac_v); // Z-MOM @ wall
 
     auto dxInv = cellSizeInv[0];
     auto dyInv = cellSizeInv[1];
@@ -312,7 +306,6 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
         auto dzInv = 1.0/dz_ptr[k];
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_u_h, interp_u_v,
-                                                    upw_frac_h, upw_frac_v,
                                                     mf_u_inv, mf_v_inv,
                                                     dxInv, dyInv, dzInv);
     });
@@ -323,7 +316,6 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
         auto dzInv = 1.0/dz_ptr[k];
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_v_h, interp_v_v,
-                                                    upw_frac_h, upw_frac_v,
                                                     mf_u_inv, mf_v_inv,
                                                     dxInv, dyInv, dzInv);
     });
@@ -334,7 +326,6 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
         auto dzInv = 2.0/(dz_ptr[k] + dz_ptr[k-1]);
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom_N(i, j, k, rho_u, rho_v, rho_w, w,
                                                     interp_w_h, interp_w_v, interp_w_wall,
-                                                    upw_frac_h, upw_frac_v,
                                                     mf_m, mf_u_inv, mf_v_inv,
                                                     vert_adv_type, lo_z_face, hi_z_face,
                                                     dxInv, dyInv, dzInv);

--- a/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
@@ -163,12 +163,12 @@ AdvectionSrcForMom_StretchedDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Centered_4th) {
                 AdvectionSrcForMomVert_N<CENTERED4>(bxx, bxy, bxz,
-                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                  rho_u, rho_v, omega, u, v, w,
-                                                  cellSizeInv, stretched_dz_d, mf_m,
-                                                  mf_u_inv, mf_v_inv,
-                                                  horiz_upw_frac, vert_upw_frac,
-                                                  vert_adv_type, lo_z_face, hi_z_face);
+                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                    rho_u, rho_v, omega, u, v, w,
+                                                    cellSizeInv, stretched_dz_d, mf_m,
+                                                    mf_u_inv, mf_v_inv,
+                                                    horiz_upw_frac, vert_upw_frac,
+                                                    vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Upwind_5th) {
                 AdvectionSrcForMomVert_N<UPWIND5>(bxx, bxy, bxz,
                                                   rho_u_rhs, rho_v_rhs, rho_w_rhs,
@@ -179,12 +179,12 @@ AdvectionSrcForMom_StretchedDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                                   vert_adv_type, lo_z_face, hi_z_face);
         } else if (horiz_adv_type == AdvType::Centered_6th) {
                 AdvectionSrcForMomVert_N<CENTERED6>(bxx, bxy, bxz,
-                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                  rho_u, rho_v, omega, u, v, w,
-                                                  cellSizeInv, stretched_dz_d, mf_m,
-                                                  mf_u_inv, mf_v_inv,
-                                                  horiz_upw_frac, vert_upw_frac,
-                                                  vert_adv_type, lo_z_face, hi_z_face);
+                                                    rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                    rho_u, rho_v, omega, u, v, w,
+                                                    cellSizeInv, stretched_dz_d, mf_m,
+                                                    mf_u_inv, mf_v_inv,
+                                                    horiz_upw_frac, vert_upw_frac,
+                                                    vert_adv_type, lo_z_face, hi_z_face);
         } else {
             AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
         }

--- a/Source/Advection/ERF_AdvectionSrcForMom_T.H
+++ b/Source/Advection/ERF_AdvectionSrcForMom_T.H
@@ -34,8 +34,6 @@ AdvectionSrcForXMom (int i, int j, int k,
                      const amrex::Array4<const amrex::Real>& detJ,
                      InterpType_H interp_u_h,
                      InterpType_V interp_u_v,
-                     const amrex::Real upw_frac_h,
-                     const amrex::Real upw_frac_v,
                      const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                      const amrex::Array4<const amrex::Real>& mf_u_inv,
                      const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -54,10 +52,10 @@ AdvectionSrcForXMom (int i, int j, int k,
     // ****************************************************************************************
 
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) * mf_u_inv(i+1,j  ,0) + rho_u(i, j, k) * mf_u_inv(i  ,j  ,0));
-    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
+    interp_u_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
 
     rho_u_avg_lo = 0.5 * (rho_u(i-1, j, k) * mf_u_inv(i-1,j  ,0) + rho_u(i, j, k) * mf_u_inv(i  ,j  ,0));
-    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_u_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
 
     amrex::Real centFluxXXNext = rho_u_avg_hi * interp_hi * 0.5 * (ax(i,j,k) + ax(i+1,j,k));
     amrex::Real centFluxXXPrev = rho_u_avg_lo * interp_lo * 0.5 * (ax(i,j,k) + ax(i-1,j,k));
@@ -66,10 +64,10 @@ AdvectionSrcForXMom (int i, int j, int k,
     // Y-fluxes (at edges in k-direction)
     // ****************************************************************************************
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) * mf_v_inv(i  ,j+1,0) + rho_v(i-1, j+1, k) * mf_v_inv(i-1,j+1,0));
-    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
+    interp_u_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) * mf_v_inv(i  ,j  ,0) + rho_v(i-1, j  , k) * mf_v_inv(i-1,j  ,0));
-    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_u_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
 
     amrex::Real edgeFluxXYNext = rho_v_avg_hi * interp_hi * Compute_h_zeta_AtEdgeCenterK(i,j+1,k,cellSizeInv,z_nd);
     amrex::Real edgeFluxXYPrev = rho_v_avg_lo * interp_lo * Compute_h_zeta_AtEdgeCenterK(i,j  ,k,cellSizeInv,z_nd);
@@ -80,8 +78,8 @@ AdvectionSrcForXMom (int i, int j, int k,
     Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i-1, j, k+1)) * 0.5 * (az(i,j,k+1) + az(i-1,j,k+1));
     Omega_avg_lo = 0.5 * (Omega(i, j, k  ) + Omega(i-1, j, k  )) * 0.5 * (az(i,j,k  ) + az(i-1,j,k  ));
 
-    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
-    interp_u_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo,upw_frac_v);
+    interp_u_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
+    interp_u_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo);
 
     amrex::Real edgeFluxXZNext = Omega_avg_hi * interp_hi;
     amrex::Real edgeFluxXZPrev = Omega_avg_lo * interp_lo;
@@ -130,8 +128,6 @@ AdvectionSrcForYMom (int i, int j, int k,
                      const amrex::Array4<const amrex::Real>& detJ,
                      InterpType_H interp_v_h,
                      InterpType_V interp_v_v,
-                     const amrex::Real upw_frac_h,
-                     const amrex::Real upw_frac_v,
                      const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                      const amrex::Array4<const amrex::Real>& mf_u_inv,
                      const amrex::Array4<const amrex::Real>& mf_v_inv)
@@ -151,8 +147,8 @@ AdvectionSrcForYMom (int i, int j, int k,
     rho_u_avg_hi = 0.5 * (rho_u(i+1,j,k) * mf_u_inv(i+1,j,0) + rho_u(i+1,j-1,k) * mf_u_inv(i+1,j-1,0));
     rho_u_avg_lo = 0.5 * (rho_u(i  ,j,k) * mf_u_inv(i  ,j,0) + rho_u(i  ,j-1,k) * mf_u_inv(i  ,j-1,0));
 
-    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
-    interp_v_h.InterpolateInX(i  ,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_v_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_v_h.InterpolateInX(i  ,j,k,0,interp_lo,rho_u_avg_lo);
 
     amrex::Real edgeFluxYXNext = rho_u_avg_hi * interp_hi * Compute_h_zeta_AtEdgeCenterK(i+1,j,k,cellSizeInv,z_nd);
     amrex::Real edgeFluxYXPrev = rho_u_avg_lo * interp_lo * Compute_h_zeta_AtEdgeCenterK(i  ,j,k,cellSizeInv,z_nd);
@@ -163,8 +159,8 @@ AdvectionSrcForYMom (int i, int j, int k,
     rho_v_avg_hi = 0.5 * (rho_v(i,j,k) * mf_v_inv(i,j,0) + rho_v(i,j+1,k) * mf_v_inv(i,j+1,0));
     rho_v_avg_lo = 0.5 * (rho_v(i,j,k) * mf_v_inv(i,j,0) + rho_v(i,j-1,k) * mf_v_inv(i,j-1,0));
 
-    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
-    interp_v_h.InterpolateInY(i,j  ,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_v_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
+    interp_v_h.InterpolateInY(i,j  ,k,0,interp_lo,rho_v_avg_lo);
 
     amrex::Real centFluxYYNext = rho_v_avg_hi * 0.5 * (ay(i,j,k) + ay(i,j+1,k)) * interp_hi;
     amrex::Real centFluxYYPrev = rho_v_avg_lo * 0.5 * (ay(i,j,k) + ay(i,j-1,k)) * interp_lo;
@@ -175,8 +171,8 @@ AdvectionSrcForYMom (int i, int j, int k,
     Omega_avg_hi = 0.5 * (Omega(i, j, k+1) + Omega(i, j-1, k+1)) * 0.5 * (az(i,j,k+1) + az(i,j-1,k+1));
     Omega_avg_lo = 0.5 * (Omega(i, j, k  ) + Omega(i, j-1, k  )) * 0.5 * (az(i,j,k  ) + az(i,j-1,k  ));
 
-    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
-    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo,upw_frac_v);
+    interp_v_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
+    interp_v_v.InterpolateInZ(i,j,k  ,0,interp_lo,Omega_avg_lo);
 
     amrex::Real edgeFluxYZNext = Omega_avg_hi * interp_hi;
     amrex::Real edgeFluxYZPrev = Omega_avg_lo * interp_lo;
@@ -232,8 +228,6 @@ AdvectionSrcForZMom (int i, int j, int k,
                      InterpType_H   interp_omega_h,
                      InterpType_V   interp_omega_v,
                      WallInterpType interp_omega_wall,
-                     const amrex::Real upw_frac_h,
-                     const amrex::Real upw_frac_v,
                      const amrex::GpuArray<amrex::Real, AMREX_SPACEDIM>& cellSizeInv,
                      const amrex::Array4<const amrex::Real>& mf_m,
                      const amrex::Array4<const amrex::Real>& mf_u_inv,
@@ -256,8 +250,8 @@ AdvectionSrcForZMom (int i, int j, int k,
     rho_u_avg_hi = 0.5 * (rho_u(i+1, j, k) + rho_u(i+1, j, k-1)) * mf_u_inv(i+1,j  ,0);
     rho_u_avg_lo = 0.5 * (rho_u(i  , j, k) + rho_u(i  , j, k-1)) * mf_u_inv(i  ,j  ,0);
 
-    interp_omega_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi,upw_frac_h);
-    interp_omega_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo,upw_frac_h);
+    interp_omega_h.InterpolateInX(i+1,j,k,0,interp_hi,rho_u_avg_hi);
+    interp_omega_h.InterpolateInX(i,j,k,0,interp_lo,rho_u_avg_lo);
 
     amrex::Real edgeFluxZXNext = rho_u_avg_hi * interp_hi * Compute_h_zeta_AtEdgeCenterJ(i+1,j,k,cellSizeInv,z_nd);
     amrex::Real edgeFluxZXPrev = rho_u_avg_lo * interp_lo * Compute_h_zeta_AtEdgeCenterJ(i  ,j,k,cellSizeInv,z_nd);
@@ -266,10 +260,10 @@ AdvectionSrcForZMom (int i, int j, int k,
     // y-fluxes (at edges in i-direction)
     // ****************************************************************************************
     rho_v_avg_hi = 0.5 * (rho_v(i, j+1, k) + rho_v(i, j+1, k-1)) * mf_v_inv(i  ,j+1,0);
-    interp_omega_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi,upw_frac_h);
+    interp_omega_h.InterpolateInY(i,j+1,k,0,interp_hi,rho_v_avg_hi);
 
     rho_v_avg_lo = 0.5 * (rho_v(i, j  , k) + rho_v(i, j  , k-1)) * mf_v_inv(i  ,j  ,0);
-    interp_omega_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo,upw_frac_h);
+    interp_omega_h.InterpolateInY(i,j,k,0,interp_lo,rho_v_avg_lo);
 
     amrex::Real edgeFluxZYNext = rho_v_avg_hi * interp_hi * Compute_h_zeta_AtEdgeCenterI(i,j+1,k,cellSizeInv,z_nd);
     amrex::Real edgeFluxZYPrev = rho_v_avg_lo * interp_lo * Compute_h_zeta_AtEdgeCenterI(i,j  ,k,cellSizeInv,z_nd);
@@ -291,15 +285,15 @@ AdvectionSrcForZMom (int i, int j, int k,
     } else {
         if (k == hi_z_face-1)
         {
-            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,0,AdvType::Centered_2nd);
+            interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,AdvType::Centered_2nd);
         } else if (k == hi_z_face-2 || k == lo_z_face+1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,0,AdvType::Centered_4th);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,AdvType::Centered_4th);
             } else {
-                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v,vert_adv_type);
+                interp_omega_wall.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,vert_adv_type);
             }
         } else {
-            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi,upw_frac_v);
+            interp_omega_v.InterpolateInZ(i,j,k+1,0,interp_hi,Omega_avg_hi);
         }
         centFluxZZNext *=  interp_hi;
     }
@@ -318,15 +312,15 @@ AdvectionSrcForZMom (int i, int j, int k,
         centFluxZZPrev *=  w(i,j,k);
     } else {
         if (k == lo_z_face+1) {
-            interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,0,AdvType::Centered_2nd);
+            interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,AdvType::Centered_2nd);
         } else if (k == lo_z_face+2 || k == hi_z_face-1) {
             if (vert_adv_type != AdvType::Centered_2nd && vert_adv_type != AdvType::Upwind_3rd) {
-                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,0,AdvType::Centered_4th);
+                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,AdvType::Centered_4th);
             } else {
-                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,upw_frac_v,vert_adv_type);
+                interp_omega_wall.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,vert_adv_type);
             }
         } else {
-            interp_omega_v.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo,upw_frac_v);
+            interp_omega_v.InterpolateInZ(i,j,k,0,interp_lo,Omega_avg_lo);
         }
         centFluxZZPrev *=  interp_lo;
     }
@@ -375,18 +369,17 @@ AdvectionSrcForMomWrapper (const amrex::Box& bxx, const amrex::Box& bxy, const a
                            const int lo_z_face, const int hi_z_face)
 {
     // Instantiate the appropriate structs
-    InterpType_H interp_u_h(u); InterpType_V interp_u_v(u); // X-MOM
-    InterpType_H interp_v_h(v); InterpType_V interp_v_v(v); // Y-MOM
-    InterpType_H interp_w_h(w); InterpType_V interp_w_v(w); // Z-MOM
-    WallInterpType interp_w_wall(w); // Z-MOM @ wall
+    InterpType_H interp_u_h(u, upw_frac_h); InterpType_V interp_u_v(u, upw_frac_v); // X-MOM
+    InterpType_H interp_v_h(v, upw_frac_h); InterpType_V interp_v_v(v, upw_frac_v); // Y-MOM
+    InterpType_H interp_w_h(w, upw_frac_h); InterpType_V interp_w_v(w, upw_frac_v); // Z-MOM
+    WallInterpType interp_w_wall(w, upw_frac_v); // Z-MOM @ wall
 
     amrex::ParallelFor(bxx,
     [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom(i, j, k, rho_u, rho_v, Omega, z_nd, ax, ay, az, detJ,
                                                   interp_u_h, interp_u_v,
-                                                  upw_frac_h, upw_frac_v,
-                                                    cellSizeInv, mf_u_inv, mf_v_inv);
+                                                  cellSizeInv, mf_u_inv, mf_v_inv);
     });
 
     amrex::ParallelFor(bxy,
@@ -394,7 +387,6 @@ AdvectionSrcForMomWrapper (const amrex::Box& bxx, const amrex::Box& bxy, const a
     {
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom(i, j, k, rho_u, rho_v, Omega, z_nd, ax, ay, az, detJ,
                                                   interp_v_h, interp_v_v,
-                                                  upw_frac_h, upw_frac_v,
                                                   cellSizeInv, mf_u_inv, mf_v_inv);
     });
 
@@ -403,7 +395,6 @@ AdvectionSrcForMomWrapper (const amrex::Box& bxx, const amrex::Box& bxy, const a
     {
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom(i, j, k, rho_u, rho_v, Omega, w, z_nd, ax, ay, az, detJ,
                                                   interp_w_h, interp_w_v, interp_w_wall,
-                                                  upw_frac_h, upw_frac_v,
                                                   cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
                                                   vert_adv_type, lo_z_face, hi_z_face);
     });

--- a/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
@@ -62,9 +62,9 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
 {
     BL_PROFILE_VAR("AdvectionSrcForMom_TF", AdvectionSrcForMom_TF);
 
-    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
-
     AMREX_ALWAYS_ASSERT(bxz.smallEnd(2) > 0);
+
+    auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
     // compute mapfactor inverses
     Box box2d_u(bxx);   box2d_u.setRange(2,0);   box2d_u.grow({3,3,0});
@@ -84,9 +84,9 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
         mf_v_inv(i,j,0) = 1. / mf_v(i,j,0);
     });
 
-        // Inline with 2nd order for efficiency
-        if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
-        {
+    // Inline with 2nd order for efficiency
+    if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
+    {
             ParallelFor(bxx, bxy, bxz,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
@@ -114,11 +114,10 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-
                 rho_u_rhs(i, j, k) = -advectionSrc / (0.5 * (detJ(i,j,k) + detJ(i-1,j,k)));
-            },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
 
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterK(i+1,j,k,cellSizeInv,z_nd);
                 Real xflux_hi = 0.25 * (rho_u(i+1,j,k)*mf_u_inv(i+1,j,0) + rho_u(i+1,j-1,k)*mf_u_inv(i+1,j-1,0)) *
@@ -144,11 +143,10 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-
                 rho_v_rhs(i, j, k) = -advectionSrc / (0.5 * (detJ(i,j,k) + detJ(i,j-1,k)));
-            },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
-            {
+        },
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
                 Real xflux_hi = 0.25*(rho_u(i+1,j  ,k) + rho_u(i+1,j,k-1)) * mf_u_inv(i+1,j,0) *
                                      (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi;
@@ -176,49 +174,53 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-
                 rho_w_rhs(i, j, k) = -advectionSrc / (0.5*(detJ(i,j,k) + detJ(i,j,k-1)));
             });
-        // Template higher order methods
-        } else {
-            if (horiz_adv_type == AdvType::Centered_2nd) {
+
+    // Template higher order methods
+    } else {
+        if (horiz_adv_type == AdvType::Centered_2nd) {
                 AdvectionSrcForMomVert<CENTERED2>(bxx, bxy, bxz,
-                                                rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                rho_u, rho_v, Omega, u, v, w, z_nd, ax, ay, az, detJ,
-                                                cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
-                                                horiz_upw_frac, vert_upw_frac,
-                                                vert_adv_type, lo_z_face, hi_z_face);
-            } else if (horiz_adv_type == AdvType::Upwind_3rd) {
+                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                  rho_u, rho_v, Omega, u, v, w,
+                                                  z_nd, ax, ay, az, detJ,
+                                                  cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
+                                                  vert_adv_type, lo_z_face, hi_z_face);
+        } else if (horiz_adv_type == AdvType::Upwind_3rd) {
                 AdvectionSrcForMomVert<UPWIND3>(bxx, bxy, bxz,
                                                 rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                rho_u, rho_v, Omega, u, v, w, z_nd, ax, ay, az, detJ,
+                                                rho_u, rho_v, Omega, u, v, w,
+                                                z_nd, ax, ay, az, detJ,
                                                 cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
                                                 horiz_upw_frac, vert_upw_frac,
                                                 vert_adv_type, lo_z_face, hi_z_face);
-            } else if (horiz_adv_type == AdvType::Centered_4th) {
+        } else if (horiz_adv_type == AdvType::Centered_4th) {
                 AdvectionSrcForMomVert<CENTERED4>(bxx, bxy, bxz,
-                                                rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                rho_u, rho_v, Omega, u, v, w, z_nd, ax, ay, az, detJ,
-                                                cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
-                                                horiz_upw_frac, vert_upw_frac,
-                                                vert_adv_type, lo_z_face, hi_z_face);
-            } else if (horiz_adv_type == AdvType::Upwind_5th) {
+                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                  rho_u, rho_v, Omega, u, v, w,
+                                                  z_nd, ax, ay, az, detJ,
+                                                  cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
+                                                  vert_adv_type, lo_z_face, hi_z_face);
+        } else if (horiz_adv_type == AdvType::Upwind_5th) {
                 AdvectionSrcForMomVert<UPWIND5>(bxx, bxy, bxz,
                                                 rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                rho_u, rho_v, Omega, u, v, w, z_nd, ax, ay, az, detJ,
+                                                rho_u, rho_v, Omega, u, v, w,
+                                                z_nd, ax, ay, az, detJ,
                                                 cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
                                                 horiz_upw_frac, vert_upw_frac,
                                                 vert_adv_type, lo_z_face, hi_z_face);
-            } else if (horiz_adv_type == AdvType::Centered_6th) {
+        } else if (horiz_adv_type == AdvType::Centered_6th) {
                 AdvectionSrcForMomVert<CENTERED6>(bxx, bxy, bxz,
-                                                rho_u_rhs, rho_v_rhs, rho_w_rhs,
-                                                rho_u, rho_v, Omega, u, v, w, z_nd, ax, ay, az, detJ,
-                                                cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
-                                                horiz_upw_frac, vert_upw_frac,
-                                                vert_adv_type, lo_z_face, hi_z_face);
-            } else {
-                    AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
-            }
-        } // higher order
+                                                  rho_u_rhs, rho_v_rhs, rho_w_rhs,
+                                                  rho_u, rho_v, Omega, u, v, w,
+                                                  z_nd, ax, ay, az, detJ,
+                                                  cellSizeInv, mf_m, mf_u_inv, mf_v_inv,
+                                                  horiz_upw_frac, vert_upw_frac,
+                                                  vert_adv_type, lo_z_face, hi_z_face);
+        } else {
+            AMREX_ASSERT_WITH_MESSAGE(false, "Unknown advection scheme!");
+        }
+    }
 }
-

--- a/Source/Advection/ERF_AdvectionSrcForScalars.H
+++ b/Source/Advection/ERF_AdvectionSrcForScalars.H
@@ -17,8 +17,8 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                                const amrex::Real vert_upw_frac)
 {
     // Instantiate structs for vert/horiz interp
-    InterpType_H interp_prim_h(cell_prim);
-    InterpType_V interp_prim_v(cell_prim);
+    InterpType_H interp_prim_h(cell_prim, horiz_upw_frac);
+    InterpType_V interp_prim_v(cell_prim, vert_upw_frac);
 
     const amrex::Box xbx = amrex::surroundingNodes(bx,0);
     const amrex::Box ybx = amrex::surroundingNodes(bx,1);
@@ -31,7 +31,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
 
         amrex::Real interpx(0.);
 
-        interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i  ,j  ,k  ),horiz_upw_frac);
+        interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i  ,j  ,k  ));
         (flx_arr[0])(i,j,k,cons_index) = avg_xmom(i,j,k) * interpx;
     });
     amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
@@ -40,7 +40,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         const int prim_index = cons_index - 1;
 
         amrex::Real interpy(0.);
-        interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ),horiz_upw_frac);
+        interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ));
 
         (flx_arr[1])(i,j,k,cons_index) = avg_ymom(i,j,k) * interpy;
     });
@@ -51,7 +51,7 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
 
         amrex::Real interpz(0.);
 
-        interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i  ,j  ,k  ),vert_upw_frac);
+        interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i  ,j  ,k  ));
 
         (flx_arr[2])(i,j,k,cons_index) = avg_zmom(i,j,k) * interpz;
     });

--- a/Source/EB/ERF_EBAdvectionSrcForScalars.H
+++ b/Source/EB/ERF_EBAdvectionSrcForScalars.H
@@ -26,15 +26,15 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                                 const amrex::Real vert_upw_frac)
 {
     // Instantiate structs for vert/horiz interp
-    InterpType_H interp_prim_h(cell_prim);
-    InterpType_V interp_prim_v(cell_prim);
+    InterpType_H interp_prim_h(cell_prim, horiz_upw_frac);
+    InterpType_V interp_prim_v(cell_prim, vert_upw_frac);
 
     const int ncells_h = interp_prim_h.GetUpwindCellNumber();
     const int ncells_v = interp_prim_v.GetUpwindCellNumber();
 
     // Instantiate structs for lower-order vert/horiz interp
-    CENTERED2 interp_prim_CEN2(cell_prim);
-    UPWIND3   interp_prim_UPW3(cell_prim);
+    CENTERED2 interp_prim_CEN2(cell_prim, 0);
+    UPWIND3   interp_prim_UPW3(cell_prim, horiz_upw_frac);
 
     const amrex::Box xbx = amrex::surroundingNodes(bx,0);
     const amrex::Box ybx = amrex::surroundingNodes(bx,1);
@@ -73,12 +73,12 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             amrex::Real interpx(0.);
 
             if (icell==ncells_h-1) {
-                interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k),horiz_upw_frac);
+                interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k));
             } else {
                 if (icell==1) {
-                    interp_prim_CEN2.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k),horiz_upw_frac);
+                    interp_prim_CEN2.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k));
                 } else if (icell==2) {
-                    interp_prim_UPW3.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k),horiz_upw_frac);
+                    interp_prim_UPW3.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k));
                 }
             }
             (flx_arr[0])(i,j,k,cons_index) = avg_xmom(i,j,k) * interpx;
@@ -122,12 +122,12 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             amrex::Real interpy(0.);
 
             if (jcell==ncells_h-1) {
-                interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k),horiz_upw_frac);
+                interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k));
             } else {
                 if (jcell==1) {
-                    interp_prim_CEN2.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k),horiz_upw_frac);
+                    interp_prim_CEN2.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k));
                 } else if (jcell==2) {
-                    interp_prim_UPW3.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k),horiz_upw_frac);
+                    interp_prim_UPW3.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k));
                 }
             }
             (flx_arr[1])(i,j,k,cons_index) = avg_ymom(i,j,k) * interpy;
@@ -137,6 +137,8 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             (flx_arr[1])(i,j,k,cons_index) = 0.;
         }
     });
+
+    interp_prim_UPW3.SetUpwinding(vert_upw_frac);
 
     amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
@@ -171,12 +173,12 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             amrex::Real interpz(0.);
 
             if (kcell==ncells_v-1) {
-                interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k),vert_upw_frac);
+                interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k));
             } else {
                 if (kcell==1) {
-                    interp_prim_CEN2.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k),vert_upw_frac);
+                    interp_prim_CEN2.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k));
                 } else if (kcell==2) {
-                    interp_prim_UPW3.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k),vert_upw_frac);
+                    interp_prim_UPW3.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k));
                 }
             }
             (flx_arr[2])(i,j,k,cons_index) = avg_zmom(i,j,k) * interpz;

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -8,7 +8,8 @@
  */
 struct CENTERED2
 {
-    CENTERED2 (const amrex::Array4<const amrex::Real>& phi)
+    CENTERED2 (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -19,8 +20,7 @@ struct CENTERED2
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -38,8 +38,7 @@ struct CENTERED2
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -57,8 +56,7 @@ struct CENTERED2
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real s   = m_phi(i  , j  , k  , qty_index);
@@ -93,8 +91,11 @@ private:
  */
 struct UPWIND3
 {
-    UPWIND3 (const amrex::Array4<const amrex::Real>& phi)
-        : m_phi(phi) {}
+    UPWIND3 (const amrex::Array4<const amrex::Real>& phi,
+             const amrex::Real upw_frac)
+        : m_phi(phi)
+        , m_upw_frac(upw_frac)
+    {}
 
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
@@ -104,8 +105,7 @@ struct UPWIND3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -117,7 +117,7 @@ struct UPWIND3
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
@@ -131,8 +131,7 @@ struct UPWIND3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -144,7 +143,7 @@ struct UPWIND3
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
@@ -158,8 +157,7 @@ struct UPWIND3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -171,7 +169,7 @@ struct UPWIND3
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp1,s,sm1,sm2,upw_lo);
@@ -198,8 +196,11 @@ struct UPWIND3
 
     int GetUpwindCellNumber() const {return 2;}
 
+    void SetUpwinding(amrex::Real upw_frac) {m_upw_frac = upw_frac;}
+
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
+    amrex::Real m_upw_frac; // Upwinding fraction
     static constexpr amrex::Real g1=(7.0/12.0);
     static constexpr amrex::Real g2=(1.0/12.0);
 };
@@ -210,7 +211,8 @@ private:
  */
 struct CENTERED4
 {
-    CENTERED4 (const amrex::Array4<const amrex::Real>& phi)
+    CENTERED4 (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -221,8 +223,7 @@ struct CENTERED4
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -242,8 +243,7 @@ struct CENTERED4
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -263,8 +263,7 @@ struct CENTERED4
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -305,8 +304,11 @@ private:
  */
 struct UPWIND5
 {
-    UPWIND5 (const amrex::Array4<const amrex::Real>& phi)
-        : m_phi(phi) {}
+    UPWIND5 (const amrex::Array4<const amrex::Real>& phi,
+             const amrex::Real upw_frac)
+        : m_phi(phi)
+        , m_upw_frac(upw_frac)
+    {}
 
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
@@ -316,8 +318,7 @@ struct UPWIND5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -331,7 +332,7 @@ struct UPWIND5
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
@@ -345,8 +346,7 @@ struct UPWIND5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -360,7 +360,7 @@ struct UPWIND5
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
@@ -374,8 +374,7 @@ struct UPWIND5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real upw_frac) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -389,7 +388,7 @@ struct UPWIND5
         if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
         // Add blending
-        upw_lo *= upw_frac;
+        upw_lo *= m_upw_frac;
 
         // Interpolate lo
         val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo);
@@ -420,8 +419,11 @@ struct UPWIND5
 
     int GetUpwindCellNumber() const {return 3;}
 
+    void SetUpwinding(amrex::Real upw_frac) {m_upw_frac = upw_frac;}
+
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
+    amrex::Real m_upw_frac; // Upwinding fraction
     static constexpr amrex::Real g1=(37.0/60.0);
     static constexpr amrex::Real g2=(2.0/15.0);
     static constexpr amrex::Real g3=(1.0/60.0);
@@ -432,7 +434,8 @@ private:
  */
 struct CENTERED6
 {
-    CENTERED6 (const amrex::Array4<const amrex::Real>& phi)
+    CENTERED6 (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -443,8 +446,7 @@ struct CENTERED6
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -466,8 +468,7 @@ struct CENTERED6
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -489,8 +490,7 @@ struct CENTERED6
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real /*upw_lo*/,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real /*upw_lo*/) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -537,8 +537,11 @@ private:
  */
 struct UPWINDALL
 {
-    UPWINDALL (const amrex::Array4<const amrex::Real>& phi)
-        : m_phi(phi) {}
+    UPWINDALL (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real upw_frac)
+        : m_phi(phi)
+        , m_upw_frac(upw_frac)
+    {}
 
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
@@ -549,7 +552,6 @@ struct UPWINDALL
                     const int& qty_index,
                     amrex::Real& val_lo,
                     amrex::Real upw_lo,
-                    const amrex::Real upw_frac,
                     const AdvType adv_type) const
     {
         if (adv_type == AdvType::Centered_2nd) {
@@ -568,7 +570,7 @@ struct UPWINDALL
             if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
 
             // Add blending
-            upw_lo *= upw_frac;
+            upw_lo *= m_upw_frac;
 
             // Interpolate lo
             val_lo = Evaluate(sp2,sp1,s,sm1,sm2,sm3,upw_lo,adv_type);
@@ -613,6 +615,7 @@ struct UPWINDALL
 
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
+    amrex::Real m_upw_frac; // Upwinding fraction
     static constexpr amrex::Real g1_3_4=( 7.0/12.0);
     static constexpr amrex::Real g2_3_4=( 1.0/12.0);
     static constexpr amrex::Real g1_5_6=(37.0/60.0);

--- a/Source/Utils/ERF_Interpolation_WENO.H
+++ b/Source/Utils/ERF_Interpolation_WENO.H
@@ -8,7 +8,8 @@
  */
 struct WENO3
 {
-    WENO3 (const amrex::Array4<const amrex::Real>& phi)
+    WENO3 (const amrex::Array4<const amrex::Real>& phi,
+           const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -19,8 +20,7 @@ struct WENO3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -45,8 +45,7 @@ struct WENO3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -71,8 +70,7 @@ struct WENO3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -128,7 +126,8 @@ private:
  */
 struct WENO5
 {
-    WENO5 (const amrex::Array4<const amrex::Real>& phi)
+    WENO5 (const amrex::Array4<const amrex::Real>& phi,
+           const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -139,8 +138,7 @@ struct WENO5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -167,8 +165,7 @@ struct WENO5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -195,8 +192,7 @@ struct WENO5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -264,7 +260,8 @@ private:
  */
 struct WENO7
 {
-    WENO7 (const amrex::Array4<const amrex::Real>& phi)
+    WENO7 (const amrex::Array4<const amrex::Real>& phi,
+           const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -275,8 +272,7 @@ struct WENO7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i+3, j  , k  , qty_index);
@@ -305,8 +301,7 @@ struct WENO7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i  , j+3, k  , qty_index);
@@ -335,8 +330,7 @@ struct WENO7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i  , j  , k+2, qty_index);

--- a/Source/Utils/ERF_Interpolation_WENO_Z.H
+++ b/Source/Utils/ERF_Interpolation_WENO_Z.H
@@ -8,7 +8,8 @@
  */
 struct WENO_Z3
 {
-    WENO_Z3 (const amrex::Array4<const amrex::Real>& phi)
+    WENO_Z3 (const amrex::Array4<const amrex::Real>& phi,
+             const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -19,8 +20,7 @@ struct WENO_Z3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -45,8 +45,7 @@ struct WENO_Z3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -71,8 +70,7 @@ struct WENO_Z3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -129,7 +127,8 @@ private:
  */
 struct WENO_MZQ3
 {
-    WENO_MZQ3 (const amrex::Array4<const amrex::Real>& phi)
+    WENO_MZQ3 (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -140,8 +139,7 @@ struct WENO_MZQ3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
@@ -166,8 +164,7 @@ struct WENO_MZQ3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
@@ -192,8 +189,7 @@ struct WENO_MZQ3
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
@@ -255,7 +251,8 @@ private:
  */
 struct WENO_Z5
 {
-    WENO_Z5 (const amrex::Array4<const amrex::Real>& phi)
+    WENO_Z5 (const amrex::Array4<const amrex::Real>& phi,
+             const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -266,8 +263,7 @@ struct WENO_Z5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i+2, j  , k  , qty_index);
@@ -294,8 +290,7 @@ struct WENO_Z5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j+2, k  , qty_index);
@@ -322,8 +317,7 @@ struct WENO_Z5
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp2 = m_phi(i  , j  , k+2, qty_index);
@@ -392,7 +386,8 @@ private:
  */
 struct WENO_Z7
 {
-    WENO_Z7 (const amrex::Array4<const amrex::Real>& phi)
+    WENO_Z7 (const amrex::Array4<const amrex::Real>& phi,
+             const amrex::Real /*upw_frac*/)
         : m_phi(phi) {}
 
     AMREX_GPU_DEVICE
@@ -403,8 +398,7 @@ struct WENO_Z7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i+3, j  , k  , qty_index);
@@ -433,8 +427,7 @@ struct WENO_Z7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i  , j+3, k  , qty_index);
@@ -463,8 +456,7 @@ struct WENO_Z7
                     const int& k,
                     const int& qty_index,
                     amrex::Real& val_lo,
-                    amrex::Real upw_lo,
-                    const amrex::Real /*upw_frac*/) const
+                    amrex::Real upw_lo) const
     {
         // Data to interpolate on
         amrex::Real sp3 = m_phi(i  , j  , k+2, qty_index);


### PR DESCRIPTION
As described in https://github.com/erf-model/ERF/issues/1522. The upwinding fraction (`upw_frac`) is now saved as a member variable when the interpolation object is created, instead of being passed as an argument each time `interp_[uvw]_[hv].InterpolateIn[XYZ]()` is called.

Verified
* `Blended_3rd4th` w/ upw_frac=1 is identical to `Upwind_3rd`
* `Blended_3rd4th` w/ upw_frac=0 is identical to `Centered_4th`
* `Blended_5th6th` w/ upw_frac=1 is identical to `Upwind_5rd`
* `Blended_5th6th` w/ upw_frac=0 is identical to `Centered_6th`