### PR TITLE
[Hurricane] Hurricane track output

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -148,8 +148,8 @@ public:
     // Tag cells for refinement
     void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
 
-	// Refinement criteria for hurricanes
-	void HurricaneTracker(int lev,
+    // Refinement criteria for hurricanes
+    void HurricaneTracker(int lev,
                           const amrex::MultiFab& U_new,
                           const amrex::MultiFab& V_new,
                           const amrex::MultiFab& W_new,
@@ -157,7 +157,7 @@ public:
                           const bool is_track_io,
                           amrex::TagBoxArray* tags = nullptr);
 
-	// Hurricane track line output as VTKPulyline
+    // Hurricane track line output as VTKPulyline
     amrex::Vector<std::array<amrex::Real, 2>> hurricane_track_xy;
     std::string MakeVTKFilename(int nstep);
     void WriteVTKPolyline(const std::string& filename,

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -157,7 +157,7 @@ public:
                           const bool is_track_io,
                           amrex::TagBoxArray* tags = nullptr);
 
-    // Hurricane track line output as VTKPulyline
+    // Hurricane track line output as VTKPolyline
     amrex::Vector<std::array<amrex::Real, 2>> hurricane_track_xy;
     std::string MakeVTKFilename(int nstep);
     void WriteVTKPolyline(const std::string& filename,

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -148,12 +148,20 @@ public:
     // Tag cells for refinement
     void ErrorEst (int lev, amrex::TagBoxArray& tags, amrex::Real time, int ngrow) override;
 
-    void HurricaneTracker (int lev,
+	// Refinement criteria for hurricanes
+	void HurricaneTracker(int lev,
                           const amrex::MultiFab& U_new,
                           const amrex::MultiFab& V_new,
                           const amrex::MultiFab& W_new,
                           const amrex::Real velmag_threshold,
-                          amrex::TagBoxArray& tags);
+                          const bool is_track_io,
+                          amrex::TagBoxArray* tags = nullptr);
+
+	// Hurricane track line output as VTKPulyline
+    amrex::Vector<std::array<amrex::Real, 2>> hurricane_track_xy;
+    std::string MakeVTKFilename(int nstep);
+    void WriteVTKPolyline(const std::string& filename,
+                          amrex::Vector<std::array<amrex::Real, 2>>& points_xy);
 
     // Initialize multilevel data
     void InitData ();

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -638,7 +638,7 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
       }
     }
 
-	bool is_hurricane_tracker_io=false;
+    bool is_hurricane_tracker_io=false;
     ParmParse pp("erf");
     pp.query("is_hurricane_tracker_io", is_hurricane_tracker_io);
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -637,6 +637,32 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
         make_zcc(geom[lev],*z_phys_nd[lev],*z_phys_cc[lev]);
       }
     }
+
+	bool is_hurricane_tracker_io=false;
+    ParmParse pp("erf");
+    pp.query("is_hurricane_tracker_io", is_hurricane_tracker_io);
+
+    if(is_hurricane_tracker_io) {
+        if(nstep == 0 or (nstep+1)%m_plot_int_1 == 0){
+            std::string filename = MakeVTKFilename(nstep);
+            Real velmag_threshold = 1e10;
+            pp.query("hurr_track_io_velmag_greater_than", velmag_threshold);
+            if(velmag_threshold==1e10) {
+                Abort("As hurricane tracking IO is active using erf.is_hurricane_tracker_io = true"
+                      " there needs to be an input erf.hurr_track_io_velmag_greater_than which specifies the"
+                      " magnitude of velocity above which cells will be tagged for refinement.");
+            }
+            int levc=finest_level;
+            MultiFab& U_new = vars_new[levc][Vars::xvel];
+            MultiFab& V_new = vars_new[levc][Vars::yvel];
+            MultiFab& W_new = vars_new[levc][Vars::zvel];
+
+            HurricaneTracker(levc, U_new, V_new, W_new, velmag_threshold, true);
+            if (ParallelDescriptor::IOProcessor()) {
+                WriteVTKPolyline(filename,hurricane_track_xy);
+            }
+        }
+    }
 } // post_timestep
 
 // This is called from main.cpp and handles all initialization, whether from start or restart

--- a/Source/ERF_Tagging.cpp
+++ b/Source/ERF_Tagging.cpp
@@ -113,7 +113,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
                     break;
                 }
             }
