### PR TITLE
Total Mass and Energy Data Log

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -214,6 +214,7 @@ public:
     // Diagnostics
     void sum_integrated_quantities (amrex::Real time);
     void sum_derived_quantities (amrex::Real time);
+    void sum_energy_quantities (amrex::Real time);
 
     void write_1D_profiles (amrex::Real time);
     void write_1D_profiles_stag (amrex::Real time);
@@ -1374,6 +1375,19 @@ private:
         amrex::ParallelDescriptor::Barrier("ERF::setRecordDerDataInfo");
     }
 
+    void setRecordEnergyDataInfo (int i, const std::string& filename) // NOLINT
+    {
+        if (amrex::ParallelDescriptor::IOProcessor())
+        {
+            energy_datalog[i] = std::make_unique<std::fstream>();
+            energy_datalog[i]->open(filename.c_str(),std::ios::out|std::ios::app);
+            if (!energy_datalog[i]->good()) {
+                amrex::FileOpenFailed(filename);
+            }
+        }
+        amrex::ParallelDescriptor::Barrier("ERF::setRecordDerDataInfo");
+    }
+
     void setRecordSamplePointInfo (int i, int lev, amrex::IntVect& cell, const std::string& filename) // NOLINT
     {
         amrex::MultiFab dummy(grids[lev],dmap[lev],1,0);
@@ -1413,10 +1427,12 @@ private:
     amrex::Real sampler_per = -1.0;
     std::unique_ptr<SampleData> data_sampler = nullptr;
 
-    amrex::Vector<std::unique_ptr<std::fstream> > datalog;
-    amrex::Vector<std::unique_ptr<std::fstream> > der_datalog;
-    amrex::Vector<std::string>     datalogname;
-    amrex::Vector<std::string> der_datalogname;
+    amrex::Vector<std::unique_ptr<std::fstream> >        datalog;
+    amrex::Vector<std::unique_ptr<std::fstream> >    der_datalog;
+    amrex::Vector<std::unique_ptr<std::fstream> > energy_datalog;
+    amrex::Vector<std::string>        datalogname;
+    amrex::Vector<std::string>    der_datalogname;
+    amrex::Vector<std::string> energy_datalogname;
 
     amrex::Vector<std::unique_ptr<std::fstream> > sampleptlog;
     amrex::Vector<std::string> sampleptlogname;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -568,6 +568,7 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
     if (is_it_time_for_action(nstep, time, dt_lev0, sum_interval, sum_per)) {
         sum_integrated_quantities(time);
         sum_derived_quantities(time);
+        sum_energy_quantities(time);
     }
 
     if (solverChoice.pert_type == PerturbationType::Source ||
@@ -1178,8 +1179,9 @@ ERF::InitData_post ()
         datalog.resize(num_datalogs);
         datalogname.resize(num_datalogs);
         pp.queryarr("data_log",datalogname,0,num_datalogs);
-        for (int i = 0; i < num_datalogs; i++)
+        for (int i = 0; i < num_datalogs; i++) {
             setRecordDataInfo(i,datalogname[i]);
+        }
     }
 
     if (pp.contains("der_data_log"))
@@ -1188,8 +1190,20 @@ ERF::InitData_post ()
         der_datalog.resize(num_der_datalogs);
         der_datalogname.resize(num_der_datalogs);
         pp.queryarr("der_data_log",der_datalogname,0,num_der_datalogs);
-        for (int i = 0; i < num_der_datalogs; i++)
+        for (int i = 0; i < num_der_datalogs; i++) {
             setRecordDerDataInfo(i,der_datalogname[i]);
+        }
+    }
+
+    if (pp.contains("energy_data_log"))
+    {
+        int num_energy_datalogs = pp.countval("energy_data_log");
+        energy_datalog.resize(num_energy_datalogs);
+        energy_datalogname.resize(num_energy_datalogs);
+        pp.queryarr("energy_data_log",energy_datalogname,0,num_energy_datalogs);
+        for (int i = 0; i < num_energy_datalogs; i++) {
+            setRecordEnergyDataInfo(i,energy_datalogname[i]);
+        }
     }
 
 
@@ -1266,6 +1280,7 @@ ERF::InitData_post ()
     if (is_it_time_for_action(istep[0], t_new[0], dt[0], sum_interval, sum_per)) {
         sum_integrated_quantities(t_new[0]);
         sum_derived_quantities(t_new[0]);
+        sum_energy_quantities(t_new[0]);
     }
 
     // Create object to do line and plane sampling if needed

