### PR TITLE
EB: Removed potential SIGILL sources

### DIFF
--- a/Exec/DryRegTests/Terrain3d_Hemisphere/ERF_Prob.cpp
+++ b/Exec/DryRegTests/Terrain3d_Hemisphere/ERF_Prob.cpp
@@ -176,7 +176,7 @@ Problem::init_custom_terrain (
     // Note that these factors must match those in Source/ERF_MakeNewArrays.cpp
     //
     ParmParse pp("erf");
-    bool test_mapfactor;
+    bool test_mapfactor = false;
     pp.query("test_mapfactor",test_mapfactor);
 
     Real mf_x, mf_y;
@@ -205,7 +205,7 @@ Problem::init_custom_terrain (
             Real y = (jj  * dx[1] - ycen) * mf_y;
 
             if(std::pow(x*x + y*y, 0.5) < a){
-                z_arr(i,j,k0) = std::pow(a*a - x*x - y*y , 0.5);
+                z_arr(i,j,k0) = std::pow(amrex::max(a*a - x*x - y*y, 0.0) , 0.5);
             }
             else{
                 z_arr(i,j,k0) = 0.0;

--- a/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
+++ b/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
@@ -108,7 +108,7 @@ Problem::init_custom_terrain (
     // Note that these factors must match those in Source/ERF_MakeNewArrays.cpp
     //
     ParmParse pp("erf");
-    bool test_mapfactor;
+    bool test_mapfactor = false;
     pp.query("test_mapfactor",test_mapfactor);
 
     Real mf_x;
@@ -131,6 +131,11 @@ Problem::init_custom_terrain (
     Real a    = 0.5;
     Real num  = 8. * a * a * a;
     Real xcen = 0.5 * (ProbLoArr[0] + ProbHiArr[0]) / mf_x;
+    // SK *****************************************************************
+    Print()<<"SK:Problem::init_custom_terrain: test_mapfactor = "<< test_mapfactor << std::endl;
+    Print()<<"SK:Problem::init_custom_terrain: ProbLoArr[0] = "<< ProbLoArr[0] 
+    <<", ProbHiArr[0] = "<< ProbHiArr[0] <<", mf_x = "<< mf_x <<", xcen = "<< xcen << std::endl;
+    // SK *****************************************************************
 
     // if hm is nonzero, then use alternate hill definition
     Real hm = parms.hmax;
@@ -188,6 +193,16 @@ Problem::init_custom_terrain (
             } else {
                 Real x_L = x / L;
                 z_arr(i,j,k0) = hm / (1 + x_L*x_L);
+                // SK *****************************************************************
+                if (i==4 && j==0) {
+                    Print()<<"SK:Problem::init_custom_terrain: i,j,k0 = "<<i<<","<<j<<","<<k0
+                    <<", z_arr(i,j,k0) = "<< z_arr(i,j,k0) << std::endl;
+                    Print()<<"SK:Problem::init_custom_terrain: hm = "<<hm 
+                    <<", x = "<<x<<", L = "<<L<<", x_L = "<<x_L<<std::endl;
+                    Print()<<"SK:Problem::init_custom_terrain: ProbLoArr[0] = "<<ProbLoArr[0] 
+                    <<", ii = "<<ii<<", dx[0] = "<<dx[0]<<", xcen = "<<xcen<< std::endl;
+                }
+                // SK *****************************************************************
             }
         });
 #endif

--- a/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
+++ b/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
@@ -131,11 +131,6 @@ Problem::init_custom_terrain (
     Real a    = 0.5;
     Real num  = 8. * a * a * a;
     Real xcen = 0.5 * (ProbLoArr[0] + ProbHiArr[0]) / mf_x;
-    // SK *****************************************************************
-    Print()<<"SK:Problem::init_custom_terrain: test_mapfactor = "<< test_mapfactor << std::endl;
-    Print()<<"SK:Problem::init_custom_terrain: ProbLoArr[0] = "<< ProbLoArr[0] 
-    <<", ProbHiArr[0] = "<< ProbHiArr[0] <<", mf_x = "<< mf_x <<", xcen = "<< xcen << std::endl;
-    // SK *****************************************************************
 
     // if hm is nonzero, then use alternate hill definition
     Real hm = parms.hmax;
@@ -193,16 +188,6 @@ Problem::init_custom_terrain (
             } else {
                 Real x_L = x / L;
                 z_arr(i,j,k0) = hm / (1 + x_L*x_L);
-                // SK *****************************************************************
-                if (i==4 && j==0) {
-                    Print()<<"SK:Problem::init_custom_terrain: i,j,k0 = "<<i<<","<<j<<","<<k0
-                    <<", z_arr(i,j,k0) = "<< z_arr(i,j,k0) << std::endl;
-                    Print()<<"SK:Problem::init_custom_terrain: hm = "<<hm 
-                    <<", x = "<<x<<", L = "<<L<<", x_L = "<<x_L<<std::endl;
-                    Print()<<"SK:Problem::init_custom_terrain: ProbLoArr[0] = "<<ProbLoArr[0] 
-                    <<", ii = "<<ii<<", dx[0] = "<<dx[0]<<", xcen = "<<xcen<< std::endl;
-                }
-                // SK *****************************************************************
             }
         });
 #endif

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_EB
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_EB
@@ -74,7 +74,7 @@ erf.eb_diff_constraint_y = true
 
 erf.abl_driver_type = "PressureGradient"
 #erf.abl_driver_type = "None"
-erf.abl_pressure_grad = -1.0 0. 0.
+erf.abl_pressure_grad = -0.02 0. 0.
 
 erf.project_initial_velocity = false
 

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_EB
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_EB
@@ -69,6 +69,7 @@ erf.terrain_smoothing = 0
 erf.molec_diff_type   = "Constant"
 erf.dynamic_viscosity = 60.0 # [kg/(m-s)]
 erf.alpha_T           = 0.0 # [m^2/s]
+erf.theta_ref = 300.0
 erf.eb_diff_constraint_y = true
 
 erf.abl_driver_type = "PressureGradient"

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_FittedMesh
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_FittedMesh
@@ -22,7 +22,7 @@ geometry.is_periodic = 1 1 0
 #xlo.theta    = 300.
 #xlo.scalar   = 0.
     
-zlo.type = "SlipWall"
+zlo.type = "NoSlipWall"
 zhi.type = "SlipWall"
 #zhi.theta_grad = 0.003
 
@@ -54,11 +54,14 @@ erf.use_gravity = true
 erf.use_coriolis = false
 erf.les_type = "None"
 
-erf.molec_diff_type = "None"
+erf.molec_diff_type   = "Constant"
+erf.dynamic_viscosity = 60.0 # [kg/(m-s)]
+erf.alpha_T           = 0.0 # [m^2/s]
+erf.theta_ref = 300.0
 
 erf.abl_driver_type = "PressureGradient"
 #erf.abl_driver_type = "None"
-erf.abl_pressure_grad = -1.0 0. 0.
+erf.abl_pressure_grad = -0.02 0. 0.
 
 erf.rayleigh_damp_W = true
 erf.rayleigh_zdamp = 5000.0

--- a/Source/Diffusion/ERF_DiffSetup.H
+++ b/Source/Diffusion/ERF_DiffSetup.H
@@ -9,7 +9,7 @@
     const auto& dom_lo = lbound(domain);
     const auto& dom_hi = ubound(domain);
 
-    Real l_inv_theta0 = (turbChoice.theta_ref > 0.0_rt) ? 1.0_rt / turbChoice.theta_ref : 0.0_rt;
+    Real l_inv_theta0 = 1.0 / turbChoice.theta_ref;
     Real l_abs_g      = std::abs(grav_gpu[2]);
 
     bool l_use_keqn = turbChoice.use_keqn;

--- a/Source/Diffusion/ERF_DiffSetup.H
+++ b/Source/Diffusion/ERF_DiffSetup.H
@@ -9,8 +9,8 @@
     const auto& dom_lo = lbound(domain);
     const auto& dom_hi = ubound(domain);
 
-    Real l_inv_theta0    = 1.0 / turbChoice.theta_ref;
-    Real l_abs_g         = std::abs(grav_gpu[2]);
+    Real l_inv_theta0 = (turbChoice.theta_ref > 0.0_rt) ? 1.0_rt / turbChoice.theta_ref : 0.0_rt;
+    Real l_abs_g      = std::abs(grav_gpu[2]);
 
     bool l_use_keqn = turbChoice.use_keqn;
     bool l_use_mynn = turbChoice.use_pbl_tke;

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -113,7 +113,6 @@ define( int const& a_idim,
       bool l_periodic   = a_geom.isPeriodic(a_idim);
 
       // Initialization
-      // This is an ad-hoc; ideally, eb_aux should be defined in bx_grown.
 
       // Extended domain in the direction of periodicity
       Box dom_grown = domain;
@@ -823,6 +822,7 @@ define( int const& a_idim,
   for (MFIter mfi(*m_cellflags, false); mfi.isValid(); ++mfi) {
 
     const Box& bx = mfi.validbox();
+    const Box domain = surroundingNodes(a_geom.Domain(), a_idim);
 
     if (FlagFab[mfi].getType(bx) == FabType::singlevalued ) {
 
@@ -835,13 +835,106 @@ define( int const& a_idim,
       {
         EB2::build_cellflag_from_ap (i, j, k, aux_flag, aux_afrac_x, aux_afrac_y, aux_afrac_z);
       });
-    } // if (FlagFab[mfi].getType(bx) == FabType::singlevalued )
-  } // MFIter
+
+      // Set disconnected non-periodicfaces 
+
+      bool l_periodic_x = a_geom.isPeriodic(0);
+      bool l_periodic_y = a_geom.isPeriodic(1);
+      bool l_periodic_z = a_geom.isPeriodic(2);
+
+      if (!l_periodic_x) {
+        Box dom_grown = grow(grow(domain,1,1),2,1);
+        Box dom_face_x_lo = dom_grown;
+        Box dom_face_x_hi = dom_grown;
+        dom_face_x_lo.setSmall(0, bx.smallEnd(0));
+        dom_face_x_lo.setBig(  0, bx.smallEnd(0));
+        dom_face_x_hi.setSmall(0, bx.bigEnd(0));
+        dom_face_x_hi.setBig(  0, bx.bigEnd(0));
+
+        const Box bx_grown  = grow(grow(bx,1,1),2,1);
+        const Box bx_face_x_lo = bx_grown & dom_face_x_lo;
+        const Box bx_face_x_hi = bx_grown & dom_face_x_hi;
+
+        ParallelFor(bx_face_x_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int kk(-1); kk<=1; kk++) {
+          for(int jj(-1); jj<=1; jj++) {
+            aux_flag(i,j,k).setDisconnected(-1,jj,kk);
+          }}
+        });
+        ParallelFor(bx_face_x_hi, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int kk(-1); kk<=1; kk++) {
+          for(int jj(-1); jj<=1; jj++) {
+            aux_flag(i,j,k).setDisconnected( 1,jj,kk);
+          }}
+        });
+      }
+
+      if (!l_periodic_y) {
+        Box dom_grown = grow(grow(domain,0,1),2,1);
+        Box dom_face_y_lo = dom_grown;
+        Box dom_face_y_hi = dom_grown;
+        dom_face_y_lo.setSmall(1, bx.smallEnd(1));
+        dom_face_y_lo.setBig(  1, bx.smallEnd(1));
+        dom_face_y_hi.setSmall(1, bx.bigEnd(1));
+        dom_face_y_hi.setBig(  1, bx.bigEnd(1));
+
+        const Box bx_grown  = grow(grow(bx,0,1),2,1);
+        const Box bx_face_y_lo = bx_grown & dom_face_y_lo;
+        const Box bx_face_y_hi = bx_grown & dom_face_y_hi;
+
+        ParallelFor(bx_face_y_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int kk(-1); kk<=1; kk++) {
+          for(int ii(-1); ii<=1; ii++) {
+            aux_flag(i,j,k).setDisconnected(ii,-1,kk);
+          }}
+        });
+        ParallelFor(bx_face_y_hi, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int kk(-1); kk<=1; kk++) {
+          for(int ii(-1); ii<=1; ii++) {
+            aux_flag(i,j,k).setDisconnected(ii, 1,kk);
+          }}
+        });
+      }
+
+      if (!l_periodic_z) {
+        Box dom_grown = grow(grow(domain,0,1),1,1);
+        Box dom_face_z_lo = dom_grown;
+        Box dom_face_z_hi = dom_grown;
+        dom_face_z_lo.setSmall(2, bx.smallEnd(2));
+        dom_face_z_lo.setBig(  2, bx.smallEnd(2));
+        dom_face_z_hi.setSmall(2, bx.bigEnd(2));
+        dom_face_z_hi.setBig(  2, bx.bigEnd(2));
+
+        const Box bx_grown  = grow(grow(bx,0,1),1,1);
+        const Box bx_face_z_lo = bx_grown & dom_face_z_lo;
+        const Box bx_face_z_hi = bx_grown & dom_face_z_hi;
+
+        ParallelFor(bx_face_z_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int jj(-1); jj<=1; jj++) {
+          for(int ii(-1); ii<=1; ii++) {
+            aux_flag(i,j,k).setDisconnected(ii,jj,-1);
+          }}
+        });
+        ParallelFor(bx_face_z_hi, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+          for(int jj(-1); jj<=1; jj++) {
+          for(int ii(-1); ii<=1; ii++) {
+            aux_flag(i,j,k).setDisconnected(ii,jj, 1);
+          }}
+        });
+      }
+    }
+
+  }
 
   // Fill Boundary
 
   m_cellflags->FillBoundary(a_geom.periodicity());
-
 
 }
 

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -836,7 +836,7 @@ define( int const& a_idim,
         EB2::build_cellflag_from_ap (i, j, k, aux_flag, aux_afrac_x, aux_afrac_y, aux_afrac_z);
       });
 
-      // Set disconnected non-periodicfaces 
+      // Set disconnected non-periodicfaces
 
       bool l_periodic_x = a_geom.isPeriodic(0);
       bool l_periodic_y = a_geom.isPeriodic(1);


### PR DESCRIPTION
This PR removes the potential source of SIGILL:
- Set the default `test_mapfactor = false` in `ERF_Prob`.
- Set disconnected cells on non-periodic boundaries.