### PR TITLE
Minor fixes to SAM and RRTMGP.

### DIFF
--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -151,7 +151,7 @@ public:
     NewtonIterSat (int& i, int& j, int& k,
                    const int& SAM_moisture_type,
                    const amrex::Real& fac_cond,
-                   const amrex::Real& fac_fus,
+                   const amrex::Real& /*fac_fus*/,
                    const amrex::Real& fac_sub,
                    const amrex::Real& an,
                    const amrex::Real& bn,
@@ -208,7 +208,6 @@ public:
                 // Cloud water not permitted (sublimation & fusion)
                 else if(tabs <= tbgmin) {
                     omn    = 0.0;
-                    lstarw = fac_sub;
                 }
                 // Mixed cloud phase (condensation & fusion)
                 else {

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -191,7 +191,7 @@ public:
         do {
             // Latent heats and their derivatives wrt to T
             lstarw  = fac_cond;
-            lstari  = fac_fus;
+            lstari  = fac_sub;
             domn    = 0.0;
 
             // Saturation moisture fractions

--- a/Source/SourceTerms/ERF_MakeSources.cpp
+++ b/Source/SourceTerms/ERF_MakeSources.cpp
@@ -202,7 +202,7 @@ void make_sources (int level,
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // Short-wavelength and long-wavelength radiation source terms
-                cell_src(i,j,k,RhoTheta_comp) += qheating_arr(i,j,k,0) + qheating_arr(i,j,k,1);
+                cell_src(i,j,k,RhoTheta_comp) += cell_data(i,j,k,Rho_comp) * ( qheating_arr(i,j,k,0) + qheating_arr(i,j,k,1) );
             });
         }
 


### PR DESCRIPTION
This PR addresses two issues that occur in SAM microphysics and the RRTMGP thermal source.

1. The SAM microphysics does saturation adjustment calculations that drive cloud water and cloud ice to/from the vapor. Therefore, the conversion of cloud ice to vapor is a sublimation process and we should use the heat of sublimation for lstari.

2. The thermal source computed from RRTMGP is for the time derivative of T. We convert that to a time derivative of theta_d with the exner function. However, we still need to multiply by rho when adding this as a thermal source since the transported variable is rho*theta_d.