### PR TITLE
Fix Ekman Regtest

### DIFF
--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -244,10 +244,7 @@ ERF::init_from_wrfinput (int lev)
                     mult_rho = true;
                     icomp    = RhoQ3_comp;
                     if (n_qstate > 3) { icomp = RhoQ4_comp; }
-                    if (n_qstate < 3) {
-                        var_fab.clear();
-                        continue;
-                    }
+                    if (n_qstate < 3) { success = 0; }
                   }
 
                   if (success) {
@@ -438,6 +435,11 @@ ERF::init_from_wrfinput (int lev)
 
           // Initialize MapFac U
           if ( var_name == "MAPFAC_U" ) {
+              Real max_val = var_fab.template max<RunOn::Device>();
+              if (std::fabs(max_val) < std::numeric_limits<Real>::epsilon()) {
+                  Print() << "MAPFAC_U cannot be 0, resetting to 1!\n";
+                  var_fab.template setVal<RunOn::Device>(1.0);
+              }
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -451,6 +453,11 @@ ERF::init_from_wrfinput (int lev)
 
           // Initialize MapFac V
           if ( var_name == "MAPFAC_V" ) {
+              Real max_val = var_fab.template max<RunOn::Device>();
+              if (std::fabs(max_val) < std::numeric_limits<Real>::epsilon()) {
+                  Print() << "MAPFAC_V cannot be 0, resetting to 1!\n";
+                  var_fab.template setVal<RunOn::Device>(1.0);
+              }
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -464,6 +471,11 @@ ERF::init_from_wrfinput (int lev)
 
           // Initialize MapFac M
           if ( var_name == "MAPFAC_M" ) {
+              Real max_val = var_fab.template max<RunOn::Device>();
+              if (std::fabs(max_val) < std::numeric_limits<Real>::epsilon()) {
+                  Print() << "MAPFAC_M cannot be 0, resetting to 1!\n";
+                  var_fab.template setVal<RunOn::Device>(1.0);
+              }
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif


### PR DESCRIPTION
The change to how we read `mapfac` caused an issue with the Ekman Spiral case. The wrfinput file has `0` for `MAPFAC_M` but `1` for `MAPFAC_MY`. This PR checks if the mapfac maxval is 0 and if it is then it runs a setVal(1.) since we cannot divide by 0 to get the true velocity.