### PR TITLE
Terrain Subsidence

### DIFF
--- a/Exec/MoistRegTests/Bomex/ERF_Prob.H
+++ b/Exec/MoistRegTests/Bomex/ERF_Prob.H
@@ -105,7 +105,7 @@ public:
         amrex::Vector<amrex::Real>& wbar,
         amrex::Gpu::DeviceVector<amrex::Real>& d_wbar,
         const amrex::Geometry& geom,
-        std::unique_ptr<amrex::MultiFab>& z_phys_cc) override;
+        std::unique_ptr<amrex::MultiFab>& z_phys_nd) override;
 
     void update_geostrophic_profile (
         const amrex::Real& /*time*/,

--- a/Exec/MoistRegTests/Bomex/ERF_Prob.cpp
+++ b/Exec/MoistRegTests/Bomex/ERF_Prob.cpp
@@ -244,8 +244,7 @@ Problem::update_rhotheta_sources (const Real& /*time*/,
     // varies in time and or space, then the the height needs to be
     // calculated at each time step. Here, we assume that only grid
     // stretching exists.
-    if (z_phys_cc && zlevels.empty()) {
-        Print() << "Initializing z levels on stretched grid" << std::endl;
+    if (z_phys_cc) {
         zlevels.resize(khi+1);
         reduce_to_max_per_height(zlevels, z_phys_cc);
     }
@@ -287,8 +286,7 @@ Problem::update_rhoqt_sources (const Real& /*time*/,
     // varies in time and or space, then the the height needs to be
     // calculated at each time step. Here, we assume that only grid
     // stretching exists.
-    if (z_phys_cc && zlevels.empty()) {
-        Print() << "Initializing z levels on stretched grid" << std::endl;
+    if (z_phys_cc) {
         zlevels.resize(khi+1);
         reduce_to_max_per_height(zlevels, z_phys_cc);
     }
@@ -318,7 +316,7 @@ Problem::update_w_subsidence (const Real& /*time*/,
                               Vector<Real>& wbar,
                               Gpu::DeviceVector<Real>& d_wbar,
                               const Geometry& geom,
-                              std::unique_ptr<MultiFab>& z_phys_cc)
+                              std::unique_ptr<MultiFab>& z_phys_nd)
 {
     if (wbar.empty()) return;
 
@@ -326,23 +324,22 @@ Problem::update_w_subsidence (const Real& /*time*/,
     const Real* prob_lo = geom.ProbLo();
     const auto dx       = geom.CellSize();
 
-    // Note: If z_phys_cc, then use_terrain=1 was set. If the z coordinate
+    // Note: If z_phys_nd, then use_terrain=1 was set. If the z coordinate
     // varies in time and or space, then the the height needs to be
     // calculated at each time step. Here, we assume that only grid
     // stretching exists.
-    if (z_phys_cc && zlevels.empty()) {
-        Print() << "Initializing z levels on stretched grid" << std::endl;
+    if (z_phys_nd) {
         zlevels.resize(khi+1);
-        reduce_to_max_per_height(zlevels, z_phys_cc);
+        reduce_to_max_per_height(zlevels, z_phys_nd);
     }
 
     // Linearly increase wbar to the cutoff_max and then linearly decrease to cutoff_min
-    Real z_0    = 0.0; // (z_phys_cc) ? zlevels[0] : prob_lo[2] + 0.5 * dx[2];
+    Real z_0    = (z_phys_nd) ? zlevels[0] : prob_lo[2];
     Real slope1 =  parms.wbar_sub_max / (parms.wbar_cutoff_max - z_0);
     Real slope2 = -parms.wbar_sub_max / (parms.wbar_cutoff_min - parms.wbar_cutoff_max);
     wbar[0]     = 0.0;
     for (int k = 1; k <= khi; k++) {
-        const Real z_cc = (z_phys_cc) ? zlevels[k] : prob_lo[2] + k*dx[2];
+        const Real z_cc = (z_phys_nd) ? zlevels[k] : prob_lo[2] + k*dx[2];
         if (z_cc <= parms.wbar_cutoff_max) {
             wbar[k] = slope1 * (z_cc - z_0);
         } else if (z_cc <= parms.wbar_cutoff_min) {
@@ -378,8 +375,7 @@ Problem::update_geostrophic_profile (const Real& /*time*/,
     // varies in time and or space, then the the height needs to be
     // calculated at each time step. Here, we assume that only grid
     // stretching exists.
-    if (z_phys_cc && zlevels.empty()) {
-        Print() << "Initializing z levels on stretched grid" << std::endl;
+    if (z_phys_cc) {
         zlevels.resize(khi+1);
         reduce_to_max_per_height(zlevels, z_phys_cc);
     }

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -805,7 +805,7 @@ ERF::InitData_post ()
             d_w_subsid[lev].resize(domlen, 0.0_rt);
             prob->update_w_subsidence(t_new[0],
                                       h_w_subsid[lev], d_w_subsid[lev],
-                                      geom[lev], z_phys_cc[lev]);
+                                      geom[lev], z_phys_nd[lev]);
         }
     }
 

--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -195,11 +195,11 @@ public:
                          amrex::Vector<amrex::Real>& wbar,
                          amrex::Gpu::DeviceVector<amrex::Real>& d_wbar,
                          const amrex::Geometry& geom,
-                         std::unique_ptr<amrex::MultiFab>& z_phys_cc)
+                         std::unique_ptr<amrex::MultiFab>& z_phys_nd)
     {
         if (wbar.empty()) return;
 
-        if (z_phys_cc) {
+        if (z_phys_nd) {
             // use_terrain=1
             amrex::Error("Moisture forcing not defined for "+name()+" problem with terrain");
         } else {

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -695,22 +695,12 @@ make_zcc (const Geometry& geom,
           MultiFab& z_phys_nd,
           MultiFab& z_phys_cc)
 {
-    // Domain valid box (z_nd is nodal)
-    const Box& domain = geom.Domain();
-    int domlo_z = domain.smallEnd(2);
-
-    // Number of ghost cells
-    int ngrow= z_phys_cc.nGrow();
-
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
     for ( MFIter mfi(z_phys_cc, TilingIfNotGPU()); mfi.isValid(); ++mfi )
     {
-        Box gbx = mfi.growntilebox(ngrow);
-        if (gbx.smallEnd(2) < domlo_z) {
-            gbx.setSmall(2,domlo_z);
-        }
+        Box gbx = mfi.growntilebox();
         Array4<Real const> z_nd = z_phys_nd.const_array(mfi);
         Array4<Real      > z_cc = z_phys_cc.array(mfi);
         ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {


### PR DESCRIPTION
Fix issues with subsidence source term and terrain. Note the `wbar` is located at z faces so we should use `z_phys_nd` for obtaining the `zlevels` and we need to fill the ghost cells of `z_cc` so the center diff for the subsidence doesn't touch uninitialized data.