### PR TITLE
Clean up Qmoist

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -772,7 +772,7 @@ private:
     amrex::Vector<amrex::MultiFab> zmom_crse_rhs;
 
     std::unique_ptr<Microphysics> micro;
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>> qmoist; // (lev,ncomp) This has up to 8 components: qt, qv, qc, qi, qp, qr, qs, qg
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>> qmoist; // (lev,ncomp) rain_accum, snow_accum, graup_accum
 
     // Variables for wind farm parametrization models
 

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -161,16 +161,16 @@ ERF::WriteCheckpointFile () const
 
         // We must read and write qmoist with ghost cells because we don't directly impose BCs on these vars
         // Write the moisture model restart variables
-        std::vector<int> qmoist_indices(0);
-        std::vector<std::string> qmoist_names(0);
+        std::vector<int> qmoist_indices;
+        std::vector<std::string> qmoist_names;
         micro->Get_Qmoist_Restart_Vars(lev, solverChoice, qmoist_indices, qmoist_names);
         int qmoist_nvar = qmoist_indices.size();
         for (int var = 0; var < qmoist_nvar; var++) {
-           IntVect ng_moist = qmoist[lev][qmoist_indices[var]]->nGrowVect();
-           const int ncomp = 1;
-           MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng_moist);
-           MultiFab::Copy(moist_vars,*(qmoist[lev][qmoist_indices[var]]),0,0,ncomp,ng_moist);
-           VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", qmoist_names[var]));
+            const int ncomp  = 1;
+            IntVect ng_moist = qmoist[lev][qmoist_indices[var]]->nGrowVect();
+            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng_moist);
+            MultiFab::Copy(moist_vars,*(qmoist[lev][qmoist_indices[var]]),0,0,ncomp,ng_moist);
+            VisMF::Write(moist_vars, amrex::MultiFabFileFullPrefix(lev, checkpointname, "Level_", qmoist_names[var]));
         }
 
 #if defined(ERF_USE_WINDFARM)
@@ -517,16 +517,16 @@ ERF::ReadCheckpointFile ()
         }
 
         // Read in the moisture model restart variables
