### PR TITLE
Update custom w subsidence term each timestep

### DIFF
--- a/Source/TimeIntegration/ERF_AdvanceDycore.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceDycore.cpp
@@ -244,6 +244,12 @@ void ERF::advance_dycore(int level,
                                    fine_geom, z_phys_cc[level]);
     }
 
+    if (solverChoice.custom_w_subsidence) {
+        prob->update_w_subsidence(old_time,
+                                  h_w_subsid[level], d_w_subsid[level],
+                                  fine_geom, z_phys_nd[level]);
+    }
+
     // ***********************************************************************************************
     // Convert old velocity available on faces to old momentum on faces to be used in time integration
     // ***********************************************************************************************


### PR DESCRIPTION
This updates the custom w subsidence term each timestep following the other custom source terms. Previously, this was only called once at t=0.