### PR TITLE
Fix typo in SampleData

### DIFF
--- a/Source/IO/ERF_SampleData.H
+++ b/Source/IO/ERF_SampleData.H
@@ -398,7 +398,7 @@ public:
                        amrex::Vector<amrex::Geometry>& geom)
     {
         if (m_ls) m_ls->write_line_mfs(time, level_steps, ref_ratio, geom);
-        if (m_ls) m_ps->write_plane_mfs(time, level_steps, ref_ratio, geom);
+        if (m_ps) m_ps->write_plane_mfs(time, level_steps, ref_ratio, geom);
     }
 
 private:


### PR DESCRIPTION
The code crashes when `erf.do_line_sampling` is turned on without plane sampling.