-            HurricaneTracker(levc, U_new, V_new, W_new, velmag_threshold, tags);
+			HurricaneTracker(levc, U_new, V_new, W_new, velmag_threshold, false, &tags);
 #ifdef ERF_USE_PARTICLES
         } else {
             //
@@ -393,7 +393,8 @@ ERF::HurricaneTracker(int levc,
                       const MultiFab& V_new,
                       const MultiFab& W_new,
                       const Real velmag_threshold,
-                      TagBoxArray& tags)
+                      const bool is_track_io,
+                      TagBoxArray* tags)
 {
     const auto dx = geom[levc].CellSizeArray();
     const auto prob_lo = geom[levc].ProbLoArray();
@@ -463,10 +464,19 @@ ERF::HurricaneTracker(int levc,
         eye_x = h_coords[0]/h_found[0];
         eye_y = h_coords[1]/h_found[0];
 
-         Real rad_tag = 3e5*std::pow(2, max_level-1-levc);
+		// Data structure to hold the hurricane track for I/O
+        if (amrex::ParallelDescriptor::IOProcessor() and is_track_io) {
+            hurricane_track_xy.push_back({eye_x, eye_y});
+        }
 
-        for (MFIter mfi(tags); mfi.isValid(); ++mfi) {
-            TagBox& tag = tags[mfi];
+		if(is_track_io) {
+        	return;
+    	}
+
+        Real rad_tag = 3e5*std::pow(2, max_level-1-levc);
+
+        for (MFIter mfi(*tags); mfi.isValid(); ++mfi) {
+            TagBox& tag = (*tags)[mfi];
             auto tag_arr = tag.array();  // Get device-accessible array
 
             const Box& tile_box = mfi.tilebox(); // The box for this tile

--- a/Source/ERF_Tagging.cpp
+++ b/Source/ERF_Tagging.cpp
@@ -113,7 +113,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
                     break;
                 }
             }
-			HurricaneTracker(levc, U_new, V_new, W_new, velmag_threshold, false, &tags);
+            HurricaneTracker(levc, U_new, V_new, W_new, velmag_threshold, false, &tags);
 #ifdef ERF_USE_PARTICLES
         } else {
             //
@@ -464,14 +464,14 @@ ERF::HurricaneTracker(int levc,
         eye_x = h_coords[0]/h_found[0];
         eye_y = h_coords[1]/h_found[0];
 
-		// Data structure to hold the hurricane track for I/O
+        // Data structure to hold the hurricane track for I/O
         if (amrex::ParallelDescriptor::IOProcessor() and is_track_io) {
             hurricane_track_xy.push_back({eye_x, eye_y});
         }
 
-		if(is_track_io) {
-        	return;
-    	}
+        if(is_track_io) {
+            return;
+        }
 
         Real rad_tag = 3e5*std::pow(2, max_level-1-levc);
 

--- a/Source/IO/ERF_Write1DProfiles.cpp
+++ b/Source/IO/ERF_Write1DProfiles.cpp
@@ -2,6 +2,8 @@
 
 #include "ERF.H"
 #include "ERF_EOS.H"
+#include <filesystem>
+namespace fs = std::filesystem;
 
 using namespace amrex;
 
@@ -572,3 +574,70 @@ ERF::derive_stress_profiles (Gpu::HostVector<Real>& h_avg_tau11, Gpu::HostVector
         h_avg_diss[k] /= area_z;
     }
 }
+
+std::string
+ERF::MakeVTKFilename(int nstep) {
+    // Ensure output directory exists
+    const std::string dir = "Output_HurricaneTracker";
+    if (!fs::exists(dir)) {
+        fs::create_directory(dir);
+    }
+
+    // Construct filename with zero-padded step
+    std::ostringstream oss;
+    if(nstep==0){
+        oss << dir << "/hurricane_track_" << std::setw(7) << std::setfill('0') << nstep << ".vtk";
+    } else {
+        oss << dir << "/hurricane_track_" << std::setw(7) << std::setfill('0') << nstep+1 << ".vtk";
+    }
+
+    return oss.str();
+}
+
+void
+ERF::WriteVTKPolyline(const std::string& filename,
+                      Vector<std::array<Real, 2>>& points_xy)
+{
+    std::ofstream vtkfile(filename);
+    if (!vtkfile.is_open()) {
+        std::cerr << "Error: Cannot open file " << filename << std::endl;
+        return;
+    }
+
+    int num_points = points_xy.size();
+    if (num_points == 0) {
+        vtkfile << "# vtk DataFile Version 3.0\n";
+        vtkfile << "Hurricane Track\n";
+        vtkfile << "ASCII\n";
+        vtkfile << "DATASET POLYDATA\n";
+        vtkfile << "POINTS " << num_points << " float\n";
+        vtkfile.close();
+        return;
+    }
+    if (num_points < 2) {
+        points_xy.push_back(points_xy[0]);
+    }
+    num_points = points_xy.size();
+
+    vtkfile << "# vtk DataFile Version 3.0\n";
+    vtkfile << "Hurricane Track\n";
+    vtkfile << "ASCII\n";
+    vtkfile << "DATASET POLYDATA\n";
+
+    // Write points (Z=0 assumed)
+    vtkfile << "POINTS " << num_points << " float\n";
+    for (const auto& pt : points_xy) {
+        vtkfile << pt[0] << " " << pt[1] << " 10000.0\n";
+    }
+
+    // Write polyline connectivity
+    vtkfile << "LINES 1 " << num_points + 1 << "\n";
+    vtkfile << num_points << " ";
+    for (int i = 0; i < num_points; ++i) {
+        vtkfile << i << " ";
+    }
+    vtkfile << "\n";
+
+    vtkfile.close();
+}
+


### PR DESCRIPTION
This PR adds the capability to write out a line output (vtk format, which can be visualized in ParaView) for the hurricane track (see animation below). The line currently tracks the centroid of the group of cells that satisfy the user provided criterion based on velocity magnitude (see Fig. 1). The inputs options are
```
erf.is_hurricane_tracker_io  = true
erf.hurr_track_io_velmag_greater_than = 130.0 #km/hr
```

A criterion based on minimum pressure can be used to track the eye of the hurricane, which will be added in another PR.

<img width="362" alt="Screen Shot 2025-04-19 at 5 55 08 AM" src="https://github.com/user-attachments/assets/0078a648-4362-4e5c-8adb-c32cc773fe86" />

![tmp-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/cc4c90a9-20c5-4f85-80d4-8dd317a22060)


