### PR TITLE
Fixes for wrfinput path

### DIFF
--- a/Source/IO/ERF_ReadFromWRFBdy.cpp
+++ b/Source/IO/ERF_ReadFromWRFBdy.cpp
@@ -128,8 +128,6 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
 
         // Width of the boundary region
         width = arrays[0].get_vshape()[1];
-
-        AMREX_ALWAYS_ASSERT(1 <= width && width <= 5);
     }
     ParallelDescriptor::Bcast(&width,1,ioproc);
 

--- a/Source/IO/ERF_ReadFromWRFInput.cpp
+++ b/Source/IO/ERF_ReadFromWRFInput.cpp
@@ -40,16 +40,16 @@ read_from_wrfinput (int lev,
         amrex::ignore_unused(NC_dateTime); amrex::ignore_unused(NC_epochTime);
 
         // Verify the inputs geometry matches what the NETCDF file has
-        Real tol   = 1.0e-3;
+        Real rtol   = 1.0e-7;
         Real Len_x = NC_dx * Real(NC_nx-1);
         Real Len_y = NC_dy * Real(NC_ny-1);
-        if (std::fabs(Len_x - (geom.ProbHi(0) - geom.ProbLo(0))) > tol) {
+        if (std::fabs((Len_x - (geom.ProbHi(0) - geom.ProbLo(0))) / Len_x) > rtol) {
             Print() << "X problem extent " << (geom.ProbHi(0) - geom.ProbLo(0)) << " does not match NETCDF file "
                     << Len_x << "!\n";
             Print() << "dx: " << NC_dx << ' ' << "Nx: " << NC_nx-1 << "\n";
             Abort("Domain specification error");
         }
-        if (std::fabs(Len_y - (geom.ProbHi(1) - geom.ProbLo(1))) > tol) {
+        if (std::fabs((Len_y - (geom.ProbHi(1) - geom.ProbLo(1))) / Len_y) > rtol) {
             Print() << "Y problem extent " << (geom.ProbHi(1) - geom.ProbLo(1)) << " does not match NETCDF file "
                     << Len_y << "!\n";
             Print() << "dy: " << NC_dy << ' ' << "Ny: " << NC_ny-1 << "\n";


### PR DESCRIPTION
Use relative tolerance for wrfinput domain check, example:
* wrf input `dx = 33.333333333` is truncated to 33.333332 in single precision, which is what is written out in wrfinput_d01.
* An 85.5 km domain (`n_cell[0] = 2565`) will look like 85499.99658, which fails the old abs diff test.

Also, allow larger fringe regions in the wrfbdy.