### PR TITLE
Add `ERF_ENABLE_TOOLS` cmake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ option(ERF_ENABLE_SYCL "Enable SYCL" OFF)
 #Options for NOAH-MP
 option(ERF_ENABLE_NOAH "Enable Noah-MP" OFF)
 
+#Option to build tools
+option(ERF_ENABLE_TOOLS "Enable building of additional tools" OFF)
+
 #Options for C++
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_EXTENSIONS OFF)
@@ -129,7 +132,7 @@ endif()
 
 ########################## NETCDF ##################################
 
-if(ERF_ENABLE_NETCDF)
+if(ERF_ENABLE_NETCDF OR ERF_ENABLE_TOOLS)
   set(CMAKE_PREFIX_PATH ${NETCDF_DIR} ${CMAKE_PREFIX_PATH})
 ##  set(NETCDF_CXX "YES")
   find_package (NetCDF REQUIRED)

--- a/Exec/CMakeLists.txt
+++ b/Exec/CMakeLists.txt
@@ -44,4 +44,10 @@ else ()
   add_subdirectory(DevTests/TemperatureSource)
   add_subdirectory(DevTests/TropicalCyclone)
 endif()
+
+if(ERF_ENABLE_TOOLS)
+  message(STATUS "Building additional ERF tools")
+  add_subdirectory(Tools)
 endif()
+
+endif() # NOT ERF_BUILD_LIBRARY_ONLY

--- a/Exec/Tools/CMakeLists.txt
+++ b/Exec/Tools/CMakeLists.txt
@@ -1,0 +1,41 @@
+if(ERF_ENABLE_NETCDF)
+    # PlotFile-NetCDF converter
+    set(tool_exe erf_plt_to_nc)
+    add_executable(${tool_exe}
+        ${CMAKE_SOURCE_DIR}/Source/Tools/ERF_PlotfileToNetCDF.cpp
+        ${CMAKE_SOURCE_DIR}/Source/IO/ERF_NCPlotFile.cpp
+        ${CMAKE_SOURCE_DIR}/Source/IO/ERF_NCInterface.cpp
+    )
+
+    target_include_directories(${tool_exe}
+        PRIVATE
+        ${CMAKE_SOURCE_DIR}/Source/Tools
+        ${CMAKE_SOURCE_DIR}/Source/IO
+        ${AMREX_SUBMOD_LOCATION}/Src/Base
+        ${AMREX_SUBMOD_LOCATION}/Src/EB
+        ${AMREX_SUBMOD_LOCATION}/Src/Extern/HDF5
+        ${AMReX_BINARY_DIR}
+        ${NETCDF_INCLUDE_DIRS}
+    )
+
+    target_link_libraries(${tool_exe}
+        PUBLIC
+        AMReX::amrex
+        ${NETCDF_LINK_LIBRARIES}
+    )
+    if(ERF_ENABLE_MPI)
+        target_link_libraries(${tool_exe} PUBLIC $<$<BOOL:${MPI_CXX_FOUND}>:MPI::MPI_CXX>)
+    endif()
+
+    include(${CMAKE_SOURCE_DIR}/CMake/SetERFCompileFlags.cmake)
+    set_erf_compile_flags(${tool_exe})
+
+    target_compile_features(${tool_exe} PRIVATE cxx_std_17)
+
+    install(TARGETS ${tool_exe}
+        RUNTIME DESTINATION bin
+    )
+
+else()
+    message(WARNING "${tool_exe} was not compiled because ERF_ENABLE_NETCDF was not set")
+endif() # ERF_ENABLE_NETCDF


### PR DESCRIPTION
to build `erf_plt_to_nc` utility, comparable to running gmake in Exec/Tools.

FYI @hawbecker