### PR TITLE
Restore clipping for qv

### DIFF
--- a/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
@@ -32,7 +32,7 @@ void SatAdj::AdvanceSatAdj (const SolverChoice& /*solverChoice*/)
             Real qsat;
             erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsat);
 
-            // There is enough moisutre to drive to equilibrium
+            // There is enough moisture to drive to equilibrium
             if ((qv_array(i,j,k)+qc_array(i,j,k)) > qsat) {
                 Real qvprev = qv_array(i,j,k);
                 Real qcprev = qc_array(i,j,k);

--- a/Source/TimeIntegration/ERF_SlowRhsPost.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPost.cpp
@@ -514,7 +514,7 @@ void erf_slow_rhs_post (int level, int finest_level,
                         if (ivar == RhoKE_comp) {
                             cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), eps);
                         } else if (ivar >= RhoQ1_comp) {
-                            //cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), 0.0);
+                            cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), 0.0);
                         }
                     });
 
@@ -528,7 +528,7 @@ void erf_slow_rhs_post (int level, int finest_level,
                         if (ivar == RhoKE_comp) {
                             cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), eps);
                         } else if (ivar >= RhoQ1_comp) {
-                            //cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), 0.0);
+                            cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), 0.0);
                         }
                     });
 


### PR DESCRIPTION
@AMLattanzi we had previously discussed the possibility of clipping causing issues for conservation of total water. https://github.com/erf-model/ERF/pull/2383#issuecomment-3007455029 shows that getting rid of qv clipping ("+ satadj conserv clip") doesn't have an appreciable effect on the solution. So I'm putting these two lines of code back in, which fixes the bubble regtests. 

The change to how qc is clipped in the SatAdj scheme (https://github.com/ewquon/ERF/blob/3b5e65a5868e24abf53af94664d835c1da12888a/Source/Microphysics/SatAdj/ERF_SatAdj.cpp#L40-L44)  is still in there but doesn't affect the regtests.