### PR TITLE
Radiation Minor Clean Up

### DIFF
--- a/Source/Radiation/ERF_RRTMGP_Utils.H
+++ b/Source/Radiation/ERF_RRTMGP_Utils.H
@@ -20,9 +20,10 @@ using yakl::intrinsics::sum;
 
 template<class T, int myMem, int myStyle>
 void
-mixing_ratio_to_cloud_mass (yakl::Array<T,2,myMem,myStyle> const &mixing_ratio,
+mixing_ratio_to_cloud_mass (yakl::Array<T,2,myMem,myStyle> const &mixing_ratio  ,
                             yakl::Array<T,2,myMem,myStyle> const &cloud_fraction,
-                            yakl::Array<T,2,myMem,myStyle> const &dp,
+                            yakl::Array<T,2,myMem,myStyle> const &rho           ,
+                            yakl::Array<T,2,myMem,myStyle> const &dz            ,
                             yakl::Array<T,2,myMem,myStyle>       &cloud_mass)
 {
     int ncol = mixing_ratio.dimension[0];
@@ -36,7 +37,7 @@ mixing_ratio_to_cloud_mass (yakl::Array<T,2,myMem,myStyle> const &mixing_ratio,
         if (cloud_fraction(icol,ilay) > 0) {
             // Compute layer-integrated cloud mass (per unit area)
             auto incloud_mixing_ratio = std::min(mixing_ratio(icol,ilay) / std::max(0.0001, cloud_fraction(icol,ilay)), 0.005);
-            cloud_mass(icol,ilay) = incloud_mixing_ratio * dp(icol,ilay) / CONST_GRAV;
+            cloud_mass(icol,ilay) = incloud_mixing_ratio * rho(icol,ilay) * dz(icol,ilay);
         } else {
             cloud_mass(icol,ilay) = 0;
         }
@@ -47,8 +48,8 @@ mixing_ratio_to_cloud_mass (yakl::Array<T,2,myMem,myStyle> const &mixing_ratio,
 template<class S, class T>
 void
 limit_to_bounds (S const &arr_in,
-                 T const lower,
-                 T const upper,
+                 T const lower  ,
+                 T const upper  ,
                  S &arr_out)
 {
     yakl::c::parallel_for(arr_in.totElems(), YAKL_LAMBDA(int i)
@@ -73,25 +74,16 @@ void
 compute_heating_rate (yakl::Array<T,2,myMem,myStyle> const &flux_up,
                       yakl::Array<T,2,myMem,myStyle> const &flux_dn,
                       yakl::Array<T,2,myMem,myStyle> const &rho    ,
-                      yakl::Array<T,2,myMem,myStyle> const &dz    ,
+                      yakl::Array<T,2,myMem,myStyle> const &dz     ,
                       yakl::Array<T,2,myMem,myStyle> &heating_rate)
 {
     auto ncol = flux_up.dimension[0];
     auto nlay = flux_up.dimension[1]-1;
     yakl::fortran::parallel_for(yakl::fortran::SimpleBounds<2>(nlay,ncol), YAKL_LAMBDA(int ilay, int icol)
     {
-        heating_rate(icol,ilay) = -1.0 * ( flux_up(icol,ilay+1) - flux_up(icol,ilay)
-                                         - flux_dn(icol,ilay+1) + flux_dn(icol,ilay) )
-                                         / (Cp_d * rho(icol,ilay) * dz(icol,ilay));
-
-        /*
-        if (icol == 1) {
-            printf("Heating Rate %i %e %e %e %e %e %e\n",ilay,
-                   flux_up(icol,ilay+1), flux_up(icol,ilay),
-                   flux_dn(icol,ilay+1), flux_dn(icol,ilay),
-                   rho(icol,ilay), dz(icol,ilay));
-        }
-        */
+        heating_rate(icol,ilay) = ( flux_up(icol,ilay+1) - flux_up(icol,ilay)
+                                  - flux_dn(icol,ilay+1) + flux_dn(icol,ilay) )
+                                  / ( -rho(icol,ilay) * dz(icol,ilay) * Cp_d );
     });
 }
 

--- a/Source/Radiation/ERF_Radiation.H
+++ b/Source/Radiation/ERF_Radiation.H
@@ -52,25 +52,27 @@ public:
     // Destructor
     ~Radiation () = default;
 
-    virtual void Init(const amrex::Geometry& geom,
-                    const amrex::BoxArray& ba,
-                    amrex::MultiFab* cons_in) override {};
+    virtual void Init (const amrex::Geometry& geom,
+                       const amrex::BoxArray& ba,
+                       amrex::MultiFab* cons_in) override {};
 
-    virtual void Run(int& level,
-                     int& step,
-                     amrex::Real& time,
-                     const amrex::Real& dt,
-                     const amrex::BoxArray& ba,
-                     amrex::Geometry& geom,
-                     amrex::MultiFab* cons_in,
-                     amrex::MultiFab* lsm_fluxes,
-                     amrex::MultiFab* lsm_zenith,
-                     amrex::MultiFab* qheating_rates,
-                     amrex::MultiFab* z_phys,
-                     amrex::MultiFab* lat,
-                     amrex::MultiFab* lon) override
+    virtual void Run (int& level,
+                      int& step,
+                      amrex::Real& time,
+                      const amrex::Real& dt,
+                      const amrex::BoxArray& ba,
+                      amrex::Geometry& geom,
+                      amrex::MultiFab* cons_in,
+                      amrex::MultiFab* lsm_fluxes,
+                      amrex::MultiFab* lsm_zenith,
+                      amrex::MultiFab* qheating_rates,
+                      amrex::MultiFab* z_phys,
+                      amrex::MultiFab* lat,
+                      amrex::MultiFab* lon) override
     {
-        set_grids(level, step, time, dt, ba, geom, cons_in, lsm_fluxes, lsm_zenith, qheating_rates, z_phys, lat, lon);
+        set_grids(level, step, time, dt, ba, geom,
+                  cons_in, lsm_fluxes, lsm_zenith,
+                  qheating_rates, z_phys, lat, lon);
         rad_run_impl();
     }
 
@@ -91,7 +93,7 @@ public:
                amrex::MultiFab* lon);
 
     template<typename LandSurfaceModelType>
-    void set_lsm_inputs(LandSurfaceModelType *model)
+    void set_lsm_inputs (LandSurfaceModelType *model)
     {
         if constexpr(std::is_same_v<LandSurfaceModelType, SLM>)
         {
@@ -197,9 +199,9 @@ public:
         }
     }
 
-    void populateDatalogMF();
+    void populateDatalogMF ();
 
-    virtual void WriteDataLog(const amrex::Real &time) override;
+    virtual void WriteDataLog (const amrex::Real &time) override;
 
 private:
 

--- a/Source/Radiation/ERF_Radiation.cpp
+++ b/Source/Radiation/ERF_Radiation.cpp
@@ -209,7 +209,8 @@ Radiation::alloc_buffers ()
 
     // 1d size (1 or nlay)
     m_o3_size = m_o3vmr.size();
-    AMREX_ASSERT_WITH_MESSAGE(((m_o3_size==1) || (m_o3_size==m_nlay)), "O3 VMR array must be length 1 or nlay");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(((m_o3_size==1) || (m_o3_size==m_nlay)),
+                                     "O3 VMR array must be length 1 or nlay");
     o3_lay = real1d("o3_lay", m_o3_size);
     realHost1d o3_lay_h("o3_lay_h", m_o3_size);
     parallel_for(m_o3_size, YAKL_LAMBDA (int io3)
@@ -864,7 +865,7 @@ Radiation::run_impl ()
     // Want day + fraction; calday 1 == Jan 1 0Z
     static constexpr real dpy[] = {0.0, 31.0, 59.0, 90.0, 120.0, 151.0, 181.0, 212.0, 243.0, 273.0, 304.0, 334.0};
     bool leap = (m_orbital_year % 4 == 0 && (!(m_orbital_year % 100 == 0) || (m_orbital_year % 400 == 0))) ? true : false;
-    real calday = dpy[m_orbital_mon] + m_orbital_day + m_orbital_sec/86400.0;
+    real calday = dpy[m_orbital_mon-1] + (m_orbital_day-1.0) + m_orbital_sec/86400.0;
     // add extra day if leap year
     if (leap) {
         calday += 1.0;
@@ -951,8 +952,6 @@ Radiation::run_impl ()
     }
     h_mu0.deep_copy_to(mu0);
 
-    // NOTE: p_del uses std::abs() and is always positive
-    //
     // Compute layer cloud mass (per unit area), populates lwp/iwp
     rrtmgp::mixing_ratio_to_cloud_mass(qc_lay, cldfrac_tot, r_lay, z_del, lwp);
     rrtmgp::mixing_ratio_to_cloud_mass(qi_lay, cldfrac_tot, r_lay, z_del, iwp);
@@ -1061,8 +1060,21 @@ Radiation::run_impl ()
     rrtmgp::compute_heating_rate(sw_flux_up, sw_flux_dn, r_lay, z_del, sw_heating);
     rrtmgp::compute_heating_rate(lw_flux_up, lw_flux_dn, r_lay, z_del, lw_heating);
 
+    /*
+    // AML DEBUG
+    parallel_for(nlay+1, YAKL_LAMBDA (int ilay)
+    {
+        printf("Fluxes: %i %e %e %e %e %e\n",ilay,
+                                             sw_flux_up(1,ilay), sw_flux_dn(1,ilay), sw_flux_dn_dir(1,ilay),
+                                             lw_flux_up(1,ilay), lw_flux_dn(1,ilay));
+    });
+    parallel_for(nlay, YAKL_LAMBDA (int ilay)
+    {
+        printf("Heating Rate: %i %e %e\n",ilay,sw_heating(1,ilay),lw_heating(1,ilay));
+    });
+    */
+
     // Compute surface fluxes
-    //const int kbot = nlay + 1; // Should this be 1 for our layout?
     const int kbot = 1;
     parallel_for(SimpleBounds<3>(ncol, nlay+1, nswbands), YAKL_LAMBDA (int icol, int ilay, int ibnd)
     {

--- a/Source/Radiation/ERF_Radiation.cpp
+++ b/Source/Radiation/ERF_Radiation.cpp
@@ -474,15 +474,15 @@ Radiation::mf_to_yakl_buffers ()
             qv_lay(icol,ilay) = qv;
             qc_lay(icol,ilay) = qc;
             qi_lay(icol,ilay) = qi;
-            cldfrac_tot(icol,ilay) = ((qc+qi)>1.0e-5) ? 1. : 0.;
+            cldfrac_tot(icol,ilay) = ((qc+qi)>0.0) ? 1. : 0.;
 
             // NOTE: These are populated in 'mixing_ratio_to_cloud_mass'
             lwp(icol,ilay) = 0.0;
             iwp(icol,ilay) = 0.0;
 
             // NOTE: These would be populated from P3 (we use the constants in p3_main_impl.hpp)
-            eff_radius_qc(icol,ilay) = (qc>1.0e-12) ? 10.0e-6 : 0.0;
-            eff_radius_qi(icol,ilay) = (qi>1.0e-12) ? 25.0e-6 : 0.0;
+            eff_radius_qc(icol,ilay) = (qc>0.0) ? 10.0e-6 : 0.0;
+            eff_radius_qi(icol,ilay) = (qi>0.0) ? 25.0e-6 : 0.0;
 
             // Buffers on z-faces (nlay+1)
             p_lev(icol,ilay) = getPgivenRTh(rt_avg, qv_avg);
@@ -518,7 +518,6 @@ Radiation::mf_to_yakl_buffers ()
         p_del(icol,ilay)  = std::abs(p_lev(icol,ilay+1) - p_lev(icol,ilay));
     });
 
-    // TODO: Fill properly
     // No LSM, so follow EAMXX dummy atmos and set constants
     if (!lsm) {
         yakl::memset(mu0, 0.86);
@@ -528,7 +527,7 @@ Radiation::mf_to_yakl_buffers ()
         yakl::memset(sfc_alb_dif_nir, 0.06);
     }
 
-    // TODO: Fill properly
+    // Initialize
     yakl::memset(aero_tau_sw, 0.0);
     yakl::memset(aero_ssa_sw, 0.0);
     yakl::memset(aero_g_sw  , 0.0);
@@ -561,19 +560,6 @@ Radiation::yakl_buffers_to_mf ()
             Real exner = getExnergivenP(Real(p_lay(icol,ilay)), R_d/Cp_d);
             q_arr(i,j,k,0) *= exner;
             q_arr(i,j,k,1) *= exner;
-
-            /*
-            if (i==0 && j==0) {
-                AllPrint() << "Qsrcs: " << IntVect(i,j,k) << ' '
-                           << IntVect(icol,0,ilay) << ' '
-                           << q_arr(i,j,k,0) << ' '
-                           << q_arr(i,j,k,1) << ' '
-                           << sw_heating(icol,ilay) << ' '
-                           << lw_heating(icol,ilay) << ' '
-                           << exner << "\n";
-            }
-            */
-
         });
         if (m_lsm_fluxes) {
             const Array4<Real>& lsm_arr =  m_lsm_fluxes->array(mfi);
@@ -645,7 +631,7 @@ Radiation::write_rrtmgp_fluxes ()
    WriteSingleLevelPlotfile(plotfilename, mf_flux, flux_names, m_geom, m_time, m_step);
 }
 
-void Radiation::populateDatalogMF()
+void Radiation::populateDatalogMF ()
 {
     for (MFIter mfi(datalog_mf); mfi.isValid(); ++mfi) {
         const auto& vbx      = mfi.validbox();
@@ -705,7 +691,7 @@ void Radiation::populateDatalogMF()
    }
 }
 
-void Radiation::WriteDataLog(const amrex::Real &time)
+void Radiation::WriteDataLog (const amrex::Real &time)
 {
     constexpr int datwidth = 14;
     constexpr int datprecision = 9;
@@ -965,9 +951,11 @@ Radiation::run_impl ()
     }
     h_mu0.deep_copy_to(mu0);
 
+    // NOTE: p_del uses std::abs() and is always positive
+    //
     // Compute layer cloud mass (per unit area), populates lwp/iwp
-    rrtmgp::mixing_ratio_to_cloud_mass(qc_lay, cldfrac_tot, p_del, lwp);
-    rrtmgp::mixing_ratio_to_cloud_mass(qi_lay, cldfrac_tot, p_del, iwp);
+    rrtmgp::mixing_ratio_to_cloud_mass(qc_lay, cldfrac_tot, r_lay, z_del, lwp);
+    rrtmgp::mixing_ratio_to_cloud_mass(qi_lay, cldfrac_tot, r_lay, z_del, iwp);
 
     // Convert to g/m2 (needed by RRTMGP)
     parallel_for(SimpleBounds<2>(ncol, nlay), YAKL_LAMBDA (int icol, int ilay)
@@ -993,14 +981,16 @@ Radiation::run_impl ()
                         aero_tau_sw, aero_ssa_sw, aero_g_sw, aero_tau_lw,
                         cld_tau_sw_bnd, cld_tau_lw_bnd,
                         cld_tau_sw_gpt, cld_tau_lw_gpt,
-                        sw_flux_up, sw_flux_dn, sw_flux_dn_dir, lw_flux_up, lw_flux_dn,
+                        sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
+                        lw_flux_up, lw_flux_dn,
                         sw_clnclrsky_flux_up, sw_clnclrsky_flux_dn, sw_clnclrsky_flux_dn_dir,
                         sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dn_dir,
                         sw_clnsky_flux_up, sw_clnsky_flux_dn, sw_clnsky_flux_dn_dir,
                         lw_clnclrsky_flux_up, lw_clnclrsky_flux_dn,
                         lw_clrsky_flux_up, lw_clrsky_flux_dn,
                         lw_clnsky_flux_up, lw_clnsky_flux_dn,
-                        sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir, lw_bnd_flux_up, lw_bnd_flux_dn,
+                        sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
+                        lw_bnd_flux_up, lw_bnd_flux_dn,
                         eccf, m_extra_clnclrsky_diag, m_extra_clnsky_diag);
 
 #if 0
@@ -1053,15 +1043,17 @@ Radiation::run_impl ()
                         aero_tau_sw, aero_ssa_sw, aero_g_sw, aero_tau_lw,
                         cld_tau_sw_bnd, cld_tau_lw_bnd,
                         cld_tau_sw_gpt, cld_tau_lw_gpt,
-                        sw_flux_up, sw_flux_dn, sw_flux_dn_dir, lw_flux_up, lw_flux_dn,
+                        sw_flux_up, sw_flux_dn, sw_flux_dn_dir,
+                        lw_flux_up, lw_flux_dn,
                         sw_clnclrsky_flux_up, sw_clnclrsky_flux_dn, sw_clnclrsky_flux_dn_dir,
                         sw_clrsky_flux_up, sw_clrsky_flux_dn, sw_clrsky_flux_dn_dir,
                         sw_clnsky_flux_up, sw_clnsky_flux_dn, sw_clnsky_flux_dn_dir,
                         lw_clnclrsky_flux_up, lw_clnclrsky_flux_dn,
                         lw_clrsky_flux_up, lw_clrsky_flux_dn,
                         lw_clnsky_flux_up, lw_clnsky_flux_dn,
-                        sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir, lw_bnd_flux_up, lw_bnd_flux_dn,
-                        1.0);
+                        sw_bnd_flux_up, sw_bnd_flux_dn, sw_bnd_flux_dir,
+                        lw_bnd_flux_up, lw_bnd_flux_dn,
+                        1.0, true, true);
     //================================================================================
 #endif
 

--- a/Source/Radiation/ERF_RadiationInterface.H
+++ b/Source/Radiation/ERF_RadiationInterface.H
@@ -15,27 +15,27 @@ class IRadiation
 public:
     virtual ~IRadiation () = default;
 
-    virtual void Init(const amrex::Geometry& geom,
+    virtual void Init (const amrex::Geometry& geom,
+                       const amrex::BoxArray& ba,
+                       amrex::MultiFab* cons_in) = 0;
+
+    virtual void Run (int& level,
+                      int& step,
+                      amrex::Real& time,
+                      const amrex::Real& dt,
                       const amrex::BoxArray& ba,
-                      amrex::MultiFab* cons_in) = 0;
+                      amrex::Geometry& geom,
+                      amrex::MultiFab* cons_in,
+                      amrex::MultiFab* lsm_fluxes,
+                      amrex::MultiFab* lsm_zenith,
+                      amrex::MultiFab* qheating_rates,
+                      amrex::MultiFab* z_phys,
+                      amrex::MultiFab* lat,
+                      amrex::MultiFab* lon) = 0;
 
-    virtual void Run(int& level,
-                     int& step,
-                     amrex::Real& time,
-                     const amrex::Real& dt,
-                     const amrex::BoxArray& ba,
-                     amrex::Geometry& geom,
-                     amrex::MultiFab* cons_in,
-                     amrex::MultiFab* lsm_fluxes,
-                     amrex::MultiFab* lsm_zenith,
-                     amrex::MultiFab* qheating_rates,
-                     amrex::MultiFab* z_phys,
-                     amrex::MultiFab* lat,
-                     amrex::MultiFab* lon) = 0;
+    virtual void WriteDataLog (const amrex::Real &time) = 0;
 
-    virtual void WriteDataLog(const amrex::Real &time) = 0;
-
-    void setupDataLog()
+    void setupDataLog ()
     {
         amrex::ParmParse pp("erf.rad");
         if (pp.contains("datalog")) {
@@ -45,11 +45,11 @@ public:
         }
     }
 
-    void setDataLogFrequency(const int nstep) {
+    void setDataLogFrequency (const int nstep) {
         datalog_int = nstep;
     }
 
-    bool hasDatalog() { return (datalog != nullptr && datalog->good()); }
+    bool hasDatalog () { return (datalog != nullptr && datalog->good()); }
 
 protected:
     std::unique_ptr<std::fstream> datalog = nullptr;


### PR DESCRIPTION
Minor changes to conform to ERF coding style. Additionally, use `rho*dz` for the cloud mass calculation instead of the pressure gradient since we use height coordinates.