### PR TITLE
bug fixes: only enter boxes owned by rank, ML constant pert amp

### DIFF
--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -160,6 +160,10 @@ struct TurbulentPerturbation {
             pb_local_etime.resize(max_level+1);
             pb_amp.resize(max_level+1);
             pb_cell.resize(max_level+1);
+            tpi_Lpb.resize(max_level+1);
+            tpi_Wpb.resize(max_level+1);
+            tpi_Hpb.resize(max_level+1);
+            tpi_lref.resize(max_level+1);
         }
 
         // Initializing mean magnitude vector
@@ -176,12 +180,10 @@ struct TurbulentPerturbation {
         pb_cell[lev].setVal(0.);
 
         // Computing perturbation reference length
-        tpi_Lpb = tpi_boxDim[0]*dx[0];
-        tpi_Wpb = tpi_boxDim[1]*dx[1];
-        tpi_Hpb = tpi_boxDim[2]*dx[2];
-        if (lev == 0) { // only need to define reference length scale for coarses level
-            tpi_lref = sqrt(tpi_Lpb*tpi_Lpb + tpi_Wpb*tpi_Wpb);
-        }
+        tpi_Lpb[lev] = tpi_boxDim[0]*dx[0];
+        tpi_Wpb[lev] = tpi_boxDim[1]*dx[1];
+        tpi_Hpb[lev] = tpi_boxDim[2]*dx[2];
+        tpi_lref[lev] = sqrt(tpi_Lpb[lev]*tpi_Lpb[lev] + tpi_Wpb[lev]*tpi_Wpb[lev]);
 
         tpi_pert_adjust = 0.;
         tpi_net_buoyant = 0.;
@@ -201,7 +203,7 @@ struct TurbulentPerturbation {
         amrex::PrintToFile("BoxPerturbationOutput") << "perturbation_nondimensional: " << tpi_nonDim << "\n";
         amrex::PrintToFile("BoxPerturbationOutput") << "perturbation_T_infinity: " << tpi_Tinf << "\n";
         amrex::PrintToFile("BoxPerturbationOutput") << "perturbation_T_intensity: " << tpi_Ti << "\n";
-        amrex::PrintToFile("BoxPerturbationOutput") << "Reference length per box = " << tpi_lref << "\n\n";
+        amrex::PrintToFile("BoxPerturbationOutput") << "Reference length per box = " << tpi_lref[lev] << "\n\n";
         amrex::PrintToFile("BoxPerturbationOutput") << "Turbulent perturbation BoxArray:\n" << pb_ba[lev] << "\n";
         */
     }
@@ -240,8 +242,8 @@ struct TurbulentPerturbation {
 
         for (int boxIdx = 0; boxIdx < pb_ba[lev].size(); boxIdx++) {
 
-            // Check if the local elapsed time is greater than the update interval
-            if ( pb_interval[lev][boxIdx] <= pb_local_etime[lev][boxIdx] ) {
+            // Check if the local elapsed time is greater than the update interval and don't go into boxes the rank doesn't own
+            if ( pb_interval[lev][boxIdx] <= pb_local_etime[lev][boxIdx] && pb_local_etime[lev][boxIdx] != -1.0 ) {
 
                 // Compute mean velocity of each perturbation box
                 calc_tpi_meanMag_perBox(boxIdx, lev, mf_cons, mf_xvel, mf_yvel);
@@ -249,8 +251,15 @@ struct TurbulentPerturbation {
                 // Only the rank owning the box will be able to access the storage location
                 // Done for parallelism to avoid Inf being stored in array
                 if (pb_mag[lev][boxIdx] !=0.) {
-                    amrex::Real interval = tpi_lref / pb_mag[lev][boxIdx];
+                    amrex::Real interval = tpi_lref[lev] / pb_mag[lev][boxIdx];
                     pb_interval[lev][boxIdx] = RandomReal(0.9*interval,1.1*interval); // 10% variation
+
+                    // Reset local elapsed time
+                    pb_local_etime[lev][boxIdx] = 0.;
+                } else {
+                    // this box is not on this rank, we shouldn't enter it again.
+                    // Technically, all boxes are looped through on the very first step of a simulation and this is when this is set
+                    pb_local_etime[lev][boxIdx] = -1.0;
                 }
 
                 // Trigger amplitude calculation per perturbation box
@@ -259,11 +268,10 @@ struct TurbulentPerturbation {
                 // Trigger random amplitude storage per cell within perturbation box
                 pseudoRandomPert(boxIdx, lev, m_ixtype);
 
-                // Reset local elapsed time
-                pb_local_etime[lev][boxIdx] = 0.;
+
             } else {
-                // Increase by timestep of level 0
-                pb_local_etime[lev][boxIdx] += dt;
+                // Increase by timestep of level 0 (but only if the box is owned by this rank)
+                if (pb_local_etime[lev][boxIdx] != -1.0) { pb_local_etime[lev][boxIdx] += dt; }
             } // if
 
             // Per iteration operation of net-zero buoyant force check
@@ -326,10 +334,10 @@ struct TurbulentPerturbation {
             total_ref_ratio *= ref_ratio[level-1][2];
         }
         // calculation needs to be scale-aware since the formulation relies on the physical size of the box
-        if (tpi_Ti > 0.) g = (tpi_nonDim * Um * Um) / (tpi_Ti * tpi_Hpb) * 1 / total_ref_ratio;
+        if (tpi_Ti > 0.) g = (tpi_nonDim * Um * Um) / (tpi_Ti * tpi_Hpb[lev]) * 1 / total_ref_ratio;
 
         // Ma and Senocak (2023) Eq. 8, solving for delta phi
-        pb_amp[lev][boxIdx] = (tpi_nonDim * Um * Um) / (g * beta * tpi_Hpb) * 1 / total_ref_ratio;
+        pb_amp[lev][boxIdx] = (tpi_nonDim * Um * Um) / (g * beta * tpi_Hpb[lev]) * 1 / total_ref_ratio;
 
         if (pt_type == 0) {
             // Performing this step converts the perturbation proportionality into
@@ -587,10 +595,10 @@ struct TurbulentPerturbation {
     amrex::Real tpi_Tinf;             // Reference temperature [K]
 
     // Physical dimensions
-    amrex::Real tpi_Hpb;              // PB height [m]
-    amrex::Real tpi_Lpb;              // PB length [m]
-    amrex::Real tpi_Wpb;              // PB width  [m]
-    amrex::Real tpi_lref;             // PB reference length [m]
+    amrex::Vector<amrex::Real> tpi_Hpb;              // PB height [m]
+    amrex::Vector<amrex::Real> tpi_Lpb;              // PB length [m]
+    amrex::Vector<amrex::Real> tpi_Wpb;              // PB width  [m]
+    amrex::Vector<amrex::Real> tpi_lref;             // PB reference length [m]
 
     amrex::Real tpi_net_buoyant;      // Perturbation net-zero calculation storage
     amrex::Real tpi_pert_adjust;      // Perturbation adjust for net-zero per cell adjustment


### PR DESCRIPTION
Two bug fixes:
1. When parallelizing, the old routine had a bug where the routines would be called for boxes that weren't owned by the rank. This resulted in significant slowdowns when a large number of perturbation boxes is used. The new logic checks whether the box is owned by the rank (pb_local_etime[lev][boxIdx] == -1). Whether a box is owned by a rank is determined on the first step of the simulation when every single box is looped through; however, the first step is the only time when all boxes are looped through. After the first step, the logic catches whether a box is owned by the rank or not.
2. On multi-level simulations, there was a bug where the perturbation amplitude incorrectly increased after initialization. This was because the physical properties of the box (which are used to calculate the perturbation magnitude) were not stored per level. As a result, after initialization, the amplitude was calculated using the physical properties of the finest level. The physical properties are now stored per level so that the perturbation amplitude stays constant across levels.