### PR TITLE
MOST Iterations

### DIFF
--- a/Exec/DevTests/Hurricane/ERF_Prob.cpp
+++ b/Exec/DevTests/Hurricane/ERF_Prob.cpp
@@ -144,7 +144,13 @@ Problem::init_custom_pert (
     pp.query("IC_file", filename);
 
     if (filename.empty()) {
-        amrex::Abort("Error: IC_file is not specified in the input file.");
+        if ( (sc.init_type == InitType::WRFInput) ||
+             (sc.init_type == InitType::Metgrid)  ||
+             (sc.init_type == InitType::NCFile) ) {
+            return;
+        } else {
+            amrex::Abort("Error: IC_file is not specified in the input file.");
+        }
     }
 
     Vector<Real> latvec_h, lonvec_h;

--- a/Exec/DevTests/Hurricane/GNUmakefile
+++ b/Exec/DevTests/Hurricane/GNUmakefile
@@ -23,6 +23,7 @@ DEBUG = FALSE
 
 TEST = FALSE
 USE_ASSERTION = FALSE
+USE_NETCDF = TRUE
 
 # GNU Make
 Bpack := ./Make.package

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1070,7 +1070,11 @@ struct surface_temp
             qflux = (spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
 
-            Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            Olen  = (1.0 - alpha) * olen_arr(i,j,k) -
+                    alpha * ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
+            zeta  = mdata.zref / Olen;
+            psi_m = sfuns.calc_psi_m(zeta);
+            psi_h = sfuns.calc_psi_h(zeta);
 
             ++iter;
         } while ( (std::abs(olen_arr(i,j,k) - Olen) > tol) && (iter <= max_iters) );
@@ -1093,6 +1097,7 @@ private:
     bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol = 1.0e-5;
+    const amrex::Real alpha = 0.5;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
 };
 

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1053,7 +1053,7 @@ struct surface_temp
         do {
             // Under-relax the update for stability
             olen_arr(i,j,k) = (1.0 - alpha) * olen_arr(i,j,k) + alpha * Olen;
-            zeta  = mdata.zref / Olen;
+            zeta  = mdata.zref / olen_arr(i,j,k);
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
 

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1024,7 +1024,7 @@ struct surface_temp
             // Initial guess from Byun 1990
             // DOI: https://doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2
             amrex::Real Rib = ( (mdata.gravity * mdata.zref) / t_surf_arr(i,j,k) ) *
-                              ( (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / umm );
+                              ( (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / (umm * umm) );
             if (Rib < 0.0) {
                 // Unstable (surface heating atmos)
                 zeta  = (mdata.zref/(mdata.zref-z0_arr(i,j,k))) * std::log(mdata.zref / z0_arr(i,j,k)) * Rib;

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1039,6 +1039,7 @@ struct surface_temp
                 zeta *= (1.0 - 2.0 * Bh * Rib) - std::sqrt(1.0 + (4.0 * (Bh - Bm) * Rib) / Pr0);
                 Olen  = mdata.zref / zeta;
             }
+            olen_arr(i,j,k) = Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         } else {
@@ -1050,7 +1051,11 @@ struct surface_temp
 
         // Fixed point iterations on Olen
         do {
-            olen_arr(i,j,k) = Olen;
+            // Under-relax the update for stability
+            olen_arr(i,j,k) = (1.0 - alpha) * olen_arr(i,j,k) + alpha * Olen;
+            zeta  = mdata.zref / Olen;
+            psi_m = sfuns.calc_psi_m(zeta);
+            psi_h = sfuns.calc_psi_h(zeta);
 
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1070,11 +1075,8 @@ struct surface_temp
             qflux = (spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
 
-            Olen  = (1.0 - alpha) * olen_arr(i,j,k) -
-                    alpha * ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
-            psi_m = sfuns.calc_psi_m(zeta);
-            psi_h = sfuns.calc_psi_h(zeta);
+            // New predicted Olen
+            Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
 
             ++iter;
         } while ( (std::abs(olen_arr(i,j,k) - Olen) > tol) && (iter <= max_iters) );
@@ -1096,8 +1098,8 @@ private:
     most_data mdata;
     bool spec_qflux;
     similarity_funs sfuns;
-    const amrex::Real tol = 1.0e-5;
-    const amrex::Real alpha = 0.5;
+    const amrex::Real tol   = 1.0e-5;
+    const amrex::Real alpha = 0.25;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
 };
 

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1089,8 +1089,8 @@ struct surface_temp
                         (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
                 qstar = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
                         (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
-                tflux = -ustar * tstar;// * (1 + 0.61*qvm_arr(i,j,k));
-                qflux = 0.0; //(spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
+                tflux = -ustar * tstar * (1 + 0.61*qvm_arr(i,j,k));
+                qflux = (spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
                 tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
 
                 R_new = Olen_new + ustar * ustar * ustar * tvm_arr(i,j,k) /

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1019,6 +1019,8 @@ struct surface_temp
         amrex::Real Olen  = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
 
+        amrex::Real IG;
+
         // Seed the fixed point iterations
         if (u_star_arr(i,j,k) == 1.E34) {
             // Initial guess from Byun 1990
@@ -1049,14 +1051,10 @@ struct surface_temp
             psi_h = sfuns.calc_psi_h(zeta);
         }
 
+        IG = olen_arr(i,j,k);
+
         // Fixed point iterations on Olen
         do {
-            // Under-relax the update for stability
-            olen_arr(i,j,k) = (1.0 - alpha) * olen_arr(i,j,k) + alpha * Olen;
-            zeta  = mdata.zref / olen_arr(i,j,k);
-            psi_m = sfuns.calc_psi_m(zeta);
-            psi_h = sfuns.calc_psi_h(zeta);
-
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1078,11 +1076,66 @@ struct surface_temp
             // New predicted Olen
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
 
+            // Dynamic under-relaxation
+            amrex::Real alpha = 1.0;
+            amrex::Real R_cur = olen_arr(i,j,k) - Olen;
+            amrex::Real R_new = 1.0e12;
+            amrex::Real Olen_new = Olen;
+            do {
+                Olen_new = (1.0 - alpha) * olen_arr(i,j,k) + alpha * Olen;
+                zeta  = mdata.zref / Olen_new;
+                psi_m = sfuns.calc_psi_m(zeta);
+                psi_h = sfuns.calc_psi_h(zeta);
+
+                ustar = mdata.kappa * umm /
+                        (std::log(mdata.zref / z0_arr(i,j,k)) - psi_m); // <w'u'>
+                tstar = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
+                        (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
+                qstar = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                        (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                tflux = -ustar * tstar;// * (1 + 0.61*qvm_arr(i,j,k));
+                qflux = 0.0; //(spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
+                tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
+
+                R_new = Olen_new + ustar * ustar * ustar * tvm_arr(i,j,k) /
+                                   (mdata.kappa * mdata.gravity * tflux);
+
+                alpha *= 0.5;
+            } while ( (alpha > 0.001) && (std::fabs(R_new) > std::fabs(R_cur)) );
+
+            // Perform the update
+            if (alpha > 0.001) {
+                olen_arr(i,j,k) = Olen_new;
+            } else {
+                olen_arr(i,j,k) = Olen;
+            }
+            zeta  = mdata.zref / olen_arr(i,j,k);
+            psi_m = sfuns.calc_psi_m(zeta);
+            psi_h = sfuns.calc_psi_h(zeta);
+
             ++iter;
         } while ( (std::abs(olen_arr(i,j,k) - Olen) > tol) && (iter <= max_iters) );
-        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
+        //AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
 
-        olen_arr(i,j,k)   = Olen;
+        if (i==332 && j==7) {
+          amrex::AllPrint() << "Non convergent: " << amrex::IntVect(i,j,k) << ' '
+                            << IG << ' '
+                            << olen_arr(i,j,k) << ' '
+                            << Olen << ' '
+                            << umm << ' '
+                            << tm_arr(i,j,k) << ' '
+                            << t_surf_arr(i,j,k) << "\n";
+        }
+        if (iter >= max_iters) {
+          amrex::AllPrint() << "Non convergent: " << amrex::IntVect(i,j,k) << ' '
+                            << IG << ' '
+                            << olen_arr(i,j,k) << ' '
+                            << Olen << ' '
+                            << umm << ' '
+                            << tm_arr(i,j,k) << ' '
+                            << t_surf_arr(i,j,k) << "\n";
+        }
+
         u_star_arr(i,j,k) = ustar;
         t_star_arr(i,j,k) = tstar;
         if (spec_qflux) {
@@ -1099,7 +1152,6 @@ private:
     bool spec_qflux;
     similarity_funs sfuns;
     const amrex::Real tol   = 1.0e-5;
-    const amrex::Real alpha = 0.25;
     const amrex::Real WSMIN = 0.1; // minimum wind speed
 };
 

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1101,9 +1101,13 @@ struct surface_temp
 
             // Perform the update
             if (alpha > 0.001) {
+                // Acceptable update
                 olen_arr(i,j,k) = Olen_new;
             } else {
+                // Take a large step to get out of local mininma
+                Olen_new = olen_arr(i,j,k);
                 olen_arr(i,j,k) = Olen;
+                Olen = Olen_new;
             }
             zeta  = mdata.zref / olen_arr(i,j,k);
             psi_m = sfuns.calc_psi_m(zeta);

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1021,8 +1021,24 @@ struct surface_temp
 
         // Seed the fixed point iterations
         if (u_star_arr(i,j,k) == 1.E34) {
-            Olen  = 1.0e3; // Stable initial guess at start up
-            zeta  = mdata.zref / Olen;
+            // Initial guess from Byun 1990
+            // DOI: https://doi.org/10.1175/1520-0450(1990)029<0652:OTASOF>2.0.CO;2
+            amrex::Real Rib = ( (mdata.gravity * mdata.zref) / t_surf_arr(i,j,k) ) *
+                              ( (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / umm );
+            if (Rib < 0.0) {
+                // Unstable (surface heating atmos)
+                zeta  = (mdata.zref/(mdata.zref-z0_arr(i,j,k))) * std::log(mdata.zref / z0_arr(i,j,k)) * Rib;
+                Olen  = mdata.zref / zeta;
+            } else {
+                // Stable (surface cooling atmos)
+                amrex::Real Pr0 = 0.74;
+                amrex::Real Bm  = 4.7;
+                amrex::Real Bh  = 6.35;
+                zeta  = (mdata.zref/(mdata.zref-z0_arr(i,j,k))) * std::log(mdata.zref / z0_arr(i,j,k));
+                zeta /= (2.0 * Bh * (Bm * Rib - 1.0));
+                zeta *= (1.0 - 2.0 * Bh * Rib) - std::sqrt(1.0 + (4.0 * (Bh - Bm) * Rib) / Pr0);
+                Olen  = mdata.zref / zeta;
+            }
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         } else {

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1008,6 +1008,8 @@ struct surface_temp
     {
         int iter = 0;
         amrex::Real ustar = 0.0;
+        amrex::Real tstar = 0.0;
+        amrex::Real qstar = 0.0;
         amrex::Real wstar = 0.0;
         amrex::Real tflux = 0.0;
         amrex::Real qflux = 0.0;
@@ -1015,26 +1017,25 @@ struct surface_temp
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
-        amrex::Real Oleno = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
+
+        // Seed the fixed point iterations
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            Olen  = 1.0e3; // Stable initial guess at start up
+            zeta  = mdata.zref / Olen;
+            psi_m = sfuns.calc_psi_m(zeta);
+            psi_h = sfuns.calc_psi_h(zeta);
         } else {
             Olen  = olen_arr(i,j,k);
-            Oleno = Olen;
             zeta  = mdata.zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
+
+        // Fixed point iterations on Olen
         do {
-            ustar = u_star_arr(i,j,k);
-            tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
-            tflux *= (1 + 0.61*qvm_arr(i,j,k));
-            qflux = (spec_qflux) ? mdata.surf_moist_flux :
-                                 -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
-            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
+            olen_arr(i,j,k) = Olen;
+
             if (w_star_arr) {
                 // update w* and Umagmean
                 w_star_arr(i,j,k) = calc_wstar(tflux, pblh_arr(i,j,k), tvm_arr(i,j,k));
@@ -1042,32 +1043,32 @@ struct surface_temp
                 umm = std::sqrt(umm_arr(i,j,k)*umm_arr(i,j,k) + wstar*wstar);
                 umm = std::max(umm, WSMIN);
             }
+
+            ustar = mdata.kappa * umm /
+                    (std::log(mdata.zref / z0_arr(i,j,k)) - psi_m); // <w'u'>
+            tstar = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
+                    (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'T'>
+            qstar = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
+                    (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+            tflux = -ustar * tstar * (1 + 0.61*qvm_arr(i,j,k));
+            qflux = (spec_qflux) ? mdata.surf_moist_flux : -ustar * qstar;
+            tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
+
             Olen = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            if ( (((Olen >= 0.0) && (Oleno <= 0.0)) ||
-                  ((Olen <= 0.0) && (Oleno >= 0.0))) &&
-                 std::fabs(Olen) + std::fabs(Oleno) < 1.) {
-                Olen = 0.5 * (Olen + Oleno);
-            }
-            Oleno = Olen;
 
-            zeta  = mdata.zref / Olen;
-            psi_m = sfuns.calc_psi_m(zeta);
-            psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0_arr(i,j,k)) - psi_m);
             ++iter;
-        } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
-        AMREX_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
+        } while ( (std::abs(olen_arr(i,j,k) - Olen) > tol) && (iter <= max_iters) );
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
 
-        t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
-          olen_arr(i,j,k) = Olen;
+        olen_arr(i,j,k)   = Olen;
+        u_star_arr(i,j,k) = ustar;
+        t_star_arr(i,j,k) = tstar;
         if (spec_qflux) {
             q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
-            q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+            q_star_arr(i,j,k) = qstar;
         }
     }
 

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1115,26 +1115,7 @@ struct surface_temp
 
             ++iter;
         } while ( (std::abs(olen_arr(i,j,k) - Olen) > tol) && (iter <= max_iters) );
-        //AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
-
-        if (i==332 && j==7) {
-          amrex::AllPrint() << "Non convergent: " << amrex::IntVect(i,j,k) << ' '
-                            << IG << ' '
-                            << olen_arr(i,j,k) << ' '
-                            << Olen << ' '
-                            << umm << ' '
-                            << tm_arr(i,j,k) << ' '
-                            << t_surf_arr(i,j,k) << "\n";
-        }
-        if (iter >= max_iters) {
-          amrex::AllPrint() << "Non convergent: " << amrex::IntVect(i,j,k) << ' '
-                            << IG << ' '
-                            << olen_arr(i,j,k) << ' '
-                            << Olen << ' '
-                            << umm << ' '
-                            << tm_arr(i,j,k) << ' '
-                            << t_surf_arr(i,j,k) << "\n";
-        }
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters, "Maximum number of MOST iterations reached.");
 
         u_star_arr(i,j,k) = ustar;
         t_star_arr(i,j,k) = tstar;

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -1019,8 +1019,6 @@ struct surface_temp
         amrex::Real Olen  = 0.0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
 
-        amrex::Real IG;
-
         // Seed the fixed point iterations
         if (u_star_arr(i,j,k) == 1.E34) {
             // Initial guess from Byun 1990
@@ -1050,8 +1048,6 @@ struct surface_temp
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
-
-        IG = olen_arr(i,j,k);
 
         // Fixed point iterations on Olen
         do {

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -395,7 +395,7 @@ public:
   void
   update_fluxes (const int& lev,
                  const amrex::Real& time,
-                 int max_iters = 500);
+                 int max_iters = 50);
 
   template <typename FluxIter>
   void compute_fluxes (const int& lev,

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -395,7 +395,7 @@ public:
   void
   update_fluxes (const int& lev,
                  const amrex::Real& time,
-                 int max_iters = 50);
+                 int max_iters = 1000);
 
   template <typename FluxIter>
   void compute_fluxes (const int& lev,


### PR DESCRIPTION
# Fixed Point Iteration on Olen
This PR changes the MOST surface temperature iterator to rigorously test for convergence and to perform fixed point iterations on the Obhukov length scale with dynamic under relaxation.

## Algorithm
- Initial guess for `surface_temp` case comes from [Byun 1990](https://doi.org/10.1175/1520-0450(1990)029%3C0652:OTASOF%3E2.0.CO;2)
- Fixed point iterations are performed on `Olen`
- Dynamic under relaxation is performed to reduce oscillations
- Algorithm was verified against data from [Basu et al 2008](https://link.springer.com/article/10.2478/s11600-007-0038-y) (see Figure 2).

## Unresolved issues
- [Basu et al 2008](https://link.springer.com/article/10.2478/s11600-007-0038-y) mentions that a root may not exist. In these cases, which seem to be characterized by small driving forces (`wsp` or `\Delta Th`) the algorithm seems to drive `Olen -> 0` to obtain a FreeSlip wall.
- The nonconvergent cases are at odds with [Byun 1990](https://doi.org/10.1175/1520-0450(1990)029%3C0652:OTASOF%3E2.0.CO;2), whose analytical solution only depends upon the bulk Richardson number `Rib`.
- The analytical solution of [Byun 1990](https://doi.org/10.1175/1520-0450(1990)029%3C0652:OTASOF%3E2.0.CO;2) can differ appreciably from the iterative solution for some inputs of `wsp` and `\Delta Th` (particularly near the non convergent regions). 