### PR TITLE
Radiation multilevel and clean up.

### DIFF
--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -363,6 +363,14 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
         qmoist[lev][mvar] = micro->Get_Qmoist_Ptr(lev,mvar);
     }
 
+    //********************************************************************************************
+    // Radiation
+    // *******************************************************************************************
+    if (solverChoice.rad_type != RadiationType::None)
+    {
+        rad[lev]->Init(geom[lev], ba, &vars_new[lev][Vars::cons]);
+    }
+
     // *****************************************************************************************************
     // Initialize the boundary conditions (after initializing the terrain but before calling
     //     initHSE or FillCoarsePatch)
@@ -598,6 +606,14 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
     }
     for (int mvar(0); mvar<qmoist[lev].size(); ++mvar) {
         qmoist[lev][mvar] = micro->Get_Qmoist_Ptr(lev,mvar);
+    }
+
+    //********************************************************************************************
+    // Radiation
+    // *******************************************************************************************
+    if (solverChoice.rad_type != RadiationType::None)
+    {
+        rad[lev]->Init(geom[lev], ba, &vars_new[lev][Vars::cons]);
     }
 
     // ********************************************************************************************

--- a/Source/Radiation/ERF_RRTMGP_Interface.H
+++ b/Source/Radiation/ERF_RRTMGP_Interface.H
@@ -37,9 +37,6 @@ using optical_props1_t   = OpticalProps1sclK<RealT, layout_t, RadDefaultDevice>;
 using optical_props2_t   = OpticalProps2strK<RealT, layout_t, RadDefaultDevice>;
 using source_func_t      =     SourceFuncLWK<RealT, layout_t, RadDefaultDevice>;
 
