### PR TITLE
Fix nudging from input sounding when restarting

### DIFF
--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -133,6 +133,26 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
             // make_physbcs is called inside init_only
             init_only(lev, start_time);
         }
+    } else {
+        // if restarting and nudging from input sounding, load the input sounding files
+        if (lev == 0 && solverChoice.init_type == InitType::Input_Sounding && solverChoice.nudging_from_input_sounding)
+        {
+            if (input_sounding_data.input_sounding_file.empty()) {
+                Error("input_sounding file name must be provided via input");
+            }
+
+            input_sounding_data.resize_arrays();
+
+            // this will interpolate the input profiles to the nominal height levels
+            // (ranging from 0 to the domain top)
+            for (int n = 0; n < input_sounding_data.n_sounding_files; n++) {
+                input_sounding_data.read_from_file(geom[lev], zlevels_stag[lev], n);
+            }
+
+            // this will calculate the hydrostatically balanced density and pressure
+            // profiles following WRF ideal.exe
+            if (init_sounding_ideal) input_sounding_data.calc_rho_p(0);
+        }
     }
 
      // Read in tables needed for windfarm simulations


### PR DESCRIPTION
This fixes a crash that would occur if restarting a simulation with `erf.nudging_from_input_sounding = true`. The input sounding data would not be loaded on restart, causing an error when nudging in `make_sources`.

This loads the input sounding data if restarting and using `erf.nudging_from_input_sounding = true`.