### PR TITLE
Surface Layer Moisture Flux

### DIFF
--- a/Docs/sphinx_doc/SurfaceLayer.rst
+++ b/Docs/sphinx_doc/SurfaceLayer.rst
@@ -36,6 +36,8 @@ With these assumptions, the MOST theory can be written as:
 
   \overline{w^{'}} \overline{\theta^{'}} = {\rm const} = -u_{\star}\theta_{\star},
 
+  \overline{w^{'}} \overline{q_{v}^{'}} = {\rm const} = -u_{\star}q_{v,\star},
+
   \Phi_{m}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \overline{u}(z)}{\partial z},
 
   \Phi_{h}(\zeta) = \frac{\kappa z}{u_{\star}} \frac{\partial \overline{\theta}(z)}{\partial z}
@@ -47,7 +49,7 @@ Here, :math:`L` is the Monin-Obukhov length,
 :math:`\overline{\theta}` is the reference virtual potential temperature for the ASL,
 and :math:`\kappa` is the von Karman constant (taken to be :math:`0.41`).
 
-Integration of the MOST assumption equations give the classical MOST profiles of mean velocity and potential temperature
+Integration of the MOST assumption equations give the classical MOST profiles of mean velocity, potential temperature, and water vapor
 
 .. math::
 
@@ -55,8 +57,10 @@ Integration of the MOST assumption equations give the classical MOST profiles of
 
   \overline{\theta}(z) - \theta_0 &= \frac{\theta_{\star}}{\kappa} \left[ \mathrm{ln}\left(\frac{z}{z_0}\right) - \Psi_{h}(\zeta) \right]
 
+  \overline{q_{v}}(z) - q_{v,0} &= \frac{q_{v,\star}}{\kappa} \left[ \mathrm{ln}\left(\frac{z}{z_0}\right) - \Psi_{h}(\zeta) \right]
 
-where :math:`\theta_0` is the surface potential temperature and  :math:`z_0` is a characteristic roughness height. The integrated similarity functions,
+
+where :math:`\theta_0` and :math:`q_{v,0}` are the surface values and :math:`z_0` is a characteristic roughness height. The integrated similarity functions,
 
 .. math::
 
@@ -133,8 +137,12 @@ with the flux type. Therefore, the MOST implementation in ERF is a specific meth
                                                 u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| ({\theta} - \overline{\theta})  +
                                                 \sqrt{u^2+v^2} (\overline{\theta} - \theta_0) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
 
-   where :math:`\bar{u}`, :math:`\bar{v}` and :math:`\overline{\theta}` are the plane averaged values (at :math:`z_{ref}`) of the
-   two horizontal velocity components and the potential temperature, respectively, and
+     \left.  \frac{\tau_{q_{v} z}}{\rho} \right|_0  &= q_{v,\star} u_{\star} \frac{|\mathbf{\bar{u}}| ({q_{v}} - \overline{q_{v}}) +
+                                                \sqrt{u^2+v^2}  (\overline{q_{v}} - q_{v,0}) }{ |\mathbf{\bar{u}}| (\overline{q_{v}} - q_{v,0}) } =
+                                                u_{\star} \kappa  \frac{|\mathbf{\bar{u}}| ({q_{v}} - \overline{q_{v}})  +
+                                                \sqrt{u^2+v^2} (\overline{q_{v}} - q_{v,0}) }{ |\mathbf{\bar{u}}| [  \mathrm{ln}(z_{ref} / z_0)-\Psi_{h}(z_{ref}/L)] }
+
+   where :math:`\bar{\psi}` are plane averaged values (at :math:`z_{ref}`) and
    :math:`|\mathbf{\bar{u}}|` is the plane averaged magnitude of horizontal velocity (plane averaged wind speed).
    We note a slight variation in the denominator of the velocity terms from the form of the
    equations presented in Moeng. This difference is due to how the stress components are computed
@@ -175,7 +183,9 @@ When computing an average :math:`\overline{\phi}` for the MOST boundary, where :
    erf.most.z0                = FLOAT  #SURFACE ROUGHNESS
    erf.most.zref              = FLOAT  #QUERY DISTANCE (HEIGHT OR NORM LENGTH)
    erf.most.surf_temp         = FLOAT  #SPECIFIED SURFACE TEMP
-   erf.most.surf_temp_flux    = FLOAT  #SPECIFIED SURFACE FLUX
+   erf.most.surf_temp_flux    = FLOAT  #SPECIFIED SURFACE TEMP FLUX
+   erf.most.surf_moist        = FLOAT  #SPECIFIED SURFACE MOISTURE
+   erf.most.surf_moist_flux   = FLOAT  #SPECIFIED SURFACE MOISTURE FLUX
    erf.most.k_arr_in          = INT    #SPECIFIED K INDEX ARRAY (MAXLEV)
    erf.most.radius            = INT    #SPECIFIED REGION RADIUS
    erf.most.time_window       = FLOAT  #WINDOW FOR TIME AVG
@@ -189,6 +199,8 @@ We now consider two concrete examples. To employ an instantaneous ``planar avera
    erf.most.time_average      = false
    erf.most.z0                = 0.1
    erf.most.zref              = 1.0
+   erf.most.surf_temp_flux    = 0.0
+   erf.most.surf_moist_flux   = 0.0
 
 By contrast, ``local region averaging`` would be employed in conjunction with ``time averaging`` for the following inputs:
 
@@ -201,6 +213,7 @@ By contrast, ``local region averaging`` would be employed in conjunction with ``
    erf.most.z0                = 0.1
    erf.most.zref              = 1.0
    erf.most.surf_temp_flux    = 0.0
+   erf.most.surf_moist_flux   = 0.0
    erf.most.radius            = 1
    erf.most.time_window       = 10.0
 

--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
@@ -19,10 +19,11 @@ zhi.type = "SlipWall"
 
 zlo.type = "surface_layer"
 erf.most.average_policy = 1
-erf.most.radius    = 0
-erf.most.zref      = 10.0
-erf.most.z0        = 0.1
-erf.most.surf_temp = 300.0
+erf.most.radius     = 0
+erf.most.zref       = 10.0
+erf.most.z0         = 0.1
+erf.most.surf_temp  = 300.0
+erf.most.surf_moist = 1.0e-5
 
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.5  # fixed time step depending on grid resolution

--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
@@ -23,7 +23,6 @@ erf.most.radius     = 0
 erf.most.zref       = 10.0
 erf.most.z0         = 0.1
 erf.most.surf_temp  = 300.0
