### PR TITLE
Fix parallel netcdf write.

### DIFF
--- a/Source/IO/ERF_NCPlotFile.cpp
+++ b/Source/IO/ERF_NCPlotFile.cpp
@@ -86,12 +86,12 @@ writeNCPlotFile (int lev, int which_subdomain, const std::string& dir,
     ncf.def_var("Geom.bigend"  , NC_INT, {ndim_name});
     ncf.def_var("CellSize"     , NC_FLOAT, {ndim_name});
 
-    ncf.def_var("x_grid", NC_FLOAT, {np_name});
-    ncf.def_var("y_grid", NC_FLOAT, {np_name});
-    ncf.def_var("z_grid", NC_FLOAT, {np_name});
+    ncf.def_var("x_grid", NC_DOUBLE, {np_name});
+    ncf.def_var("y_grid", NC_DOUBLE, {np_name});
+    ncf.def_var("z_grid", NC_DOUBLE, {np_name});
 
     for (int i = 0; i < plot_var_names.size(); i++) {
-        ncf.def_var(plot_var_names[i], NC_FLOAT, {nz_name, ny_name, nx_name});
+        ncf.def_var(plot_var_names[i], NC_DOUBLE, {nz_name, ny_name, nx_name});
     }
 
     ncf.exit_def_mode();


### PR DESCRIPTION
Definition for the variables must match the data type. This mismatch was causing the error `NetCDF: Numeric conversion not representable` with multiple processors. Unclear why parallelization was needed to catch the error.