### PR TITLE
Implement `ReadTimeSliceFromNetCDFFile`, update time output precision

### DIFF
--- a/Exec/MoistRegTests/WPS_Test/inputs_real_ChisholmView
+++ b/Exec/MoistRegTests/WPS_Test/inputs_real_ChisholmView
@@ -1,6 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
 max_step = 1
-start_time = 1385042400.
 
 amrex.fpe_trap_invalid = 1
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -912,6 +912,12 @@ private:
     int last_check_file_step;
     int plot_file_on_restart = 1;
 
+    // Output control
+    const int datwidth = 14;
+    const int datprecision = 6;
+    const int timeprecision = 13; // e.g., 1-yr LES: 31,536,000 s with dt ~ 0.01 ==> min prec = 10
+                                  // epoch time for 2030-01-01 00:00:00 is 1,893,456,000 s with dt ~ 0.01 ==> min prec = 12
+
     ////////////////
     // runtime parameters
 
@@ -919,6 +925,7 @@ private:
     int max_step = std::numeric_limits<int>::max();
     amrex::Real start_time = 0.0;
     amrex::Real  stop_time = std::numeric_limits<amrex::Real>::max();
+
     bool use_datetime = false;
     const std::string datetime_format = "%Y-%m-%d %H:%M:%S";
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -412,8 +412,7 @@ ERF::Evolve ()
     for (int step = istep[0]; step < max_step && cur_time < stop_time; ++step)
     {
         if (use_datetime) {
-            Print() << "\n" << getTimestamp(static_cast<std::time_t>(cur_time),
-                                            datetime_format)
+            Print() << "\n" << getTimestamp(cur_time, datetime_format)
                     << "  (" << cur_time-start_time << " s elapsed)"
                     << std::endl;
         }

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -413,7 +413,7 @@ ERF::Evolve ()
     {
         if (use_datetime) {
             Print() << "\n" << getTimestamp(cur_time, datetime_format)
-                    << "  (" << cur_time-start_time << " s elapsed)"
+                    << " (" << cur_time-start_time << " s elapsed)"
                     << std::endl;
         }
         Print() << "\nCoarse STEP " << step+1 << " starts ..." << std::endl;
@@ -1407,6 +1407,15 @@ ERF::init_only (int lev, Real time)
         // The base state is initialized from WRF wrfinput data, output by
         // ideal.exe or real.exe
         init_from_wrfinput(lev);
+        if (lev==0) {
+            if ((start_time > 0) && (start_time != t_new[lev])) {
+                Print() << "Ignoring specified start_time="
+                        << std::setprecision(timeprecision) << start_time
+                        << std::endl;
+            }
+            start_time = t_new[lev];
+        }
+        use_datetime = true;
 
         // The physbc's need the terrain but are needed for initHSE
         if (!solverChoice.use_real_bcs) {

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1480,7 +1480,6 @@ ERF::ReadParameters ()
 
         std::string start_datetime, stop_datetime;
         if (pp.query("start_datetime", start_datetime)) {
-            // Both start and stop datetimes must be provided
             start_time = getEpochTime(start_datetime, datetime_format);
             if (pp.query("stop_datetime", stop_datetime)) {
                 stop_time = getEpochTime(stop_datetime, datetime_format);

--- a/Source/IO/ERF_NCInterface.H
+++ b/Source/IO/ERF_NCInterface.H
@@ -66,6 +66,9 @@ struct NCVar
     //! Shape of the array (size in each array dimension)
     [[nodiscard]] std::vector<size_t> shape () const;
 
+    //! Dimension names of the array (str in each array dimension)
+    [[nodiscard]] std::vector<std::string> dimnames () const;
+
     //! Write out the entire variable
     void put (const double*) const;
     void put (const float*) const;

--- a/Source/IO/ERF_NCInterface.cpp
+++ b/Source/IO/ERF_NCInterface.cpp
@@ -65,6 +65,27 @@ int NCVar::ndim () const
 }
 
 /**
+ * Error-checking function to get the name of each dimension from a NetCDF identity
+ */
+std::vector<std::string> NCVar::dimnames () const
+{
+    int ndims = ndim();
+    std::vector<int> dimids(ndims);
+    std::vector<std::string> vnames(ndims);
+
+    for (int i = 0; i < ndims; ++i)
+        check_nc_error(nc_inq_vardimid(ncid, varid, dimids.data()));
+
+    char buf[80];
+    for (int i = 0; i < ndims; ++i) {
+        check_nc_error(nc_inq_dimname(ncid, dimids[i], buf));
+        vnames[i] = std::string(buf);
+    }
+
+    return vnames;
+}
+
+/**
  * Error-checking function to get the length of each dimension from a NetCDF identity
  */
 std::vector<size_t> NCVar::shape () const

--- a/Source/IO/ERF_NCWpsFile.H
+++ b/Source/IO/ERF_NCWpsFile.H
@@ -128,6 +128,8 @@ int BuildFABsFromWRFBdyFile (const std::string &fname,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_ylo,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_yhi);
 
+#define NCTEST 0
+
 template<typename DType>
 void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
                      amrex::Vector<NDArray<DType> >& arrays, amrex::Vector<int>& success)
@@ -172,19 +174,29 @@ void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
 
             if (success[n] == 1) {
 
+                std::vector<std::string> dimnames = ncf.var(vname_to_read).dimnames();
+                AMREX_ALWAYS_ASSERT(dimnames[0] == "Time");
+
                 std::vector<size_t> shape = ncf.var(vname_to_read).shape();
                 arrays[n]                 = NDArray<DType>(vname_to_read,shape);
                 DType* dataPtr            = arrays[n].get_data();
 
                 std::vector<size_t> start(shape.size(), 0);
 
-                // auto numPts               = arrays[n].ndim();
-                // amrex::Print() << "NetCDF Variable name = " << vname_to_read << std::endl;
-                // amrex::Print() << "numPts read from NetCDF file/var = " << numPts << std::endl;
-                // amrex::Print()  << "Dims of the variable = (";
-                // for (auto &dim:shape)
-                //     amrex::Print() << dim << ", " ;
-                // amrex::Print()  << ")" << std::endl;
+#ifdef NCTEST
+                auto numPts               = arrays[n].ndim();
+                amrex::Print() << "NetCDF Variable name = " << vname_to_read << std::endl;
+                amrex::Print() << "numPts read from NetCDF file/var = " << numPts << std::endl;
+                amrex::Print() << "Dims in var = " << ncf.var(vname_to_read).ndim() << std::endl;
+                amrex::Print()  << "Dim names = (";
+                for (auto &dim:dimnames)
+                    amrex::Print() << dim << ", " ;
+                amrex::Print()  << ")" << std::endl;
+                amrex::Print()  << "Dims of the variable = (";
+                for (auto &dim:shape)
+                    amrex::Print() << dim << ", " ;
+                amrex::Print()  << ")" << std::endl;
+#endif
 
                 ncf.var(vname_to_read).get(dataPtr, start, shape);
 

--- a/Source/IO/ERF_NCWpsFile.H
+++ b/Source/IO/ERF_NCWpsFile.H
@@ -128,7 +128,52 @@ int BuildFABsFromWRFBdyFile (const std::string &fname,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_ylo,
                              amrex::Vector<amrex::Vector<amrex::FArrayBox>>& bdy_data_yhi);
 
-#define NCTEST 0
+template<typename DType>
+void ReadTimeSliceFromNetCDFFile(const std::string& fname,
+                                 const int tidx,
+                                 amrex::Vector<std::string> names,
+                                 amrex::Vector<NDArray<DType> >& arrays,
+                                 amrex::Vector<int>& success)
+{
+    amrex::Print() << "Reading time slice " << tidx << " from " << fname << std::endl;
+    AMREX_ASSERT(arrays.size() == names.size());
+
+    if (amrex::ParallelDescriptor::IOProcessor())
+    {
+        auto ncf = ncutils::NCFile::open(fname, NC_CLOBBER | NC_NETCDF4);
+
+        int ntimes = ncf.dim("Time").len();
+        AMREX_ALWAYS_ASSERT((tidx >= 0) && (tidx < ntimes));
+
+        for (auto n=0; n<arrays.size(); ++n)
+        {
+            std::string vname_to_write = names[n];
+            std::string vname_to_read  = names[n];
+            if (vname_to_read.substr(0,2) == "R_") {
+                vname_to_read  = names[n+4]; // This allows us to read "T" instead -- we will over-write this later
+            }
+
+            success[n] = ncf.has_var(vname_to_read);
+
+            if (success[n] == 1)
+            {
+                std::vector<std::string> dimnames = ncf.var(vname_to_read).dimnames();
+                AMREX_ALWAYS_ASSERT(dimnames[0] == "Time");
+
+                std::vector<size_t> count = ncf.var(vname_to_read).shape();
+                std::vector<size_t> start(count.size(), 0);
+                start[0] = tidx;
+                count[0] = 1;
+
+                arrays[n] = NDArray<DType>(vname_to_read, count);
+                DType* dataPtr = arrays[n].get_data();
+
+                ncf.var(vname_to_read).get(dataPtr, start, count);
+            } // has_var
+        }
+        ncf.close();
+    }
+}
 
 template<typename DType>
 void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
@@ -183,7 +228,7 @@ void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
 
                 std::vector<size_t> start(shape.size(), 0);
 
-#ifdef NCTEST
+#if 0
                 auto numPts               = arrays[n].ndim();
                 amrex::Print() << "NetCDF Variable name = " << vname_to_read << std::endl;
                 amrex::Print() << "numPts read from NetCDF file/var = " << numPts << std::endl;

--- a/Source/IO/ERF_ReadFromWRFBdy.cpp
+++ b/Source/IO/ERF_ReadFromWRFBdy.cpp
@@ -71,6 +71,7 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
         for (int nt(0); nt < ntimes; nt++) {
             std::string date(&timeStamps[nt][0], &timeStamps[nt][dateStrLen-1]+1);
             auto epochTime = getEpochTime(date, dateTimeFormat);
+            Print() << "  wrfbdy datetime " << nt << " : " << date << " " << epochTime << std::endl;
             epochTimes.push_back(epochTime);
 
             if (nt == 1) {
@@ -120,11 +121,55 @@ read_from_wrfbdy (const std::string& nc_bdy_file, const Box& domain,
     if (ParallelDescriptor::IOProcessor())
     {
         Vector<int> success(nc_var_names.size());
+
+#if 1
+        for (int itime=0; itime < ntimes; ++itime) {
+            Vector<RARRAY> tslice(nc_var_names.size());
+            ReadTimeSliceFromNetCDFFile(nc_bdy_file, itime, nc_var_names, tslice, success);
+
+            /*
+             * DEV TEST: Copy tslice into full array to verify result
+             */
+            for (int n=0; n < nc_var_names.size(); ++n) {
+                std::vector<size_t> vshape = tslice[n].get_vshape();
+                size_t offset{1};
+                for (auto &dim:vshape) offset *= dim;
+
+                Print() << "Time " << itime << " " << nc_var_names[n] << "(";
+                for (auto &dim:vshape)
+                    amrex::Print() << dim << ",";
+                Print() << ") offset=" << offset << std::endl;
+
+                if (itime==0) {
+                    // allocate full array
+                    vshape[0] = ntimes;
+                    arrays[n] = NDArray<float>(tslice[n].get_vname(), vshape);
+                }
+
+                float* fullPtr = arrays[n].get_data();
+                float* slicePtr = tslice[n].get_data();
+                std::copy(slicePtr, slicePtr+offset, fullPtr+itime*offset);
+            }
+        }
+
+        for (auto &istat:success) {
+            AMREX_ALWAYS_ASSERT(istat==1);
+        }
+
+        //for (int n=0; n < nc_var_names.size(); ++n) {
+        //    std::vector<size_t> shape = arrays[n].get_vshape();
+        //    Print() << "Read " << nc_var_names[n] << "(";
+        //    for (auto &dim:shape)
+        //        amrex::Print() << dim << ",";
+        //    Print() << ")" << std::endl;
+        //}
+#else
         ReadNetCDFFile(nc_bdy_file, nc_var_names, arrays, success);
 
         // Assert that the data has the same number of time snapshots
         int itimes = static_cast<int>(arrays[0].get_vshape()[0]);
         AMREX_ALWAYS_ASSERT(itimes == ntimes);
+#endif
 
         // Width of the boundary region
         width = arrays[0].get_vshape()[1];

--- a/Source/IO/ERF_SampleData.H
+++ b/Source/IO/ERF_SampleData.H
@@ -300,7 +300,7 @@ struct LineSampler
     void
     write_line_ascii (amrex::Vector<amrex::Real>& time)
     {
-        // same as write_1D_profiles
+        // same as definitions in ERF.H
         constexpr int datwidth = 14;
         constexpr int datprecision = 6;
         constexpr int timeprecision = 13;

--- a/Source/IO/ERF_Write1DProfiles.cpp
+++ b/Source/IO/ERF_Write1DProfiles.cpp
@@ -16,10 +16,6 @@ ERF::write_1D_profiles (Real time)
 {
     BL_PROFILE("ERF::write_1D_profiles()");
 
-    int datwidth = 14;
-    int datprecision = 6;
-    int timeprecision = 13; // e.g., 1-yr LES: 31,536,000 s with dt ~ 0.01 ==> min prec = 10
-
     if (NumDataLogs() > 1)
     {
         // Define the 1d arrays we will need

--- a/Source/IO/ERF_Write1DProfiles_stag.cpp
+++ b/Source/IO/ERF_Write1DProfiles_stag.cpp
@@ -26,10 +26,6 @@ ERF::write_1D_profiles_stag (Real time)
 {
     BL_PROFILE("ERF::write_1D_profiles()");
 
-    int datwidth = 14;
-    int datprecision = 6;
-    int timeprecision = 13; // e.g., 1-yr LES: 31,536,000 s with dt ~ 0.01 ==> min prec = 10
-
     if (NumDataLogs() > 1)
     {
         // Define the 1d arrays we will need

--- a/Source/IO/ERF_WriteScalarProfiles.cpp
+++ b/Source/IO/ERF_WriteScalarProfiles.cpp
@@ -19,10 +19,6 @@ ERF::sum_integrated_quantities (Real time)
     if (verbose <= 0)
       return;
 
-    int datwidth = 14;
-    int datprecision = 6;
-    int timeprecision = 13; // e.g., 1-yr LES: 31,536,000 s with dt ~ 0.01 ==> min prec = 10
-
     // Single level sum
     Real mass_sl;
 
@@ -107,22 +103,23 @@ ERF::sum_integrated_quantities (Real time)
         scal_ml = foo[i++];
 
         Print() << '\n';
+        Print() << "TIME= " << std::setw(datwidth) << std::setprecision(timeprecision) << std::left << time << '\n';
         if (finest_level ==  0) {
 #if 1
-           Print() << "TIME= " << time << "     MASS          = " << mass_sl << '\n';
+           Print() << " MASS       = " << mass_sl << '\n';
 #else
-           Print() << "TIME= " << time << " PERT MASS         = " << mass_sl << '\n';
+           Print() << " PERT MASS  = " << mass_sl << '\n';
 #endif
-           Print() << "TIME= " << time << " RHO THETA         = " << rhth_sl << '\n';
-           Print() << "TIME= " << time << " RHO SCALAR        = " << scal_sl << '\n';
+           Print() << " RHO THETA  = " << rhth_sl << '\n';
+           Print() << " RHO SCALAR = " << scal_sl << '\n';
         } else {
 #if 1
-           Print() << "TIME= " << time << "      MASS   SL/ML = " << mass_sl << " " << mass_ml << '\n';
+           Print() << " MASS       SL/ML = " << mass_sl << " " << mass_ml << '\n';
 #else
-           Print() << "TIME= " << time << " PERT MASS   SL/ML = " << mass_sl << " " << mass_ml << '\n';
+           Print() << " PERT MASS  SL/ML = " << mass_sl << " " << mass_ml << '\n';
 #endif
-           Print() << "TIME= " << time << " RHO THETA   SL/ML = " << rhth_sl << " " << rhth_ml << '\n';
-           Print() << "TIME= " << time << " RHO SCALAR  SL/ML = " << scal_sl << " " << scal_ml << '\n';
+           Print() << " RHO THETA  SL/ML = " << rhth_sl << " " << rhth_ml << '\n';
+           Print() << " RHO SCALAR SL/ML = " << scal_sl << " " << scal_ml << '\n';
         }
 
         // The first data log only holds scalars
@@ -174,10 +171,6 @@ ERF::sum_derived_quantities (Real time)
     if (verbose <= 0 || NumDerDataLogs() <= 0) return;
 
     int lev = 0;
-
-    int datwidth = 14;
-    int datprecision = 6;
-    int timeprecision = 13; // e.g., 1-yr LES: 31,536,000 s with dt ~ 0.01 ==> min prec = 10
 
     AMREX_ALWAYS_ASSERT(lev == 0);
 
@@ -332,8 +325,6 @@ ERF::cloud_fraction (Real /*time*/)
 void
 ERF::sample_points (int /*lev*/, Real time, IntVect cell, MultiFab& mf)
 {
-    int datwidth = 14;
-
     int ifile = 0;
 
     //
@@ -370,9 +361,6 @@ ERF::sample_points (int /*lev*/, Real time, IntVect cell, MultiFab& mf)
 void
 ERF::sample_lines (int lev, Real time, IntVect cell, MultiFab& mf)
 {
-    int datwidth = 14;
-    int datprecision = 6;
-
     int ifile = 0;
 
     const int ncomp = mf.nComp(); // cell-centered state vars

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -696,6 +696,9 @@ ERF::init_from_wrfinput (int lev)
         // Note we only have start_bdy_time if at level 0 and init_type == InitType:WRFInput
         //
         if (lev == 0) {
+            Print() << "Setting start_time to "
+                    << std::setprecision(timeprecision) << start_bdy_time
+                    << " from wrfbdy" << std::endl;
             t_new[lev] = start_bdy_time;
             t_old[lev] = start_bdy_time - 1.e200;
         } else {

--- a/Source/TimeIntegration/ERF_TI_no_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_no_substep_fun.H
@@ -17,6 +17,7 @@
         const amrex::GpuArray<int, IntVars::NumTypes> ncomp_fast = {2,1,1,1};
 
         if (verbose) amrex::Print() << " No-substepping time integration at level " << level
+                                    << std::setprecision(timeprecision)
                                     << " to " << time_for_fp
                                     << " with dt = " << slow_dt << std::endl;
 

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
@@ -24,8 +24,10 @@
         }
 
         BL_PROFILE("slow_rhs_fun_pre");
-        if (verbose) Print() << "Making slow rhs at time " << old_stage_time << " for fast variables advancing from " <<
-                                old_step_time << " to " << new_stage_time << std::endl;
+        if (verbose) Print() << std::setprecision(timeprecision)
+                             << "Making slow rhs at time " << old_stage_time
+                             << " for fast variables advancing from " << old_step_time
+                             << " to " << new_stage_time << std::endl;
 
         Real slow_dt = new_stage_time - old_step_time;
 
@@ -106,12 +108,14 @@
             make_J             (fine_geom,*z_phys_nd[level], *detJ_cc[level]);
             make_areas         (fine_geom,*z_phys_nd[level], *ax[level], *ay[level], *az[level]);
 
-            if (verbose) Print() << "Making src geometry at old_stage_time:  " << old_stage_time << std::endl;
+            if (verbose) Print() << "Making src geometry at old_stage_time:  "
+                                 << std::setprecision(timeprecision) << old_stage_time << std::endl;
             make_terrain_fitted_coords(level,fine_geom,*z_phys_nd_src[level], zlevels_stag[level], phys_bc_type);
             make_J             (fine_geom,*z_phys_nd_src[level], *detJ_cc_src[level]);
             make_areas         (fine_geom,*z_phys_nd_src[level], *ax_src[level], *ay_src[level], *az_src[level]);
 
-            if (verbose) Print() << "Making new geometry at new_stage_time: " << new_stage_time << std::endl;
+            if (verbose) Print() << "Making new geometry at new_stage_time: "
+                                 << std::setprecision(timeprecision) << new_stage_time << std::endl;
             make_terrain_fitted_coords(level,fine_geom,*z_phys_nd_new[level], zlevels_stag[level], phys_bc_type);
             make_J             (fine_geom,*z_phys_nd_new[level], *detJ_cc_new[level]);
             make_areas         (fine_geom,*z_phys_nd_new[level], *ax_new[level], *ay_new[level], *az_new[level]);
@@ -334,6 +338,7 @@
         Real slow_dt = new_stage_time - old_step_time;
 
         if (verbose) amrex::Print() << "Time integration of scalars at level " << level
+                                    << std::setprecision(timeprecision)
                                     << " from " << old_step_time << " to " << new_stage_time
                                     << " with dt = " << slow_dt
                                     << " using RHS created at " << old_stage_time << std::endl;
@@ -416,8 +421,10 @@
                                 const int nrk)
     {
         BL_PROFILE("slow_rhs_fun_inc");
-        if (verbose) Print() << "Making slow rhs at time " << old_stage_time << " for fast variables advancing from " <<
-                                old_step_time << " to " << new_stage_time << std::endl;
+        if (verbose) Print() << std::setprecision(timeprecision)
+                             << "Making slow rhs at time " << old_stage_time
+                             << " for fast variables advancing from " << old_step_time
+                             << " to " << new_stage_time << std::endl;
         //
         // Define primitive variables for all later RK stages
         // (We have already done this for the first RK step)

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -14,6 +14,7 @@ auto fast_rhs_fun = [&](int fast_step, int /*n_sub*/, int nrk,
     {
         BL_PROFILE("fast_rhs_fun");
         if (verbose) amrex::Print() << "Fast time integration at level " << level
+                                    << std::setprecision(timeprecision)
                                     << " from " << old_substep_time << " to " << new_substep_time
                                     << " with dt = " << dtau << std::endl;
 
@@ -53,12 +54,14 @@ auto fast_rhs_fun = [&](int fast_step, int /*n_sub*/, int nrk,
             // Make "old" fast geom -- store in z_phys_nd for convenience
             Box terrain_bx(surroundingNodes(Geom(0).Domain())); terrain_bx.grow(z_phys_nd[level]->nGrow());
 
-            if (verbose) Print() << "Making geometry at start of substep time: " << old_substep_time << std::endl;
+            if (verbose) Print() << "Making geometry at start of substep time: "
+                                 << std::setprecision(timeprecision) << old_substep_time << std::endl;
             FArrayBox terrain_fab_old(makeSlab(terrain_bx,2,0),1);
             prob->init_terrain_surface(fine_geom,terrain_fab_old,old_substep_time);
 
             // Make "new" fast geom
-            if (verbose) Print() << "Making geometry for end of substep time :" << new_substep_time << std::endl;
+            if (verbose) Print() << "Making geometry for end of substep time :"
+                                 << std::setprecision(timeprecision) << new_substep_time << std::endl;
             FArrayBox terrain_fab_new(makeSlab(terrain_bx,2,0),1);
             prob->init_terrain_surface(fine_geom,terrain_fab_new,new_substep_time);
 

--- a/Source/TimeIntegration/ERF_TimeStep.cpp
+++ b/Source/TimeIntegration/ERF_TimeStep.cpp
@@ -79,7 +79,8 @@ ERF::timeStep (int lev, Real time, int /*iteration*/)
 
     if (Verbose()) {
         amrex::Print() << "[Level " << lev << " step " << istep[lev]+1 << "] ";
-        amrex::Print() << "ADVANCE from time = " << t_old[lev] << " to " << t_new[lev]
+        amrex::Print() << std::setprecision(timeprecision)
+                       << "ADVANCE from time = " << t_old[lev] << " to " << t_new[lev]
                        << " with dt = " << dt[lev] << std::endl;
     }
 

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -36,14 +36,21 @@ getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
 
 AMREX_FORCE_INLINE
 std::string
-getTimestamp (const std::time_t epoch, const std::string& datetime_format)
+getTimestamp (const amrex::Real epoch_real, const std::string& datetime_format)
 {
-    std::tm *time_info = std::gmtime(&epoch);
+    auto epoch_nearest_sec = static_cast<std::time_t>(epoch_real);
+    std::tm *time_info = std::gmtime(&epoch_nearest_sec);
 
     char buffer[80];
     std::strftime(buffer, sizeof(buffer), datetime_format.c_str(), time_info);
+    std::string str_nearest_sec(buffer);
 
-    return std::string(buffer);
+    double frac_sec = epoch_real - epoch_nearest_sec;
+    sprintf(buffer, "%.6f", frac_sec);
+    AMREX_ASSERT(buffer[0] == '0');
+    std::string str_frac_sec(buffer);
+
+    return str_nearest_sec + str_frac_sec.substr(1);
 }
 
 

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -46,7 +46,7 @@ getTimestamp (const amrex::Real epoch_real, const std::string& datetime_format)
     std::string str_nearest_sec(buffer);
 
     double frac_sec = epoch_real - epoch_nearest_sec;
-    sprintf(buffer, "%.6f", frac_sec);
+    snprintf(buffer, 80, "%.6f", frac_sec);
     AMREX_ASSERT(buffer[0] == '0');
     std::string str_frac_sec(buffer);
 


### PR DESCRIPTION
Verified with the WPS_Test case that calling`ReadTimeSliceFromNetCDFFile` for all time indices in the wrfbdy file gives identical results as the original `ReadFromNetCDFFile` code after running 10 steps.  https://github.com/ewquon/ERF/blob/7cbba65d2c46e896cb57d93d326c0195fe5aef5d/Source/IO/ERF_ReadFromWRFBdy.cpp#L125-L165

Note: This dev test only verifies that the the first two timeslices were correctly input but I believe the implementation is general.