-erf.most.surf_moist = 1.0e-5
 
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.5  # fixed time step depending on grid resolution

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1035,7 +1035,6 @@ struct surface_temp
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
                                   (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
-            amrex::Print() << "Added value: " << amrex::IntVect(i,j,k) << ' ' << 0.61*tm_arr(i,j,k) * qflux << "\n";
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -499,10 +499,15 @@ struct surface_flux
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
-        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
-                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
-        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
-        olen_arr(i,j,k)   = Olen;
+          olen_arr(i,j,k) = Olen;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -610,11 +615,16 @@ struct surface_flux_charnock
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
-        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
-                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
-        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
            z0_arr(i,j,k)  = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -714,11 +724,16 @@ struct surface_flux_mod_charnock
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
-        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
-                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
-        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
-           z0_arr(i,j,k)  = z0;
+            z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -815,11 +830,16 @@ struct surface_flux_donelan
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
-        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
-                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
-        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
-           z0_arr(i,j,k)  = z0;
+            z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -922,11 +942,16 @@ struct surface_flux_wave_coupled
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
-        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
-                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
-        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
-           z0_arr(i,j,k)  = z0;
+            z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -1010,6 +1035,7 @@ struct surface_temp
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
                                   (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
+            amrex::Print() << "Added value: " << amrex::IntVect(i,j,k) << ' ' << 0.61*tm_arr(i,j,k) * qflux << "\n";
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1033,9 +1059,15 @@ struct surface_temp
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
-        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
-        olen_arr(i,j,k)   = Olen;
+          olen_arr(i,j,k) = Olen;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -1152,10 +1184,16 @@ struct surface_temp_charnock
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
-        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -1264,10 +1302,16 @@ struct surface_temp_mod_charnock
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
-        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -1373,10 +1417,16 @@ struct surface_temp_donelan
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
-        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:
@@ -1488,10 +1538,16 @@ struct surface_temp_wave_coupled
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
-        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
+        if (spec_qflux) {
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                                (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+            q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
+        } else {
+            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        }
     }
 
 private:

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -423,11 +423,13 @@ struct surface_flux
 {
     surface_flux (amrex::Real zref,
                   amrex::Real Tflux,
-                  amrex::Real Qvflux)
+                  amrex::Real Qvflux,
+                  bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -458,6 +460,7 @@ struct surface_flux
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -473,8 +476,10 @@ struct surface_flux
         }
         do {
             ustar = u_star_arr(i,j,k);
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
-                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -502,6 +507,7 @@ struct surface_flux
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -517,13 +523,15 @@ struct surface_flux_charnock
                            amrex::Real Tflux,
                            amrex::Real Qvflux,
                            amrex::Real cnk_a,
-                           bool cnk_visc)
+                           bool cnk_visc,
+                           bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
         mdata.visc  = cnk_visc;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -554,6 +562,7 @@ struct surface_flux_charnock
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
@@ -578,8 +587,10 @@ struct surface_flux_charnock
             } else {
                 z0 = COARE3_roughness(mdata.zref, umm, ustar);
             }
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
-                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -608,6 +619,7 @@ struct surface_flux_charnock
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -622,13 +634,15 @@ struct surface_flux_mod_charnock
     surface_flux_mod_charnock (amrex::Real zref,
                                amrex::Real Tflux,
                                amrex::Real Qvflux,
-                               amrex::Real depth)
+                               amrex::Real depth,
+                               bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
+        spec_qflux  = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -659,6 +673,7 @@ struct surface_flux_mod_charnock
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
@@ -676,8 +691,10 @@ struct surface_flux_mod_charnock
         do {
             ustar = u_star_arr(i,j,k);
             z0    = std::exp( (2.7*ustar - 1.8/mdata.Cnk_b) / (ustar + 0.17/mdata.Cnk_b) );
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
-                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -706,6 +723,7 @@ struct surface_flux_mod_charnock
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -719,11 +737,13 @@ struct surface_flux_donelan
 {
     surface_flux_donelan (amrex::Real zref,
                           amrex::Real Tflux,
-                          amrex::Real Qvflux)
+                          amrex::Real Qvflux,
+                          bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -754,6 +774,7 @@ struct surface_flux_donelan
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
@@ -771,8 +792,10 @@ struct surface_flux_donelan
         do {
             ustar = u_star_arr(i,j,k);
             z0    = Donelan_roughness(ustar);
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
-                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -801,6 +824,7 @@ struct surface_flux_donelan
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -814,11 +838,13 @@ struct surface_flux_wave_coupled
 {
     surface_flux_wave_coupled (amrex::Real zref,
                                amrex::Real Tflux,
-                               amrex::Real Qvflux)
+                               amrex::Real Qvflux,
+                               bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -849,6 +875,7 @@ struct surface_flux_wave_coupled
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
@@ -872,8 +899,10 @@ struct surface_flux_wave_coupled
             ustar = u_star_arr(i,j,k);
             z0    = std::min( std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
                                       + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps), z0_max );
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
-                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -902,6 +931,7 @@ struct surface_flux_wave_coupled
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real eps = 1e-15;
@@ -918,11 +948,13 @@ struct surface_temp
 {
     surface_temp (amrex::Real zref,
                   amrex::Real Tflux,
-                  amrex::Real Qvflux)
+                  amrex::Real Qvflux,
+                  bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -974,8 +1006,9 @@ struct surface_temp
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1007,6 +1040,7 @@ struct surface_temp
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -1022,13 +1056,15 @@ struct surface_temp_charnock
                            amrex::Real Tflux,
                            amrex::Real Qvflux,
                            amrex::Real cnk_a,
-                           bool cnk_visc)
+                           bool cnk_visc,
+                           bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
         mdata.visc  = cnk_visc;
+        spec_qflux  = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1089,8 +1125,9 @@ struct surface_temp_charnock
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1123,6 +1160,7 @@ struct surface_temp_charnock
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -1137,13 +1175,15 @@ struct surface_temp_mod_charnock
     surface_temp_mod_charnock (amrex::Real zref,
                                amrex::Real Tflux,
                                amrex::Real Qvflux,
-                               amrex::Real depth)
+                               amrex::Real depth,
+                               bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
+        spec_qflux  = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1197,8 +1237,9 @@ struct surface_temp_mod_charnock
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1231,6 +1272,7 @@ struct surface_temp_mod_charnock
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -1244,11 +1286,13 @@ struct surface_temp_donelan
 {
     surface_temp_donelan (amrex::Real zref,
                           amrex::Real Tflux,
-                          amrex::Real Qvflux)
+                          amrex::Real Qvflux,
+                          bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1302,8 +1346,9 @@ struct surface_temp_donelan
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1336,6 +1381,7 @@ struct surface_temp_donelan
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
@@ -1349,11 +1395,13 @@ struct surface_temp_wave_coupled
 {
     surface_temp_wave_coupled (amrex::Real zref,
                                amrex::Real Tflux,
-                               amrex::Real Qvflux)
+                               amrex::Real Qvflux,
+                               bool cons_qflux)
     {
         mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
+        spec_qflux = cons_qflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1413,8 +1461,9 @@ struct surface_temp_wave_coupled
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            qflux = (spec_qflux) ? mdata.surf_moist_flux :
+                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1447,6 +1496,7 @@ struct surface_temp_wave_coupled
 
 private:
     most_data mdata;
+    bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
     const amrex::Real eps = 1e-15;

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1015,13 +1015,11 @@ struct surface_temp
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1043,11 +1041,6 @@ struct surface_temp
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1132,13 +1125,11 @@ struct surface_temp_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1168,11 +1159,6 @@ struct surface_temp_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1257,13 +1243,11 @@ struct surface_temp_mod_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1286,11 +1270,6 @@ struct surface_temp_mod_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1372,13 +1351,11 @@ struct surface_temp_donelan
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         amrex::Real umm = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1401,11 +1378,6 @@ struct surface_temp_donelan
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1487,7 +1459,6 @@ struct surface_temp_wave_coupled
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         int ie, je;
         ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
         je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
@@ -1498,7 +1469,6 @@ struct surface_temp_wave_coupled
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1522,11 +1492,6 @@ struct surface_temp_wave_coupled
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -12,18 +12,19 @@
 struct most_data
 {
 public:
-    amrex::Real zref{10.0};          ///< Reference height (m)
-    amrex::Real z0_const{0.1};       ///< Roughness height -- default constant value(m)
-    amrex::Real kappa{KAPPA};        ///< von Karman constant
-    amrex::Real gravity{CONST_GRAV}; ///< Acceleration due to gravity (m/s^2)
-    amrex::Real surf_temp_flux{0.0}; ///< Heat flux
+    amrex::Real zref{10.0};           ///< Reference height (m)
+    amrex::Real z0_const{0.1};        ///< Roughness height -- default constant value(m)
+    amrex::Real kappa{KAPPA};         ///< von Karman constant
+    amrex::Real gravity{CONST_GRAV};  ///< Acceleration due to gravity (m/s^2)
+    amrex::Real surf_temp_flux{0.0};  ///< Heat flux
+    amrex::Real surf_moist_flux{0.0}; ///< Moisture flux
 
-    amrex::Real Cnk_a{0.0185};       ///< Standard Charnock constant https://doi.org/10.1175/JAMC-D-17-0137.1
-    amrex::Real Cnk_b1{1.0/30.0};    ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
-    amrex::Real Cnk_b2{1260.0};      ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
-    amrex::Real Cnk_d{30.0};         ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_a{0.0185};        ///< Standard Charnock constant https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_b1{1.0/30.0};     ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_b2{1260.0};       ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
+    amrex::Real Cnk_d{30.0};          ///< Modified Charnock Eq (4) https://doi.org/10.1175/JAMC-D-17-0137.1
     amrex::Real Cnk_b;
-    bool visc{false};                ///< Use viscous Charnock formulation
+    bool visc{false};                 ///< Use viscous Charnock formulation
 
     const amrex::Real Bjr_beta = 1.2; // Empirical parameter from Beljaars 1995 QJRMS
 };
@@ -89,10 +90,12 @@ air_viscosity (amrex::Real T_degK)
 struct adiabatic
 {
     adiabatic (amrex::Real zref,
-               amrex::Real flux)
+               amrex::Real Tflux,
+               amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -110,8 +113,9 @@ struct adiabatic
                   const amrex::Array4<amrex::Real>& u_star_arr,
                   const amrex::Array4<amrex::Real>& /*w_star_arr*/,
                   const amrex::Array4<amrex::Real>& t_star_arr,
-                  const amrex::Array4<amrex::Real>& /*q_star_arr*/,
+                  const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& /*t_surf_arr*/,
+                  const amrex::Array4<amrex::Real>& /*q_surf_arr*/,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& /*pblh_arr*/,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -120,6 +124,7 @@ struct adiabatic
     {
         u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0_arr(i,j,k));
         t_star_arr(i,j,k) = 0.0;
+        q_star_arr(i,j,k) = 0.0;
         olen_arr(i,j,k)   = 1.0e16;
     }
 
@@ -135,14 +140,16 @@ private:
 struct adiabatic_charnock
 {
     adiabatic_charnock (amrex::Real zref,
-                        amrex::Real flux,
+                        amrex::Real Tflux,
+                        amrex::Real Qvflux,
                         amrex::Real cnk_a,
                         bool cnk_visc)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
-        mdata.visc = cnk_visc;
+        mdata.visc  = cnk_visc;
     }
 
     AMREX_GPU_DEVICE
@@ -160,8 +167,9 @@ struct adiabatic_charnock
                   const amrex::Array4<amrex::Real>& u_star_arr,
                   const amrex::Array4<amrex::Real>& /*w_star_arr*/,
                   const amrex::Array4<amrex::Real>& t_star_arr,
-                  const amrex::Array4<amrex::Real>& /*q_star_arr*/,
+                  const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& /*t_surf_arr*/,
+                  const amrex::Array4<amrex::Real>& /*q_surf_arr*/,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& /*pblh_arr*/,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -188,6 +196,7 @@ struct adiabatic_charnock
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
 
         t_star_arr(i,j,k) = 0.0;
+        q_star_arr(i,j,k) = 0.0;
           olen_arr(i,j,k) = 1.0e16;
             z0_arr(i,j,k) = z0;
     }
@@ -206,11 +215,13 @@ private:
 struct adiabatic_mod_charnock
 {
     adiabatic_mod_charnock (amrex::Real zref,
-                            amrex::Real flux,
+                            amrex::Real Tflux,
+                            amrex::Real Qvflux,
                             amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
     }
@@ -230,8 +241,9 @@ struct adiabatic_mod_charnock
                   const amrex::Array4<amrex::Real>& u_star_arr,
                   const amrex::Array4<amrex::Real>& /*w_star_arr*/,
                   const amrex::Array4<amrex::Real>& t_star_arr,
-                  const amrex::Array4<amrex::Real>& /*q_star_arr*/,
+                  const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& /*t_surf_arr*/,
+                  const amrex::Array4<amrex::Real>& /*q_surf_arr*/,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& /*pblh_arr*/,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -251,6 +263,7 @@ struct adiabatic_mod_charnock
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
 
         t_star_arr(i,j,k) = 0.0;
+        q_star_arr(i,j,k) = 0.0;
           olen_arr(i,j,k) = 1.0e16;
             z0_arr(i,j,k) = z0;
     }
@@ -269,10 +282,12 @@ private:
 struct adiabatic_donelan
 {
     adiabatic_donelan (amrex::Real zref,
-                       amrex::Real flux)
+                       amrex::Real Tflux,
+                       amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -290,8 +305,9 @@ struct adiabatic_donelan
                   const amrex::Array4<amrex::Real>& u_star_arr,
                   const amrex::Array4<amrex::Real>& /*w_star_arr*/,
                   const amrex::Array4<amrex::Real>& t_star_arr,
-                  const amrex::Array4<amrex::Real>& /*q_star_arr*/,
+                  const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& /*t_surf_arr*/,
+                  const amrex::Array4<amrex::Real>& /*q_surf_arr*/,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& /*pblh_arr*/,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -314,6 +330,7 @@ struct adiabatic_donelan
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
 
         t_star_arr(i,j,k) = 0.0;
+        q_star_arr(i,j,k) = 0.0;
           olen_arr(i,j,k) = 1.0e16;
             z0_arr(i,j,k) = z0;
     }
@@ -332,10 +349,12 @@ private:
 struct adiabatic_wave_coupled
 {
     adiabatic_wave_coupled (amrex::Real zref,
-                            amrex::Real flux)
+                            amrex::Real Tflux,
+                            amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -353,8 +372,9 @@ struct adiabatic_wave_coupled
                   const amrex::Array4<amrex::Real>& u_star_arr,
                   const amrex::Array4<amrex::Real>& /*w_star_arr*/,
                   const amrex::Array4<amrex::Real>& t_star_arr,
-                  const amrex::Array4<amrex::Real>& /*q_star_arr*/,
+                  const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& /*t_surf_arr*/,
+                  const amrex::Array4<amrex::Real>& /*q_surf_arr*/,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& /*pblh_arr*/,
                   const amrex::Array4<amrex::Real>& Hwave_arr,
@@ -380,6 +400,7 @@ struct adiabatic_wave_coupled
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
 
         t_star_arr(i,j,k) = 0.0;
+        q_star_arr(i,j,k) = 0.0;
           olen_arr(i,j,k) = 1.0e16;
             z0_arr(i,j,k) = z0;
     }
@@ -401,10 +422,12 @@ private:
 struct surface_flux
 {
     surface_flux (amrex::Real zref,
-                  amrex::Real flux)
+                  amrex::Real Tflux,
+                  amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -424,6 +447,7 @@ struct surface_flux
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -449,7 +473,8 @@ struct surface_flux
         }
         do {
             ustar = u_star_arr(i,j,k);
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) - 0.61*tm_arr(i,j,k)*ustar*q_star_arr(i,j,k);
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
+                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -469,6 +494,9 @@ struct surface_flux
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
+        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         olen_arr(i,j,k)   = Olen;
     }
 
@@ -486,14 +514,16 @@ private:
 struct surface_flux_charnock
 {
     surface_flux_charnock (amrex::Real zref,
-                           amrex::Real flux,
+                           amrex::Real Tflux,
+                           amrex::Real Qvflux,
                            amrex::Real cnk_a,
                            bool cnk_visc)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
-        mdata.visc = cnk_visc;
+        mdata.visc  = cnk_visc;
     }
 
     AMREX_GPU_DEVICE
@@ -513,6 +543,7 @@ struct surface_flux_charnock
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -547,7 +578,8 @@ struct surface_flux_charnock
             } else {
                 z0 = COARE3_roughness(mdata.zref, umm, ustar);
             }
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) - 0.61*tm_arr(i,j,k)*ustar*q_star_arr(i,j,k);
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
+                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -567,6 +599,9 @@ struct surface_flux_charnock
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
+        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
+                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
            z0_arr(i,j,k)  = z0;
     }
@@ -585,11 +620,13 @@ private:
 struct surface_flux_mod_charnock
 {
     surface_flux_mod_charnock (amrex::Real zref,
-                               amrex::Real flux,
+                               amrex::Real Tflux,
+                               amrex::Real Qvflux,
                                amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
     }
@@ -611,6 +648,7 @@ struct surface_flux_mod_charnock
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -638,7 +676,8 @@ struct surface_flux_mod_charnock
         do {
             ustar = u_star_arr(i,j,k);
             z0    = std::exp( (2.7*ustar - 1.8/mdata.Cnk_b) / (ustar + 0.17/mdata.Cnk_b) );
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) - 0.61*tm_arr(i,j,k)*ustar*q_star_arr(i,j,k);
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
+                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -658,6 +697,9 @@ struct surface_flux_mod_charnock
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
+        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
+                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
            z0_arr(i,j,k)  = z0;
     }
@@ -676,10 +718,12 @@ private:
 struct surface_flux_donelan
 {
     surface_flux_donelan (amrex::Real zref,
-                          amrex::Real flux)
+                          amrex::Real Tflux,
+                          amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -699,6 +743,7 @@ struct surface_flux_donelan
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -726,7 +771,8 @@ struct surface_flux_donelan
         do {
             ustar = u_star_arr(i,j,k);
             z0    = Donelan_roughness(ustar);
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) - 0.61*tm_arr(i,j,k)*ustar*q_star_arr(i,j,k);
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
+                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -746,6 +792,9 @@ struct surface_flux_donelan
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
+        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
+                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
            z0_arr(i,j,k)  = z0;
     }
@@ -764,10 +813,12 @@ private:
 struct surface_flux_wave_coupled
 {
     surface_flux_wave_coupled (amrex::Real zref,
-                               amrex::Real flux)
+                               amrex::Real Tflux,
+                               amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -787,6 +838,7 @@ struct surface_flux_wave_coupled
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& Hwave_arr,
@@ -820,7 +872,8 @@ struct surface_flux_wave_coupled
             ustar = u_star_arr(i,j,k);
             z0    = std::min( std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
                                       + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps), z0_max );
-            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) - 0.61*tm_arr(i,j,k)*ustar*q_star_arr(i,j,k);
+            tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k))
+                  + mdata.surf_moist_flux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -840,6 +893,9 @@ struct surface_flux_wave_coupled
         t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
