### PR TITLE
Update dirichlet_file inflow option

### DIFF
--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -107,6 +107,8 @@ vertical coordinate z. The input file is expected to contain either ``{z  u  v  
 named ``inflow_file`` that contains the variables ``{z  u  v  w}``, one would use
 the inputs below; note, that if the inflow file contains ``{z  u  v  w  theta}`` then the
 below example should be modified to ``not`` include ``xlo.theta = <val>``.
+If ``theta`` is provided, it is by default the primitive variable, not the conserved quantity
+rho*theta. To specify rho*theta instead, ``xlo.read_prim_theta = false`` should be set.
 
 ::
 

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
@@ -92,14 +92,18 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if ( (l_bc_type == ERFBCType::ext_dir) ||
                      (l_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= 0.) )
                 {
-                    if (dest_comp == RhoTheta_comp) {
-                        dest_arr(i,j,k,dest_comp) = (th_bc_ptr) ? th_bc_ptr[k] : l_bc_extdir_vals_d[bc_comp][0];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][0];
                     }
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_lo.x,j,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][0];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                    } else {
+                        dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][0];
+                    }
                 }
             },
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
@@ -113,14 +117,18 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if ( (h_bc_type == ERFBCType::ext_dir) ||
                      (h_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= 0.) )
                 {
-                    if (dest_comp == RhoTheta_comp) {
-                        dest_arr(i,j,k,dest_comp) = (th_bc_ptr) ? th_bc_ptr[k] : l_bc_extdir_vals_d[bc_comp][3];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][3];
                     }
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_hi.x,j,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][3];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                    } else {
+                        dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][3];
+                    }
                 }
             }
         );