-void init_kls ();
-void finalize_kls ();
-
 namespace rrtmgp {
 
 extern std::unique_ptr<gas_optics_t> k_dist_sw_k;

--- a/Source/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/Radiation/ERF_RRTMGP_Interface.cpp
@@ -1,18 +1,5 @@
 #include "ERF_RRTMGP_Interface.H"
 
-void init_kls ()
-{
-  // Initialize kokkos
-  if(!Kokkos::is_initialized()) { Kokkos::initialize(); }
-}
-
-void finalize_kls()
-{
-  // Finalize kokkos
-  Kokkos::finalize();
-}
-
-
 namespace rrtmgp {
 
 /*

--- a/Source/Radiation/ERF_Radiation.H
+++ b/Source/Radiation/ERF_Radiation.H
@@ -52,13 +52,39 @@ public:
                SolverChoice& sc);
 
     // Destructor
-    ~Radiation () = default;
+    ~Radiation ()
+    {
+        // Finalize kokkos
+        Kokkos::finalize();
+    }
 
     virtual
     void
     Init (const amrex::Geometry& geom,
           const amrex::BoxArray& ba,
-          amrex::MultiFab* cons_in) override {};
+          amrex::MultiFab* cons_in) override
+    {
+        // Ensure the boxes span klo -> khi
+        int klo = geom.Domain().smallEnd(2);
+        int khi = geom.Domain().bigEnd(2);
+
+        // Reset vector of offsets for columnar data
+        m_nlay = geom.Domain().length(2);
+
+        m_ncol = 0;
+        m_col_offsets.clear();
+        m_col_offsets.resize(int(ba.size()));
+        for (amrex::MFIter mfi(*cons_in); mfi.isValid(); ++mfi) {
+            const amrex::Box& vbx = mfi.validbox();
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE((klo == vbx.smallEnd(2)) &&
+                                             (khi == vbx.bigEnd(2)),
+                                             "Vertical decomposition with radiation is not allowed.");
+            int nx = vbx.length(0);
+            int ny = vbx.length(1);
+            m_col_offsets[mfi.index()] = m_ncol;
+            m_ncol += nx * ny;
+        }
+    };
 
     virtual
     void

--- a/Source/Radiation/ERF_Radiation.cpp
+++ b/Source/Radiation/ERF_Radiation.cpp
@@ -164,19 +164,7 @@ Radiation::set_grids (int& level,
     if (m_rad_freq_in_steps > 0) { m_update_rad = ( (m_step == 0) || (m_step % m_rad_freq_in_steps == 0) ); }
 
     if (m_update_rad) {
-        // Reset vector of offsets for columnar data
-        m_nlay = geom.Domain().length(2);
-
-        m_ncol = 0;
-        m_col_offsets.clear();
-        m_col_offsets.resize(int(ba.size()));
-        for (MFIter mfi(*m_cons_in); mfi.isValid(); ++mfi) {
-            const auto& vbx = mfi.validbox();
-            int nx = vbx.length(0);
-            int ny = vbx.length(1);
-            m_col_offsets[mfi.index()] = m_ncol;
-            m_ncol += nx * ny;
-        }
+        // Call to Init() has set the dimensions: ncol & nlay
 
         // Allocate the buffer arrays
         alloc_buffers();

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -7,44 +7,41 @@ void ERF::advance_radiation (int lev,
                              const Real& dt_advance)
 {
     if (solverChoice.rad_type != RadiationType::None) {
-        // TODO: Address issue with lev>0 not spanning all z?
-        if (lev == 0) {
 #ifdef ERF_USE_NETCDF
-            MultiFab *lat_ptr = lat_m[lev].get();
-            MultiFab *lon_ptr = lon_m[lev].get();
+        MultiFab *lat_ptr = lat_m[lev].get();
+        MultiFab *lon_ptr = lon_m[lev].get();
 #else
-            MultiFab *lat_ptr = nullptr;
-            MultiFab *lon_ptr = nullptr;
+        MultiFab *lat_ptr = nullptr;
+        MultiFab *lon_ptr = nullptr;
 #endif
-            // RRTMGP inputs names and pointers
-            Vector<std::string> lsm_input_names = rad[lev]->get_lsm_input_varnames();
-            Vector<MultiFab*> lsm_input_ptrs(lsm_input_names.size(),nullptr);
-            for (int i(0); i<lsm_input_ptrs.size(); ++i) {
-                int varIdx = lsm.Get_VarIdx(lev,lsm_input_names[i]);
-                lsm_input_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
-            }
-
-            // RRTMGP output names and pointers
-            Vector<std::string> lsm_output_names = rad[lev]->get_lsm_output_varnames();
-            Vector<MultiFab*> lsm_output_ptrs(lsm_output_names.size(),nullptr);
-            for (int i(0); i<lsm_output_ptrs.size(); ++i) {
-                int varIdx = lsm.Get_VarIdx(lev,lsm_output_names[i]);
-                lsm_output_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
-            }
-
-            // Enter radiation class driver
-            rad[lev]->Run(lev, istep[lev]  , t_new[lev], dt_advance,
-                          cons.boxArray()  , geom[lev], &(cons),
-                          sw_lw_fluxes[lev].get(), solar_zenith[lev].get(),
-                          lsm_input_ptrs   , lsm_output_ptrs,
-                          qheating_rates[lev].get(), z_phys_nd[lev].get()   ,
-                          lat_ptr, lon_ptr);
-            /*
-            // TODO: fix this - can't use set_lsm_inputs with IRadiation::Run()
-            if (solverChoice.lsm_type == LandSurfaceType::SLM) {
-                rad[lev]->set_lsm_inputs(lsm.get_model_lev<SLM>(lev));
-            }
-            */
+        // RRTMGP inputs names and pointers
+        Vector<std::string> lsm_input_names = rad[lev]->get_lsm_input_varnames();
+        Vector<MultiFab*> lsm_input_ptrs(lsm_input_names.size(),nullptr);
+        for (int i(0); i<lsm_input_ptrs.size(); ++i) {
+            int varIdx = lsm.Get_VarIdx(lev,lsm_input_names[i]);
+            lsm_input_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
         }
+
+        // RRTMGP output names and pointers
+        Vector<std::string> lsm_output_names = rad[lev]->get_lsm_output_varnames();
+        Vector<MultiFab*> lsm_output_ptrs(lsm_output_names.size(),nullptr);
+        for (int i(0); i<lsm_output_ptrs.size(); ++i) {
+            int varIdx = lsm.Get_VarIdx(lev,lsm_output_names[i]);
+            lsm_output_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
+        }
+
+        // Enter radiation class driver
+        rad[lev]->Run(lev, istep[lev]  , t_new[lev], dt_advance,
+                      cons.boxArray()  , geom[lev], &(cons),
+                      sw_lw_fluxes[lev].get(), solar_zenith[lev].get(),
+                      lsm_input_ptrs   , lsm_output_ptrs,
+                      qheating_rates[lev].get(), z_phys_nd[lev].get()   ,
+                      lat_ptr, lon_ptr);
+        /*
+        // TODO: fix this - can't use set_lsm_inputs with IRadiation::Run()
+        if (solverChoice.lsm_type == LandSurfaceType::SLM) {
+        rad[lev]->set_lsm_inputs(lsm.get_model_lev<SLM>(lev));
+        }
+        */
     }
 }


### PR DESCRIPTION
## Radiation Multi-level
1. Fix the null `init` call to now set up the `ncol & nlay` dimensions. Also, assert that the boxes in the boxarray span the domain in the vertical.
2. Call the `init` routine above when we regrid.
3. Call the radiation update on all the levels (not just 0).

## Radiation Clean Up
1. Remove unused `init_kls` and `finalize_kls`
2. Call `kokkos::finalize` in the destructor (should move to ERF in the future)