--- a/Source/IO/ERF_WriteScalarProfiles.cpp
+++ b/Source/IO/ERF_WriteScalarProfiles.cpp
@@ -221,7 +221,17 @@ ERF::sum_derived_quantities (Real time)
     Real  r_wted_avg = volWgtSumMF(lev, r_wted_magvelsq, 0, *mapfac_m[lev],false);
     Real enstrsq_avg = volWgtSumMF(lev, enstrophysq,     0, *mapfac_m[lev],false);
 
-    Real vol = geom[lev].ProbDomain().volume(); // Volume of the domain;
+    // Get volume including terrain (consistent with volWgtSumMF routine)
+    Real vol = geom[lev].ProbDomain().volume();
+    if (SolverChoice::mesh_type != MeshType::ConstantDz) {
+        MultiFab volume(grids[lev], dmap[lev], 1, 0);
+        auto const& dx = geom[lev].CellSizeArray();
+        Real cell_vol  = dx[0]*dx[1]*dx[2];
+        volume.setVal(cell_vol);
+        MultiFab::Multiply(volume, *detJ_cc[lev], 0, 0, 1, 0);
+        vol = volume.sum();
+    }
+
      unwted_avg /= vol;
      r_wted_avg /= vol;
     enstrsq_avg /= vol;
@@ -254,6 +264,126 @@ ERF::sum_derived_quantities (Real time)
         data_log_der << std::setw(datwidth) << std::setprecision(datprecision)  <<  r_wted_avg;
         data_log_der << std::setw(datwidth) << std::setprecision(datprecision)  << enstrsq_avg;
         data_log_der << std::endl;
