### PR TITLE
fix restart; add use_shoc to inputs; fix precision issue with FP

### DIFF
--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -78,8 +78,10 @@ ERF::FillPatchFineLevel (int lev, Real time,
     Vector<Real> ftime    = {t_old[lev  ], t_new[lev  ]};
     Vector<Real> ctime    = {t_old[lev-1], t_new[lev-1]};
 
+    amrex::Real small_dt = 1.e-8 * (ftime[1] - ftime[0]);
+
     Vector<MultiFab*> fmf;
-    if (amrex::almostEqual(time,ftime[0])) {
+    if ( amrex::almostEqual(time,ftime[0]) || (time-ftime[0]) < small_dt ) {
         fmf = {&vars_old[lev][Vars::cons], &vars_old[lev][Vars::cons]};
     } else if (amrex::almostEqual(time,ftime[1])) {
         fmf = {&vars_new[lev][Vars::cons], &vars_new[lev][Vars::cons]};
@@ -197,38 +199,37 @@ ERF::FillPatchFineLevel (int lev, Real time,
             MultiFab& mf_v = *mfs_vel[Vars::yvel];
             MultiFab& mf_w = *mfs_vel[Vars::zvel];
 
+            Vector<MultiFab*> fmf_u; Vector<MultiFab*> fmf_v; Vector<MultiFab*> fmf_w;
+            Vector<MultiFab*> cmf_u; Vector<MultiFab*> cmf_v; Vector<MultiFab*> cmf_w;
+
             // **********************************************************************
 
-            if (amrex::almostEqual(time,ftime[0])) {
-                fmf = {&vars_old[lev][Vars::xvel], &vars_old[lev][Vars::xvel]};
-            } else if (amrex::almostEqual(time,ftime[1])) {
-                fmf = {&vars_new[lev][Vars::xvel], &vars_new[lev][Vars::xvel]};
+            if ( amrex::almostEqual(time,ftime[0]) || (time-ftime[0]) < small_dt ) {
+                fmf_u = {&vars_old[lev][Vars::xvel], &vars_old[lev][Vars::xvel]};
+                fmf_v = {&vars_old[lev][Vars::yvel], &vars_old[lev][Vars::yvel]};
+                fmf_w = {&vars_old[lev][Vars::zvel], &vars_old[lev][Vars::zvel]};
+            } else if ( amrex::almostEqual(time,ftime[1]) ) {
+                fmf_u = {&vars_new[lev][Vars::xvel], &vars_new[lev][Vars::xvel]};
+                fmf_v = {&vars_new[lev][Vars::yvel], &vars_new[lev][Vars::yvel]};
+                fmf_w = {&vars_new[lev][Vars::zvel], &vars_new[lev][Vars::zvel]};
             } else {
-                fmf = {&vars_old[lev][Vars::xvel], &vars_new[lev][Vars::xvel]};
+                fmf_u = {&vars_old[lev][Vars::xvel], &vars_new[lev][Vars::xvel]};
+                fmf_v = {&vars_old[lev][Vars::yvel], &vars_new[lev][Vars::yvel]};
+                fmf_w = {&vars_old[lev][Vars::zvel], &vars_new[lev][Vars::zvel]};
             }
-            cmf = {&vars_old[lev-1][Vars::xvel], &vars_new[lev-1][Vars::xvel]};
+            cmf_u = {&vars_old[lev-1][Vars::xvel], &vars_new[lev-1][Vars::xvel]};
+            cmf_v = {&vars_old[lev-1][Vars::yvel], &vars_new[lev-1][Vars::yvel]};
+            cmf_w = {&vars_old[lev-1][Vars::zvel], &vars_new[lev-1][Vars::zvel]};
 
             // Call FillPatchTwoLevels which ASSUMES that all ghost cells at lev-1 have already been filled
             FillPatchTwoLevels(mf_u, ngvect_vels, IntVect(0,0,0),
-                               time, cmf, ctime, fmf, ftime,
+                               time, cmf_u, ctime, fmf_u, ftime,
                                0, 0, 1, geom[lev-1], geom[lev],
                                refRatio(lev-1), mapper, domain_bcs_type,
                                BCVars::xvel_bc);
 
-            // **********************************************************************
-
-            if (amrex::almostEqual(time,ftime[0])) {
-                fmf = {&vars_old[lev][Vars::yvel], &vars_old[lev][Vars::yvel]};
-            } else if (amrex::almostEqual(time,ftime[1])) {
-                fmf = {&vars_new[lev][Vars::yvel], &vars_new[lev][Vars::yvel]};
-            } else {
-                fmf = {&vars_old[lev][Vars::yvel], &vars_new[lev][Vars::yvel]};
-            }
-            cmf = {&vars_old[lev-1][Vars::yvel], &vars_new[lev-1][Vars::yvel]};
-
-            // Call FillPatchTwoLevels which ASSUMES that all ghost cells at lev-1 have already been filled
             FillPatchTwoLevels(mf_v, ngvect_vels, IntVect(0,0,0),
-                               time, cmf, ctime, fmf, ftime,
+                               time, cmf_v, ctime, fmf_v, ftime,
                                0, 0, 1, geom[lev-1], geom[lev],
                                refRatio(lev-1), mapper, domain_bcs_type,
                                BCVars::yvel_bc);
@@ -243,18 +244,9 @@ ERF::FillPatchFineLevel (int lev, Real time,
 
             // **********************************************************************
 
-            if (amrex::almostEqual(time,ftime[0])) {
-                fmf = {&vars_old[lev][Vars::zvel], &vars_old[lev][Vars::zvel]};
-            } else if (amrex::almostEqual(time,ftime[1])) {
-                fmf = {&vars_new[lev][Vars::zvel], &vars_new[lev][Vars::zvel]};
-            } else {
-                fmf = {&vars_old[lev][Vars::zvel], &vars_new[lev][Vars::zvel]};
-            }
-            cmf = {&vars_old[lev-1][Vars::zvel], &vars_new[lev-1][Vars::zvel]};
-
             // Call FillPatchTwoLevels which ASSUMES that all ghost cells at lev-1 have already been filled
             FillPatchTwoLevels(mf_w, ngvect_vels, IntVect(0,0,0),
-                               time, cmf, ctime, fmf, ftime,
+                               time, cmf_w, ctime, fmf_w, ftime,
                                0, 0, 1, geom[lev-1], geom[lev],
                                refRatio(lev-1), mapper, domain_bcs_type,
                                BCVars::zvel_bc);

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -505,6 +505,14 @@ struct SolverChoice {
             }
         }
 
+        // Are we using SHOC?
+        pp.query("use_shoc", use_shoc);
+#ifndef ERF_USE_SHOC
+        if (use_shoc) {
+            amrex::Abort("You set use_shoc to true but didn't build with SHOC; you must rebuild the executable");
+        }
+#endif
+
         // Which type of multilevel coupling
         coupling_type = CouplingType::TwoWay; // Default
         pp.query_enum_case_insensitive("coupling_type",coupling_type);
@@ -834,6 +842,9 @@ struct SolverChoice {
 
     // MOST stress rotations
     bool use_rotate_surface_flux = false;
+
+    // Should we use SHOC?
+    bool use_shoc = false;
 
     // User wishes to output time averaged velocity fields
     bool time_avg_vel = false;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -915,11 +915,12 @@ ERF::InitData_post ()
 
             int n_time_old = static_cast<int>(t_new[0] /  dT);
 
-            // I don't think this works if lev > 0 ...?
-            AMREX_ALWAYS_ASSERT(finest_level == 0);
             int lev = 0;
             bool use_moist = (solverChoice.moisture_type != MoistureType::None);
-            for (int itime = n_time_old; itime < n_time_old+3; itime++)
+
+            int ntimes = std::min(n_time_old+3, static_cast<int>(bdy_data_xlo.size()));
+
+            for (int itime = n_time_old; itime < ntimes; itime++)
             {
                 read_from_wrfbdy(itime,nc_bdy_file,geom[0].Domain(),
                                  bdy_data_xlo,bdy_data_xhi,bdy_data_ylo,bdy_data_yhi,


### PR DESCRIPTION
1)fix restart when we have wrfbdy files with only two time slices; 
2)add use_shoc to inputs; 
3)fix precision issue with Fillpatching