### PR TITLE
Add datetime options for time control

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -381,31 +381,41 @@ Simulation Time
 List of Parameters
 ------------------
 
-+-----------------+---------------------------+--------------+---------+
-| Parameter       | Definition                | Acceptable   | Default |
-|                 |                           | Values       |         |
-+=================+===========================+==============+=========+
-| **max_step**    | maximum number of level 0 | Integer >= 0 | -1      |
-|                 | time steps                |              |         |
-+-----------------+---------------------------+--------------+---------+
-| **start_time**  | starting simulation       | Real >= 0    |  0.0    |
-|                 | time                      |              |         |
-+-----------------+---------------------------+--------------+---------+
-| **stop_time**   | final simulation          | Real >= 0    | Very    |
-|                 | time                      |              | Large   |
-+-----------------+---------------------------+--------------+---------+
++---------------------+---------------------------+--------------+---------+
+| Parameter           | Definition                | Acceptable   | Default |
+|                     |                           | Values       |         |
++=====================+===========================+==============+=========+
+| **max_step**        | maximum number of level 0 | Integer >= 0 | -1      |
+|                     | time steps                |              |         |
++---------------------+---------------------------+--------------+---------+
+| **start_time**      | starting simulation       | Real >= 0    |  0.0    |
+|                     | time                      |              |         |
++---------------------+---------------------------+--------------+---------+
+| **stop_time**       | final simulation          | Real >= 0    | Very    |
+|                     | time                      |              | Large   |
++---------------------+---------------------------+--------------+---------+
+| **start_datetime**  | starting simulation       | String       | None    |
+|                     | date/time                 | (see notes)  |         |
++---------------------+---------------------------+--------------+---------+
+| **stop_datetime**   | final simulation          | String       | None    |
+|                     | date/time                 | (see notes)  |         |
++---------------------+---------------------------+--------------+---------+
 
 .. _notes-3:
 
 Notes
 -----
 
-To control the number of time steps, you can limit by the maximum number
-of level-0 time steps (**max_step**), or the final simulation time
-(**stop_time**), or both. The code will stop at whichever criterion
-comes first. Note that if the code reaches **stop_time** then the final
-time step will be shortened so as to end exactly at **stop_time**, not
-pass it.
+- To control the number of time steps, you can limit by the maximum number
+  of level-0 time steps (**max_step**), or the final simulation time
+  (**stop_time**), or both. The code will stop at whichever criterion
+  comes first. Note that if the code reaches **stop_time** then the final
+  time step will be shortened so as to end exactly at **stop_time**, not
+  pass it.
+- For real data cases, the start and stop times is the epoch time in seconds.
+- **start_datetime** and **stop_datetime** are in UTC and use the following
+  strftime format: "%Y-%m-%d %H:%M:%S", e.g., "2001-01-01 18:00:00".
+  The start/stop datetime inputs have precedence over the time inputs.
 
 .. _examples-of-usage-4:
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -915,6 +915,8 @@ private:
     int max_step = std::numeric_limits<int>::max();
     amrex::Real start_time = 0.0;
     amrex::Real  stop_time = std::numeric_limits<amrex::Real>::max();
