### PR TITLE
Fix Particle Plotfile 

### DIFF
--- a/Source/Particles/ERF_ParticleData.H
+++ b/Source/Particles/ERF_ParticleData.H
@@ -63,7 +63,7 @@ class ParticleData
                 for (ParticlesNamesVector::size_type i = 0; i < m_namelist.size(); i++) {
                     auto name( m_namelist[i] );
                     auto particles( m_particle_species.at(name) );
-                    particles->WritePlotFile(a_fname, name, true, particles->varNames());
+                    particles->WritePlotFile(a_fname, name, particles->varNames());
                 }
             }
         }


### PR DESCRIPTION
The call signature for the particle `writeplotfile` call does not have a bool flag. This pathway also assumes the vector of variable names is for `real` data types.