+        q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0) - psi_h) /
+                            (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
+        q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
           olen_arr(i,j,k) = Olen;
            z0_arr(i,j,k)  = z0;
     }
@@ -851,7 +907,7 @@ private:
     const amrex::Real eps = 1e-15;
     const amrex::Real z0_eps = 1.0e-6;
     const amrex::Real z0_max = 0.1;
-    const amrex::Real WSMIN = 0.1; // minimum wind speed
+    const amrex::Real WSMIN  = 0.1; // minimum wind speed
 };
 
 
@@ -861,10 +917,12 @@ private:
 struct surface_temp
 {
     surface_temp (amrex::Real zref,
-                  amrex::Real flux)
+                  amrex::Real Tflux,
+                  amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -884,6 +942,7 @@ struct surface_temp
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -894,6 +953,7 @@ struct surface_temp
         amrex::Real ustar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -914,7 +974,9 @@ struct surface_temp
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            tflux += 0.61*tm_arr(i,j,k) * -ustar*q_star_arr(i,j,k); // ~= <w'Tv'>
+            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -938,6 +1000,8 @@ struct surface_temp
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                            (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
         olen_arr(i,j,k)   = Olen;
     }
 
@@ -955,14 +1019,16 @@ private:
 struct surface_temp_charnock
 {
     surface_temp_charnock (amrex::Real zref,
-                           amrex::Real flux,
+                           amrex::Real Tflux,
+                           amrex::Real Qvflux,
                            amrex::Real cnk_a,
                            bool cnk_visc)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
-        mdata.visc = cnk_visc;
+        mdata.visc  = cnk_visc;
     }
 
     AMREX_GPU_DEVICE
@@ -982,6 +1048,7 @@ struct surface_temp_charnock
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -993,6 +1060,7 @@ struct surface_temp_charnock
         amrex::Real wstar = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -1021,7 +1089,9 @@ struct surface_temp_charnock
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            tflux += 0.61*tm_arr(i,j,k) * -ustar*q_star_arr(i,j,k); // ~= <w'Tv'>
+            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1045,6 +1115,8 @@ struct surface_temp_charnock
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
+        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
     }
@@ -1063,11 +1135,13 @@ private:
 struct surface_temp_mod_charnock
 {
     surface_temp_mod_charnock (amrex::Real zref,
-                               amrex::Real flux,
+                               amrex::Real Tflux,
+                               amrex::Real Qvflux,
                                amrex::Real depth)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
         mdata.Cnk_b = mdata.Cnk_b1 * std::log(mdata.Cnk_b2 / mdata.Cnk_d);
     }
@@ -1089,6 +1163,7 @@ struct surface_temp_mod_charnock
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -1100,6 +1175,7 @@ struct surface_temp_mod_charnock
         amrex::Real wstar = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -1121,7 +1197,9 @@ struct surface_temp_mod_charnock
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            tflux += 0.61*tm_arr(i,j,k) * -ustar*q_star_arr(i,j,k); // ~= <w'Tv'>
+            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1145,6 +1223,8 @@ struct surface_temp_mod_charnock
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
+        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
     }
@@ -1163,10 +1243,12 @@ private:
 struct surface_temp_donelan
 {
     surface_temp_donelan (amrex::Real zref,
-                          amrex::Real flux)
+                          amrex::Real Tflux,
+                          amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1186,6 +1268,7 @@ struct surface_temp_donelan
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& /*Hwave_arr*/,
@@ -1197,6 +1280,7 @@ struct surface_temp_donelan
         amrex::Real wstar = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -1218,7 +1302,9 @@ struct surface_temp_donelan
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            tflux += 0.61*tm_arr(i,j,k) * -ustar*q_star_arr(i,j,k); // ~= <w'Tv'>
+            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1242,6 +1328,8 @@ struct surface_temp_donelan
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
+        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
     }
@@ -1260,10 +1348,12 @@ private:
 struct surface_temp_wave_coupled
 {
     surface_temp_wave_coupled (amrex::Real zref,
-                               amrex::Real flux)
+                               amrex::Real Tflux,
+                               amrex::Real Qvflux)
     {
         mdata.zref = zref;
-        mdata.surf_temp_flux = flux;
+        mdata.surf_temp_flux  = Tflux;
+        mdata.surf_moist_flux = Qvflux;
     }
 
     AMREX_GPU_DEVICE
@@ -1283,6 +1373,7 @@ struct surface_temp_wave_coupled
                   const amrex::Array4<amrex::Real>& t_star_arr,
                   const amrex::Array4<amrex::Real>& q_star_arr,
                   const amrex::Array4<amrex::Real>& t_surf_arr,
+                  const amrex::Array4<amrex::Real>& q_surf_arr,
                   const amrex::Array4<amrex::Real>& olen_arr,
                   const amrex::Array4<amrex::Real>& pblh_arr,
                   const amrex::Array4<amrex::Real>& Hwave_arr,
@@ -1294,6 +1385,7 @@ struct surface_temp_wave_coupled
         amrex::Real wstar = 0.0;
         amrex::Real z0    = 0.0;
         amrex::Real tflux = 0.0;
+        amrex::Real qflux = 0.0;
         amrex::Real zeta  = 0.0;
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
@@ -1321,7 +1413,9 @@ struct surface_temp_wave_coupled
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
                      (std::log(mdata.zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            tflux += 0.61*tm_arr(i,j,k) * -ustar*q_star_arr(i,j,k); // ~= <w'Tv'>
+            qflux = -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
+                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1345,6 +1439,8 @@ struct surface_temp_wave_coupled
 
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
                             (std::log(mdata.zref / z0) - psi_h);
+        q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                            (std::log(mdata.zref / z0) - psi_h);
           olen_arr(i,j,k) = Olen;
             z0_arr(i,j,k) = z0;
     }
@@ -1356,7 +1452,7 @@ private:
     const amrex::Real eps = 1e-15;
     const amrex::Real z0_eps = 1.0e-6;
     const amrex::Real z0_max = 0.1;
-    const amrex::Real WSMIN = 0.1; // minimum wind speed
+    const amrex::Real WSMIN  = 0.1; // minimum wind speed
 };
 
 
@@ -1370,20 +1466,37 @@ struct moeng_flux
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real
-    compute_q_flux (const int& /*i*/,
-                    const int& /*j*/,
-                    const int& /*k*/,
-                    const amrex::Array4<const amrex::Real>& /*cons_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*velx_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*vely_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*umm_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*qm_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*q_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
+    compute_q_flux (const int& i,
+                    const int& j,
+                    const int& k,
+                    const amrex::Array4<const amrex::Real>& cons_arr,
+                    const amrex::Array4<const amrex::Real>& velx_arr,
+                    const amrex::Array4<const amrex::Real>& vely_arr,
+                    const amrex::Array4<const amrex::Real>& umm_arr,
+                    const amrex::Array4<const amrex::Real>& qvm_arr,
+                    const amrex::Array4<const amrex::Real>& u_star_arr,
+                    const amrex::Array4<const amrex::Real>& q_star_arr,
+                    const amrex::Array4<const amrex::Real>& q_surf_arr) const
     {
-        // NOTE: this is rho*<q'w'> = -K dqdz
-        amrex::Real moflux  = 0.0;
+        amrex::Real rho   = cons_arr(i,j,k,Rho_comp);
+        amrex::Real qv    = cons_arr(i,j,k,RhoQ1_comp) / rho;
+        amrex::Real velx  = 0.5 * ( velx_arr(i,j,k) + velx_arr(i+1,j  ,k) );
+        amrex::Real vely  = 0.5 * ( vely_arr(i,j,k) + vely_arr(i  ,j+1,k) );
+
+        amrex::Real qv_mean  = qvm_arr(i,j,k);
+        amrex::Real ustar    = u_star_arr(i,j,k);
+        amrex::Real qstar    = q_star_arr(i,j,k);
+        amrex::Real qv_surf  = q_surf_arr(i,j,k);
+        amrex::Real wsp_mean = umm_arr(i,j,k);
+        wsp_mean = std::max(wsp_mean, WSMIN);
+
+        amrex::Real wsp     = sqrt(velx*velx+vely*vely);
+        amrex::Real num1    = wsp * (qv_mean-qv_surf);
+        amrex::Real num2    = wsp_mean * (qv-qv_mean);
+
+        // NOTE: this is rho*<Qv'w'> = -K dQvdz
+        amrex::Real moflux  = (std::abs(qstar) > eps) ?
+                              -rho*qstar*ustar*(num1+num2)/((qv_mean-qv_surf)*wsp_mean) : 0.0;
 
         return moflux;
     }
@@ -1526,7 +1639,7 @@ struct donelan_flux
                     const amrex::Array4<const amrex::Real>& /*qm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& /*q_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
+                    const amrex::Array4<const amrex::Real>& /*q_surf_arr*/) const
     {
         // NOTE: this is rho*<q'w'> = -K dqdz
         amrex::Real moflux  = 0.0;
@@ -1658,7 +1771,7 @@ struct custom_flux
                     const amrex::Array4<const amrex::Real>& /*qm_arr*/,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
                     const amrex::Array4<const amrex::Real>& q_star_arr,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
+                    const amrex::Array4<const amrex::Real>& /*q_surf_arr*/) const
     {
         amrex::Real rho   =   cons_arr(i,j,k,Rho_comp);
         amrex::Real qstar = q_star_arr(i,j,k);
@@ -1748,7 +1861,7 @@ struct custom_flux
     }
 
 private:
-    const amrex::Real     eps = 1e-15;
+    const amrex::Real eps = 1e-15;
 
 };
 
@@ -1769,15 +1882,17 @@ struct rotate_flux
                     const amrex::Array4<const amrex::Real>& /*velx_arr*/,
                     const amrex::Array4<const amrex::Real>& /*vely_arr*/,
                     const amrex::Array4<const amrex::Real>& /*umm_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*qm_arr*/,
+                    const amrex::Array4<const amrex::Real>& qvm_arr,
                     const amrex::Array4<const amrex::Real>& /*u_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*q_star_arr*/,
