### PR TITLE
Minor fixes for radiation

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -136,7 +136,7 @@ get_subsampled_clouds (const int ncol,
     int1d_k seeds("seeds", ncol);
     Kokkos::parallel_for(ncol, KOKKOS_LAMBDA(int icol)
     {
-        seeds(icol) = 1.0e9 * (p_lay(icol,nlay) - int(p_lay(icol,nlay)));
+        seeds(icol) = 1.0e9 * (p_lay(icol,nlay-1) - int(p_lay(icol,nlay-1)));
     });
     auto cldmask = get_subcolumn_mask(ncol, nlay, ngpt, cldfrac_rad, overlap, seeds);
 

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -479,6 +479,11 @@ Radiation::mf_to_kokkos_buffers (Vector<MultiFab*>& lsm_input_ptrs)
             Real r_lo  = cons_arr(i,j,k-1,Rho_comp);
             Real rt_lo = cons_arr(i,j,k-1,RhoTheta_comp);
             Real qv_lo = (moist) ? cons_arr(i,j,k-1,RhoQ1_comp)/r_lo : 0.0;
+
+            // make sure qv is >= 0 for H2O VMR
+            qv_lo = std::max(0.0, qv_lo);
+            qv = std::max(0.0, qv);
+
             Real r_avg  = 0.5 * (r  + r_lo);
             Real rt_avg = 0.5 * (rt + rt_lo);
             Real qv_avg = 0.5 * (qv + qv_lo);
@@ -511,6 +516,7 @@ Radiation::mf_to_kokkos_buffers (Vector<MultiFab*>& lsm_input_ptrs)
                 Real r_hi  = cons_arr(i,j,k+1,Rho_comp);
                 Real rt_hi = cons_arr(i,j,k+1,RhoTheta_comp);
                 Real qv_hi = (moist) ? cons_arr(i,j,k+1,RhoQ1_comp)/r_hi : 0.0;
+                qv_hi = std::max(0.0, qv_hi);
                 r_avg  = 0.5 * (r  + r_hi);
                 rt_avg = 0.5 * (rt + rt_hi);
                 qv_avg = 0.5 * (qv + qv_hi);


### PR DESCRIPTION
This makes sure the qv input to the radiation model is >=0.0, otherwise a negative H2O VMR could be calculated resulting in nan fluxes. This also fixes a out-of-bounds index issue getting the pressure in the `get_subsampled_clouds` function.