### PR TITLE
MOST Set Qsurf Over Water

### DIFF
--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
@@ -23,6 +23,7 @@ erf.most.radius     = 0
 erf.most.zref       = 10.0
 erf.most.z0         = 0.1
 erf.most.surf_temp  = 300.0
+erf.most.surf_moist = 0.0
 
 # TIME STEP CONTROL
 erf.fixed_dt           = 0.5  # fixed time step depending on grid resolution
@@ -45,8 +46,6 @@ erf.plot_int_1      = 1       # number of timesteps between plotfiles
 erf.plot_vars_1     = density rhoQ1 x_velocity y_velocity z_velocity pressure temp theta pres_hse z_phys qt qp qv qc
 
 # SOLVER CHOICE
-erf.alpha_T = 0.0
-erf.alpha_C = 0.0
 erf.use_gravity = true
 
 erf.terrain_type = StaticFittedMesh
@@ -54,8 +53,8 @@ erf.terrain_type = StaticFittedMesh
 erf.moisture_model = "Kessler"
 
 erf.molec_diff_type = "None"
-erf.les_type        = "Smagorinsky"
-erf.Cs              = 0.005
+erf.les_type        = "Smagorinsky2D"
+erf.Cs              = 0.1
 
 erf.has_lat_lon = true
     
@@ -67,7 +66,7 @@ erf.rotational_time_period = 86164.0900027328
 
 # PROBLEM PARAMETERS (optional)
 prob.rho_0 = 1.0
-prob.T_0 = 300.0
+prob.T_0   = 300.0
 
 # INITIALIZATION WITH ATM DATA
 erf.real_width     = 1

--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/inputs_wps
@@ -53,8 +53,8 @@ erf.terrain_type = StaticFittedMesh
 erf.moisture_model = "Kessler"
 
 erf.molec_diff_type = "None"
-erf.les_type        = "Smagorinsky2D"
-erf.Cs              = 0.1
+erf.les_type        = "Smagorinsky"
+erf.Cs              = 0.005
 
 erf.has_lat_lon = true
     

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -14,6 +14,7 @@
 #include "ERF_MOSTStress.H"
 #include "ERF_TerrainMetrics.H"
 #include "ERF_PBLHeight.H"