@@ -149,14 +157,18 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if ( (l_bc_type == ERFBCType::ext_dir) ||
                      (l_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= 0.) )
                 {
-                    if (dest_comp == RhoTheta_comp) {
-                        dest_arr(i,j,k,dest_comp) = (th_bc_ptr) ? th_bc_ptr[k] : l_bc_extdir_vals_d[bc_comp][1];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][1];
                     }
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_lo.y,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][1];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                    } else {
+                        dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][1];
+                    }
                 }
             },
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
@@ -169,14 +181,18 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if ( (h_bc_type == ERFBCType::ext_dir) ||
                      (h_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= 0.) )
                 {
-                    if (dest_comp == RhoTheta_comp) {
-                        dest_arr(i,j,k,dest_comp) = (th_bc_ptr) ? th_bc_ptr[k] : l_bc_extdir_vals_d[bc_comp][4];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][4];
                     }
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_hi.y,k,Rho_comp);
-                    dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][4];
+                    if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                    } else {
+                        dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][4];
+                    }
                 }
             }
         );

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -20,10 +20,11 @@ using namespace amrex;
 void ERF::init_bcs ()
 {
     bool rho_read = false;
+    bool read_prim_theta = true;
     Vector<Real> cons_dir_init(NBCVAR_max,0.0);
     cons_dir_init[BCVars::Rho_bc_comp] = 1.0;
     cons_dir_init[BCVars::RhoTheta_bc_comp] = -1.0;
-    auto f = [this,&rho_read] (std::string const& bcid, Orientation ori)
+    auto f = [this,&rho_read,&read_prim_theta] (std::string const& bcid, Orientation ori)
     {
         // These are simply defaults for Dirichlet faces -- they should be over-written below
         m_bc_extdir_vals[BCVars::Rho_bc_comp][ori]       =  1.0;
@@ -119,6 +120,7 @@ void ERF::init_bcs ()
                 std::string dirichlet_file;
                 auto file_exists = pp.query("dirichlet_file", dirichlet_file);
                 if (file_exists) {
+                    pp.query("read_prim_theta", read_prim_theta);
                     init_Dirichlet_bc_data(dirichlet_file);
                 } else {
                     pp.getarr("velocity", v, 0, AMREX_SPACEDIM);
@@ -564,8 +566,10 @@ void ERF::init_bcs ()
                 if (side == Orientation::low) {
                     for (int i = 0; i < NBCVAR_max; i++) {
                         domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::ext_dir);
-                        if (BCVars::cons_bc+i == RhoTheta_comp && th_bc_data[0].data() != nullptr) {
-                            domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::ext_dir_prim);
+                        if ((BCVars::cons_bc+i == RhoTheta_comp) &&
+                            (th_bc_data[0].data() != nullptr))
+                        {
+                            if (read_prim_theta) domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::ext_dir_prim);
                         }
                         else if (input_bndry_planes && dir < 2 && (
                            ( (BCVars::cons_bc+i == BCVars::Rho_bc_comp)       && m_r2d->ingested_density()) ||
@@ -584,7 +588,12 @@ void ERF::init_bcs ()
                 } else {
                     for (int i = 0; i < NBCVAR_max; i++) {
                         domain_bcs_type[BCVars::cons_bc+i].setHi(dir, ERFBCType::ext_dir);
-                        if (input_bndry_planes && dir < 2 && (
+                        if ((BCVars::cons_bc+i == RhoTheta_comp) &&
+                            (th_bc_data[0].data() != nullptr))
+                        {
+                            if (read_prim_theta) domain_bcs_type[BCVars::cons_bc+i].setHi(dir, ERFBCType::ext_dir_prim);
+                        }
+                        else if (input_bndry_planes && dir < 2 && (
                            ( (BCVars::cons_bc+i == BCVars::Rho_bc_comp)       && m_r2d->ingested_density()) ||
                            ( (BCVars::cons_bc+i == BCVars::RhoTheta_bc_comp)  && m_r2d->ingested_theta()  ) ||
                            ( (BCVars::cons_bc+i == BCVars::RhoKE_bc_comp)     && m_r2d->ingested_KE()     ) ||

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -564,8 +564,10 @@ void ERF::init_bcs ()
                 if (side == Orientation::low) {
                     for (int i = 0; i < NBCVAR_max; i++) {
                         domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::ext_dir);
-                        if (BCVars::cons_bc+i == RhoTheta_comp && th_bc_data[0].data() != nullptr) { continue; }
-                        if (input_bndry_planes && dir < 2 && (
+                        if (BCVars::cons_bc+i == RhoTheta_comp && th_bc_data[0].data() != nullptr) {
+                            domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::ext_dir_prim);
+                        }
+                        else if (input_bndry_planes && dir < 2 && (
                            ( (BCVars::cons_bc+i == BCVars::Rho_bc_comp)       && m_r2d->ingested_density()) ||
                            ( (BCVars::cons_bc+i == BCVars::RhoTheta_bc_comp)  && m_r2d->ingested_theta()  ) ||
                            ( (BCVars::cons_bc+i == BCVars::RhoKE_bc_comp)     && m_r2d->ingested_KE()     ) ||

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -768,7 +768,7 @@ void ERF::init_Dirichlet_bc_data (const std::string input_file)
             v_inp[k]   = interpolate_1d(z_inp_tmp.dataPtr(), v_inp_tmp.dataPtr(), zcc_inp[k], Ninp);
             w_inp[k]   = interpolate_1d(z_inp_tmp.dataPtr(), w_inp_tmp.dataPtr(), znd_inp[k], Ninp);
             if (th_read) {
-                th_inp[k] = interpolate_1d(z_inp_tmp.dataPtr(), th_inp_tmp.dataPtr(), znd_inp[k], Ninp);
+                th_inp[k] = interpolate_1d(z_inp_tmp.dataPtr(), th_inp_tmp.dataPtr(), zcc_inp[k], Ninp);
             }
         }
         znd_inp[Nz] = ztop;


### PR DESCRIPTION
Default behavior is to be consistent with the docs -- the last column of the `dirichlet_file` is theta, not rho * theta. For backwards compatibility, an additional option is provided, `read_prim_theta` (default: true) to control whether the input profile is theta or rho*theta. 

FYI @mchurchf, this should address your inlet issue.