### PR TITLE
Fix getEpochTime error on GPUs

### DIFF
--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -14,6 +14,7 @@ AMREX_FORCE_INLINE
 std::time_t getEpochTime(const std::string& dateTime, const std::string& dateTimeFormat) {
     std::tm tmTime{};
 
+    (void)dateTimeFormat;
     // Manually parse the date string
     if (sscanf(dateTime.c_str(), "%d-%d-%d_%d:%d:%dUTC",
                &tmTime.tm_year, &tmTime.tm_mon, &tmTime.tm_mday,

--- a/Source/Utils/ERF_EpochTime.H
+++ b/Source/Utils/ERF_EpochTime.H
@@ -11,27 +11,22 @@
 #endif
 
 AMREX_FORCE_INLINE
-std::time_t
-getEpochTime (const std::string& dateTime, const std::string& dateTimeFormat)
-{
-    // Create a tm object to store the parsed date and time.
-    std::tm tmTime;
+std::time_t getEpochTime(const std::string& dateTime, const std::string& dateTimeFormat) {
+    std::tm tmTime{};
 
-    // Create a stream which we will use to parse the string,
-    // which we provide to constructor of stream to fill the buffer.
-    std::istringstream ss{ dateTime };
+    // Manually parse the date string
+    if (sscanf(dateTime.c_str(), "%d-%d-%d_%d:%d:%dUTC",
+               &tmTime.tm_year, &tmTime.tm_mon, &tmTime.tm_mday,
+               &tmTime.tm_hour, &tmTime.tm_min, &tmTime.tm_sec) != 6) {
+        return -1; // Indicate failure if parsing fails
+    }
 
-    // Now we read from buffer using get_time manipulator
-    // and formatting the input appropriately.
-    ss >> std::get_time(&tmTime, dateTimeFormat.c_str());
+    // Adjust year and month for tm structure
+    tmTime.tm_year -= 1900; // tm_year is years since 1900
+    tmTime.tm_mon -= 1;     // tm_mon is zero-based
 
-    // Convert the tm structure to time_t value and return.
-    // Here we use timegm since the output should be relative to UTC.
-    auto epoch = timegm(&tmTime);
-    // Print() << "Time Stamp: "<< std::put_time(&tmTime, "%c")
-    //         << " , Epoch: " << epoch << std::endl;
-
-    return epoch;
+    // Convert to epoch time (UTC)
+    return timegm(&tmTime);
 }
 
 AMREX_FORCE_INLINE


### PR DESCRIPTION
This PR fixes a segfault with `getEpochTime` when running on GPUs. Although, it gets called only on the host, the `std::get_time` has issues with `nvcc` compiler. This new version of the routine just uses C-style `sscanf` and works both on CPUs and GPUs.