### PR TITLE
Fix for `erf.terrain_smoothing=1`

### DIFF
--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -319,6 +319,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                   // Return height for max
                   return { z_arr(i,j,k0) };
                 });
+        amrex::ParallelDescriptor::ReduceRealMax(h_m);
 
         if (h_m < std::numeric_limits<Real>::epsilon()) h_m = 1e-16;
 


### PR DESCRIPTION
This fixes the sensitivity to the number of processors that was observed. The discontinuities at internal grid boundaries will distort the flow.

E.g., Witch of Agnesi mesh displacement field, 1 proc (expected result):
![WoA_nu_1proc](https://github.com/user-attachments/assets/5966373c-cf5d-4ae3-9ed0-5a3bbece281d)

\>1 proc:
![WoA_nu_10procs](https://github.com/user-attachments/assets/694f803f-72ca-41d2-857a-f7f8c5dcaccf)

\>\>1 proc:
![WoA_nu_48procs](https://github.com/user-attachments/assets/66db5f7b-a99e-4c27-bb8c-0a80a709c8ee)