-                    const amrex::Array4<const amrex::Real>& /*t_surf_arr*/) const
+                    const amrex::Array4<const amrex::Real>& q_star_arr,
+                    const amrex::Array4<const amrex::Real>& q_surf_arr) const
     {
         // NOTE: this is the total stress
-        amrex::Real rho    = cons_arr(i,j,k,Rho_comp);
-        amrex::Real qstar  = 0.0; //q_star_arr(i,j,k);
-        amrex::Real moflux = (std::abs(qstar) > eps) ? -rho * qstar : 0.0;
+        amrex::Real qv_mean = qvm_arr(i,j,k);
+        amrex::Real qv_surf = q_surf_arr(i,j,k);
+        amrex::Real rho     = cons_arr(i,j,k,Rho_comp);
+        amrex::Real qstar   = q_star_arr(i,j,k);
+        amrex::Real moflux  = (std::abs(qstar) > eps) ? -rho * qstar * (qv_mean-qv_surf): 0.0;
 
         return moflux;
     }

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1043,11 +1043,13 @@ struct surface_temp
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
+                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
+
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1168,8 +1170,9 @@ struct surface_temp_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
+                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
@@ -1286,8 +1289,9 @@ struct surface_temp_mod_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
+                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
@@ -1401,8 +1405,9 @@ struct surface_temp_donelan
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
+                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
@@ -1522,8 +1527,9 @@ struct surface_temp_wave_coupled
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
+                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1015,11 +1015,13 @@ struct surface_temp
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1041,6 +1043,11 @@ struct surface_temp
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+                Olen = 0.5 * (Olen + Oleno);
+            }
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1125,11 +1132,13 @@ struct surface_temp_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1159,6 +1168,11 @@ struct surface_temp_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+                Olen = 0.5 * (Olen + Oleno);
+            }
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1243,11 +1257,13 @@ struct surface_temp_mod_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1270,6 +1286,11 @@ struct surface_temp_mod_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+                Olen = 0.5 * (Olen + Oleno);
+            }
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1351,11 +1372,13 @@ struct surface_temp_donelan
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real Oleno = 0.0;
         amrex::Real umm = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1378,6 +1401,11 @@ struct surface_temp_donelan
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+                Olen = 0.5 * (Olen + Oleno);
+            }
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1459,6 +1487,7 @@ struct surface_temp_wave_coupled
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real Oleno = 0.0;
         int ie, je;
         ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
         je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
@@ -1469,6 +1498,7 @@ struct surface_temp_wave_coupled
             u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
@@ -1492,6 +1522,11 @@ struct surface_temp_wave_coupled
                 umm = std::max(umm, WSMIN);
             }
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            if ( ((Olen >= 0.0) && (Oleno <= 0.0)) ||
+                 ((Olen <= 0.0) && (Oleno >= 0.0)) ) {
+                Olen = 0.5 * (Olen + Oleno);
+            }
+            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -97,18 +97,13 @@ public:
       }
 
       // Get surface temperature
-      bool erf_sq = false;
       auto erf_st = pp.query("most.surf_temp", surf_temp);