-        std::vector<int> qmoist_indices(0);
-        std::vector<std::string> qmoist_names(0);
+        std::vector<int> qmoist_indices;
+        std::vector<std::string> qmoist_names;
         micro->Get_Qmoist_Restart_Vars(lev, solverChoice, qmoist_indices, qmoist_names);
         int qmoist_nvar = qmoist_indices.size();
         for (int var = 0; var < qmoist_nvar; var++) {
+            const int ncomp  = 1;
             IntVect ng_moist = qmoist[lev][qmoist_indices[var]]->nGrowVect();
-            const int ncomp_moist = 1;
-            MultiFab moist_vars(grids[lev],dmap[lev],ncomp_moist,ng_moist);
+            MultiFab moist_vars(grids[lev],dmap[lev],ncomp,ng_moist);
             VisMF::Read(moist_vars, amrex::MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", qmoist_names[var]));
-            MultiFab::Copy(*(qmoist[lev][qmoist_indices[var]]),moist_vars,0,0,ncomp_moist,ng_moist);
+            MultiFab::Copy(*(qmoist[lev][qmoist_indices[var]]),moist_vars,0,0,ncomp,ng_moist);
         }
 
 #if defined(ERF_USE_WINDFARM)

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1159,7 +1159,7 @@ ERF::WritePlotFile (int which, PlotFileType plotfile_type, Vector<std::string> p
             if(solverChoice.moisture_type == MoistureType::Kessler){
                 if (containerHasElement(plot_var_names, "rain_accum"))
                 {
-                    MultiFab::Copy(mf[lev],*(qmoist[lev][4]),0,mf_comp,1,0);
+                    MultiFab::Copy(mf[lev],*(qmoist[lev][0]),0,mf_comp,1,0);
                     mf_comp += 1;
                 }
             }
@@ -1167,17 +1167,17 @@ ERF::WritePlotFile (int which, PlotFileType plotfile_type, Vector<std::string> p
             {
                 if (containerHasElement(plot_var_names, "rain_accum"))
                 {
-                    MultiFab::Copy(mf[lev],*(qmoist[lev][8]),0,mf_comp,1,0);
+                    MultiFab::Copy(mf[lev],*(qmoist[lev][0]),0,mf_comp,1,0);
                     mf_comp += 1;
                 }
                 if (containerHasElement(plot_var_names, "snow_accum"))
                 {
-                    MultiFab::Copy(mf[lev],*(qmoist[lev][9]),0,mf_comp,1,0);
+                    MultiFab::Copy(mf[lev],*(qmoist[lev][1]),0,mf_comp,1,0);
                     mf_comp += 1;
                 }
                 if (containerHasElement(plot_var_names, "graup_accum"))
                 {
-                    MultiFab::Copy(mf[lev],*(qmoist[lev][10]),0,mf_comp,1,0);
+                    MultiFab::Copy(mf[lev],*(qmoist[lev][2]),0,mf_comp,1,0);
                     mf_comp += 1;
                 }
             }

--- a/Source/Microphysics/Kessler/ERF_InitKessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_InitKessler.cpp
@@ -34,7 +34,7 @@ void Kessler::Init (const MultiFab& cons_in,
     m_detJ_cc   = detJ_cc.get();
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_Kess::qt, MicVar_Kess::qv, MicVar_Kess::qcl, MicVar_Kess::qp, MicVar_Kess::rain_accum};
+    MicVarMap = {MicVar_Kess::rain_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Kess::NumVars; ++ivar) {

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -115,20 +115,20 @@ public:
     Qstate_Size () override { return Kessler::m_qstate_size; }
 
     void
-    Qmoist_Restart_Vars (const SolverChoice& a_sc,
+    Qmoist_Restart_Vars (const SolverChoice& /*a_sc*/,
                          std::vector<int>& a_idx,
                          std::vector<std::string>& a_names) const override
     {
         a_idx.clear();
         a_names.clear();
-        if (a_sc.moisture_type == MoistureType::Kessler) {
-            a_idx.push_back(4); a_names.push_back("RainAccum");
-        }
+
+        // NOTE: These are the indices to access into qmoist (not mic_fab_vars)
+        a_idx.push_back(0); a_names.push_back("RainAccum");
     }
 
 private:
-    // Number of qmoist variables (qt, qv, qcl, qp)
-    int m_qmoist_size = 5;
+    // Number of qmoist variables (rain_accum)
+    int m_qmoist_size = 1;
 
     // Number of qstate variables
     int m_qstate_size = 3;

--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -28,7 +28,7 @@ Morrison::Init (const MultiFab& cons_in,
 {
     amrex::Abort("Morrison not actually implemented yet; this is SAM");
 
-    dt = dt_advance;
+    dt     = dt_advance;
     m_geom = geom;
     m_gtoe = grids;
 
@@ -36,8 +36,7 @@ Morrison::Init (const MultiFab& cons_in,
     m_detJ_cc   = detJ_cc.get();
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_Morr::qt, MicVar_Morr::qv , MicVar_Morr::qcl, MicVar_Morr::qci,
-                 MicVar_Morr::qp, MicVar_Morr::qpr, MicVar_Morr::qps, MicVar_Morr::qpg, MicVar_Morr::rain_accum, MicVar_Morr::snow_accum, MicVar_Morr::graup_accum};
+    MicVarMap = {MicVar_Morr::rain_accum, MicVar_Morr::snow_accum, MicVar_Morr::graup_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_Morr::NumVars; ++ivar) {

--- a/Source/Microphysics/Morrison/ERF_Morrison.H
+++ b/Source/Microphysics/Morrison/ERF_Morrison.H
@@ -258,14 +258,16 @@ public:
     {
         a_idx.clear();
         a_names.clear();
-        a_idx.push_back( 8); a_names.push_back("RainAccum");
-        a_idx.push_back( 9); a_names.push_back("SnowAccum");
-        a_idx.push_back(10); a_names.push_back("GraupAccum");
+
+        // NOTE: These are the indices to access into qmoist (not mic_fab_vars)
+        a_idx.push_back(0); a_names.push_back("RainAccum");
+        a_idx.push_back(1); a_names.push_back("SnowAccum");
+        a_idx.push_back(2); a_names.push_back("GraupAccum");
     }
 
 private:
-    // Number of qmoist variables (qt, qv, qcl, qci, qp, qpr, qps, qpg)
-    int m_qmoist_size = 11;
+    // Number of qmoist variables (rain_accum, snow_accum, graup_accum)
+    int m_qmoist_size = 3;
 
     // Number of qstate variables
     int m_qstate_size = 6;

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -66,7 +66,7 @@ public:
     }
 
 private:
-    int m_qmoist_size = 1;
+    int m_qmoist_size = 0;
     int m_qstate_size = 0;
 };
 

--- a/Source/Microphysics/SAM/ERF_InitSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_InitSAM.cpp
@@ -34,8 +34,7 @@ SAM::Init (const MultiFab& cons_in,
     m_detJ_cc   = detJ_cc.get();
 
     MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar::qt, MicVar::qv , MicVar::qcl, MicVar::qci,
-                 MicVar::qp, MicVar::qpr, MicVar::qps, MicVar::qpg, MicVar::rain_accum, MicVar::snow_accum, MicVar::graup_accum};
+    MicVarMap = {MicVar::rain_accum, MicVar::snow_accum, MicVar::graup_accum};
 
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar::NumVars; ++ivar) {

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -46,7 +46,6 @@ namespace MicVar {
       rain_accum,
       snow_accum,
       graup_accum,
-      omega,
       NumVars
   };
 }
@@ -261,24 +260,22 @@ public:
     }
 
     void
-    Qmoist_Restart_Vars (const SolverChoice& a_sc,
+    Qmoist_Restart_Vars (const SolverChoice& /*a_sc*/,
                          std::vector<int>& a_idx,
                          std::vector<std::string>& a_names) const override
     {
         a_idx.clear();
         a_names.clear();
-        if (a_sc.moisture_type == MoistureType::SAM) {
-            a_idx.push_back( 8); a_names.push_back("RainAccum");
-            a_idx.push_back( 9); a_names.push_back("SnowAccum");
-            a_idx.push_back(10); a_names.push_back("GraupAccum");
-        } else if (a_sc.moisture_type == MoistureType::SAM_NoIce) {
-            a_idx.push_back( 8); a_names.push_back("RainAccum");
-        }
+
+        // NOTE: These are the indices to access into qmoist (not mic_fab_vars)
+        a_idx.push_back(0); a_names.push_back("RainAccum");
+        a_idx.push_back(1); a_names.push_back("SnowAccum");
+        a_idx.push_back(2); a_names.push_back("GraupAccum");
     }
 
 private:
-    // Number of qmoist variables (qt, qv, qcl, qci, qp, qpr, qps, qpg)
-    int m_qmoist_size = 11;
+    // Number of qmoist variables (rain_accum, snow_accum, graup_accum)
+    int m_qmoist_size = 3;
 
     // Number of qstate variables
     int m_qstate_size = 6;

--- a/Source/Microphysics/SatAdj/ERF_InitSatAdj.cpp
+++ b/Source/Microphysics/SatAdj/ERF_InitSatAdj.cpp
@@ -24,9 +24,6 @@ void SatAdj::Init (const MultiFab& cons_in,
     dt = dt_advance;
     m_geom = geom;
 
-    MicVarMap.resize(m_qmoist_size);
-    MicVarMap = {MicVar_SatAdj::qv, MicVar_SatAdj::qc};
-
     // initialize microphysics variables
     for (auto ivar = 0; ivar < MicVar_SatAdj::NumVars; ++ivar) {
         mic_fab_vars[ivar] = std::make_shared<MultiFab>(cons_in.boxArray(), cons_in.DistributionMap(),

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.H
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.H
@@ -105,7 +105,7 @@ public:
     Qmoist_Ptr (const int& varIdx) override
     {
         AMREX_ALWAYS_ASSERT(varIdx < m_qmoist_size);
-        return mic_fab_vars[MicVarMap[varIdx]].get();
+        return nullptr;
     }
 
     int
@@ -189,14 +189,11 @@ public:
     }
 
 private:
-    // Number of qmoist variables (qv, qc)
-    int m_qmoist_size = 2;
+    // Number of qmoist variables (no precipitating comps to accumulate)
+    int m_qmoist_size = 0;
 
     // Number of qstate variables
     int m_qstate_size = 2;
-
-    // MicVar map (Qmoist indices -> MicVar enum)
-    amrex::Vector<int> MicVarMap;
 
     // geometry
     amrex::Geometry m_geom;


### PR DESCRIPTION
`Qmoist` was previously a holder for moisture variables. Since we now transport each component, linear combinations of the moisture variables (e.g., `qt, qn, qp`) are computed from the dycore variables. Therefore, the only variables the dycore may need to access are those  that are derived from the state variables (e.g., `rain_accum, snow_accum, graup_accum`). This PR cleans up `qmoist` to only encompass the variables that need access, and by extension, cleans up the `micvar_map`.

This PR was tested for restart/plotting capabilities on the moist bubble with Kessler microphysics. 