### PR TITLE
Fix Issue 2206 Pt2

### DIFF
--- a/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
+++ b/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
@@ -11,7 +11,7 @@ void
 ERF::FillBdyCCVels (Vector<MultiFab>& mf_cc_vel, int levc)
 {
     // Impose bc's at domain boundaries
-    for (int ilev(0); ilev < mf_cc_vel.size(); ++lev)
+    for (int ilev(0); ilev < mf_cc_vel.size(); ++ilev)
     {
         int lev = ilev + levc;
         Box domain(Geom(lev).Domain());

--- a/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
+++ b/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
@@ -11,10 +11,9 @@ void
 ERF::FillBdyCCVels (Vector<MultiFab>& mf_cc_vel, int levc)
 {
     // Impose bc's at domain boundaries
-    int lev_start = std::max(0,levc);
-    int lev_end   = mf_cc_vel.size();
-    for (int lev(lev_start); lev < lev_end; ++lev)
+    for (int ilev(0); ilev < mf_cc_vel.size(); ++lev)
     {
+        int lev = ilev + levc;
         Box domain(Geom(lev).Domain());
 
         int ihi = domain.bigEnd(0);

--- a/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
+++ b/Source/BoundaryConditions/ERF_FillBdyCCVels.cpp
@@ -8,10 +8,12 @@
 using namespace amrex;
 
 void
-ERF::FillBdyCCVels (Vector<MultiFab>& mf_cc_vel)
+ERF::FillBdyCCVels (Vector<MultiFab>& mf_cc_vel, int levc)
 {
     // Impose bc's at domain boundaries
-    for (int lev = 0; lev <= finest_level; ++lev)
+    int lev_start = std::max(0,levc);
+    int lev_end   = mf_cc_vel.size();
+    for (int lev(lev_start); lev < lev_end; ++lev)
     {
         Box domain(Geom(lev).Domain());
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -214,7 +214,7 @@ public:
     amrex::Real cloud_fraction (amrex::Real time);
 
     // Fill the physical boundary conditions for cell-centered velocity (diagnostic only)
-    void FillBdyCCVels (amrex::Vector<amrex::MultiFab>& mf_cc_vel);
+    void FillBdyCCVels (amrex::Vector<amrex::MultiFab>& mf_cc_vel, int levc=-1);
 
     void sample_points (int lev, amrex::Real time, amrex::IntVect cell, amrex::MultiFab& mf);
     void sample_lines (int lev, amrex::Real time, amrex::IntVect cell, amrex::MultiFab& mf);

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -214,7 +214,7 @@ public:
     amrex::Real cloud_fraction (amrex::Real time);
 
     // Fill the physical boundary conditions for cell-centered velocity (diagnostic only)
-    void FillBdyCCVels (amrex::Vector<amrex::MultiFab>& mf_cc_vel, int levc=-1);
+    void FillBdyCCVels (amrex::Vector<amrex::MultiFab>& mf_cc_vel, int levc=0);
 
     void sample_points (int lev, amrex::Real time, amrex::IntVect cell, amrex::MultiFab& mf);
     void sample_lines (int lev, amrex::Real time, amrex::IntVect cell, amrex::MultiFab& mf);

--- a/Source/ERF_Tagging.cpp
+++ b/Source/ERF_Tagging.cpp
@@ -66,7 +66,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
             average_face_to_cellcenter(mf_cc_vel[0],0,Array<const MultiFab*,3>{&U_new, &V_new, &W_new});
 
             // Impose bc's at domain boundaries at all levels
-            FillBdyCCVels(mf_cc_vel);
+            FillBdyCCVels(mf_cc_vel,levc);
 
             mf->setVal(0.);
 


### PR DESCRIPTION
This PR addresses the vector out of bounds access raised in [Issue 2206](https://github.com/erf-model/ERF/issues/2206#issuecomment-2743346709). The root cause of the issue is that `ERF_Tagging` operates per level and thus the vector `mf_cc_vels` has 1 element for the current level. However, the called function `FillBdyCCVels` expects that the vector of MFs to be of size `finest_level`. Therefore, we create an optional argument that allows us to modify the bounds of the outer for loop; this allows `FillBdyCCVels` to be called per level or for all levels. 