### PR TITLE
Allow satadj to run with wrfinput.

### DIFF
--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -244,6 +244,10 @@ ERF::init_from_wrfinput (int lev)
                     mult_rho = true;
                     icomp    = RhoQ3_comp;
                     if (n_qstate > 3) { icomp = RhoQ4_comp; }
+                    if (n_qstate < 3) {
+                        var_fab.clear();
+                        continue;
+                    }
                   }
 
                   if (success) {


### PR DESCRIPTION
Cycle `qrain` if it doesn't exist in the dycore vars. This allows `satadj` to run with wrfinput. This is useful for debugging the hurrican henri case.