### PR TITLE
Sponging with r_hse 

### DIFF
--- a/Exec/DevTests/ScharMountain/inputs
+++ b/Exec/DevTests/ScharMountain/inputs
@@ -1,6 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 3000000
-max_step = 100000
+max_step = 20000
 
 amrex.fpe_trap_invalid = 0
 
@@ -20,6 +19,17 @@ xhi.type = "Outflow"
 
 zlo.type = "SlipWall"
 zhi.type = "Outflow"
+
+erf.use_xlo_sponge_damping = true
+erf.use_xhi_sponge_damping = true
+erf.use_zhi_sponge_damping = true
+erf.sponge_strength   =      1.0
+erf.xlo_sponge_end    = -20000.0
+erf.xhi_sponge_start  =  20000.0
+erf.zhi_sponge_start  =  15000.0
+erf.sponge_x_velocity =     10.0
+erf.sponge_y_velocity =      0.0
+erf.sponge_z_velocity =      0.0
 
 #erf.initial_dz = 10
 #erf.grid_stretching_ratio = 1.075065

--- a/Source/DataStructs/ERF_SpongeStruct.H
+++ b/Source/DataStructs/ERF_SpongeStruct.H
@@ -36,7 +36,7 @@ struct SpongeChoice {
         pp.query("zlo_sponge_end"  , zlo_sponge_end);
         pp.query("zhi_sponge_start", zhi_sponge_start);
 
-        pp.query("sponge_density" , sponge_density);
+        pp.query("sponge_density"    , sponge_density);
         pp.query("sponge_x_velocity" , sponge_x_velocity);
         pp.query("sponge_y_velocity" , sponge_y_velocity);
         pp.query("sponge_z_velocity" , sponge_z_velocity);
@@ -60,6 +60,7 @@ struct SpongeChoice {
     amrex::Real xlo_sponge_end, xhi_sponge_start;
     amrex::Real ylo_sponge_end, yhi_sponge_start;
     amrex::Real zlo_sponge_end, zhi_sponge_start;
-    amrex::Real sponge_density, sponge_x_velocity, sponge_y_velocity, sponge_z_velocity;
+    amrex::Real sponge_density = -1.0;
+    amrex::Real sponge_x_velocity, sponge_y_velocity, sponge_z_velocity;
 };
 #endif

--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
@@ -4,13 +4,13 @@
 using namespace amrex;
 
 void
-ApplySpongeZoneBCsForCC (
-  const SpongeChoice& spongeChoice,
-  const Geometry geom,
-  const Box& bx,
-  const Array4<Real>& cell_rhs,
-  const Array4<const Real>& cell_data,
-  const Array4<const Real>& z_phys_cc)
+ApplySpongeZoneBCsForCC (const SpongeChoice& spongeChoice,
+                         const Geometry geom,
+                         const Box& bx,
+                         const Array4<Real>& cell_rhs,
+                         const Array4<const Real>& cell_data,
+                         const Array4<const Real>& r0,
+                         const Array4<const Real>& z_phys_cc)
 {
     // Domain cell size and real bounds
     auto dx = geom.CellSizeArray();
@@ -39,7 +39,8 @@ ApplySpongeZoneBCsForCC (
     const Real zlo_sponge_end   = spongeChoice.zlo_sponge_end;
     const Real zhi_sponge_start = spongeChoice.zhi_sponge_start;
 
-    const Real sponge_density = spongeChoice.sponge_density;
+    const Real sponge_density_tmp = spongeChoice.sponge_density;
+    const bool use_base = (sponge_density_tmp < 0.);
 
     // Domain valid box
     const Box& domain = geom.Domain();
@@ -63,6 +64,8 @@ ApplySpongeZoneBCsForCC (
         Real x = ProbLoArr[0] + (ii+0.5) * dx[0];
         Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
         Real z = z_phys_cc(i,j,k);
+
+        Real sponge_density = (use_base) ? r0(i,j,k) : sponge_density_tmp;
 
         // x left sponge
         if(use_xlo_sponge_damping){
@@ -112,20 +115,20 @@ ApplySpongeZoneBCsForCC (
 }
 
 void
-ApplySpongeZoneBCsForMom (
-  const SpongeChoice& spongeChoice,
-  const Geometry geom,
-  const Box& tbx,
-  const Box& tby,
-  const Box& tbz,
-  const Array4<Real>& rho_u_rhs,
-  const Array4<Real>& rho_v_rhs,
-  const Array4<Real>& rho_w_rhs,
-  const Array4<const Real>& rho_u,
-  const Array4<const Real>& rho_v,
-  const Array4<const Real>& rho_w,
-  const Array4<const Real>& z_phys_nd,
-  const Array4<const Real>& z_phys_cc)
+ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
+                          const Geometry geom,
+                          const Box& tbx,
+                          const Box& tby,
+                          const Box& tbz,
+                          const Array4<Real>& rho_u_rhs,
+                          const Array4<Real>& rho_v_rhs,
+                          const Array4<Real>& rho_w_rhs,
+                          const Array4<const Real>& rho_u,
+                          const Array4<const Real>& rho_v,
+                          const Array4<const Real>& rho_w,
+                          const Array4<const Real>& r0,
+                          const Array4<const Real>& z_phys_nd,
+                          const Array4<const Real>& z_phys_cc)
 {
     // Domain cell size and real bounds
     auto dx = geom.CellSizeArray();
@@ -154,10 +157,12 @@ ApplySpongeZoneBCsForMom (
     const Real zlo_sponge_end   = spongeChoice.zlo_sponge_end;
     const Real zhi_sponge_start = spongeChoice.zhi_sponge_start;
 
-    const Real sponge_density = spongeChoice.sponge_density;
     const Real sponge_x_velocity = spongeChoice.sponge_x_velocity;
     const Real sponge_y_velocity = spongeChoice.sponge_y_velocity;
     const Real sponge_z_velocity = spongeChoice.sponge_z_velocity;
+
+    const Real sponge_density_tmp = spongeChoice.sponge_density;
+    const bool use_base = (sponge_density_tmp < 0.);
 
     // Domain valid box
     const Box& domain = geom.Domain();
@@ -181,6 +186,8 @@ ApplySpongeZoneBCsForMom (
         Real x = ProbLoArr[0] + ii * dx[0];
         Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
         Real z = z_phys_cc(i,j,k);
+
+        Real sponge_density = (use_base) ? 0.5 * (r0(i,j,k) + r0(i-1,j,k)) : sponge_density_tmp;
 
         // x lo sponge
         if(use_xlo_sponge_damping){
@@ -240,6 +247,8 @@ ApplySpongeZoneBCsForMom (
         Real y = ProbLoArr[1] + jj * dx[1];
         Real z = z_phys_cc(i,j,k);
 
+        Real sponge_density = (use_base) ?  0.5 * (r0(i,j,k) + r0(i,j-1,k)) : sponge_density_tmp;
+
         // x lo sponge
         if(use_xlo_sponge_damping){
             if (x < xlo_sponge_end) {
@@ -297,6 +306,8 @@ ApplySpongeZoneBCsForMom (
         Real x = ProbLoArr[0] + (ii+0.5) * dx[0];
         Real y = ProbLoArr[1] + (jj+0.5) * dx[1];
         Real z = z_phys_nd(i,j,k);
+
+        Real sponge_density = (use_base) ? 0.5 * (r0(i,j,k) + r0(i,j,k-1)) : sponge_density_tmp;
 
         // x left sponge
         if(use_xlo_sponge_damping){

--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs_ReadFromFile.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs_ReadFromFile.cpp
@@ -5,18 +5,17 @@
 using namespace amrex;
 
 void
-ApplySpongeZoneBCsForMom_ReadFromFile (
-  const SpongeChoice& spongeChoice,
-  const Geometry geom,
-  const Box& tbx,
-  const Box& tby,
-  const Array4<const Real>& cell_data,
-  const Array4<const Real>& z_phys_cc,
-  const Array4<Real>& rho_u_rhs,
-  const Array4<Real>& rho_v_rhs,
-  const Array4<const Real>& rho_u,
-  const Array4<const Real>& rho_v,
-  const Vector<Real*> d_sponge_ptrs_at_lev)
+ApplySpongeZoneBCsForMom_ReadFromFile (const SpongeChoice& spongeChoice,
+                                       const Geometry geom,
+                                       const Box& tbx,
+                                       const Box& tby,
+                                       const Array4<const Real>& cell_data,
+                                       const Array4<const Real>& z_phys_cc,
+                                       const Array4<Real>& rho_u_rhs,
+                                       const Array4<Real>& rho_v_rhs,
+                                       const Array4<const Real>& rho_u,
+                                       const Array4<const Real>& rho_v,
+                                       const Vector<Real*> d_sponge_ptrs_at_lev)
 {
     // Domain cell size and real bounds
     auto dx = geom.CellSizeArray();

--- a/Source/SourceTerms/ERF_MakeBuoyancy.cpp
+++ b/Source/SourceTerms/ERF_MakeBuoyancy.cpp
@@ -32,7 +32,7 @@ using namespace amrex;
 void make_buoyancy (Vector<MultiFab>& S_data,
                     const MultiFab& S_prim,
                           MultiFab& buoyancy,
-                    const amrex::Geometry geom,
+                    const Geometry geom,
                     const SolverChoice& solverChoice,
                     const MultiFab& base_state,
                     const int n_qstate,

--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -79,6 +79,8 @@ void make_mom_sources (int level,
     ymom_src.setVal(0.0);
     zmom_src.setVal(0.0);
 
+    MultiFab r_hse (base_state, make_alias, BaseState::r0_comp , 1);
+
     // *****************************************************************************
     // Define source term for all three components of momenta from
     //    1. buoyancy           for (zmom)
@@ -232,6 +234,8 @@ void make_mom_sources (int level,
         const Array4<      Real>& xmom_src_arr = xmom_src.array(mfi);
         const Array4<      Real>& ymom_src_arr = ymom_src.array(mfi);
         const Array4<      Real>& zmom_src_arr = zmom_src.array(mfi);
+
+        const Array4<const Real>& r0 = r_hse.const_array(mfi);
 
         // Map factors
         //const Array4<const Real>& mf_m   = mapfac_m->const_array(mfi);
@@ -525,7 +529,7 @@ void make_mom_sources (int level,
         {
             ApplySpongeZoneBCsForMom(solverChoice.spongeChoice, geom, tbx, tby, tbz,
                                      xmom_src_arr, ymom_src_arr, zmom_src_arr, rho_u, rho_v, rho_w,
-                                     z_nd_arr, z_cc_arr);
+                                     r0, z_nd_arr, z_cc_arr);
         }
 
         // *****************************************************************************

--- a/Source/SourceTerms/ERF_MakeSources.cpp
+++ b/Source/SourceTerms/ERF_MakeSources.cpp
@@ -34,6 +34,7 @@ void make_sources (int level,
                    Vector<MultiFab>& S_data,
                    const  MultiFab & S_prim,
                           MultiFab & source,
+                   const  MultiFab & base_state,
                    std::unique_ptr<MultiFab>& z_phys_cc,
 #ifdef ERF_USE_RRTMGP
                    const MultiFab* qheating_rates,
@@ -67,6 +68,8 @@ void make_sources (int level,
     const Box& domain = geom.Domain();
 
     const GpuArray<Real, AMREX_SPACEDIM> dxInv = geom.InvCellSizeArray();
+
+    MultiFab r_hse (base_state, make_alias, BaseState::r0_comp , 1);
 
     Real* thetabar = d_rayleigh_ptrs_at_lev[Rayleigh::thetabar];
 
@@ -181,9 +184,11 @@ void make_sources (int level,
     {
         Box bx  = mfi.tilebox();
 
-        const Array4<const Real> & cell_data  = S_data[IntVars::cons].array(mfi);
-        const Array4<const Real> & cell_prim  = S_prim.array(mfi);
-        const Array4<Real>       & cell_src   = source.array(mfi);
+        const Array4<const Real>& cell_data  = S_data[IntVars::cons].array(mfi);
+        const Array4<const Real>& cell_prim  = S_prim.array(mfi);
+        const Array4<Real>      & cell_src   = source.array(mfi);
+
+        const Array4<const Real>& r0 = r_hse.const_array(mfi);
 
         const Array4<const Real>& z_cc_arr = z_phys_cc->const_array(mfi);
 
@@ -357,7 +362,7 @@ void make_sources (int level,
         // 7. Add sponging
         // *************************************************************************************
         if(!(solverChoice.spongeChoice.sponge_type == "input_sponge")){
-            ApplySpongeZoneBCsForCC(solverChoice.spongeChoice, geom, bx, cell_src, cell_data, z_cc_arr);
+            ApplySpongeZoneBCsForCC(solverChoice.spongeChoice, geom, bx, cell_src, cell_data, r0, z_cc_arr);
         }
 
         // *************************************************************************************

--- a/Source/SourceTerms/ERF_SrcHeaders.H
+++ b/Source/SourceTerms/ERF_SrcHeaders.H
@@ -27,6 +27,7 @@ void make_sources (int level, int nrk,
                    amrex::Vector<amrex::MultiFab>& S_data,
                    const amrex::MultiFab& S_prim,
                          amrex::MultiFab& cc_source,
+                   const amrex::MultiFab& base_state,
                    std::unique_ptr<amrex::MultiFab>& z_phys_cc,
 #if defined(ERF_USE_RRTMGP)
                    const amrex::MultiFab* qheating_rates,
@@ -107,6 +108,7 @@ void ApplySpongeZoneBCsForCC (const SpongeChoice& spongeChoice,
                               const amrex::Box& bx,
                               const amrex::Array4<amrex::Real>& cell_rhs,
                               const amrex::Array4<const amrex::Real>& cell_data,
+                              const amrex::Array4<const amrex::Real>& r0,
                               const amrex::Array4<const amrex::Real>& z_phys_cc);
 
 void ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
@@ -120,6 +122,7 @@ void ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
                                const amrex::Array4<const amrex::Real>& rho_u,
                                const amrex::Array4<const amrex::Real>& rho_v,
                                const amrex::Array4<const amrex::Real>& rho_w,
+                               const amrex::Array4<const amrex::Real>& r0,
                                const amrex::Array4<const amrex::Real>& z_phys_nd,
                                const amrex::Array4<const amrex::Real>& z_phys_cc);
 

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_fun.H
@@ -61,7 +61,8 @@
         }
 
         // Construct the source terms for the cell-centered (conserved) variables
-        make_sources(level, nrk, slow_dt, old_stage_time, S_data, S_prim, cc_src, z_phys_cc[level],
+        make_sources(level, nrk, slow_dt, old_stage_time,
+                     S_data, S_prim, cc_src, base_state[level], z_phys_cc[level],
 #if defined(ERF_USE_RRTMGP)
                      qheating_rates[level].get(),
 #endif
@@ -465,7 +466,8 @@
             terrain_blank = terrain_blanking[level].get();
         }
 
-        make_sources(level, nrk, slow_dt, old_stage_time, S_data, S_prim, cc_src, z_phys_cc[level],
+        make_sources(level, nrk, slow_dt, old_stage_time,
+                     S_data, S_prim, cc_src, base_state[level], z_phys_cc[level],
 #if defined(ERF_USE_RRTMGP)
                      qheating_rates[level].get(),
 #endif


### PR DESCRIPTION
This PR allows for sponging with the base state density rather than a constant from the inputs file. If the value `sponge_density` is not parsed, then the code will use `r_hse`. This is beneficial for tall domains where the density is significantly stratified.