### PR TITLE
Fix issue with NC has_var

### DIFF
--- a/Source/IO/ERF_NCInterface.H
+++ b/Source/IO/ERF_NCInterface.H
@@ -213,7 +213,10 @@ public:
     //! Check if a dimension exists by name
     [[nodiscard]] bool has_dim (const std::string&) const;
 
-    //! Check if a variable exists by name
+    /** Return id of variable by name
+     *
+     * Throws error if variable does not exist, use 'has_var' to check
+     */
     [[nodiscard]] int get_id (const std::string&) const;
 
     //! Check if a variable exists by name

--- a/Source/IO/ERF_NCInterface.cpp
+++ b/Source/IO/ERF_NCInterface.cpp
@@ -543,23 +543,18 @@ bool NCGroup::has_dim (const std::string& name) const
 
 int NCGroup::get_id (const std::string& name) const
 {
-    int temp_id;
+    int temp_id = 0;
     int ierr = nc_inq_varid (ncid, name.data(), &temp_id);
+    if (ierr == NC_ENOTVAR) {
+        amrex::Abort("NetCDF variable '" + name + "' does not exist");
+    }
     return temp_id;
 }
 
 bool NCGroup::has_var (const std::string& name) const
 {
-    int  rh_id;
-    int  ierr;
-    nc_type rh_type;
-    int rh_ndims;
-    int rh_dimids[NC_MAX_VAR_DIMS];
-    int rh_natts;
-
-    rh_id = get_id(name);
-    ierr  = nc_inq_var   (ncid, rh_id, 0, &rh_type, &rh_ndims, rh_dimids, &rh_natts);
-
+    int rh_id = 0;
+    int ierr = nc_inq_varid(ncid, name.data(), &rh_id);
     return (ierr  == NC_NOERR);
 }
 


### PR DESCRIPTION
This fixes an issue with `has_var` in the NetCDF interface where it returns true for variables that do not exist, causing a NetCDF runtime error. This occurred when `has_var` was used more than once on a file with at least one variable defined.

The original implementation of `has_var` was calling `nc_inq_varid` as `nc_inq_varid(ncid, name.data(), nullptr);` which would cause the function to return `NC_NOERR` despite a variable not existing. Specifying the third parameter causes the function to behave as expected and correctly determines if a variable exists.