+#include "ERF_MicrophysicsUtils.H"
 
 /** Abstraction layer for different surface layer schemes (e.g. MOST, Cd)
  *
@@ -393,6 +394,8 @@ public:
   void
   update_fluxes (const int& lev,
                  const amrex::Real& time,
+                 const amrex::MultiFab& cons_in,
+                 const std::unique_ptr<amrex::MultiFab>& z_phys_nd,
                  int max_iters = 100);
 
   template <typename FluxIter>
@@ -427,6 +430,10 @@ public:
 
   void fill_tsurf_with_sst_and_tsk (const int& lev,
                                     const amrex::Real& time);
+
+  void fill_qsurf_with_qsat (const int& lev,
+                             const amrex::MultiFab& cons_in,
+                             const std::unique_ptr<amrex::MultiFab>& z_phys_nd);
 
   void get_lsm_tsurf (const int& lev);
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -561,10 +561,11 @@ SurfaceLayer::fill_qsurf_with_qsat (const int& lev,
             if (!is_land) {
                 auto deltaZ = (z_arr) ? Compute_Zrel_AtCellCenter(i,j,k,z_arr) :
                                         0.5*dz;
+                auto Rho  = cons_arr(i,j,k,Rho_comp);
                 auto RTh  = cons_arr(i,j,k,RhoTheta_comp);
-                auto Qv   = cons_arr(i,j,k,RhoQ1_comp) / cons_arr(i,j,k,Rho_comp);
+                auto Qv   = cons_arr(i,j,k,RhoQ1_comp) / Rho;
                 auto P_cc = getPgivenRTh(RTh, Qv);
-                P_cc += deltaZ*CONST_GRAV;
+                P_cc += Rho*CONST_GRAV*deltaZ;
                 P_cc *= 0.01;
                 erf_qsatw(t_surf_arr(i,j,k), P_cc, q_surf_arr(i,j,k));
             }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -11,14 +11,28 @@ using namespace amrex;
 void
 SurfaceLayer::update_fluxes (const int& lev,
                              const Real& time,
+                             const MultiFab& cons_in,
+                             const std::unique_ptr<MultiFab>& z_phys_nd,
                              int max_iters)
 {
-    // Update SST data if we have a valid pointer
-    if (m_sst_lev[lev][0]) fill_tsurf_with_sst_and_tsk(lev, time);
+    // Update with SST/TSK data if we have a valid pointer
+    if (m_sst_lev[lev][0]) {
+        fill_tsurf_with_sst_and_tsk(lev, time);
+    }
+
+    // Apply heating rate if needed
+    if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
+        update_surf_temp(time);
+    }
+
+    // Update qsurf with qsat over sea
+    if (use_moisture) {
+        fill_qsurf_with_qsat(lev, cons_in, z_phys_nd);
+    }
 
     // TODO: we want 0 index to always be theta?
     // Update land surface temp if we have a valid pointer
-    if (m_lsm_data_lev[lev][0]) get_lsm_tsurf(lev);
+    if (m_lsm_data_lev[lev][0]) { get_lsm_tsurf(lev); }
 
     // Fill interior ghost cells
     t_surf[lev]->FillBoundary(m_geom[lev].periodicity());
@@ -40,15 +54,15 @@ SurfaceLayer::update_fluxes (const int& lev,
         bool is_land = true;
         if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-              surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
+                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
             }
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
-            update_surf_temp(time);
+
             if (rough_type_land == RoughCalcType::CONSTANT) {
-              surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
+                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
@@ -493,7 +507,7 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
                                                   Array4<int> {};
 
         if (use_tsk) {
-            const auto    tsk_arr = m_tsk_lev[lev][n_time_lo]->const_array(mfi);
+            const auto tsk_arr = m_tsk_lev[lev][n_time_lo]->const_array(mfi);
             ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 int is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
@@ -518,6 +532,45 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
         }
     }
     t_surf[lev]->FillBoundary(m_geom[lev].periodicity());
+}
+
+void
+SurfaceLayer::fill_qsurf_with_qsat (const int& lev,
+                                    const MultiFab& cons_in,
+                                    const std::unique_ptr<MultiFab>& z_phys_nd)
+{
+    // NOTE: We have already tested a moisture model exists
+
+    // Populate q_surf with qsat over water
+    auto dz = m_geom[lev].CellSize(2);
+    for (MFIter mfi(*q_surf[lev]); mfi.isValid(); ++mfi)
+    {
+        Box gtbx = mfi.growntilebox();
+
+        auto t_surf_arr = t_surf[lev]->array(mfi);
+        auto q_surf_arr = q_surf[lev]->array(mfi);
+        auto lmask_arr  = (m_lmask_lev[lev][0]) ? m_lmask_lev[lev][0]->array(mfi) :
+                                                  Array4<int> {};
+        const auto cons_arr = cons_in.const_array(mfi);
+        const auto z_arr    = (z_phys_nd) ? z_phys_nd->const_array(mfi) :
+                                            Array4<const Real> {};
+
+        ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        {
+            int is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
+            if (!is_land) {
+                auto deltaZ = (z_arr) ? Compute_Zrel_AtCellCenter(i,j,k,z_arr) :
+                                        0.5*dz;
+                auto RTh  = cons_arr(i,j,k,RhoTheta_comp);
+                auto Qv   = cons_arr(i,j,k,RhoQ1_comp) / cons_arr(i,j,k,Rho_comp);
+                auto P_cc = getPgivenRTh(RTh, Qv);
+                P_cc += deltaZ*CONST_GRAV;
+                P_cc *= 0.01;
+                erf_qsatw(t_surf_arr(i,j,k), P_cc, q_surf_arr(i,j,k));
+            }
+        });
+    }
+    q_surf[lev]->FillBoundary(m_geom[lev].periodicity());
 }
 
 void

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -26,7 +26,7 @@ SurfaceLayer::update_fluxes (const int& lev,
     }
 
     // Update qsurf with qsat over sea
-    if (use_moisture) {
+    if (use_moisture && (moist_type == MoistCalcType::SURFACE_MOISTURE)) {
         fill_qsurf_with_qsat(lev, cons_in, z_phys_nd);
     }
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -60,7 +60,6 @@ SurfaceLayer::update_fluxes (const int& lev,
                 amrex::Abort("Unknown value for rough_type_land");
             }
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
-
             if (rough_type_land == RoughCalcType::CONSTANT) {
                 surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
@@ -114,7 +113,6 @@ SurfaceLayer::update_fluxes (const int& lev,
             }
 
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
-            update_surf_temp(time);
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
                 surface_temp_charnock most_flux(m_ma.get_zref(),
                                                 surf_temp_flux, surf_moist_flux,

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -13,7 +13,7 @@ AMREX_ENUM(StratType, theta, thetav, thetal);
 
 template <typename T>
 void
-query_one_or_per_level(
+query_one_or_per_level (
   const amrex::ParmParse& pp,
   const char* query_string,
   T& query_var,
@@ -50,8 +50,8 @@ public:
 
     // Handle 2-D Smag
     if (les_type == LESType::Smagorinsky2D) {
-      les_type = LESType::Smagorinsky;
-      smag2d = true;
+        les_type = LESType::Smagorinsky;
+        smag2d = true;
     }
 
     // Which RANS closure?
@@ -59,7 +59,7 @@ public:
     query_one_or_per_level(pp, "rans_type", rans_type, lev, max_level);
 
     if ((rans_type != RANSType::None) && (les_type != LESType::None)) {
-      amrex::Error("Hybrid RANS-LES not implemented");
+        amrex::Error("Hybrid RANS-LES not implemented");
     }
 
     // Which PBL Closure

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1376,7 +1376,7 @@ ERF::InitData_post ()
                 // it will change u* and theta* from their previous values
                 m_SurfaceLayer->update_pblh(lev, vars_new, z_phys_cc[lev].get(),
                                             solverChoice.moisture_indices);
-                m_SurfaceLayer->update_fluxes(lev, time);
+                m_SurfaceLayer->update_fluxes(lev, time, vars_new[lev][Vars::cons], z_phys_nd[lev]);
             }
         }
     } // end if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::surface_layer)

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -115,7 +115,7 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
             m_SurfaceLayer->update_mac_ptrs(lev, vars_old, Theta_prim, Qv_prim, Qr_prim);
             m_SurfaceLayer->update_pblh(lev, vars_old, z_phys_cc[lev].get(),
                                         solverChoice.moisture_indices);
-            m_SurfaceLayer->update_fluxes(lev, time, S_new, z_phys_nd[lev]);
+            m_SurfaceLayer->update_fluxes(lev, time, S_old, z_phys_nd[lev]);
         }
     }
 

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -115,7 +115,7 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
             m_SurfaceLayer->update_mac_ptrs(lev, vars_old, Theta_prim, Qv_prim, Qr_prim);
             m_SurfaceLayer->update_pblh(lev, vars_old, z_phys_cc[lev].get(),
                                         solverChoice.moisture_indices);
-            m_SurfaceLayer->update_fluxes(lev, time);
+            m_SurfaceLayer->update_fluxes(lev, time, S_new, z_phys_nd[lev]);
         }
     }
 


### PR DESCRIPTION
# Setting Qsurf Over Water
When over water, the vapor mixing ratio at the surface is set to the vapor mixing ratio at saturation. This follows WRF and the Jimenez 2012 paper:
<img width="363" height="492" alt="image" src="https://github.com/user-attachments/assets/b3743d1b-9bd5-4e87-8748-3451baa6b749" />

## New Routine: fill_qsurf_with_qsat
1. Update the surface temperature with SST/TSK
2. Apply the heating rate to the surface temperature if needed
3. If we have moisture, call `fill_qsurf_with_qsat`
4. When over water, compute `qvs` and fill `q_surf_arr(i,j,k)`.
5. The above computation gets the pressure at CC and  does an HSE integration down to the surface. Additionally, the MOST surface temperature is used for the qsat computation.

## Regtest Note
- This PR changes the WPS test to be constant surface moisture. Where the surface moisture is `qsat` over sea and is dry `qv=0` over land (see below).

## User Note
- Setting `erf.most.surf_moist = <val>` will trigger the use of the computed `qvs` over water and will use `<val>` over land. If `erf.most.surf_moist` is not set, the moisture is treated as a zero flux condition. 