### PR TITLE
Add the volume centroid of cut cells for staggered grids (eb_aux class).

### DIFF
--- a/Source/EB/ERF_EBAux.H
+++ b/Source/EB/ERF_EBAux.H
@@ -25,6 +25,7 @@ class eb_aux_
     void set_verbose ( ) { m_verbose = 1; }
 
     [[nodiscard]] const amrex::MultiFab& getVolFrac () const;
+    [[nodiscard]] const amrex::MultiCutFab& getVolCent () const;
     [[nodiscard]] const amrex::MultiCutFab& getBndryArea () const;
     [[nodiscard]] const amrex::MultiCutFab& getBndryCent () const;
     [[nodiscard]] const amrex::MultiCutFab& getBndryNorm () const;
@@ -42,7 +43,7 @@ class eb_aux_
 
     amrex::MultiFab* m_volfrac = nullptr;
 
-    // amrex::MultiCutFab* m_centroid = nullptr;
+    amrex::MultiCutFab* m_volcent = nullptr;
     amrex::MultiCutFab* m_bndryarea = nullptr;
     amrex::MultiCutFab* m_bndrycent = nullptr;
     amrex::MultiCutFab* m_bndrynorm = nullptr;

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -471,8 +471,19 @@ define( int const& a_idim,
 
             aux_vfrac(i,j,k) = lo_vol + hi_vol;
 
+            /* centVol() returns the coordinates based on m_rbx.
+              The coordinates in the idim direction are in [0.0,0.5] for the low cell and in [-0.5,0.0] for the hi cell.
+              Therefore, they need to be mapped to the eb_aux space, by shifting:
+              x' = x - 0.5 (low cell), x + 0.5 (hi cell) if idim = 0
+              y' = y - 0.5 (low cell), y + 0.5 (hi cell) if idim = 1
+              z' = z - 0.5 (low cell), z + 0.5 (hi cell) if idim = 2
+            */
+
             RealVect lo_vcent {lo_eb_cc.centVol()};
             RealVect hi_vcent {hi_eb_cc.centVol()};
+
+            lo_vcent[idim] = lo_vcent[idim] - 0.5;
+            hi_vcent[idim] = hi_vcent[idim] + 0.5;
 
             aux_vcent(i,j,k,0) = ( lo_vol * lo_vcent[0] + hi_vol * hi_vcent[0] ) / aux_vfrac(i,j,k);
             aux_vcent(i,j,k,1) = ( lo_vol * lo_vcent[1] + hi_vol * hi_vcent[1] ) / aux_vfrac(i,j,k);

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -40,6 +40,7 @@ define( int const& a_idim,
   }
 
   m_volfrac = new MultiFab(grids, a_dmap, 1, a_ngrow[1], MFInfo(), FArrayBoxFactory());
+  m_volcent = new MultiCutFab(grids, a_dmap, AMREX_SPACEDIM, a_ngrow[2], *m_cellflags);
 
   for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
       const BoxArray& faceba = amrex::convert(a_grids, IntVect::TheDimensionVector(idim));
@@ -50,10 +51,6 @@ define( int const& a_idim,
   m_bndryarea = new MultiCutFab(grids, a_dmap, 1, a_ngrow[2], *m_cellflags);
   m_bndrycent = new MultiCutFab(grids, a_dmap, AMREX_SPACEDIM, a_ngrow[2], *m_cellflags);
   m_bndrynorm = new MultiCutFab(grids, a_dmap, AMREX_SPACEDIM, a_ngrow[2], *m_cellflags);
-
-#if 0
-  m_centroid = new MultiCutFab(a_ba, a_dm, AMREX_SPACEDIM, m_ngrow[1], *m_cellflags);
-#endif
 
   const auto& FlagFab = a_factory->getMultiEBCellFlagFab(); // EBFArrayBoxFactory, EBDataCollection
 
@@ -69,7 +66,6 @@ define( int const& a_idim,
 
       // Array4<Real const> const& vfrac = (a_factory->getVolFrac()).const_array(mfi);
       // Array4<Real const> const& ccent = (a_factory->getCentroid()).const_array(mfi);
-
       // Array4<Real const> const& afrac = (a_factory->getAreaFrac()[a_idim])->const_array(mfi);
 
       // EB normal and face centroid
@@ -79,6 +75,7 @@ define( int const& a_idim,
       // aux quantities
       Array4<EBCellFlag> const& aux_flag  = m_cellflags->array(mfi);
       Array4<Real>       const& aux_vfrac = m_volfrac->array(mfi);
+      Array4<Real>       const& aux_vcent = m_volcent->array(mfi);
 
       Array4<Real>       const& aux_afrac_x = m_areafrac[0]->array(mfi);
       Array4<Real>       const& aux_afrac_y = m_areafrac[1]->array(mfi);
@@ -99,7 +96,7 @@ define( int const& a_idim,
                   verbose=m_verbose,
 #endif
                   dx, bx, bnorm, bcent, flag,
-                  aux_flag, aux_vfrac,
+                  aux_flag, aux_vfrac, aux_vcent,
                   aux_afrac_x, aux_afrac_y, aux_afrac_z,
                   aux_fcent_x, aux_fcent_y, aux_fcent_z,
                   aux_barea, aux_bcent, aux_bnorm,
@@ -113,6 +110,9 @@ define( int const& a_idim,
         aux_flag(i,j,k).setDisconnected();
 
         aux_vfrac(i,j,k) = 0.0;
+        aux_vcent(i,j,k,0) = 0.0;
+        aux_vcent(i,j,k,1) = 0.0;
+        aux_vcent(i,j,k,2) = 0.0;
 
         aux_afrac_x(i,j,k) = 0.0;
         aux_afrac_y(i,j,k) = 0.0;
@@ -466,7 +466,17 @@ define( int const& a_idim,
             aux_flag(i,j,k).setSingleValued();
             aux_flag(i,j,k).setConnected(vdim);
 
-            aux_vfrac(i,j,k) = lo_eb_cc.volume() + hi_eb_cc.volume();
+            Real lo_vol {lo_eb_cc.volume()};
+            Real hi_vol {hi_eb_cc.volume()};
+
+            aux_vfrac(i,j,k) = lo_vol + hi_vol;
+
+            RealVect lo_vcent {lo_eb_cc.centVol()};
+            RealVect hi_vcent {hi_eb_cc.centVol()};
+
+            aux_vcent(i,j,k,0) = ( lo_vol * lo_vcent[0] + hi_vol * hi_vcent[0] ) / aux_vfrac(i,j,k);
+            aux_vcent(i,j,k,1) = ( lo_vol * lo_vcent[1] + hi_vol * hi_vcent[1] ) / aux_vfrac(i,j,k);
+            aux_vcent(i,j,k,2) = ( lo_vol * lo_vcent[2] + hi_vol * hi_vcent[2] ) / aux_vfrac(i,j,k);
 
             Real lo_areaLo_x {lo_eb_cc.areaLo(0)};
             Real lo_areaLo_y {lo_eb_cc.areaLo(1)};
@@ -584,7 +594,6 @@ define( int const& a_idim,
             aux_bnorm(i,j,k,0) = eb_normal[0];
             aux_bnorm(i,j,k,1) = eb_normal[1];
             aux_bnorm(i,j,k,2) = eb_normal[2];
-
           }
 
         } // flag(iv_lo) and flag(iv_hi)
@@ -601,6 +610,13 @@ eb_aux_::getVolFrac () const
 {
     AMREX_ASSERT(m_volfrac != nullptr);
     return *m_volfrac;
+}
+
+const MultiCutFab&
+eb_aux_::getVolCent () const
+{
+    AMREX_ASSERT(m_volcent != nullptr);
+    return *m_volcent;
 }
 
 const MultiCutFab&

--- a/Source/EB/ERF_EBCutCell.H
+++ b/Source/EB/ERF_EBCutCell.H
@@ -54,7 +54,7 @@ class eb_cut_cell_ {
     }
 
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-    amrex::Real volume () {
+    amrex::Real volume () const {
 
       if (m_flag.isCovered() ) { return 0.; }
       if (m_flag.isRegular() ) { return m_rbox.volume(); }
@@ -140,7 +140,7 @@ class eb_cut_cell_ {
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::RealVect centBoun () const noexcept {
       amrex::RealVect cent{0.,0.,0.};
-      if (m_flag.isSingleValued()){
+      if (m_flag.isSingleValued()) {
         cent = m_F7.get_centroid();
       }
       return cent;
@@ -149,10 +149,43 @@ class eb_cut_cell_ {
     [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     amrex::RealVect normBoun () const noexcept {
       amrex::RealVect normal{0.,0.,0.};
-      if (m_flag.isSingleValued()){
+      if (m_flag.isSingleValued()) {
         normal = m_eb_normal;
       }
       return normal;
+    }
+
+    [[nodiscard]] AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    amrex::RealVect centVol () const noexcept {
+      amrex::RealVect vcent = m_cell_cent;
+      if (m_flag.isSingleValued()) {
+        amrex::Real axm = m_lo_faces[0]->area();
+        amrex::Real axp = m_hi_faces[0]->area();
+        amrex::Real aym = m_lo_faces[1]->area();
+        amrex::Real ayp = m_hi_faces[1]->area();
+        amrex::Real azm = m_lo_faces[2]->area();
+        amrex::Real azp = m_hi_faces[2]->area();
+        
+        amrex::Real dapx = (axm - axp)*(m_dx[1]*m_dx[2]);
+        amrex::Real dapy = (aym - ayp)*(m_dx[0]*m_dx[2]);
+        amrex::Real dapz = (azm - azp)*(m_dx[0]*m_dx[1]);
+
+        amrex::Real barea = m_F7.area();
+        amrex::RealVect bcent = m_F7.get_centroid();
+
+        amrex::Real vol = volume();
+
+        amrex::Real x = ( - 0.125 * (m_dx[0]  * m_dx[0] ) * dapx
+                          + 0.5   * (bcent[0] * bcent[0]) * m_eb_normal[0] * barea ) / vol;
+        amrex::Real y = ( - 0.125 * (m_dx[1]  * m_dx[1] ) * dapy
+                          + 0.5   * (bcent[1] * bcent[1]) * m_eb_normal[1] * barea ) / vol;
+        amrex::Real z = ( - 0.125 * (m_dx[2]  * m_dx[2] ) * dapz
+                          + 0.5   * (bcent[2] * bcent[2]) * m_eb_normal[2] * barea ) / vol;
+        vcent[0] = x;
+        vcent[1] = y;
+        vcent[2] = z;
+      }
+      return vcent;
     }
 
     void debug ( int const a_face = -1 );
@@ -180,6 +213,8 @@ class eb_cut_cell_ {
 
     static int constexpr m_max_faces = 6;
     amrex::Array<amrex::RealVect,m_max_faces> m_cellface_cent; // Centroids of cell faces
+    amrex::RealVect m_cell_cent; // Centroid of cell
+    amrex::RealVect m_dx;
 
     // cut face
     polygon_ m_F7;
@@ -241,6 +276,18 @@ eb_cut_cell_ ( amrex::EBCellFlag const& a_flag,
   m_cellface_cent[3] = 0.25 * ( v0 + v3 + v6 + v2 ); // F4
   m_cellface_cent[4] = 0.25 * ( v0 + v1 + v4 + v3 ); // F5
   m_cellface_cent[5] = 0.25 * ( v2 + v5 + v7 + v6 ); // F6
+
+  // Cell centroid
+
+  m_cell_cent[0] = 0.5 * ( a_rbox.lo(0) + a_rbox.hi(0) );
+  m_cell_cent[1] = 0.5 * ( a_rbox.lo(1) + a_rbox.hi(1) );
+  m_cell_cent[2] = 0.5 * ( a_rbox.lo(2) + a_rbox.hi(2) );
+
+  // Cell size
+
+  m_dx[0] = a_rbox.hi(0) - a_rbox.lo(0);
+  m_dx[1] = a_rbox.hi(1) - a_rbox.lo(1);
+  m_dx[2] = a_rbox.hi(2) - a_rbox.lo(2);
 
   if (a_flag.isCovered() ) {
 

--- a/Source/EB/ERF_EBCutCell.H
+++ b/Source/EB/ERF_EBCutCell.H
@@ -159,31 +159,28 @@ class eb_cut_cell_ {
     amrex::RealVect centVol () const noexcept {
       amrex::RealVect vcent = m_cell_cent;
       if (m_flag.isSingleValued()) {
-        amrex::Real axm = m_lo_faces[0]->area();
-        amrex::Real axp = m_hi_faces[0]->area();
-        amrex::Real aym = m_lo_faces[1]->area();
-        amrex::Real ayp = m_hi_faces[1]->area();
-        amrex::Real azm = m_lo_faces[2]->area();
-        amrex::Real azp = m_hi_faces[2]->area();
-        
-        amrex::Real dapx = (axm - axp)*(m_dx[1]*m_dx[2]);
-        amrex::Real dapy = (aym - ayp)*(m_dx[0]*m_dx[2]);
-        amrex::Real dapz = (azm - azp)*(m_dx[0]*m_dx[1]);
+        amrex::Real xm = m_rbox.lo(0);
+        amrex::Real xp = m_rbox.hi(0);
+        amrex::Real ym = m_rbox.lo(1);
+        amrex::Real yp = m_rbox.hi(1);
+        amrex::Real zm = m_rbox.lo(2);
+        amrex::Real zp = m_rbox.hi(2);
+
+        amrex::Real axm = areaLo(0);
+        amrex::Real axp = areaHi(0);
+        amrex::Real aym = areaLo(1);
+        amrex::Real ayp = areaHi(1);
+        amrex::Real azm = areaLo(2);
+        amrex::Real azp = areaHi(2);
 
         amrex::Real barea = m_F7.area();
         amrex::RealVect bcent = m_F7.get_centroid();
 
         amrex::Real vol = volume();
 
-        amrex::Real x = ( - 0.125 * (m_dx[0]  * m_dx[0] ) * dapx
-                          + 0.5   * (bcent[0] * bcent[0]) * m_eb_normal[0] * barea ) / vol;
-        amrex::Real y = ( - 0.125 * (m_dx[1]  * m_dx[1] ) * dapy
-                          + 0.5   * (bcent[1] * bcent[1]) * m_eb_normal[1] * barea ) / vol;
-        amrex::Real z = ( - 0.125 * (m_dx[2]  * m_dx[2] ) * dapz
-                          + 0.5   * (bcent[2] * bcent[2]) * m_eb_normal[2] * barea ) / vol;
-        vcent[0] = x;
-        vcent[1] = y;
-        vcent[2] = z;
+        vcent[0] = 0.5 * ( - xm * xm * axm + xp * xp * axp + bcent[0] * bcent[0] * m_eb_normal[0] * barea ) / vol;
+        vcent[1] = 0.5 * ( - ym * ym * aym + yp * yp * ayp + bcent[1] * bcent[1] * m_eb_normal[1] * barea ) / vol;
+        vcent[2] = 0.5 * ( - zm * zm * azm + zp * zp * azp + bcent[2] * bcent[2] * m_eb_normal[2] * barea ) / vol;
       }
       return vcent;
     }
@@ -259,14 +256,14 @@ eb_cut_cell_ ( amrex::EBCellFlag const& a_flag,
   m_rbox_area[1] = m_rbox.length(0)*m_rbox.length(2);
   m_rbox_area[2] = m_rbox.length(0)*m_rbox.length(1);
 
-  RealVect v0(a_rbox.lo(0), a_rbox.lo(1), a_rbox.lo(2));
-  RealVect v1(a_rbox.hi(0), a_rbox.lo(1), a_rbox.lo(2));
-  RealVect v2(a_rbox.lo(0), a_rbox.hi(1), a_rbox.lo(2));
-  RealVect v3(a_rbox.lo(0), a_rbox.lo(1), a_rbox.hi(2));
-  RealVect v4(a_rbox.hi(0), a_rbox.lo(1), a_rbox.hi(2));
-  RealVect v5(a_rbox.hi(0), a_rbox.hi(1), a_rbox.lo(2));
-  RealVect v6(a_rbox.lo(0), a_rbox.hi(1), a_rbox.hi(2));
-  RealVect v7(a_rbox.hi(0), a_rbox.hi(1), a_rbox.hi(2));
+  RealVect v0(m_rbox.lo(0), m_rbox.lo(1), m_rbox.lo(2));
+  RealVect v1(m_rbox.hi(0), m_rbox.lo(1), m_rbox.lo(2));
+  RealVect v2(m_rbox.lo(0), m_rbox.hi(1), m_rbox.lo(2));
+  RealVect v3(m_rbox.lo(0), m_rbox.lo(1), m_rbox.hi(2));
+  RealVect v4(m_rbox.hi(0), m_rbox.lo(1), m_rbox.hi(2));
+  RealVect v5(m_rbox.hi(0), m_rbox.hi(1), m_rbox.lo(2));
+  RealVect v6(m_rbox.lo(0), m_rbox.hi(1), m_rbox.hi(2));
+  RealVect v7(m_rbox.hi(0), m_rbox.hi(1), m_rbox.hi(2));
 
   // Centoids of cell faces
 
@@ -279,15 +276,15 @@ eb_cut_cell_ ( amrex::EBCellFlag const& a_flag,
 
   // Cell centroid
 
-  m_cell_cent[0] = 0.5 * ( a_rbox.lo(0) + a_rbox.hi(0) );
-  m_cell_cent[1] = 0.5 * ( a_rbox.lo(1) + a_rbox.hi(1) );
-  m_cell_cent[2] = 0.5 * ( a_rbox.lo(2) + a_rbox.hi(2) );
+  m_cell_cent[0] = 0.5 * ( m_rbox.lo(0) + m_rbox.hi(0) );
+  m_cell_cent[1] = 0.5 * ( m_rbox.lo(1) + m_rbox.hi(1) );
+  m_cell_cent[2] = 0.5 * ( m_rbox.lo(2) + m_rbox.hi(2) );
 
   // Cell size
 
-  m_dx[0] = a_rbox.hi(0) - a_rbox.lo(0);
-  m_dx[1] = a_rbox.hi(1) - a_rbox.lo(1);
-  m_dx[2] = a_rbox.hi(2) - a_rbox.lo(2);
+  m_dx[0] = m_rbox.hi(0) - m_rbox.lo(0);
+  m_dx[1] = m_rbox.hi(1) - m_rbox.lo(1);
+  m_dx[2] = m_rbox.hi(2) - m_rbox.lo(2);
 
   if (a_flag.isCovered() ) {
 


### PR DESCRIPTION
This PR adds the volume centroid to the `eb_aux` class. The volume centroid for staggered cells is calculated by combining  two `eb_cut_cell_` objects. The results were verified on multilevel grids with WitchOfAgnesi terrain. Now, all the EB data sets are available for staggered grids.