+
+      } // if IOProcessor
+#ifdef AMREX_LAZY
+    }
+#endif
+}
+
+void
+ERF::sum_energy_quantities (Real time)
+{
+    if ( (verbose <= 0) || (energy_datalog.size() <= 0) ) { return; }
+
+    int lev = 0;
+
+    AMREX_ALWAYS_ASSERT(lev == 0);
+
+    // ************************************************************************
+    // WARNING: we are not filling ghost cells other than periodic outside the domain
+    // ************************************************************************
+
+    MultiFab mf_cc_vel(grids[lev], dmap[lev], AMREX_SPACEDIM, IntVect(1,1,1));
+    mf_cc_vel.setVal(0.); // We just do this to avoid uninitialized values
+
+    // Average all three components of velocity (on faces) to the cell center
+    average_face_to_cellcenter(mf_cc_vel,0,
+                               Array<const MultiFab*,3>{&vars_new[lev][Vars::xvel],
+                                                        &vars_new[lev][Vars::yvel],
+                                                        &vars_new[lev][Vars::zvel]});
+    mf_cc_vel.FillBoundary(geom[lev].periodicity());
+
+    if (!geom[lev].isPeriodic(0) || !geom[lev].isPeriodic(1) || !geom[lev].isPeriodic(2)) {
+        amrex::Warning("Ghost cells outside non-periodic physical boundaries are not filled -- vel set to 0 there");
+    }
+
+    MultiFab tot_mass  (grids[lev], dmap[lev], AMREX_SPACEDIM, IntVect(0,0,0));
+    MultiFab tot_energy(grids[lev], dmap[lev], AMREX_SPACEDIM, IntVect(0,0,0));
+
+    auto const& dx = geom[lev].CellSizeArray();
+    bool is_moist = (solverChoice.moisture_type != MoistureType::None);
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(tot_mass, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+
+        const Array4<Real>& cc_vel_arr     = mf_cc_vel.array(mfi);
+        const Array4<Real>& tot_mass_arr   = tot_mass.array(mfi);
+        const Array4<Real>& tot_energy_arr = tot_energy.array(mfi);
+        const Array4<const Real>& cons_arr = vars_new[lev][Vars::cons].const_array(mfi);
+        const Array4<const Real>& z_arr    = (z_phys_nd[lev]) ? z_phys_nd[lev]->const_array(mfi) :
+                                                                Array4<const Real>{};
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real Qv   = (is_moist) ? cons_arr(i,j,k,RhoQ1_comp) : 0.0;
+            Real Qc   = (is_moist) ? cons_arr(i,j,k,RhoQ2_comp) : 0.0;
+            Real Qt   = Qv + Qc;
+            Real Rhod = cons_arr(i,j,k,Rho_comp);
+            Real Rhot = Rhod * (1.0 + Qt);
+            Real Temp = getTgivenRandRTh(Rhod, cons_arr(i,j,k,RhoTheta_comp), Qv);
+            Real TKE  = 0.5 * ( cc_vel_arr(i,j,k,0)*cc_vel_arr(i,j,k,0)
+                              + cc_vel_arr(i,j,k,1)*cc_vel_arr(i,j,k,1)
+                              + cc_vel_arr(i,j,k,2)*cc_vel_arr(i,j,k,2) );
+            Real zval = (z_arr) ? z_arr(i,j,k) : Real(k)*dx[2];
+
+            Real Cv   = Cp_d - R_d;
+            Real Cvv  = Cp_v - R_v;
+            Real Cpv  = Cp_v;
+
+            tot_mass_arr(i,j,k)   = Rhot;
+            tot_energy_arr(i,j,k) = Rhod * ( (Cv + Cvv*Qv + Cpv*Qc)*Temp - L_v*Qc
+                                           + (1.0 + Qt)*TKE + (1.0 + Qt)*CONST_GRAV*zval );
+
+        });
+
+    }
+
+    Real  tot_mass_avg   = volWgtSumMF(lev, tot_mass  , 0, *mapfac_m[lev],false);
+    Real  tot_energy_avg = volWgtSumMF(lev, tot_energy, 0, *mapfac_m[lev],false);
+
+    // Get volume including terrain (consistent with volWgtSumMF routine)
+    Real vol = geom[lev].ProbDomain().volume();
+    if (SolverChoice::mesh_type != MeshType::ConstantDz) {
+        MultiFab volume(grids[lev], dmap[lev], 1, 0);
+        Real cell_vol = dx[0]*dx[1]*dx[2];
+        volume.setVal(cell_vol);
+        MultiFab::Multiply(volume, *detJ_cc[lev], 0, 0, 1, 0);
+        vol = volume.sum();
+    }
+
+    // Divide by the volume
+     tot_mass_avg   /= vol;
+     tot_energy_avg /= vol;
+
+    const int nfoo = 2;
+    Real foo[nfoo] = {tot_mass_avg,tot_energy_avg};
+#ifdef AMREX_LAZY
+    Lazy::QueueReduction([=]() mutable {
+#endif
+    ParallelDescriptor::ReduceRealSum(
+        foo, nfoo, ParallelDescriptor::IOProcessorNumber());
+
+      if (ParallelDescriptor::IOProcessor()) {
+        int i = 0;
+        tot_mass_avg   = foo[i++];
+        tot_energy_avg = foo[i++];
+
+        std::ostream& data_log_energy = *energy_datalog[0];
+
+        if (time == 0.0) {
+            data_log_energy << std::setw(datwidth) << "          time";
+            data_log_energy << std::setw(datwidth) << "      tot_mass";
+            data_log_energy << std::setw(datwidth) << "    tot_energy";
+            data_log_energy << std::endl;
+        }
+        data_log_energy << std::setw(datwidth) << std::setprecision(timeprecision) << time;
+        data_log_energy << std::setw(datwidth) << std::setprecision(datprecision)  << tot_mass_avg;
+        data_log_energy << std::setw(datwidth) << std::setprecision(datprecision)  << tot_energy_avg;
+        data_log_energy << std::endl;
 
       } // if IOProcessor
 #ifdef AMREX_LAZY


### PR DESCRIPTION
This PR adds a datalog option for total mass and energy. The logger may be activated by setting `erf.energy_data_log = <name_of_file>.txt`

There is also a change pertinent to terrain where the `vol` associated with the undeformed grid was utilized. This is not correct and has been replaced by a parallel reduce sum on the `dx*dy*dz * dJ` in each cell.

The output follows Bryan & Fritsch 2002 Eqs. 28 - 29
![image](https://github.com/user-attachments/assets/361a62fb-987e-4d50-afdc-c5983d75ba43)

This will allow us to monitor conservation in time:
![image](https://github.com/user-attachments/assets/525aafd2-6c2a-4569-b174-2d990e845561)
