### PR TITLE
State Old Alias

### DIFF
--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -150,10 +150,6 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
     BoxArray ba_z(ba); ba_z.surroundingNodes(2);
     MultiFab zmom_source(ba_z,dm,nvars,1); zmom_source.setVal(0.0);
 
-    // We don't need to call FillPatch on cons_mf because we have fillpatch'ed S_old above
-    MultiFab cons_mf(ba,dm,nvars,S_old.nGrowVect());
-    MultiFab::Copy(cons_mf,S_old,0,0,S_old.nComp(),S_old.nGrowVect());
-
     amrex::Vector<MultiFab> state_old;
     amrex::Vector<MultiFab> state_new;
 
@@ -162,7 +158,7 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
     // **************************************************************************************
     // Initial solution
     // Note that "old" and "new" here are relative to each RK stage.
-    state_old.push_back(MultiFab(cons_mf    , amrex::make_alias, 0, nvars)); // cons
+    state_old.push_back(MultiFab(S_old      , amrex::make_alias, 0, nvars)); // cons
     state_old.push_back(MultiFab(rU_old[lev], amrex::make_alias, 0,     1)); // xmom
     state_old.push_back(MultiFab(rV_old[lev], amrex::make_alias, 0,     1)); // ymom
     state_old.push_back(MultiFab(rW_old[lev], amrex::make_alias, 0,     1)); // zmom


### PR DESCRIPTION
This PR modifies the alias for `State_Old` by not using the `cons_mf` temporary MF. This avoids extra memory and copy.