### PR TITLE
Slope Limited Advection Scheme

### DIFF
--- a/Source/Advection/ERF_AdvectionSrcForScalars.H
+++ b/Source/Advection/ERF_AdvectionSrcForScalars.H
@@ -77,6 +77,12 @@ AdvectionSrcForScalarsVert (const amrex::Box& bx,
                                                             avg_xmom, avg_ymom, avg_zmom,
                                                             horiz_upw_frac, vert_upw_frac);
         break;
+    case AdvType::Upwind_3rd_SL:
+        AdvectionSrcForScalarsWrapper<InterpType_H,UPWIND3SL>(bx, cons_index,
+                                                              flx_arr, cell_prim,
+                                                              avg_xmom, avg_ymom, avg_zmom,
+                                                              horiz_upw_frac, vert_upw_frac);
+        break;
     case AdvType::Centered_4th:
         AdvectionSrcForScalarsWrapper<InterpType_H,CENTERED4>(bx, cons_index,
                                                               flx_arr, cell_prim,

--- a/Source/Advection/ERF_AdvectionSrcForState.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForState.cpp
@@ -201,6 +201,13 @@ AdvectionSrcForScalars (const Real& dt,
 
     // Template higher order methods (horizontal first)
     } else {
+
+        if (cons_index == RhoQ2_comp) {
+            AdvectionSrcForScalarsVert<UPWIND3SL>(bx, cons_index, flx_arr, cell_prim,
+                                                  avg_xmom, avg_ymom, avg_zmom,
+                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
+        }
+
         switch(horiz_adv_type) {
         case AdvType::Centered_2nd:
             AdvectionSrcForScalarsVert<CENTERED2>(bx, cons_index, flx_arr, cell_prim,

--- a/Source/Advection/ERF_AdvectionSrcForState.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForState.cpp
@@ -201,13 +201,6 @@ AdvectionSrcForScalars (const Real& dt,
 
     // Template higher order methods (horizontal first)
     } else {
-
-        if (cons_index == RhoQ2_comp) {
-            AdvectionSrcForScalarsVert<UPWIND3SL>(bx, cons_index, flx_arr, cell_prim,
-                                                  avg_xmom, avg_ymom, avg_zmom,
-                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
-        }
-
         switch(horiz_adv_type) {
         case AdvType::Centered_2nd:
             AdvectionSrcForScalarsVert<CENTERED2>(bx, cons_index, flx_arr, cell_prim,
@@ -219,6 +212,11 @@ AdvectionSrcForScalars (const Real& dt,
                                                 avg_xmom, avg_ymom, avg_zmom,
                                                 horiz_upw_frac, vert_upw_frac, vert_adv_type);
             break;
+        case AdvType::Upwind_3rd_SL:
+             AdvectionSrcForScalarsVert<UPWIND3SL>(bx, cons_index, flx_arr, cell_prim,
+                                                  avg_xmom, avg_ymom, avg_zmom,
+                                                  horiz_upw_frac, vert_upw_frac, vert_adv_type);
+             break;
         case AdvType::Centered_4th:
             AdvectionSrcForScalarsVert<CENTERED4>(bx, cons_index, flx_arr, cell_prim,
                                                   avg_xmom, avg_ymom, avg_zmom,

--- a/Source/DataStructs/ERF_AdvStruct.H
+++ b/Source/DataStructs/ERF_AdvStruct.H
@@ -111,6 +111,7 @@ struct AdvChoice {
 
         if ( (dryscal_horiz_adv_string == "Centered_2nd") ||
              (dryscal_horiz_adv_string == "Upwind_3rd"  ) ||
+             (dryscal_horiz_adv_string == "Upwind_3rd_SL") ||
              (dryscal_horiz_adv_string == "Blended_3rd4th") ||
              (dryscal_horiz_adv_string == "Centered_4th") ||
              (dryscal_horiz_adv_string == "Upwind_5th"  ) ||
@@ -129,6 +130,7 @@ struct AdvChoice {
 
         if ( (dryscal_vert_adv_string == "Centered_2nd") ||
              (dryscal_vert_adv_string == "Upwind_3rd"  ) ||
+             (dryscal_vert_adv_string == "Upwind_3rd_SL") ||
              (dryscal_vert_adv_string == "Blended_3rd4th") ||
              (dryscal_vert_adv_string == "Centered_4th") ||
              (dryscal_vert_adv_string == "Upwind_5th"  ) ||
@@ -147,6 +149,7 @@ struct AdvChoice {
 
         if ( (moistscal_horiz_adv_string == "Centered_2nd") ||
              (moistscal_horiz_adv_string == "Upwind_3rd"  ) ||
+             (moistscal_horiz_adv_string == "Upwind_3rd_SL"  ) ||
              (moistscal_horiz_adv_string == "Blended_3rd4th") ||
              (moistscal_horiz_adv_string == "Centered_4th") ||
              (moistscal_horiz_adv_string == "Upwind_5th"  ) ||
@@ -165,6 +168,7 @@ struct AdvChoice {
 
         if ( (moistscal_vert_adv_string == "Centered_2nd") ||
              (moistscal_vert_adv_string == "Upwind_3rd"  ) ||
+             (moistscal_vert_adv_string == "Upwind_3rd_SL"  ) ||
              (moistscal_vert_adv_string == "Blended_3rd4th") ||
              (moistscal_vert_adv_string == "Centered_4th") ||
              (moistscal_vert_adv_string == "Upwind_5th"  ) ||
@@ -277,6 +281,8 @@ struct AdvChoice {
             return "Centered_2nd";
         } else if (adv_int == AdvType::Upwind_3rd) {
             return "Upwind_3rd";
+        } else if (adv_int == AdvType::Upwind_3rd_SL) {
+            return "Upwind_3rd_SL";
         } else if (adv_int == AdvType::Centered_4th) {
             return "Centered_4th";
         } else if (adv_int == AdvType::Upwind_5th) {
@@ -308,6 +314,8 @@ struct AdvChoice {
             return AdvType::Centered_2nd;
         } else if ((adv_string == "Upwind_3rd") || (adv_string == "Blended_3rd4th")) {
             return AdvType::Upwind_3rd;
+        } else if (adv_string == "Upwind_3rd_SL") {
+            return AdvType::Upwind_3rd_SL;
         } else if (adv_string == "Centered_4th") {
             return AdvType::Centered_4th;
         } else if (adv_string == "Upwind_5th" || (adv_string == "Blended_5th6th")) {

--- a/Source/ERF_IndexDefines.H
+++ b/Source/ERF_IndexDefines.H
@@ -219,18 +219,19 @@ enum mathematicalBndryTypes : int {
 }
 
 enum struct AdvType : int {
-    Centered_2nd = 101,
-    Upwind_3rd   = 102,
-    Centered_4th = 103,
-    Upwind_5th   = 104,
-    Centered_6th = 105,
-    Weno_3        = 106,
-    Weno_3Z       = 107,
-    Weno_5        = 108,
-    Weno_5Z       = 109,
-    Weno_3MZQ     = 110,
-    Weno_7        = 111,
-    Weno_7Z       = 112,
-    Unknown       = 113
+    Centered_2nd  = 101,
+    Upwind_3rd    = 102,
+    Upwind_3rd_SL = 103,
+    Centered_4th  = 104,
+    Upwind_5th    = 105,
+    Centered_6th  = 106,
+    Weno_3        = 107,
+    Weno_3Z       = 108,
+    Weno_5        = 109,
+    Weno_5Z       = 110,
+    Weno_3MZQ     = 111,
+    Weno_7        = 112,
+    Weno_7Z       = 113,
+    Unknown       = 114
 };
 #endif

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -306,7 +306,7 @@ struct UPWIND3SL
     {
         amrex::Real rmh = (s - sm1) / ((sm1 - sm2) + eps);
         amrex::Real K   = l2 + 2.0*l2*rmh;
-        amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(del,K)));
+        amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(delta,K)));
         return (sm1 + 0.5 * phi * (sm1 - sm2));
     }
 
@@ -314,10 +314,10 @@ struct UPWIND3SL
 
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
-    static constexpr amrex::Real eps=(1.0e-16);
-    static constexpr amrex::Real del=(2.0);
-    static constexpr amrex::Real  l1=(1.0/6.0);
-    static constexpr amrex::Real  l2=(1.0/3.0);
+    static constexpr amrex::Real eps  =(1.0e-16);
+    static constexpr amrex::Real delta=(2.0);
+    static constexpr amrex::Real l1   =(1.0/6.0);
+    static constexpr amrex::Real l2   =(1.0/3.0);
 };
 
 

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -306,7 +306,7 @@ struct UPWIND3SL
     {
         amrex::Real rmh = (s - sm1) / ((sm1 - sm2) + eps);
         amrex::Real K   = l2 + 2.0*l2*rmh;
-        amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(delta,K)));
+        amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(2.0,K)));
         return (sm1 + 0.5 * phi * (sm1 - sm2));
     }
 
@@ -314,10 +314,9 @@ struct UPWIND3SL
 
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
-    static constexpr amrex::Real eps  =(1.0e-16);
-    static constexpr amrex::Real delta=(2.0);
-    static constexpr amrex::Real l1   =(1.0/6.0);
-    static constexpr amrex::Real l2   =(1.0/3.0);
+    static constexpr amrex::Real eps=(1.0e-16);
+    static constexpr amrex::Real l1 =(1.0/6.0);
+    static constexpr amrex::Real l2 =(1.0/3.0);
 };
 
 

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -237,8 +237,8 @@ struct UPWIND3SL
         amrex::Real sm2 = m_phi(i-2, j  , k  , qty_index);
 
         // Left and right fluxes
-        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
-        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+        amrex::Real Fhi = Evaluate(s  ,sm1,sm2);
+        amrex::Real Flo = Evaluate(sm1,s  ,sp1);
 
         // Numerical flux
         val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
@@ -264,8 +264,8 @@ struct UPWIND3SL
         amrex::Real sm2 = m_phi(i  , j-2, k  , qty_index);
 
         // Left and right fluxes
-        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
-        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+        amrex::Real Fhi = Evaluate(s  ,sm1,sm2);
+        amrex::Real Flo = Evaluate(sm1,s  ,sp1);
 
         // Numerical flux
         val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
@@ -291,8 +291,8 @@ struct UPWIND3SL
         amrex::Real sm2 = m_phi(i  , j  , k-2, qty_index);
 
         // Left and right fluxes
-        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
-        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+        amrex::Real Fhi = Evaluate(s  ,sm1,sm2);
+        amrex::Real Flo = Evaluate(sm1,s  ,sp1);
 
         // Numerical flux
         val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
@@ -301,17 +301,17 @@ struct UPWIND3SL
     AMREX_GPU_DEVICE
     AMREX_FORCE_INLINE
     amrex::Real
-    Evaluate (const amrex::Real& sp1,
-              const amrex::Real& s,
-              const amrex::Real& sm1) const
+    Evaluate (const amrex::Real& s,
+              const amrex::Real& sm1,
+              const amrex::Real& sm2) const
     {
-        if (std::abs(s - sm1) > 1.0e-15) {
-            amrex::Real rph = (sp1 - s) / (s - sm1);
-            amrex::Real K   = l2 + 2.0*l2*rph;
-            amrex::Real phi = std::max(0.0,std::min(2.0*rph,std::min(del,K)));
-            return (s + 0.5 * phi * (s - sm1));
+        if (std::abs(sm1 - sm2) > 1.0e-15) {
+            amrex::Real rmh = (s - sm1) / (sm1 - sm2);
+            amrex::Real K   = l2 + 2.0*l2*rmh;
+            amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(del,K)));
+            return (sm1 + 0.5 * phi * (sm1 - sm2));
         } else {
-            return (s + l1 * (s - sm1) + l2 * (sp1 - s) );
+            return (sm1 + l1 * (sm1 - sm2) + l2 * (s - sm1) );
         }
     }
 

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -212,9 +212,8 @@ private:
 struct UPWIND3SL
 {
     UPWIND3SL (const amrex::Array4<const amrex::Real>& phi,
-               const amrex::Real upw_frac)
+               const amrex::Real /*upw_frac*/)
         : m_phi(phi)
-        , m_upw_frac(upw_frac)
     {}
 
     AMREX_GPU_DEVICE
@@ -305,26 +304,20 @@ struct UPWIND3SL
               const amrex::Real& sm1,
               const amrex::Real& sm2) const
     {
-        if (std::abs(sm1 - sm2) > 1.0e-15) {
-            amrex::Real rmh = (s - sm1) / (sm1 - sm2);
-            amrex::Real K   = l2 + 2.0*l2*rmh;
-            amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(del,K)));
-            return (sm1 + 0.5 * phi * (sm1 - sm2));
-        } else {
-            return (sm1 + l1 * (sm1 - sm2) + l2 * (s - sm1) );
-        }
+        amrex::Real rmh = (s - sm1) / ((sm1 - sm2) + eps);
+        amrex::Real K   = l2 + 2.0*l2*rmh;
+        amrex::Real phi = std::max(0.0,std::min(2.0*rmh,std::min(del,K)));
+        return (sm1 + 0.5 * phi * (sm1 - sm2));
     }
 
     int GetUpwindCellNumber() const {return 2;}
 
-    void SetUpwinding(amrex::Real upw_frac) {m_upw_frac = upw_frac;}
-
 private:
     amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
-    amrex::Real m_upw_frac; // Upwinding fraction
-    static constexpr amrex::Real del=2.0;
-    static constexpr amrex::Real l1=(1.0/6.0);
-    static constexpr amrex::Real l2=(1.0/3.0);
+    static constexpr amrex::Real eps=(1.0e-16);
+    static constexpr amrex::Real del=(2.0);
+    static constexpr amrex::Real  l1=(1.0/6.0);
+    static constexpr amrex::Real  l2=(1.0/3.0);
 };
 
 

--- a/Source/Utils/ERF_Interpolation_UPW.H
+++ b/Source/Utils/ERF_Interpolation_UPW.H
@@ -207,6 +207,128 @@ private:
 
 
 /**
+ * Interpolation operators used for 3rd order upwind scheme
+ */
+struct UPWIND3SL
+{
+    UPWIND3SL (const amrex::Array4<const amrex::Real>& phi,
+               const amrex::Real upw_frac)
+        : m_phi(phi)
+        , m_upw_frac(upw_frac)
+    {}
+
+    AMREX_GPU_DEVICE
+    AMREX_FORCE_INLINE
+    void
+    InterpolateInX (const int& i,
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo) const
+    {
+        // Upwinding flags
+        if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+        // Data to interpolate on
+        amrex::Real sp1 = m_phi(i+1, j  , k  , qty_index);
+        amrex::Real s   = m_phi(i  , j  , k  , qty_index);
+        amrex::Real sm1 = m_phi(i-1, j  , k  , qty_index);
+        amrex::Real sm2 = m_phi(i-2, j  , k  , qty_index);
+
+        // Left and right fluxes
+        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
+        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+
+        // Numerical flux
+        val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
+    }
+
+    AMREX_GPU_DEVICE
+    AMREX_FORCE_INLINE
+    void
+    InterpolateInY (const int& i,
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo) const
+    {
+        // Upwinding flags
+        if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+        // Data to interpolate on
+        amrex::Real sp1 = m_phi(i  , j+1, k  , qty_index);
+        amrex::Real s   = m_phi(i  , j  , k  , qty_index);
+        amrex::Real sm1 = m_phi(i  , j-1, k  , qty_index);
+        amrex::Real sm2 = m_phi(i  , j-2, k  , qty_index);
+
+        // Left and right fluxes
+        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
+        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+
+        // Numerical flux
+        val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
+    }
+
+    AMREX_GPU_DEVICE
+    AMREX_FORCE_INLINE
+    void
+    InterpolateInZ (const int& i,
+                    const int& j,
+                    const int& k,
+                    const int& qty_index,
+                    amrex::Real& val_lo,
+                    amrex::Real upw_lo) const
+    {
+        // Upwinding flags
+        if (upw_lo != 0.) upw_lo = (upw_lo > 0) ? 1. : -1.;
+
+        // Data to interpolate on
+        amrex::Real sp1 = m_phi(i  , j  , k+1, qty_index);
+        amrex::Real s   = m_phi(i  , j  , k  , qty_index);
+        amrex::Real sm1 = m_phi(i  , j  , k-1, qty_index);
+        amrex::Real sm2 = m_phi(i  , j  , k-2, qty_index);
+
+        // Left and right fluxes
+        amrex::Real Fhi = Evaluate(sp1,s  ,sm1);
+        amrex::Real Flo = Evaluate(s  ,sm1,sm2);
+
+        // Numerical flux
+        val_lo = (1.0 + upw_lo)/2.0 * Fhi + (1.0 - upw_lo)/2.0 * Flo;
+    }
+
+    AMREX_GPU_DEVICE
+    AMREX_FORCE_INLINE
+    amrex::Real
+    Evaluate (const amrex::Real& sp1,
+              const amrex::Real& s,
+              const amrex::Real& sm1) const
+    {
+        if (std::abs(s - sm1) > 1.0e-15) {
+            amrex::Real rph = (sp1 - s) / (s - sm1);
+            amrex::Real K   = l2 + 2.0*l2*rph;
+            amrex::Real phi = std::max(0.0,std::min(2.0*rph,std::min(del,K)));
+            return (s + 0.5 * phi * (s - sm1));
+        } else {
+            return (s + l1 * (s - sm1) + l2 * (sp1 - s) );
+        }
+    }
+
+    int GetUpwindCellNumber() const {return 2;}
+
+    void SetUpwinding(amrex::Real upw_frac) {m_upw_frac = upw_frac;}
+
+private:
+    amrex::Array4<const amrex::Real> m_phi;   // Quantity to interpolate
+    amrex::Real m_upw_frac; // Upwinding fraction
+    static constexpr amrex::Real del=2.0;
+    static constexpr amrex::Real l1=(1.0/6.0);
+    static constexpr amrex::Real l2=(1.0/3.0);
+};
+
+
+/**
  * Interpolation operators used for 4th order centered scheme
  */
 struct CENTERED4


### PR DESCRIPTION
This PR adds a `slope limited 3rd order` advection scheme. The implementation is taken from [Hundsdorfer et al. (1995)](https://www.sciencedirect.com/science/article/pii/S002199918571042X); see Eqs. 19, 20, 40, and 43. This scheme prevented the generation of new minima and maxima with passive scalar advection, whereas the `default 3rd order` scheme did not. Furthermore, this scheme stabilized the bomex simulation without the use of the `mono_adv` flag.

Note, the `default 3rd order` scheme may also be implemented with slope limiting and that is the preferred scheme in the cited paper.