+    bool use_datetime = false;
+    const std::string datetime_format = "%Y-%m-%d %H:%M:%S";
 
     // if >= 0 we restart from a checkpoint
     std::string restart_chkfile = "";

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -395,8 +395,9 @@ ERF::Evolve ()
     for (int step = istep[0]; step < max_step && cur_time < stop_time; ++step)
     {
         if (use_datetime) {
-            Print() << "\n" << getTimestamp(cur_time, datetime_format)
-                    << "  (" << std::difftime(cur_time, start_time) << " s elapsed)"
+            Print() << "\n" << getTimestamp(static_cast<std::time_t>(cur_time),
+                                            datetime_format)
+                    << "  (" << cur_time-start_time << " s elapsed)"
                     << std::endl;
         }
         Print() << "\nCoarse STEP " << step+1 << " starts ..." << std::endl;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -11,6 +11,7 @@
 #include <ERF.H>
 #include <AMReX_buildInfo.H>
 #include <AMReX_Random.H>
+#include <ERF_EpochTime.H>
 #include <ERF_Utils.H>
 #include <ERF_TerrainMetrics.H>
 #include <memory>
@@ -393,6 +394,11 @@ ERF::Evolve ()
     //      for finer levels (with or without subcycling)
     for (int step = istep[0]; step < max_step && cur_time < stop_time; ++step)
     {
+        if (use_datetime) {
+            Print() << "\n" << getTimestamp(cur_time, datetime_format)
+                    << "  (" << std::difftime(cur_time, start_time) << " s elapsed)"
+                    << std::endl;
+        }
         Print() << "\nCoarse STEP " << step+1 << " starts ..." << std::endl;
 
         ComputeDt(step);
@@ -1447,9 +1453,18 @@ ERF::ReadParameters ()
     {
         ParmParse pp;  // Traditionally, max_step and stop_time do not have prefix.
         pp.query("max_step", max_step);
-        pp.query("stop_time", stop_time);
 
-        pp.query("start_time", start_time); // This is optional, it defaults to 0
+        std::string start_datetime, stop_datetime;
+        if (pp.query("start_datetime", start_datetime)) {
+            // Both start and stop datetimes must be provided
+            pp.get("stop_datetime", stop_datetime);
+            start_time = getEpochTime(start_datetime, datetime_format);
+            stop_time = getEpochTime(stop_datetime, datetime_format);
+            use_datetime = true;
+        } else {
+            pp.query("stop_time", stop_time);
+            pp.query("start_time", start_time); // This is optional, it defaults to 0
+        }
     }
 
     ParmParse pp(pp_prefix);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1458,7 +1458,7 @@ ERF::ReadParameters ()
         if (pp.query("start_datetime", start_datetime)) {
             // Both start and stop datetimes must be provided
             start_time = getEpochTime(start_datetime, datetime_format);
-            if (pp.get("stop_datetime", stop_datetime)) {
+            if (pp.query("stop_datetime", stop_datetime)) {
                 stop_time = getEpochTime(stop_datetime, datetime_format);
             }
             use_datetime = true;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1457,9 +1457,10 @@ ERF::ReadParameters ()
         std::string start_datetime, stop_datetime;
         if (pp.query("start_datetime", start_datetime)) {
             // Both start and stop datetimes must be provided
-            pp.get("stop_datetime", stop_datetime);
             start_time = getEpochTime(start_datetime, datetime_format);
-            stop_time = getEpochTime(stop_datetime, datetime_format);
+            if (pp.get("stop_datetime", stop_datetime)) {
+                stop_time = getEpochTime(stop_datetime, datetime_format);
+            }
             use_datetime = true;
         } else {
             pp.query("stop_time", stop_time);

--- a/Source/IO/ERF_NCWpsFile.H
+++ b/Source/IO/ERF_NCWpsFile.H
@@ -3,11 +3,11 @@
 
 #include <sstream>
 #include <string>
-#include <ctime>
 #include <atomic>
 
 #include "AMReX_FArrayBox.H"
 #include "AMReX_IArrayBox.H"
+#include "ERF_EpochTime.H"
 #include "ERF_NCInterface.H"
 
 using PlaneVector = amrex::Vector<amrex::FArrayBox>;
@@ -127,31 +127,6 @@ int BuildFABsFromWRFBdyFile (const std::string &fname,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_xhi,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_ylo,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_yhi);
-
-AMREX_FORCE_INLINE
-std::time_t
-getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
-{
-    // Create a stream which we will use to parse the string,
-    // which we provide to constructor of stream to fill the buffer.
-    std::istringstream ss{ dateTime };
-
-    // Create a tm object to store the parsed date and time.
-    std::tm tmTime;
-    memset(&tmTime, 0, sizeof(tmTime));
-
-    // Now we read from buffer using get_time manipulator
-    // and formatting the input appropriately.
-    strptime(dateTime.c_str(), dateTimeFormat.c_str(), &tmTime);
-
-    // Convert the tm structure to time_t value and return.
-    // Here we use timegm since the output should be relative to UTC.
-    auto epoch = timegm(&tmTime);
-    // Print() << "Time Stamp: "<< std::put_time(&tmTime, "%c")
-    //         << " , Epoch: " << epoch << std::endl;
-
-    return epoch;
-}
 
 template<typename DType>
 void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -2,23 +2,28 @@
 #define ERF_EPOCH_TIME_H_
 
 #include <string>
+#include <sstream>
+#include <iomanip>
 #include <ctime>
+
+#ifdef _WIN32
+#define timegm _mkgmtime
+#endif
 
 AMREX_FORCE_INLINE
 std::time_t
 getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
 {
+    // Create a tm object to store the parsed date and time.
+    std::tm tmTime;
+
     // Create a stream which we will use to parse the string,
     // which we provide to constructor of stream to fill the buffer.
     std::istringstream ss{ dateTime };
 
-    // Create a tm object to store the parsed date and time.
-    std::tm tmTime;
-    memset(&tmTime, 0, sizeof(tmTime));
-
     // Now we read from buffer using get_time manipulator
     // and formatting the input appropriately.
-    strptime(dateTime.c_str(), dateTimeFormat.c_str(), &tmTime);
+    ss >> std::get_time(&tmTime, dateTimeFormat.c_str());
 
     // Convert the tm structure to time_t value and return.
     // Here we use timegm since the output should be relative to UTC.

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -29,4 +29,17 @@ getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
     return epoch;
 }
 
+AMREX_FORCE_INLINE
+std::string
+getTimestamp (const std::time_t epoch, const std::string& datetime_format)
+{
+    std::tm *time_info = std::gmtime(&epoch);
+
+    char buffer[80];
+    std::strftime(buffer, sizeof(buffer), datetime_format.c_str(), time_info);
+
+    return std::string(buffer);
+}
+
+
 #endif

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -1,0 +1,32 @@
+#ifndef ERF_EPOCH_TIME_H_
+#define ERF_EPOCH_TIME_H_
+
+#include <string>
+#include <ctime>
+
+AMREX_FORCE_INLINE
+std::time_t
+getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
+{
+    // Create a stream which we will use to parse the string,
+    // which we provide to constructor of stream to fill the buffer.
+    std::istringstream ss{ dateTime };
+
+    // Create a tm object to store the parsed date and time.
+    std::tm tmTime;
+    memset(&tmTime, 0, sizeof(tmTime));
+
+    // Now we read from buffer using get_time manipulator
+    // and formatting the input appropriately.
+    strptime(dateTime.c_str(), dateTimeFormat.c_str(), &tmTime);
+
+    // Convert the tm structure to time_t value and return.
+    // Here we use timegm since the output should be relative to UTC.
+    auto epoch = timegm(&tmTime);
+    // Print() << "Time Stamp: "<< std::put_time(&tmTime, "%c")
+    //         << " , Epoch: " << epoch << std::endl;
+
+    return epoch;
+}
+
+#endif

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -9,7 +9,7 @@ CEXE_headers += ERF_Microphysics_Utils.H
 CEXE_headers += ERF_TerrainMetrics.H
 CEXE_headers += ERF_TileNoZ.H
 CEXE_headers += ERF_Utils.H
-
+CEXE_headers += ERF_EpochTime.H
 CEXE_headers += ERF_ParFunctions.H
 
 CEXE_headers += ERF_SatMethods.H


### PR DESCRIPTION
E.g.,
```
start_datetime = "2021-07-20 00:00:00"
stop_datetime  = "2021-07-21 00:00:00"
```
instead of
```
start_time  = 1626739200.0 
stop_time   = 1626825600.0
```

Specifying `start_datetime` or both (`start_datetime` and `stop_datetime`) will also trigger a timestamp print at the beginning of each coarse step.