### PR TITLE
Multi-Level MOST w/ Region Avg.

### DIFF
--- a/Exec/ABL/inputs_ml_most
+++ b/Exec/ABL/inputs_ml_most
@@ -14,8 +14,9 @@ geometry.is_periodic = 1 1 0
 zlo.type = "Most"
 zhi.type = "SlipWall"
 
-erf.most.z0 = 100.0
-erf.most.zref = 200.0
+erf.most.average_policy = 1
+erf.most.z0   = 0.1
+erf.most.zref = 8.0
 erf.most.surf_temp = 1.1
 
 # TIME STEP CONTROL
@@ -27,8 +28,16 @@ erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
 # REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
+amr.max_level      = 1       # maximum level number allowed
+amr.ref_ratio_vect = 20 20 1
+erf.refinement_indicators = box1
 
+erf.box1.max_level = 1
+erf.box1.in_box_lo =  400 400
+erf.box1.in_box_hi =  480 480
+
+erf.coupling_type = "TwoWay"
+    
 # CHECKPOINT FILES
 erf.check_file      = chk        # root name of checkpoint file
 erf.check_int       = 100        # number of timesteps between checkpoints
@@ -60,15 +69,7 @@ prob.W_0 = 0.0
 # Higher values of perturbations lead to instability
 # Instability seems to be coming from BC
 prob.U_0_Pert_Mag = 0.08
-prob.V_0_Pert_Mag = 0.08 #
+prob.V_0_Pert_Mag = 0.08 
 prob.W_0_Pert_Mag = 0.0
 
-amr.max_level = 1
-amr.ref_ratio_vect = 20 20 1
-erf.refinement_indicators = box1
 
-erf.box1.max_level = 1
-erf.box1.in_box_lo =  400 400
-erf.box1.in_box_hi =  480 480
-
-erf.coupling_type = "OneWay"

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -1267,28 +1267,44 @@ MOSTAverage::compute_region_averages (const int& lev)
         }
     }
 
+    // NOTE: Checking periodicity with the geom structure is not
+    //       sufficient at higher levels. The BA may be contained
+    //       within the domain and it's exterior ghost cells filled
+    //       from interpolation; yet the domain BCs are periodic.
 
     // Need to fill ghost cells outside the domain if not periodic
     bool not_per_x = !(geom.periodicity().isPeriodic(0));
     bool not_per_y = !(geom.periodicity().isPeriodic(1));
-    if (not_per_x || not_per_y) {
-        Box domain = geom.Domain();
+    Box cc_bnd_bx  = (m_fields[lev][2]->boxArray()).minimalBox();
+    Box domain     = geom.Domain();
+    if (domain.contains(cc_bnd_bx) || (not_per_x || not_per_y)) {
         for (int iavg(0); iavg < m_navg; ++iavg) {
-            IndexType ixt = averages[iavg]->boxArray().ixType();
-            Box ldomain   = domain; ldomain.convert(ixt);
-            IntVect ng    = averages[iavg]->nGrowVect(); ng[2]=0;
+            IntVect ng = averages[iavg]->nGrowVect(); ng[2]=0;
+
+            // NOTE:  Level 0 spans the whole domain, but finer
+            //        levels do not have such a restriction.
+            //        For now, use the bounding box of the boxArray.
+
+            // NOTE2: The fields and averages have different indexing.
+            //        The averages are: U/V/T/Qv/Tv/Umag
+            //        The fields   are: U/V/T/Qv/Qr/W
+            //        We clip iavg at 2 since all the remaing data is CC
+
+            // Bounded box of CC data used for normalization
+            int imf = min(iavg,2);
+            Box bnd_bx = (m_fields[lev][imf]->boxArray()).minimalBox();
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi) {
                 Box gpbx = mfi.growntilebox(ng); gpbx.setSmall(2,0); gpbx.setBig(2,0);
 
-                if (ldomain.contains(gpbx)) continue;
+                if (bnd_bx.contains(gpbx)) continue;
 
                 auto ma_arr = averages[iavg]->array(mfi);
 
-                int i_lo = ldomain.smallEnd(0); int i_hi = ldomain.bigEnd(0);
-                int j_lo = ldomain.smallEnd(1); int j_hi = ldomain.bigEnd(1);
+                int i_lo = bnd_bx.smallEnd(0); int i_hi = bnd_bx.bigEnd(0);
+                int j_lo = bnd_bx.smallEnd(1); int j_hi = bnd_bx.bigEnd(1);
                 ParallelFor(gpbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
                     int li, lj;

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -1288,7 +1288,7 @@ MOSTAverage::compute_region_averages (const int& lev)
             // NOTE2: The fields and averages have different indexing.
             //        The averages are: U/V/T/Qv/Tv/Umag
             //        The fields   are: U/V/T/Qv/Qr/W
-            //        We clip iavg at 2 since all the remaing data is CC
+            //        We clip iavg at 2 since all the remaining data is CC
 
             // Bounded box of CC data used for normalization
             int imf = min(iavg,2);


### PR DESCRIPTION
This PR builds off the correction made in [PR 2035](https://github.com/erf-model/ERF/pull/2035) where the `bounding box` was used in place of `domain` for higher levels of refinement.

Here, the `bounding box` is again used for region averaging when deciding how/when to populate ghost cells. 

Also, the `inputs_ml_most` needed to be modified to allow it to run. The `zref` and `z0` were not physical and the iterations could not converge even at level 0 with plane averaging. With the new inputs, it runs with plane and regional averaging.