### PR TITLE
More FillBoundary Optim 

### DIFF
--- a/Source/BoundaryConditions/ERF_FillIntermediatePatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillIntermediatePatch.cpp
@@ -342,4 +342,16 @@ ERF::FillIntermediatePatch (int lev, Real time,
                            Geom(lev).Domain(),
                            domain_bcs_type);
     }
+
+    // NOTE: There are not FillBoundary calls here for the following reasons:
+    // Removal of the FillBoundary (FB) calls has bee completed for the following reasons:
+    //
+    // 1. physbc_cons is called before VelocityToMomentum and a FB is completed in that functor.
+    //    Therefore, the conserved CC vars have their inter-rank ghost cells filled and then their
+    //    domain ghost cells filled from the BC operations. We should not call FB on this MF again.
+    //
+    // 2. physbc_u/v/w is also called before VelocityToMomentum and a FB is completed those functors.
+    //    Furthermore, VelocityToMomentum operates on a growntilebox so we exit that routine with momentum
+    //    filled everywhere---i.e., physbc_u/v/w fills velocity ghost cells (inter-rank and domain)
+    //    and then V2M does the conversion to momenta everywhere; so there is again no need to do a FB on momenta.
 }

--- a/Source/BoundaryConditions/ERF_FillIntermediatePatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillIntermediatePatch.cpp
@@ -342,13 +342,4 @@ ERF::FillIntermediatePatch (int lev, Real time,
                            Geom(lev).Domain(),
                            domain_bcs_type);
     }
-
-    if (cons_only) {
-        mfs_mom[IntVars::cons]->FillBoundary(icomp_cons,ncomp_cons,geom[lev].periodicity());
-    } else {
-        mfs_mom[IntVars::cons]->FillBoundary(icomp_cons,ncomp_cons,geom[lev].periodicity());
-        mfs_mom[IntVars::xmom]->FillBoundary(geom[lev].periodicity());
-        mfs_mom[IntVars::ymom]->FillBoundary(geom[lev].periodicity());
-        mfs_mom[IntVars::zmom]->FillBoundary(geom[lev].periodicity());
-    }
 }


### PR DESCRIPTION
Removal of the `FillBoundary` calls has bee completed for the following reasons:

1. `physbc_cons` is called before `VelocityToMomentum` and a FB is completed in that functor. Therefore, the conserved CC vars have their inter-rank ghost cells filled and then their domain ghost cells filled from the BC operations. We should not call FB on this MF again (print statements show it's the same pointer).
2. `physbc_u/v/w` is also called before `VelocityToMomentum` and a FB is completed those functors. Furthermore, `VelocityToMomentum` operates on a `growntilebox` so we exit that routine with momentum filled everywhere---i.e., physbc_u/v/w fills velocity ghost cells (inter-rank and domain) and then V2M does the conversion to momenta everywhere; so there is again no need to do a FB on momenta.