### PR TITLE
Anelastic Rho Pert

### DIFF
--- a/Source/Initialization/ERF_InitCustom.cpp
+++ b/Source/Initialization/ERF_InitCustom.cpp
@@ -76,7 +76,9 @@ ERF::init_custom (int lev)
     } //mfi
 
     // Add problem-specific perturbation to background flow
-    MultiFab::Add(lev_new[Vars::cons], cons_pert, Rho_comp,      Rho_comp,             1, cons_pert.nGrow());
+    if (!solverChoice.anelastic[lev]) {
+        MultiFab::Add(lev_new[Vars::cons], cons_pert, Rho_comp,      Rho_comp,             1, cons_pert.nGrow());
+    }
     MultiFab::Add(lev_new[Vars::cons], cons_pert, RhoTheta_comp, RhoTheta_comp,        1, cons_pert.nGrow());
     MultiFab::Add(lev_new[Vars::cons], cons_pert, RhoScalar_comp,RhoScalar_comp,NSCALARS, cons_pert.nGrow());
 


### PR DESCRIPTION
Do not add rho perturbation from custom initialization if anelastic, it should be the base state only.