-      if (use_moisture) { erf_sq = pp.query("most.surf_moist", surf_moist); }
-      if (erf_st || erf_sq) {
-          pp.get("most.surf_temp",surf_temp);
-          default_land_surf_temp  = surf_temp;
+      if (erf_st) { default_land_surf_temp  = surf_temp; }
 
-          if (use_moisture) {
-              pp.get("most.surf_moist",surf_moist);
-              default_land_surf_moist = surf_moist;
-          }
-      }
+      // Get surface moisture
+      bool erf_sq = false;
+      if (use_moisture) { erf_sq = pp.query("most.surf_moist", surf_moist); }
+      if (erf_sq) { default_land_surf_moist = surf_moist; }
 
       // Custom type user must specify the fluxes
       if (flux_type == FluxCalcType::CUSTOM) {
@@ -127,21 +122,18 @@ public:
 
       // Specify surface temperature/moisture or surface flux
       } else {
-          if (erf_st || erf_sq) {
+          if (erf_st) {
               theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
-              moist_type = MoistCalcType::SURFACE_MOISTURE;
               pp.query("most.surf_heating_rate", surf_heating_rate); // [K/h]
               surf_heating_rate = surf_heating_rate / 3600.0;        // [K/s]
               if (pp.query("most.surf_temp_flux", surf_temp_flux)) {
-                  amrex::Abort(
-                               "Can only specify one of surf_temp_flux or surf_heating_rate");
+                  amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }
           } else {
               pp.query("most.surf_temp_flux", surf_temp_flux);
-              pp.query("most.surf_moist_flux", surf_moist_flux);
+
               if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
-                  amrex::Abort(
-                               "Can only specify one of surf_temp_flux or surf_heating_rate");
+                  amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }
               if (std::abs(surf_temp_flux) >
                   std::numeric_limits<amrex::Real>::epsilon()) {
@@ -149,6 +141,13 @@ public:
               } else {
                   theta_type = ThetaCalcType::ADIABATIC;
               }
+
+          }
+
+          if (erf_sq) {
+              moist_type = MoistCalcType::SURFACE_MOISTURE;
+          } else {
+              pp.query("most.surf_moist_flux", surf_moist_flux);
               if (std::abs(surf_moist_flux) >
                   std::numeric_limits<amrex::Real>::epsilon()) {
                   moist_type = MoistCalcType::MOISTURE_FLUX;
@@ -377,6 +376,9 @@ public:
       t_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
       t_surf[lev]->setVal(default_land_surf_temp);
 
+      q_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      q_surf[lev]->setVal(default_land_surf_moist);
+
       // TODO: Do we want lsm_data to have theta at 0 index always?
       //       Do we want an external enum struct for indexing?
       if (m_sst_lev[lev][0] || m_tsk_lev[lev][0] || m_lsm_data_lev[lev][0]) {
@@ -384,15 +386,9 @@ public:
           // extended lambda capture) Note that land temp will be set from m_tsk_lev
           //      while sea temp will be set from m_sst_lev
           theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
-
-          // Moisture must be the same calc type
-          moist_type = MoistCalcType::SURFACE_MOISTURE;
-          pp.get("most.surf_moist",surf_moist);
-          default_land_surf_moist = surf_moist;
       }
 
-      q_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-      q_surf[lev]->setVal(default_land_surf_moist);
+
   }
 
   void
@@ -540,8 +536,8 @@ public:
 
   enum struct MoistCalcType {
     ADIABATIC = 0,
-    MOISTURE_FLUX,          ///< Qv-flux specified
-    SURFACE_MOISTURE ///< Surface Qv specified
+    MOISTURE_FLUX,      ///< Qv-flux specified
+    SURFACE_MOISTURE    ///< Surface Qv specified
   };
 
   enum struct RoughCalcType {
@@ -570,11 +566,11 @@ private:
 
   bool m_include_wstar = false;
   amrex::Real z0_const{0.1};
-  amrex::Real default_land_surf_temp = 300.;
+  amrex::Real default_land_surf_temp{300.};
   amrex::Real surf_temp;
   amrex::Real surf_heating_rate{0};
   amrex::Real surf_temp_flux{0};
-  amrex::Real default_land_surf_moist = 0.;
+  amrex::Real default_land_surf_moist{0.};
   amrex::Real surf_moist;
   amrex::Real surf_moist_flux{0};
   amrex::Real custom_ustar{0};

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -31,476 +31,494 @@ class SurfaceLayer
 
 public:
   // Constructor
-  explicit SurfaceLayer(
-    const amrex::Vector<amrex::Geometry>& geom,
-    bool& use_rot_surface_flux,
-    std::string a_pp_prefix,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd,
-    const TerrainType& a_terrain_type,
-    amrex::Real start_bdy_time = 0.0,
-    amrex::Real bdy_time_interval = 0.0)
-    : m_geom(geom),
-      m_rotate(use_rot_surface_flux),
-      m_start_bdy_time(start_bdy_time),
-      m_bdy_time_interval(bdy_time_interval),
-      m_ma(geom, (z_phys_nd[0] != nullptr), a_pp_prefix, a_terrain_type)
+  explicit SurfaceLayer (const amrex::Vector<amrex::Geometry>& geom,
+                         bool& use_rot_surface_flux,
+                         std::string a_pp_prefix,
+                         amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim,
+                         amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd,
+                         const TerrainType& a_terrain_type,
+                         amrex::Real start_bdy_time = 0.0,
+                         amrex::Real bdy_time_interval = 0.0)
+  : m_geom(geom),
+    m_rotate(use_rot_surface_flux),
+    m_start_bdy_time(start_bdy_time),
+    m_bdy_time_interval(bdy_time_interval),
+    m_ma(geom, (z_phys_nd[0] != nullptr), a_pp_prefix, a_terrain_type)
   {
-    // We have a moisture model if Qv_prim is a valid pointer
-    use_moisture = (Qv_prim[0].get());
+      // We have a moisture model if Qv_prim is a valid pointer
+      use_moisture = (Qv_prim[0].get());
 
-    // Get roughness
-    amrex::ParmParse pp("erf");
-    pp.query("most.z0", z0_const);
+      // Get roughness
+      amrex::ParmParse pp("erf");
+      pp.query("most.z0", z0_const);
 
-    // Specify how to compute the flux
-    if (use_rot_surface_flux) {
-      flux_type = FluxCalcType::ROTATE;
-    } else {
-      std::string flux_string_in;
-      std::string flux_string{"moeng"};
-      auto read_flux = pp.query("surface_layer.flux_type", flux_string_in);
-      if (read_flux) {
-        flux_string = amrex::toLower(flux_string_in);
-      }
-      if (flux_string == "donelan") {
-        flux_type = FluxCalcType::DONELAN;
-      } else if (flux_string == "moeng") {
-        flux_type = FluxCalcType::MOENG;
-      } else if (flux_string == "custom") {
-        flux_type = FluxCalcType::CUSTOM;
+      // Specify how to compute the flux
+      if (use_rot_surface_flux) {
+          flux_type = FluxCalcType::ROTATE;
       } else {
-        amrex::Abort("Undefined MOST flux type!");
+          std::string flux_string_in;
+          std::string flux_string{"moeng"};
+          auto read_flux = pp.query("surface_layer.flux_type", flux_string_in);
+          if (read_flux) {
+              flux_string = amrex::toLower(flux_string_in);
+          }
+          if (flux_string == "donelan") {
+              flux_type = FluxCalcType::DONELAN;
+          } else if (flux_string == "moeng") {
+              flux_type = FluxCalcType::MOENG;
+          } else if (flux_string == "custom") {
+              flux_type = FluxCalcType::CUSTOM;
+          } else {
+              amrex::Abort("Undefined MOST flux type!");
+          }
       }
-    }
 
-    // Include w* to handle free convection (Beljaars 1995, QJRMS)
-    pp.query("most.include_wstar", m_include_wstar);
+      // Include w* to handle free convection (Beljaars 1995, QJRMS)
+      pp.query("most.include_wstar", m_include_wstar);
 
-    std::string pblh_string_in;
-    std::string pblh_string{"none"};
-    auto read_pblh = pp.query("most.pblh_calc", pblh_string_in);
-    if (read_pblh) {
-      pblh_string = amrex::toLower(pblh_string_in);
-    }
-    if (pblh_string == "none") {
-      pblh_type = PBLHeightCalcType::None;
-    } else if (pblh_string == "mynn25") {
-      pblh_type = PBLHeightCalcType::MYNN25;
-    } else if (pblh_string == "mynnedmf") {
-      pblh_type = PBLHeightCalcType::MYNN25;
-    } else if (pblh_string == "ysu") {
-      pblh_type = PBLHeightCalcType::YSU;
-    } else if (pblh_string == "mrf") {
-      pblh_type = PBLHeightCalcType::MRF;
-    } else {
-      amrex::Abort("Undefined PBLH calc type!");
-    }
-
-    // Get surface temperature
-    auto erf_st = pp.query("most.surf_temp", surf_temp);
-    if (erf_st) {
-      default_land_surf_temp = surf_temp;
-    }
-
-    // Custom type user must specify the fluxes
-    if (flux_type == FluxCalcType::CUSTOM) {
-      theta_type = ThetaCalcType::HEAT_FLUX;
-      pp.query("most.ustar", custom_ustar);
-      pp.query("most.tstar", custom_tstar);
-      pp.query("most.qstar", custom_qstar);
-      if (custom_qstar != 0) {
-        AMREX_ASSERT_WITH_MESSAGE(
-          use_moisture,
-          "Specified custom MOST qv flux without moisture model!");
+      std::string pblh_string_in;
+      std::string pblh_string{"none"};
+      auto read_pblh = pp.query("most.pblh_calc", pblh_string_in);
+      if (read_pblh) {
+          pblh_string = amrex::toLower(pblh_string_in);
       }
-      amrex::Print() << "Using specified ustar, tstar, qstar for MOST = "
-                     << custom_ustar << " " << custom_tstar << " "
-                     << custom_qstar << std::endl;
-
-      // Specify surface temperature or surface flux
-    } else {
-      if (erf_st) {
-        theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
-        pp.query("most.surf_heating_rate", surf_heating_rate); // [K/h]
-        surf_heating_rate = surf_heating_rate / 3600.0;        // [K/s]
-        if (pp.query("most.surf_temp_flux", surf_temp_flux)) {
-          amrex::Abort(
-            "Can only specify one of surf_temp_flux or surf_heating_rate");
-        }
+      if (pblh_string == "none") {
+          pblh_type = PBLHeightCalcType::None;
+      } else if (pblh_string == "mynn25") {
+          pblh_type = PBLHeightCalcType::MYNN25;
+      } else if (pblh_string == "mynnedmf") {
+          pblh_type = PBLHeightCalcType::MYNN25;
+      } else if (pblh_string == "ysu") {
+          pblh_type = PBLHeightCalcType::YSU;
+      } else if (pblh_string == "mrf") {
+          pblh_type = PBLHeightCalcType::MRF;
       } else {
-        pp.query("most.surf_temp_flux", surf_temp_flux);
-        if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
-          amrex::Abort(
-            "Can only specify one of surf_temp_flux or surf_heating_rate");
-        }
-        if (
-          std::abs(surf_temp_flux) >
-          std::numeric_limits<amrex::Real>::epsilon()) {
+          amrex::Abort("Undefined PBLH calc type!");
+      }
+
+      // Get surface temperature
+      auto erf_st = pp.query("most.surf_temp", surf_temp);
+      auto erf_sq = pp.query("most.surf_moist", surf_moist);
+      if (erf_st || erf_sq) {
+          pp.get("most.surf_temp",surf_temp);
+          pp.get("most.surf_moist",surf_moist);
+          default_land_surf_temp  = surf_temp;
+          default_land_surf_moist = surf_moist;
+      }
+
+      // Custom type user must specify the fluxes
+      if (flux_type == FluxCalcType::CUSTOM) {
           theta_type = ThetaCalcType::HEAT_FLUX;
-        } else {
-          theta_type = ThetaCalcType::ADIABATIC;
-        }
-      }
-    }
+          moist_type = MoistCalcType::MOISTURE_FLUX;
+          pp.query("most.ustar", custom_ustar);
+          pp.query("most.tstar", custom_tstar);
+          pp.query("most.qstar", custom_qstar);
+          if (custom_qstar != 0) {
+              AMREX_ASSERT_WITH_MESSAGE(use_moisture,
+              "Specified custom MOST qv flux without moisture model!");
+          }
+          amrex::Print() << "Using specified ustar, tstar, qstar for MOST = "
+                         << custom_ustar << " " << custom_tstar << " "
+                         << custom_qstar << std::endl;
 
-    // Make sure the inputs file doesn't try to use most.roughness_type
-    std::string bogus_input;
-    if (pp.query("most.roughness_type", bogus_input) > 0) {
-      amrex::Abort("most.roughness_type is deprecated; use "
-                   "most.roughness_type_land and/or most.roughness_type_sea");
-    }
-
-    // Specify how to compute the surface flux over land (if there is any)
-    std::string rough_land_string_in;
-    std::string rough_land_string{"constant"};
-    auto read_rough_land =
-      pp.query("most.roughness_type_land", rough_land_string_in);
-    if (read_rough_land) {
-      rough_land_string = amrex::toLower(rough_land_string_in);
-    }
-    if (rough_land_string == "constant") {
-      rough_type_land = RoughCalcType::CONSTANT;
-    } else {
-      amrex::Abort("Undefined MOST roughness type for land!");
-    }
-
-    // Specify how to compute the surface flux over sea (if there is any)
-    std::string rough_sea_string_in;
-    std::string rough_sea_string{"charnock"};
-    auto read_rough_sea =
-      pp.query("most.roughness_type_sea", rough_sea_string_in);
-    if (read_rough_sea) {
-      rough_sea_string = amrex::toLower(rough_sea_string_in);
-    }
-    if (rough_sea_string == "charnock") {
-      rough_type_sea = RoughCalcType::CHARNOCK;
-      pp.query("most.charnock_constant", cnk_a);
-      pp.query("most.charnock_viscosity", cnk_visc);
-      if (cnk_a > 0) {
-        amrex::Print() << "If there is water, Charnock relation with C_a="
-                       << cnk_a << (cnk_visc ? " and viscosity" : "")
-                       << " will be used" << std::endl;
+      // Specify surface temperature/moisture or surface flux
       } else {
-        amrex::Print() << "If there is water, Charnock relation with variable "
-                          "Charnock parameter (COARE3.0)"
-                       << (cnk_visc ? " and viscosity" : "") << " will be used"
-                       << std::endl;
+          if (erf_st || erf_sq) {
+              theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
+              moist_type = MoistCalcType::SURFACE_MOISTURE;
+              pp.query("most.surf_heating_rate", surf_heating_rate); // [K/h]
+              surf_heating_rate = surf_heating_rate / 3600.0;        // [K/s]
+              if (pp.query("most.surf_temp_flux", surf_temp_flux)) {
+                  amrex::Abort(
+                               "Can only specify one of surf_temp_flux or surf_heating_rate");
+              }
+          } else {
+              pp.query("most.surf_temp_flux", surf_temp_flux);
+              pp.query("most.surf_moist_flux", surf_moist_flux);
+              if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
+                  amrex::Abort(
+                               "Can only specify one of surf_temp_flux or surf_heating_rate");
+              }
+              if (std::abs(surf_temp_flux) >
+                  std::numeric_limits<amrex::Real>::epsilon()) {
+                  theta_type = ThetaCalcType::HEAT_FLUX;
+              } else {
+                  theta_type = ThetaCalcType::ADIABATIC;
+              }
+              if (std::abs(surf_moist_flux) >
+                  std::numeric_limits<amrex::Real>::epsilon()) {
+                  moist_type = MoistCalcType::MOISTURE_FLUX;
+              } else {
+                  moist_type = MoistCalcType::ADIABATIC;
+              }
+          }
       }
-    } else if (rough_sea_string == "coare3.0") {
-      rough_type_sea = RoughCalcType::CHARNOCK;
-      amrex::Print() << "If there is water, Charnock relation with variable "
-                        "Charnock parameter (COARE3.0)"
-                     << (cnk_visc ? " and viscosity" : "") << " will be used"
-                     << std::endl;
-      cnk_a = -1;
-    } else if (rough_sea_string == "donelan") {
-      rough_type_sea = RoughCalcType::DONELAN;
-    } else if (rough_sea_string == "modified_charnock") {
-      rough_type_sea = RoughCalcType::MODIFIED_CHARNOCK;
-      pp.query("most.modified_charnock_depth", depth);
-    } else if (rough_sea_string == "wave_coupled") {
-      rough_type_sea = RoughCalcType::WAVE_COUPLED;
-    } else if (rough_sea_string == "constant") {
-      rough_type_sea = RoughCalcType::CONSTANT;
-    } else {
-      amrex::Abort("Undefined MOST roughness type for sea!");
-    }
+
+      // Make sure the inputs file doesn't try to use most.roughness_type
+      std::string bogus_input;
+      if (pp.query("most.roughness_type", bogus_input) > 0) {
+          amrex::Abort("most.roughness_type is deprecated; use "
+                       "most.roughness_type_land and/or most.roughness_type_sea");
+      }
+
+      // Specify how to compute the surface flux over land (if there is any)
+      std::string rough_land_string_in;
+      std::string rough_land_string{"constant"};
+      auto read_rough_land =
+          pp.query("most.roughness_type_land", rough_land_string_in);
+      if (read_rough_land) {
+          rough_land_string = amrex::toLower(rough_land_string_in);
+      }
+      if (rough_land_string == "constant") {
+          rough_type_land = RoughCalcType::CONSTANT;
+      } else {
+          amrex::Abort("Undefined MOST roughness type for land!");
+      }
+
+      // Specify how to compute the surface flux over sea (if there is any)
+      std::string rough_sea_string_in;
+      std::string rough_sea_string{"charnock"};
+      auto read_rough_sea = pp.query("most.roughness_type_sea", rough_sea_string_in);
+      if (read_rough_sea) {
+          rough_sea_string = amrex::toLower(rough_sea_string_in);
+      }
+      if (rough_sea_string == "charnock") {
+          rough_type_sea = RoughCalcType::CHARNOCK;
+          pp.query("most.charnock_constant", cnk_a);
+          pp.query("most.charnock_viscosity", cnk_visc);
+          if (cnk_a > 0) {
+              amrex::Print() << "If there is water, Charnock relation with C_a="
+                             << cnk_a << (cnk_visc ? " and viscosity" : "")
+                             << " will be used" << std::endl;
+          } else {
+              amrex::Print() << "If there is water, Charnock relation with variable "
+                  "Charnock parameter (COARE3.0)"
+                             << (cnk_visc ? " and viscosity" : "") << " will be used"
+                             << std::endl;
+          }
+      } else if (rough_sea_string == "coare3.0") {
+          rough_type_sea = RoughCalcType::CHARNOCK;
+          amrex::Print() << "If there is water, Charnock relation with variable "
+              "Charnock parameter (COARE3.0)"
+                         << (cnk_visc ? " and viscosity" : "") << " will be used"
+                         << std::endl;
+          cnk_a = -1;
+      } else if (rough_sea_string == "donelan") {
+          rough_type_sea = RoughCalcType::DONELAN;
+      } else if (rough_sea_string == "modified_charnock") {
+          rough_type_sea = RoughCalcType::MODIFIED_CHARNOCK;
+          pp.query("most.modified_charnock_depth", depth);
+      } else if (rough_sea_string == "wave_coupled") {
+          rough_type_sea = RoughCalcType::WAVE_COUPLED;
+      } else if (rough_sea_string == "constant") {
+          rough_type_sea = RoughCalcType::CONSTANT;
+      } else {
+          amrex::Abort("Undefined MOST roughness type for sea!");
+      }
   } // constructor
 
-  void make_SurfaceLayer_at_level(
-    const int& lev,
-    int nlevs,
-    const amrex::Vector<amrex::MultiFab*>& mfv,
-    std::unique_ptr<amrex::MultiFab>& Theta_prim,
-    std::unique_ptr<amrex::MultiFab>& Qv_prim,
-    std::unique_ptr<amrex::MultiFab>& Qr_prim,
-    std::unique_ptr<amrex::MultiFab>& z_phys_nd,
-    amrex::MultiFab* Hwave,
-    amrex::MultiFab* Lwave,
-    amrex::MultiFab* eddyDiffs,
-    amrex::Vector<amrex::MultiFab*> lsm_data,
-    amrex::Vector<amrex::MultiFab*> lsm_flux,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& sst_lev,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& tsk_lev,
-    amrex::Vector<std::unique_ptr<amrex::iMultiFab>>& lmask_lev)
+  void make_SurfaceLayer_at_level (const int& lev,
+                                   int nlevs,
+                                   const amrex::Vector<amrex::MultiFab*>& mfv,
+                                   std::unique_ptr<amrex::MultiFab>& Theta_prim,
+                                   std::unique_ptr<amrex::MultiFab>& Qv_prim,
+                                   std::unique_ptr<amrex::MultiFab>& Qr_prim,
+                                   std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                                   amrex::MultiFab* Hwave,
+                                   amrex::MultiFab* Lwave,
+                                   amrex::MultiFab* eddyDiffs,
+                                   amrex::Vector<amrex::MultiFab*> lsm_data,
+                                   amrex::Vector<amrex::MultiFab*> lsm_flux,
+                                   amrex::Vector<std::unique_ptr<amrex::MultiFab>>& sst_lev,
+                                   amrex::Vector<std::unique_ptr<amrex::MultiFab>>& tsk_lev,
+                                   amrex::Vector<std::unique_ptr<amrex::iMultiFab>>& lmask_lev)
   {
-    // Update MOST Average
-    m_ma.make_MOSTAverage_at_level(
-      lev, mfv, Theta_prim, Qv_prim, Qr_prim, z_phys_nd);
+      // Update MOST Average
+      m_ma.make_MOSTAverage_at_level(lev, mfv,
+                                     Theta_prim, Qv_prim, Qr_prim,
+                                     z_phys_nd);
 
-    // Get CC vars
-    amrex::MultiFab& mf = *(mfv[0]);
+      // Get CC vars
+      amrex::MultiFab& mf = *(mfv[0]);
 
-    amrex::ParmParse pp("erf");
+      amrex::ParmParse pp("erf");
 
-    // Do we have a time-varying surface roughness that needs to be saved?
-    if (lev == 0) {
-      const int nghost = 0; // ghost cells not included
-      int lmask_min = lmask_min_reduce(*lmask_lev[0].get(), nghost);
-      amrex::ParallelDescriptor::ReduceIntMin(lmask_min);
+      // Do we have a time-varying surface roughness that needs to be saved?
+      if (lev == 0) {
+          const int nghost = 0; // ghost cells not included
+          int lmask_min = lmask_min_reduce(*lmask_lev[0].get(), nghost);
+          amrex::ParallelDescriptor::ReduceIntMin(lmask_min);
 
-      m_var_z0 = (lmask_min < 1) & (rough_type_sea != RoughCalcType::CONSTANT);
-      if (m_var_z0) {
-        std::string rough_sea_string{"charnock"};
-        pp.query("most.roughness_type_sea", rough_sea_string);
-        amrex::Print() << "Variable sea roughness (type " << rough_sea_string
-                       << ")" << std::endl;
+          m_var_z0 = (lmask_min < 1) & (rough_type_sea != RoughCalcType::CONSTANT);
+          if (m_var_z0) {
+              std::string rough_sea_string{"charnock"};
+              pp.query("most.roughness_type_sea", rough_sea_string);
+              amrex::Print() << "Variable sea roughness (type " << rough_sea_string
+                             << ")" << std::endl;
+          }
       }
-    }
 
-    if ((lev == 0) || (lev > nlevs - 1)) {
-      m_Hwave_lev.resize(nlevs);
-      m_Lwave_lev.resize(nlevs);
-      m_eddyDiffs_lev.resize(nlevs);
+      if ((lev == 0) || (lev > nlevs - 1)) {
+          m_Hwave_lev.resize(nlevs);
+          m_Lwave_lev.resize(nlevs);
+          m_eddyDiffs_lev.resize(nlevs);
 
-      m_lsm_data_lev.resize(nlevs);
-      m_lsm_flux_lev.resize(nlevs);
+          m_lsm_data_lev.resize(nlevs);
+          m_lsm_flux_lev.resize(nlevs);
 
-      m_sst_lev.resize(nlevs);
-      m_tsk_lev.resize(nlevs);
-      m_lmask_lev.resize(nlevs);
+          m_sst_lev.resize(nlevs);
+          m_tsk_lev.resize(nlevs);
+          m_lmask_lev.resize(nlevs);
 
-      // Size the MOST params for all levels
-      z_0.resize(nlevs);
-      u_star.resize(nlevs);
-      w_star.resize(nlevs);
-      t_star.resize(nlevs);
-      q_star.resize(nlevs);
-      t_surf.resize(nlevs);
-      olen.resize(nlevs);
-      pblh.resize(nlevs);
-    }
+          // Size the MOST params for all levels
+          z_0.resize(nlevs);
+          u_star.resize(nlevs);
+          w_star.resize(nlevs);
+          t_star.resize(nlevs);
+          q_star.resize(nlevs);
+          t_surf.resize(nlevs);
+          q_surf.resize(nlevs);
+          olen.resize(nlevs);
+          pblh.resize(nlevs);
+      }
 
-    // Get pointers to SST,TSK and LANDMASK data
-    int nt_tot_sst = sst_lev.size();
-    m_sst_lev[lev].resize(nt_tot_sst);
-    for (int nt(0); nt < nt_tot_sst; ++nt) {
-      m_sst_lev[lev][nt] = sst_lev[nt].get();
-    }
-    int nt_tot_tsk = tsk_lev.size();
-    m_tsk_lev[lev].resize(nt_tot_tsk);
-    for (int nt(0); nt < nt_tot_tsk; ++nt) {
-      m_tsk_lev[lev][nt] = tsk_lev[nt].get();
-    }
-    int nt_tot_lmask = lmask_lev.size();
-    m_lmask_lev[lev].resize(nt_tot_lmask);
-    for (int nt(0); nt < nt_tot_lmask; ++nt) {
-      m_lmask_lev[lev][nt] = lmask_lev[nt].get();
-    }
+      // Get pointers to SST,TSK and LANDMASK data
+      int nt_tot_sst = sst_lev.size();
+      m_sst_lev[lev].resize(nt_tot_sst);
+      for (int nt(0); nt < nt_tot_sst; ++nt) {
+          m_sst_lev[lev][nt] = sst_lev[nt].get();
+      }
+      int nt_tot_tsk = tsk_lev.size();
+      m_tsk_lev[lev].resize(nt_tot_tsk);
+      for (int nt(0); nt < nt_tot_tsk; ++nt) {
+          m_tsk_lev[lev][nt] = tsk_lev[nt].get();
+      }
+      int nt_tot_lmask = lmask_lev.size();
+      m_lmask_lev[lev].resize(nt_tot_lmask);
+      for (int nt(0); nt < nt_tot_lmask; ++nt) {
+          m_lmask_lev[lev][nt] = lmask_lev[nt].get();
+      }
 
-    // Get pointers to wave data
-    m_Hwave_lev[lev] = Hwave;
-    m_Lwave_lev[lev] = Lwave;
-    m_eddyDiffs_lev[lev] = eddyDiffs;
+      // Get pointers to wave data
+      m_Hwave_lev[lev] = Hwave;
+      m_Lwave_lev[lev] = Lwave;
+      m_eddyDiffs_lev[lev] = eddyDiffs;
 
-    // Get pointers to LSM data and Fluxes
-    int nvar = lsm_data.size();
-    m_lsm_data_lev[lev].resize(nvar);
-    m_lsm_flux_lev[lev].resize(nvar);
-    for (int n(0); n < nvar; ++n) {
-      m_lsm_data_lev[lev][n] = lsm_data[n];
-      m_lsm_flux_lev[lev][n] = lsm_flux[n];
-    }
+      // Get pointers to LSM data and Fluxes
+      int nvar = lsm_data.size();
+      m_lsm_data_lev[lev].resize(nvar);
+      m_lsm_flux_lev[lev].resize(nvar);
+      for (int n(0); n < nvar; ++n) {
+          m_lsm_data_lev[lev][n] = lsm_data[n];
+          m_lsm_flux_lev[lev][n] = lsm_flux[n];
+      }
 
-    // Check if there is a user-specified roughness file to be read
-    std::string fname;
-    bool read_z0 = false;
-    if (
-      (flux_type == FluxCalcType::MOENG) ||
-      (flux_type == FluxCalcType::ROTATE)) {
-      read_z0 = pp.query("most.roughness_file_name", fname);
-    }
+      // Check if there is a user-specified roughness file to be read
+      std::string fname;
+      bool read_z0 = false;
+      if ( (flux_type == FluxCalcType::MOENG) ||
+           (flux_type == FluxCalcType::ROTATE)) {
+          read_z0 = pp.query("most.roughness_file_name", fname);
+      }
 
-    // Attributes for MFs and FABs
-    //--------------------------------------------------------
-    // Create a 2D ba, dm, & ghost cells
-    amrex::BoxArray ba = mf.boxArray();
-    amrex::BoxList bl2d = ba.boxList();
-    for (auto& b : bl2d) {
-      b.setRange(2, 0);
-    }
-    amrex::BoxArray ba2d(std::move(bl2d));
-    const amrex::DistributionMapping& dm = mf.DistributionMap();
-    const int ncomp = 1;
-    amrex::IntVect ng = mf.nGrowVect();
-    ng[2] = 0;
+      // Attributes for MFs and FABs
+      //--------------------------------------------------------
+      // Create a 2D ba, dm, & ghost cells
+      amrex::BoxArray ba = mf.boxArray();
+      amrex::BoxList bl2d = ba.boxList();
+      for (auto& b : bl2d) {
+          b.setRange(2, 0);
+      }
+      amrex::BoxArray ba2d(std::move(bl2d));
+      const amrex::DistributionMapping& dm = mf.DistributionMap();
+      const int ncomp = 1;
+      amrex::IntVect ng = mf.nGrowVect();
+      ng[2] = 0;
 
-    // Z0 heights FAB
-    //--------------------------------------------------------
-    amrex::Arena* Arena_Used = amrex::The_Arena();
+      // Z0 heights FAB
+      //--------------------------------------------------------
+      amrex::Arena* Arena_Used = amrex::The_Arena();
 #ifdef AMREX_USE_GPU
-    Arena_Used = amrex::The_Pinned_Arena();
+      Arena_Used = amrex::The_Pinned_Arena();
 #endif
-    amrex::Box bx = amrex::grow(m_geom[lev].Domain(), ng);
-    bx.setSmall(2, 0);
-    bx.setBig(2, 0);
-    z_0[lev].resize(bx, 1, Arena_Used);
-    z_0[lev].setVal<amrex::RunOn::Device>(z0_const);
-    if (read_z0)
-      read_custom_roughness(lev, fname);
+      amrex::Box bx = amrex::grow(m_geom[lev].Domain(), ng);
+      bx.setSmall(2, 0);
+      bx.setBig(2, 0);
+      z_0[lev].resize(bx, 1, Arena_Used);
+      z_0[lev].setVal<amrex::RunOn::Device>(z0_const);
+      if (read_z0) {
+          read_custom_roughness(lev, fname);
+      }
 
-    // 2D MFs for U*, T*, T_surf
-    //--------------------------------------------------------
-    u_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    u_star[lev]->setVal(1.E34);
+      // 2D MFs for U*, T*, T_surf
+      //--------------------------------------------------------
+      u_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      u_star[lev]->setVal(1.E34);
 
-    w_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    w_star[lev]->setVal(1.E34);
+      w_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      w_star[lev]->setVal(1.E34);
 
-    t_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    t_star[lev]->setVal(0.0); // default to neutral
+      t_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      t_star[lev]->setVal(0.0); // default to neutral
 
-    q_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    q_star[lev]->setVal(0.0); // default to dry
+      q_star[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      q_star[lev]->setVal(0.0); // default to dry
 
-    olen[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    olen[lev]->setVal(1.E34);
+      olen[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      olen[lev]->setVal(1.E34);
 
-    pblh[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    pblh[lev]->setVal(1.E34);
+      pblh[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      pblh[lev]->setVal(1.E34);
 
-    t_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
-    t_surf[lev]->setVal(default_land_surf_temp);
+      t_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      t_surf[lev]->setVal(default_land_surf_temp);
 
-    // TODO: Do we want lsm_data to have theta at 0 index always?
-    //       Do we want an external enum struct for indexing?
-    if (m_sst_lev[lev][0] || m_tsk_lev[lev][0] || m_lsm_data_lev[lev][0]) {
-      // Valid SST, TSK or LSM data; t_surf set before computing fluxes (avoids
-      // extended lambda capture) Note that land temp will be set from m_tsk_lev
-      //      while sea temp will be set from m_sst_lev
-      theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
-    }
+      // TODO: Do we want lsm_data to have theta at 0 index always?
+      //       Do we want an external enum struct for indexing?
+      if (m_sst_lev[lev][0] || m_tsk_lev[lev][0] || m_lsm_data_lev[lev][0]) {
+          // Valid SST, TSK or LSM data; t_surf set before computing fluxes (avoids
+          // extended lambda capture) Note that land temp will be set from m_tsk_lev
+          //      while sea temp will be set from m_sst_lev
+          theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
+
+          // Moisture must be the same calc type
+          moist_type = MoistCalcType::SURFACE_MOISTURE;
+          pp.get("most.surf_moist",surf_moist);
+          default_land_surf_moist = surf_moist;
+      }
+
+      q_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
+      q_surf[lev]->setVal(default_land_surf_moist);
   }
 
   void
-  update_fluxes(const int& lev, const amrex::Real& time, int max_iters = 500);
+  update_fluxes (const int& lev,
+                 const amrex::Real& time,
+                 int max_iters = 500);
 
   template <typename FluxIter>
-  void compute_fluxes(
-    const int& lev,
-    const int& max_iters,
-    const FluxIter& most_flux,
-    bool is_land);
+  void compute_fluxes (const int& lev,
+                       const int& max_iters,
+                       const FluxIter& most_flux,
+                       bool is_land);
 
-  void impose_SurfaceLayer_bcs(
-    const int& lev,
-    amrex::Vector<const amrex::MultiFab*> mfs,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,
-    amrex::MultiFab* xheat_flux,
-    amrex::MultiFab* yheat_flux,
-    amrex::MultiFab* zheat_flux,
-    amrex::MultiFab* xqv_flux,
-    amrex::MultiFab* yqv_flux,
-    amrex::MultiFab* zqv_flux,
-    const amrex::MultiFab* z_phys);
+  void impose_SurfaceLayer_bcs (const int& lev,
+                                amrex::Vector<const amrex::MultiFab*> mfs,
+                                amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,
+                                amrex::MultiFab* xheat_flux,
+                                amrex::MultiFab* yheat_flux,
+                                amrex::MultiFab* zheat_flux,
+                                amrex::MultiFab* xqv_flux,
+                                amrex::MultiFab* yqv_flux,
+                                amrex::MultiFab* zqv_flux,
+                                const amrex::MultiFab* z_phys);
 
   template <typename FluxCalc>
-  void compute_SurfaceLayer_bcs(
-    const int& lev,
-    amrex::Vector<const amrex::MultiFab*> mfs,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,
-    amrex::MultiFab* xheat_flux,
-    amrex::MultiFab* yheat_flux,
-    amrex::MultiFab* zheat_flux,
-    amrex::MultiFab* xqv_flux,
-    amrex::MultiFab* yqv_flux,
-    amrex::MultiFab* zqv_flux,
-    const amrex::MultiFab* z_phys,
-    const FluxCalc& flux_comp);
+  void compute_SurfaceLayer_bcs (const int& lev,
+                                 amrex::Vector<const amrex::MultiFab*> mfs,
+                                 amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,
+                                 amrex::MultiFab* xheat_flux,
+                                 amrex::MultiFab* yheat_flux,
+                                 amrex::MultiFab* zheat_flux,
+                                 amrex::MultiFab* xqv_flux,
+                                 amrex::MultiFab* yqv_flux,
+                                 amrex::MultiFab* zqv_flux,
+                                 const amrex::MultiFab* z_phys,
+                                 const FluxCalc& flux_comp);
 
-  void fill_tsurf_with_sst_and_tsk(const int& lev, const amrex::Real& time);
+  void fill_tsurf_with_sst_and_tsk (const int& lev,
+                                    const amrex::Real& time);
 
-  void get_lsm_tsurf(const int& lev);
+  void get_lsm_tsurf (const int& lev);
 
   /* wrapper around compute_pblh */
-  void update_pblh(
-    const int& lev,
-    amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars,
-    amrex::MultiFab* z_phys_cc,
-    const int RhoQv_comp,
-    const int RhoQc_comp,
-    const int RhoQr_comp);
+  void update_pblh (const int& lev,
+                    amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars,
+                    amrex::MultiFab* z_phys_cc,
+                    const int RhoQv_comp,
+                    const int RhoQc_comp,
+                    const int RhoQr_comp);
 
   template <typename PBLHeightEstimator>
-  void compute_pblh(
-    const int& lev,
-    amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars,
-    amrex::MultiFab* z_phys_cc,
-    const PBLHeightEstimator& est,
-    const int RhoQv_comp,
-    const int RhoQc_comp,
-    const int RhoQr_comp);
+  void compute_pblh (const int& lev,
+                     amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars,
+                     amrex::MultiFab* z_phys_cc,
+                     const PBLHeightEstimator& est,
+                     const int RhoQv_comp,
+                     const int RhoQc_comp,
+                     const int RhoQr_comp);
 
-  void read_custom_roughness(const int& lev, const std::string& fname);
+  void read_custom_roughness (const int& lev,
+                              const std::string& fname);
 
-  void update_surf_temp(const amrex::Real& time)
+  void update_surf_temp (const amrex::Real& time)
   {
-    if (surf_heating_rate != 0) {
-      int nlevs = m_geom.size();
-      for (int lev = 0; lev < nlevs; lev++) {
-        t_surf[lev]->setVal(surf_temp + surf_heating_rate * time);
-        amrex::Print() << "Surface temp at t=" << time << ": "
-                       << surf_temp + surf_heating_rate * time << std::endl;
-      }
-    }
-  }
-
-  void update_mac_ptrs(
-    const int& lev,
-    amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim,
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qr_prim)
-  {
-    m_ma.update_field_ptrs(lev, vars_old, Theta_prim, Qv_prim, Qr_prim);
-  }
-
-  amrex::MultiFab* get_u_star(const int& lev) { return u_star[lev].get(); }
-
-  amrex::MultiFab* get_w_star(const int& lev) { return w_star[lev].get(); }
-
-  amrex::MultiFab* get_t_star(const int& lev) { return t_star[lev].get(); }
-
-  amrex::MultiFab* get_q_star(const int& lev) { return q_star[lev].get(); }
-
-  amrex::MultiFab* get_olen(const int& lev) { return olen[lev].get(); }
-
-  amrex::MultiFab* get_pblh(const int& lev) { return pblh[lev].get(); }
-
-  const amrex::MultiFab* get_mac_avg(const int& lev, int comp)
-  {
-    return m_ma.get_average(lev, comp);
-  }
-
-  amrex::MultiFab* get_t_surf(const int& lev) { return t_surf[lev].get(); }
-
-  amrex::Real get_zref() { return m_ma.get_zref(); }
-
-  amrex::FArrayBox* get_z0(const int& lev) { return &z_0[lev]; }
-
-  bool have_variable_sea_roughness() { return m_var_z0; }
-
-  amrex::iMultiFab* get_lmask(const int& lev) { return m_lmask_lev[lev][0]; }
-
-  int lmask_min_reduce(amrex::iMultiFab& lmask, const int& nghost)
-  {
-    int lmask_min = amrex::ReduceMin(
-      lmask, nghost,
-      [=] AMREX_GPU_HOST_DEVICE(
-        amrex::Box const& bx, amrex::Array4<int const> const& lm_arr) -> int {
-        int locmin = std::numeric_limits<int>::max();
-        const auto lo = lbound(bx);
-        const auto hi = ubound(bx);
-        for (int j = lo.y; j <= hi.y; ++j) {
-          for (int i = lo.x; i <= hi.x; ++i) {
-            locmin = std::min(locmin, lm_arr(i, j, 0));
+      if (surf_heating_rate != 0) {
+          int nlevs = m_geom.size();
+          for (int lev = 0; lev < nlevs; lev++) {
+              t_surf[lev]->setVal(surf_temp + surf_heating_rate * time);
+              amrex::Print() << "Surface temp at t=" << time << ": "
+                             << surf_temp + surf_heating_rate * time << std::endl;
           }
-        }
-        return locmin;
-      });
+      }
+  }
 
-    return lmask_min;
+  void update_mac_ptrs (const int& lev,
+                        amrex::Vector<amrex::Vector<amrex::MultiFab>>& vars_old,
+                        amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Theta_prim,
+                        amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qv_prim,
+                        amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Qr_prim)
+  {
+      m_ma.update_field_ptrs(lev, vars_old, Theta_prim, Qv_prim, Qr_prim);
+  }
+
+  amrex::MultiFab* get_u_star (const int& lev) { return u_star[lev].get(); }
+
+  amrex::MultiFab* get_w_star (const int& lev) { return w_star[lev].get(); }
+
+  amrex::MultiFab* get_t_star (const int& lev) { return t_star[lev].get(); }
+
+  amrex::MultiFab* get_q_star (const int& lev) { return q_star[lev].get(); }
+
+  amrex::MultiFab* get_olen (const int& lev) { return olen[lev].get(); }
+
+  amrex::MultiFab* get_pblh (const int& lev) { return pblh[lev].get(); }
+
+  const amrex::MultiFab* get_mac_avg (const int& lev, int comp)
+  {
+      return m_ma.get_average(lev, comp);
+  }
+
+  amrex::MultiFab* get_t_surf (const int& lev) { return t_surf[lev].get(); }
+
+  amrex::MultiFab* get_q_surf (const int& lev) { return q_surf[lev].get(); }
+
+  amrex::Real get_zref () { return m_ma.get_zref(); }
+
+  amrex::FArrayBox* get_z0 (const int& lev) { return &z_0[lev]; }
+
+  bool have_variable_sea_roughness () { return m_var_z0; }
+
+  amrex::iMultiFab* get_lmask (const int& lev) { return m_lmask_lev[lev][0]; }
+
+  int lmask_min_reduce (amrex::iMultiFab& lmask,
+                        const int& nghost)
+  {
+      int lmask_min = amrex::ReduceMin(lmask, nghost, [=] AMREX_GPU_HOST_DEVICE(
+                      amrex::Box const& bx, amrex::Array4<int const> const& lm_arr) -> int
+                      {
+                          int locmin = std::numeric_limits<int>::max();
+                          const auto lo = lbound(bx);
+                          const auto hi = ubound(bx);
+                          for (int j = lo.y; j <= hi.y; ++j) {
+                              for (int i = lo.x; i <= hi.x; ++i) {
+                                  locmin = std::min(locmin, lm_arr(i, j, 0));
+                              }
+                          }
+                          return locmin;
+                      });
+
+      return lmask_min;
   }
 
   enum struct FluxCalcType {
@@ -516,6 +534,12 @@ public:
     SURFACE_TEMPERATURE ///< Surface temperature specified
   };
 
+  enum struct MoistCalcType {
+    ADIABATIC = 0,
+    MOISTURE_FLUX,          ///< Qv-flux specified
+    SURFACE_MOISTURE ///< Surface Qv specified
+  };
+
   enum struct RoughCalcType {
     CONSTANT = 0, ///< Constant z0
     CHARNOCK,
@@ -528,6 +552,7 @@ public:
 
   FluxCalcType flux_type{FluxCalcType::MOENG};
   ThetaCalcType theta_type{ThetaCalcType::ADIABATIC};
+  MoistCalcType moist_type{MoistCalcType::ADIABATIC};
   RoughCalcType rough_type_land{RoughCalcType::CONSTANT};
   RoughCalcType rough_type_sea{RoughCalcType::CHARNOCK};
   PBLHeightCalcType pblh_type{PBLHeightCalcType::None};
@@ -545,6 +570,9 @@ private:
   amrex::Real surf_temp;
   amrex::Real surf_heating_rate{0};
   amrex::Real surf_temp_flux{0};
+  amrex::Real default_land_surf_moist = 0.;
+  amrex::Real surf_moist;
+  amrex::Real surf_moist_flux{0};
   amrex::Real custom_ustar{0};
   amrex::Real custom_tstar{0};
   amrex::Real custom_qstar{0};
@@ -564,12 +592,13 @@ private:
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> olen;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> pblh;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> t_surf;
+  amrex::Vector<std::unique_ptr<amrex::MultiFab>> q_surf;
 
-  amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_sst_lev;
-  amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_tsk_lev;
+  amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_sst_lev;
+  amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_tsk_lev;
   amrex::Vector<amrex::Vector<amrex::iMultiFab*>> m_lmask_lev;
-  amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_lsm_data_lev;
-  amrex::Vector<amrex::Vector<amrex::MultiFab*>> m_lsm_flux_lev;
+  amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_lsm_data_lev;
+  amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_lsm_flux_lev;
   amrex::Vector<amrex::MultiFab*> m_Hwave_lev;
   amrex::Vector<amrex::MultiFab*> m_Lwave_lev;
   amrex::Vector<amrex::MultiFab*> m_eddyDiffs_lev;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -131,6 +131,7 @@ public:
               }
           } else {
               pp.query("most.surf_temp_flux", surf_temp_flux);
+
               if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
                   amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -98,12 +98,15 @@ public:
 
       // Get surface temperature
       auto erf_st = pp.query("most.surf_temp", surf_temp);
-      auto erf_sq = pp.query("most.surf_moist", surf_moist);
+      if (use_moisture) { auto erf_sq = pp.query("most.surf_moist", surf_moist); }
       if (erf_st || erf_sq) {
           pp.get("most.surf_temp",surf_temp);
-          pp.get("most.surf_moist",surf_moist);
           default_land_surf_temp  = surf_temp;
-          default_land_surf_moist = surf_moist;
+
+          if (use_moisture) {
+              pp.get("most.surf_moist",surf_moist);
+              default_land_surf_moist = surf_moist;
+          }
       }
 
       // Custom type user must specify the fluxes

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -97,8 +97,9 @@ public:
       }
 
       // Get surface temperature
+      bool erf_sq = false;
       auto erf_st = pp.query("most.surf_temp", surf_temp);
-      if (use_moisture) { auto erf_sq = pp.query("most.surf_moist", surf_moist); }
+      if (use_moisture) { erf_sq = pp.query("most.surf_moist", surf_moist); }
       if (erf_st || erf_sq) {
           pp.get("most.surf_temp",surf_temp);
           default_land_surf_temp  = surf_temp;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -131,7 +131,6 @@ public:
               }
           } else {
               pp.query("most.surf_temp_flux", surf_temp_flux);
-
               if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
                   amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -26,6 +26,10 @@ SurfaceLayer::update_fluxes (const int& lev,
     // Compute plane averages for all vars (regardless of flux type)
     m_ma.compute_averages(lev);
 
+    // Do we have a constant flux for moisture?
+    bool cons_qflux = ( (moist_type == MoistCalcType::MOISTURE_FLUX) ||
+                        (moist_type == MoistCalcType::ADIABATIC) );
+
     // ***************************************************************
     // Iterate the fluxes if moeng type
     // First iterate over land -- the only model for surface roughness
@@ -34,19 +38,17 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (flux_type == FluxCalcType::MOENG ||
         flux_type == FluxCalcType::ROTATE) {
         bool is_land = true;
-        if ((theta_type == ThetaCalcType::HEAT_FLUX) ||
-            (moist_type == MoistCalcType::MOISTURE_FLUX)) {
+        if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+              surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
             }
-        } else if ((theta_type == ThetaCalcType::SURFACE_TEMPERATURE) ||
-                   (moist_type == MoistCalcType::SURFACE_MOISTURE)) {
+        } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
             update_surf_temp(time);
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+              surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
@@ -72,49 +74,52 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (flux_type == FluxCalcType::MOENG ||
         flux_type == FluxCalcType::ROTATE) {
         bool is_land = false;
-        if ((theta_type == ThetaCalcType::HEAT_FLUX) ||
-            (moist_type == MoistCalcType::MOISTURE_FLUX)) {
+        if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
                 surface_flux_charnock most_flux(m_ma.get_zref(),
                                                 surf_temp_flux, surf_moist_flux,
-                                                cnk_a, cnk_visc);
+                                                cnk_a, cnk_visc, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
                 surface_flux_mod_charnock most_flux(m_ma.get_zref(),
                                                     surf_temp_flux, surf_moist_flux,
-                                                    depth);
+                                                    depth, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
                 surface_flux_donelan most_flux(m_ma.get_zref(),
-                                               surf_temp_flux, surf_moist_flux);
+                                               surf_temp_flux, surf_moist_flux,
+                                               cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
                 surface_flux_wave_coupled most_flux(m_ma.get_zref(),
-                                                    surf_temp_flux, surf_moist_flux);
+                                                    surf_temp_flux, surf_moist_flux,
+                                                    cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");
             }
 
-        } else if ((theta_type == ThetaCalcType::SURFACE_TEMPERATURE) ||
-                   (moist_type == MoistCalcType::SURFACE_MOISTURE)) {
+        } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
             update_surf_temp(time);
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
                 surface_temp_charnock most_flux(m_ma.get_zref(),
                                                 surf_temp_flux, surf_moist_flux,
-                                                cnk_a, cnk_visc);
+                                                cnk_a, cnk_visc, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
                 surface_temp_mod_charnock most_flux(m_ma.get_zref(),
                                                     surf_temp_flux, surf_moist_flux,
-                                                    depth);
+                                                    depth, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
                 surface_temp_donelan most_flux(m_ma.get_zref(),
-                                               surf_temp_flux, surf_moist_flux);
+                                               surf_temp_flux, surf_moist_flux,
+                                               cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                surface_temp_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+                surface_temp_wave_coupled most_flux(m_ma.get_zref(),
+                                                    surf_temp_flux, surf_moist_flux,
+                                                    cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -34,24 +34,27 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (flux_type == FluxCalcType::MOENG ||
         flux_type == FluxCalcType::ROTATE) {
         bool is_land = true;
-        if (theta_type == ThetaCalcType::HEAT_FLUX) {
+        if ((theta_type == ThetaCalcType::HEAT_FLUX) ||
+            (moist_type == MoistCalcType::MOISTURE_FLUX)) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
             }
-        } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
+        } else if ((theta_type == ThetaCalcType::SURFACE_TEMPERATURE) ||
+                   (moist_type == MoistCalcType::SURFACE_MOISTURE)) {
             update_surf_temp(time);
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
             }
-        } else if (theta_type == ThetaCalcType::ADIABATIC) {
+        } else if ((theta_type == ThetaCalcType::ADIABATIC) &&
+                   (moist_type == MoistCalcType::ADIABATIC)) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                adiabatic most_flux(m_ma.get_zref(), surf_temp_flux);
+                adiabatic most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
@@ -69,53 +72,71 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (flux_type == FluxCalcType::MOENG ||
         flux_type == FluxCalcType::ROTATE) {
         bool is_land = false;
-        if (theta_type == ThetaCalcType::HEAT_FLUX) {
+        if ((theta_type == ThetaCalcType::HEAT_FLUX) ||
+            (moist_type == MoistCalcType::MOISTURE_FLUX)) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                surface_flux_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a, cnk_visc);
+                surface_flux_charnock most_flux(m_ma.get_zref(),
+                                                surf_temp_flux, surf_moist_flux,
+                                                cnk_a, cnk_visc);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                surface_flux_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
+                surface_flux_mod_charnock most_flux(m_ma.get_zref(),
+                                                    surf_temp_flux, surf_moist_flux,
+                                                    depth);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                surface_flux_donelan most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_flux_donelan most_flux(m_ma.get_zref(),
+                                               surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                surface_flux_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_flux_wave_coupled most_flux(m_ma.get_zref(),
+                                                    surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");
             }
 
-        } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
+        } else if ((theta_type == ThetaCalcType::SURFACE_TEMPERATURE) ||
+                   (moist_type == MoistCalcType::SURFACE_MOISTURE)) {
             update_surf_temp(time);
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                surface_temp_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a, cnk_visc);
+                surface_temp_charnock most_flux(m_ma.get_zref(),
+                                                surf_temp_flux, surf_moist_flux,
+                                                cnk_a, cnk_visc);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                surface_temp_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
+                surface_temp_mod_charnock most_flux(m_ma.get_zref(),
+                                                    surf_temp_flux, surf_moist_flux,
+                                                    depth);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                surface_temp_donelan most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_temp_donelan most_flux(m_ma.get_zref(),
+                                               surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                surface_temp_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux);
+                surface_temp_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");
             }
 
-        } else if (theta_type == ThetaCalcType::ADIABATIC) {
+        } else if ((theta_type == ThetaCalcType::ADIABATIC) &&
+                   (moist_type == MoistCalcType::ADIABATIC)) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                adiabatic_charnock most_flux(m_ma.get_zref(), surf_temp_flux, cnk_a, cnk_visc);
+                adiabatic_charnock most_flux(m_ma.get_zref(),
+                                             surf_temp_flux, surf_moist_flux,
+                                             cnk_a, cnk_visc);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                adiabatic_mod_charnock most_flux(m_ma.get_zref(), surf_temp_flux, depth);
+                adiabatic_mod_charnock most_flux(m_ma.get_zref(),
+                                                 surf_temp_flux, surf_moist_flux,
+                                                 depth);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                adiabatic_donelan most_flux(m_ma.get_zref(), surf_temp_flux);
+                adiabatic_donelan most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                adiabatic_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux);
+                adiabatic_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");
@@ -161,6 +182,7 @@ SurfaceLayer::compute_fluxes (const int& lev,
         auto t_star_arr = t_star[lev]->array(mfi);
         auto q_star_arr = q_star[lev]->array(mfi);
         auto t_surf_arr = t_surf[lev]->array(mfi);
+        auto q_surf_arr = q_surf[lev]->array(mfi);
         auto olen_arr   = olen[lev]->array(mfi);
 
         const auto tm_arr  = tm_ptr->array(mfi);
@@ -190,9 +212,9 @@ SurfaceLayer::compute_fluxes (const int& lev,
             {
                 most_flux.iterate_flux(i, j, k, max_iters,
                                        z0_arr, umm_arr, tm_arr, tvm_arr, qvm_arr,
-                                       u_star_arr, w_star_arr,  // to be updated
-                                       t_star_arr, q_star_arr,  // to be updated
-                                       t_surf_arr, olen_arr,    // to be updated
+                                       u_star_arr, w_star_arr,           // to be updated
+                                       t_star_arr, q_star_arr,           // to be updated
+                                       t_surf_arr, q_surf_arr, olen_arr, // to be updated
                                        pblh_arr, Hwave_arr, Lwave_arr, eta_arr);
             }
         });
@@ -323,6 +345,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         const auto t_star_arr = t_star[lev]->array(mfi);
         const auto q_star_arr = q_star[lev]->array(mfi);
         const auto t_surf_arr = t_surf[lev]->array(mfi);
+        const auto q_surf_arr = q_surf[lev]->array(mfi);
 
         // Get LSM fluxes
         auto lmask_arr    = (m_lmask_lev[lev][0])    ? m_lmask_lev[lev][0]->array(mfi) :
@@ -356,14 +379,13 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
 
         // Rho*Qv flux
         //============================================================================
-        // TODO: Generalize MOST q flux
-        if ((flux_type == FluxCalcType::CUSTOM) && use_moisture) {
+        if (use_moisture) {
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 Real Qflux = flux_comp.compute_q_flux(i, j, k,
                                                       cons_arr, velx_arr, vely_arr,
                                                       umm_arr, qm_arr, u_star_arr,
-                                                      q_star_arr, t_surf_arr);
+                                                      q_star_arr, q_surf_arr);
 
                 if (rotate) {
                     rotate_scalar_flux(i, j, k, Qflux, dxInv, zphys_arr,


### PR DESCRIPTION
This PR parallels the notes given below to implement moisture fluxes in the `SurfaceLayer` module. 

**NOTE: This PR creates** `q_surf` **for the surface moisture. We can now populate that variable with** `SMOIS` **from the wrfintput file, analogous to populating** `t_surf` **from** `TSK`.

**NOTE2: This PR will modify the WPS regtest.**

![image](https://github.com/user-attachments/assets/f9fbeb7b-2a32-489d-8ba2-6872966a2d89)
