### PR TITLE
NOAHMP + SurfaceLayer

### DIFF
--- a/Build/cmake_with_noahmp.sh
+++ b/Build/cmake_with_noahmp.sh
@@ -1,0 +1,20 @@
+
+# Example CMake config script for an OSX laptop with OpenMPI
+
+cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
+      -DCMAKE_CXX_COMPILER:STRING=mpicxx \
+      -DCMAKE_C_COMPILER:STRING=mpicc \
+      -DCMAKE_Fortran_COMPILER:STRING=mpifort \
+      -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DHDF5_DIR=/usr/local/hdf5 \
+      -DERF_DIM:STRING=3 \
+      -DERF_ENABLE_MPI:BOOL=ON \
+      -DERF_ENABLE_TESTS:BOOL=ON \
+      -DERF_ENABLE_FCOMPARE:BOOL=ON \
+      -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+      -DERF_ENABLE_NOAHMP:BOOL=ON \
+      -DERF_ENABLE_NETCDF:BOOL=ON \
+      -DERF_ENABLE_HDF5:BOOL=ON \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+      .. && make -j8

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -231,7 +231,9 @@ public:
                                    amrex::MultiFab* Lwave,
                                    amrex::MultiFab* eddyDiffs,
                                    amrex::Vector<amrex::MultiFab*> lsm_data,
+                                   amrex::Vector<std::string>      lsm_data_name,
                                    amrex::Vector<amrex::MultiFab*> lsm_flux,
+                                   amrex::Vector<std::string>      lsm_flux_name,
                                    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& sst_lev,
                                    amrex::Vector<std::unique_ptr<amrex::MultiFab>>& tsk_lev,
                                    amrex::Vector<std::unique_ptr<amrex::iMultiFab>>& lmask_lev)
@@ -308,11 +310,22 @@ public:
       m_eddyDiffs_lev[lev] = eddyDiffs;
 
       // Get pointers to LSM data and Fluxes
-      int nvar = static_cast<int>(lsm_data.size());
-      m_lsm_data_lev[lev].resize(nvar);
-      m_lsm_flux_lev[lev].resize(nvar);
-      for (int n(0); n < nvar; ++n) {
+      int ndata = static_cast<int>(lsm_data.size());
+      int nflux = static_cast<int>(lsm_flux.size());
+      m_lsm_data_name.resize(ndata);
+      m_lsm_data_lev[lev].resize(ndata);
+      m_lsm_flux_name.resize(nflux);
+      m_lsm_flux_lev[lev].resize(nflux);
+      for (int n(0); n < ndata; ++n) {
+          m_lsm_data_name[n]     = lsm_data_name[n];
           m_lsm_data_lev[lev][n] = lsm_data[n];
+          if (amrex::toLower(lsm_data_name[n]) == "theta") {
+              m_has_lsm_tsurf  = true;
+              m_lsm_tsurf_indx = n;
+          }
+      }
+      for (int n(0); n < nflux; ++n) {
+          m_lsm_flux_name[n]     = lsm_flux_name[n];
           m_lsm_flux_lev[lev][n] = lsm_flux[n];
       }
 
@@ -372,9 +385,8 @@ public:
       q_surf[lev] = std::make_unique<amrex::MultiFab>(ba2d, dm, ncomp, ng);
       q_surf[lev]->setVal(default_land_surf_moist);
 
-      // TODO: Do we want lsm_data to have theta at 0 index always?
-      //       Do we want an external enum struct for indexing?
-      if (m_sst_lev[lev][0] || m_tsk_lev[lev][0] || m_lsm_data_lev[lev][0]) {
+      // TODO: Do we want an enum struct for indexing?
+      if (m_sst_lev[lev][0] || m_tsk_lev[lev][0] || m_has_lsm_tsurf) {
           // Valid SST, TSK or LSM data; t_surf set before computing fluxes (avoids
           // extended lambda capture) Note that land temp will be set from m_tsk_lev
           //      while sea temp will be set from m_sst_lev
@@ -579,6 +591,8 @@ private:
   bool m_var_z0{false};
 
   bool use_moisture;
+  bool m_has_lsm_tsurf  = false;
+  int  m_lsm_tsurf_indx = -1;
 
   MOSTAverage m_ma;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> u_star;
@@ -595,6 +609,8 @@ private:
   amrex::Vector<amrex::Vector<amrex::iMultiFab*>> m_lmask_lev;
   amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_lsm_data_lev;
   amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_lsm_flux_lev;
+  amrex::Vector<std::string> m_lsm_data_name;
+  amrex::Vector<std::string> m_lsm_flux_name;
   amrex::Vector<amrex::MultiFab*> m_Hwave_lev;
   amrex::Vector<amrex::MultiFab*> m_Lwave_lev;
   amrex::Vector<amrex::MultiFab*> m_eddyDiffs_lev;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -30,9 +30,8 @@ SurfaceLayer::update_fluxes (const int& lev,
         fill_qsurf_with_qsat(lev, cons_in, z_phys_nd);
     }
 
-    // TODO: we want 0 index to always be theta?
     // Update land surface temp if we have a valid pointer
-    if (m_lsm_data_lev[lev][0]) { get_lsm_tsurf(lev); }
+    if (m_has_lsm_tsurf) { get_lsm_tsurf(lev); }
 
     // Fill interior ghost cells
     t_surf[lev]->FillBoundary(m_geom[lev].periodicity());
@@ -372,10 +371,19 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         const auto q_surf_arr = q_surf[lev]->array(mfi);
 
         // Get LSM fluxes
-        auto lmask_arr    = (m_lmask_lev[lev][0])    ? m_lmask_lev[lev][0]->array(mfi) :
-                                                       Array4<int> {};
-        auto lsm_flux_arr = (m_lsm_flux_lev[lev][0]) ? m_lsm_flux_lev[lev][0]->array(mfi) :
-                                                       Array4<Real> {};
+        auto lmask_arr      = (m_lmask_lev[lev][0]) ? m_lmask_lev[lev][0]->array(mfi) :
+                                                      Array4<int> {};
+        auto lsm_t_flux_arr = Array4<Real> {};
+        auto lsm_q_flux_arr = Array4<Real> {};
+        auto lsm_tau13_arr  = Array4<Real> {};
+        auto lsm_tau23_arr  = Array4<Real> {};
+        for (int n(0); n<m_lsm_flux_lev[lev].size(); ++n) {
+            if (toLower(m_lsm_flux_name[n]) == "t_flux") { lsm_t_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }
+            if (toLower(m_lsm_flux_name[n]) == "q_flux") { lsm_q_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }
+            if (toLower(m_lsm_flux_name[n]) == "tau13")  { lsm_tau13_arr  = m_lsm_flux_lev[lev][n]->array(mfi); }
+            if (toLower(m_lsm_flux_name[n]) == "tau23")  { lsm_tau23_arr  = m_lsm_flux_lev[lev][n]->array(mfi); }
+        }
+
 
         // Rho*Theta flux
         //============================================================================
@@ -384,20 +392,25 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         bx.makeSlab(2,klo);
         ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real Tflux = flux_comp.compute_t_flux(i, j, k,
-                                                  cons_arr, velx_arr, vely_arr,
-                                                  umm_arr, tm_arr, u_star_arr,
-                                                  t_star_arr, t_surf_arr);
+            // Valid theta flux from LSM and over land
+            Real Tflux;
+            int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+            if (lsm_t_flux_arr && is_land) {
+                Tflux = lsm_t_flux_arr(i,j,k);
+            } else {
+                Tflux = flux_comp.compute_t_flux(i, j, k,
+                                                 cons_arr, velx_arr, vely_arr,
+                                                 umm_arr, tm_arr, u_star_arr,
+                                                 t_star_arr, t_surf_arr);
 
+            }
+
+            // Do scalar flux rotations?
             if (rotate) {
                 rotate_scalar_flux(i, j, k, Tflux, dxInv, zphys_arr,
                                    hfx1_arr, hfx2_arr, hfx3_arr);
             } else {
                 hfx3_arr(i,j,klo) = Tflux;
-                int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
-                if (is_land && lsm_flux_arr) {
-                    lsm_flux_arr(i,j,k) = Tflux;
-                }
             }
         });
 
@@ -406,11 +419,19 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         if (use_moisture) {
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real Qflux = flux_comp.compute_q_flux(i, j, k,
-                                                      cons_arr, velx_arr, vely_arr,
-                                                      umm_arr, qm_arr, u_star_arr,
-                                                      q_star_arr, q_surf_arr);
+                // Valid qv flux from LSM and over land
+                Real Qflux;
+                int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+                if (lsm_q_flux_arr && is_land) {
+                    Qflux = lsm_q_flux_arr(i,j,k);
+                } else {
+                    Qflux = flux_comp.compute_q_flux(i, j, k,
+                                                     cons_arr, velx_arr, vely_arr,
+                                                     umm_arr, qm_arr, u_star_arr,
+                                                     q_star_arr, q_surf_arr);
+                }
 
+                // Do scalar flux rotations?
                 if (rotate) {
                     rotate_scalar_flux(i, j, k, Qflux, dxInv, zphys_arr,
                                        qfx1_arr, qfx2_arr, qfx3_arr);
@@ -425,10 +446,20 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         Box bxx = surroundingNodes(bx,0);
         ParallelFor(bxx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real stressx = flux_comp.compute_u_flux(i, j, k,
-                                                    cons_arr, velx_arr, vely_arr,
-                                                    umm_arr, um_arr, u_star_arr);
+            // Valid tau13 from LSM and over land
+            Real stressx;
+            int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+            if (lsm_tau13_arr && is_land) {
+                stressx = lsm_tau13_arr(i,j,k);
+            } else {
+                stressx = flux_comp.compute_u_flux(i, j, k,
+                                                   cons_arr, velx_arr, vely_arr,
+                                                   umm_arr, um_arr, u_star_arr);
 
+
+            }
+
+            // Do stress rotations?
             if (rotate) {
                 rotate_stress_tensor(i, j, k, stressx, dxInv, zphys_arr,
                                      velx_arr, vely_arr, velz_arr,
@@ -440,23 +471,31 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 t13_arr(i,j,k) = stressx;
                 if (t31_arr) { t31_arr(i,j,k) = stressx; }
             }
+
         });
 
         // Rho*v flux
         //============================================================================
-        Box bxy = surroundingNodes(bx,1);
-        ParallelFor(bxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-        {
-            Real stressy = flux_comp.compute_v_flux(i, j, k,
-                                                    cons_arr, velx_arr, vely_arr,
-                                                    umm_arr, vm_arr, u_star_arr);
+        // NOTE: One stress rotation for ALL the stress components
+        if (!rotate) {
+            Box bxy = surroundingNodes(bx,1);
+            ParallelFor(bxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Valid tau13 from LSM and over land
+                Real stressy;
+                int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+                if (lsm_tau23_arr && is_land) {
+                    stressy = lsm_tau23_arr(i,j,k);
+                } else {
+                    stressy = flux_comp.compute_v_flux(i, j, k,
+                                                       cons_arr, velx_arr, vely_arr,
+                                                       umm_arr, vm_arr, u_star_arr);
+                }
 
-            // NOTE: One stress rotation for ALL the stress components
-            if (!rotate) {
                 t23_arr(i,j,k) = stressy;
                 if (t32_arr) { t32_arr(i,j,k) = stressy; }
-            }
-        });
+            });
+        }
     } // mfiter
 }
 
@@ -579,11 +618,10 @@ SurfaceLayer::get_lsm_tsurf (const int& lev)
     {
         Box gtbx = mfi.growntilebox();
 
-        // TODO: LSM does not carry lateral ghost cells.
+        // NOTE: LSM does not carry lateral ghost cells.
         //       This copies the valid box into the ghost cells.
         //       Fillboundary is called after this to pick up the
-        //       interior ghost and periodic directions. Is there
-        //       a better approach?
+        //       interior ghost and periodic directions.
         Box vbx  = mfi.validbox();
         int i_lo = vbx.smallEnd(0); int i_hi = vbx.bigEnd(0);
         int j_lo = vbx.smallEnd(1); int j_hi = vbx.bigEnd(1);
@@ -591,7 +629,7 @@ SurfaceLayer::get_lsm_tsurf (const int& lev)
         auto t_surf_arr = t_surf[lev]->array(mfi);
         auto lmask_arr  = (m_lmask_lev[lev][0]) ? m_lmask_lev[lev][0]->array(mfi) :
                                                   Array4<int> {};
-        const auto lsm_arr = m_lsm_data_lev[lev][0]->const_array(mfi);
+        const auto lsm_arr = m_lsm_data_lev[lev][m_lsm_tsurf_indx]->const_array(mfi);
 
         ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -829,8 +829,10 @@ private:
 #endif
 
     LandSurface lsm;
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_data; // (lev,ncomp) Components: theta, q1, q2
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_flux; // (lev,ncomp) Components: theta, q1, q2
+    amrex::Vector<std::string> lsm_data_name;                // (ncomp)
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_data; // (lev,ncomp)
+    amrex::Vector<std::string> lsm_flux_name;                // (ncomp)
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_flux; // (lev,ncomp)
 
     amrex::Vector<std::unique_ptr<IRadiation>> rad; // Radiation model at each level
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> qheating_rates;  // radiation heating rate source terms (SW, LW)

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1353,8 +1353,8 @@ ERF::InitData_post ()
                                                        mfv_old, Theta_prim[lev], Qv_prim[lev],
                                                        Qr_prim[lev], z_phys_nd[lev],
                                                        Hwave[lev].get(),Lwave[lev].get(),eddyDiffs_lev[lev].get(),
-                                                       lsm_data[lev], lsm_flux[lev], sst_lev[lev],
-                                                       tsk_lev[lev], lmask_lev[lev]);
+                                                       lsm_data[lev], lsm_data_name, lsm_flux[lev], lsm_flux_name,
+                                                       sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
         }
 
 

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -101,9 +101,12 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
     //********************************************************************************************
     // Land Surface Model
     // *******************************************************************************************
-    int lsm_size  = lsm.Get_Data_Size();
-    lsm_data[lev].resize(lsm_size);
-    lsm_flux[lev].resize(lsm_size);
+    int lsm_data_size  = lsm.Get_Data_Size();
+    int lsm_flux_size  = lsm.Get_Flux_Size();
+    lsm_data[lev].resize(lsm_data_size);
+    lsm_data_name.resize(lsm_data_size);
+    lsm_flux[lev].resize(lsm_flux_size);
+    lsm_flux_name.resize(lsm_flux_size);
     lsm.Define(lev, solverChoice);
     if (solverChoice.lsm_type != LandSurfaceType::None)
     {
@@ -111,8 +114,14 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
     }
     for (int mvar(0); mvar<lsm_data[lev].size(); ++mvar) {
         lsm_data[lev][mvar] = lsm.Get_Data_Ptr(lev,mvar);
-        lsm_flux[lev][mvar] = lsm.Get_Flux_Ptr(lev,mvar);
+        lsm_data_name[mvar] = lsm.Get_DataName(mvar);
     }
+    for (int mvar(0); mvar<lsm_flux[lev].size(); ++mvar) {
+        lsm_flux[lev][mvar] = lsm.Get_Flux_Ptr(lev,mvar);
+        lsm_flux_name[mvar] = lsm.Get_FluxName(mvar);
+    }
+
+
 
     // ********************************************************************************************
     // Build the data structures for calculating diffusive/turbulent terms
@@ -428,7 +437,8 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
                                                    mfv_old, Theta_prim[lev], Qv_prim[lev],
                                                    Qr_prim[lev], z_phys_nd[lev],
                                                    Hwave[lev].get(), Lwave[lev].get(), eddyDiffs_lev[lev].get(),
-                                                   lsm_data[lev], lsm_flux[lev], sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
+                                                   lsm_data[lev], lsm_data_name, lsm_flux[lev], lsm_flux_name,
+                                                   sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
     }
 
 #ifdef ERF_USE_PARTICLES
@@ -641,7 +651,8 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
                                                    mfv_old, Theta_prim[lev], Qv_prim[lev],
                                                    Qr_prim[lev], z_phys_nd[lev],
                                                    Hwave[lev].get(),Lwave[lev].get(),eddyDiffs_lev[lev].get(),
-                                                   lsm_data[lev], lsm_flux[lev], sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
+                                                   lsm_data[lev], lsm_data_name, lsm_flux[lev], lsm_flux_name,
+                                                   sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
     }
 
     // These calls are done in AmrCore::regrid if this is a regrid at lev > 0

--- a/Source/LandSurfaceModel/ERF_LandSurface.H
+++ b/Source/LandSurfaceModel/ERF_LandSurface.H
@@ -91,11 +91,20 @@ public:
     int
     Get_Data_Size () { return m_lsm_model[0]->Lsm_Data_Size(); }
 
+    int
+    Get_Flux_Size () { return m_lsm_model[0]->Lsm_Flux_Size(); }
+
     std::string
-    Get_VarName (const int& varIdx) { return m_lsm_model[0]->Lsm_VarName(varIdx); }
+    Get_DataName (const int& varIdx) { return m_lsm_model[0]->Lsm_DataName(varIdx); }
 
     int
-    Get_VarIdx (const int& lev, std::string& varname) { return m_lsm_model[lev]->Lsm_VarIndex(varname); }
+    Get_DataIdx (const int& lev, std::string& varname) { return m_lsm_model[lev]->Lsm_DataIndex(varname); }
+
+    std::string
+    Get_FluxName (const int& varIdx) { return m_lsm_model[0]->Lsm_FluxName(varIdx); }
+
+    int
+    Get_FluxIdx (const int& lev, std::string& varname) { return m_lsm_model[lev]->Lsm_FluxIndex(varname); }
 
     void
     Plot_Lsm_Data (amrex::Real time,
@@ -123,7 +132,7 @@ public:
                 for (int n(0); n<nvar; ++n) {
                     mf_lsm = this->Get_Data_Ptr(lev,n);
                     amrex::MultiFab::Copy(m_lsm_data_lev[lev],*(mf_lsm),0,n,1,0);
-                    if (lev==0) varnames[n] = this->Get_VarName(n);
+                    if (lev==0) varnames[n] = this->Get_DataName(n);
                 }
             }
             WriteMultiLevelPlotfile (plotfilename, nlev, GetVecOfConstPtrs(m_lsm_data_lev),

--- a/Source/LandSurfaceModel/MM5/ERF_MM5.H
+++ b/Source/LandSurfaceModel/MM5/ERF_MM5.H
@@ -100,7 +100,7 @@ public:
 
     // Get variable names
     std::string
-    Lsm_VarName (const int& varIdx) override
+    Lsm_DataName (const int& varIdx) override
     {
         int lsmIdx = LsmVarMap[varIdx];
         AMREX_ALWAYS_ASSERT(lsmIdx < MM5::m_lsm_size && lsmIdx>=0);

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
@@ -19,18 +19,29 @@
 // External include from the noahmp library
 #include <NoahmpIO.H>
 
-namespace LsmVar_NOAHMP {
+namespace LsmData_NOAHMP {
    enum {
-      // 2D coupling variables
-      t_sfc = 0,
-      sfc_emis,
-      sfc_alb_dir_vis,
-      sfc_alb_dir_nir,
-      sfc_alb_dif_vis,
-      sfc_alb_dif_nir,
-      sw_flux_dn,
-      lw_flux_dn,
-      NumVars
+         // 2D RRTMGP coupling vars
+         t_sfc = 0,
+         sfc_emis,
+         sfc_alb_dir_vis,
+         sfc_alb_dir_nir,
+         sfc_alb_dif_vis,
+         sfc_alb_dif_nir,
+         sw_flux_dn,
+         lw_flux_dn,
+         NumVars
+  };
+}
+
+namespace LsmFlux_NOAHMP {
+   enum {
+         // 2D SurfaceLayer flux vars
+         q_flux,
+         t_flux,
+         tau13,
+         tau23,
+         NumVars
   };
 }
 
@@ -49,9 +60,7 @@ public:
     void
     Define (SolverChoice& /*sc*/) override
     {
-        // NOTE: We should parse things from sc here,
-        //       but they are hard coded because this
-        //       is a demonstration for now.
+        // NOTE: We should parse constants from sc here if needed,
     }
 
     // Initialize data structures
@@ -76,17 +85,17 @@ public:
     amrex::MultiFab*
     Lsm_Data_Ptr (const int& varIdx) override
     {
-        int lsmIdx = LsmVarMap[varIdx];
-        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_size && lsmIdx>=0);
-        return lsm_fab_vars[lsmIdx].get();
+        int lsmIdx = LsmDataMap[varIdx];
+        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_data_size && lsmIdx>=0);
+        return lsm_fab_data[lsmIdx].get();
     }
 
     // Get flux vars from lsm class
     amrex::MultiFab*
     Lsm_Flux_Ptr (const int& varIdx) override
     {
-        int lsmIdx = LsmVarMap[varIdx];
-        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_size && lsmIdx>=0);
+        int lsmIdx = LsmFluxMap[varIdx];
+        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_flux_size && lsmIdx>=0);
         return lsm_fab_flux[lsmIdx].get();
     }
 
@@ -96,24 +105,52 @@ public:
 
     // Get number of vars lsm class contains
     int
-    Lsm_Data_Size () override { return NOAHMP::m_lsm_size; }
+    Lsm_Data_Size () override { return NOAHMP::m_lsm_data_size; }
+
+    // Get number of fluxes lsm class contains
+    int
+    Lsm_Flux_Size () override { return NOAHMP::m_lsm_flux_size; }
 
     // Get variable names
     std::string
-    Lsm_VarName (const int& varIdx) override
+    Lsm_DataName (const int& varIdx) override
     {
-        int lsmIdx = LsmVarMap[varIdx];
-        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_size && lsmIdx>=0);
-        return LsmVarName[lsmIdx];
+        int lsmIdx = LsmDataMap[varIdx];
+        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_data_size && lsmIdx>=0);
+        return LsmDataName[lsmIdx];
     }
 
+    // Get variable index from name
     int
-    Lsm_VarIndex (std::string varname) override
+    Lsm_DataIndex (std::string varname) override
     {
         int varIdx = -1;
         std::string lc_varname = amrex::toLower(varname);
-        for (int idx(0); idx<LsmVar_NOAHMP::NumVars; ++idx) {
-            if (lc_varname == amrex::toLower(LsmVarName[idx])) {
+        for (int idx(0); idx<LsmData_NOAHMP::NumVars; ++idx) {
+            if (lc_varname == amrex::toLower(LsmDataName[idx])) {
+                varIdx = idx;
+            }
+        }
+        return varIdx;
+    }
+
+    // Get flux variable names
+    std::string
+    Lsm_FluxName (const int& varIdx) override
+    {
+        int lsmIdx = LsmFluxMap[varIdx];
+        AMREX_ALWAYS_ASSERT(lsmIdx < NOAHMP::m_lsm_flux_size && lsmIdx>=0);
+        return LsmFluxName[lsmIdx];
+    }
+
+    // Get flux variable index from name
+    int
+    Lsm_FluxIndex (std::string varname) override
+    {
+        int varIdx = -1;
+        std::string lc_varname = amrex::toLower(varname);
+        for (int idx(0); idx<LsmFlux_NOAHMP::NumVars; ++idx) {
+            if (lc_varname == amrex::toLower(LsmFluxName[idx])) {
                 varIdx = idx;
             }
         }
@@ -121,14 +158,23 @@ public:
     }
 
 private:
-    // number of lsm variables (theta)
-    int m_lsm_size = LsmVar_NOAHMP::NumVars;
+    // number of lsm data variables
+    int m_lsm_data_size = LsmData_NOAHMP::NumVars;
 
-    // LsmVar map (state indices -> LsmVar enum)
-    amrex::Vector<int> LsmVarMap;
+    // number of lsm flux variables
+    int m_lsm_flux_size = LsmFlux_NOAHMP::NumVars;
 
-    // Lsm varnames
-    amrex::Vector<std::string> LsmVarName;
+    // LsmData map (state indices -> LsmVar enum)
+    amrex::Vector<int> LsmDataMap;
+
+    // LsmFlux map (state indices -> LsmFlux enum)
+    amrex::Vector<int> LsmFluxMap;
+
+    // Lsm data names
+    amrex::Vector<std::string> LsmDataName;
+
+    // Lsm flux names
+    amrex::Vector<std::string> LsmFluxName;
 
     // geometry for atmosphere
     amrex::Geometry m_geom;
@@ -142,41 +188,22 @@ private:
     // domain klo-1 or lsm khi
     int khi_lsm;
 
-    // constants
-    // amrex::Real m_fac_cond;
-    // amrex::Real m_fac_fus;
-    // amrex::Real m_fac_sub;
-    // amrex::Real m_gOcp;
-
-    // independent variables
-    amrex::Array<FabPtr, LsmVar_NOAHMP::NumVars> lsm_fab_vars;
-
-    // flux array for conjugate transfer
-    amrex::Array<FabPtr, LsmVar_NOAHMP::NumVars> lsm_fab_flux;
-
-    // Vars that should be parsed
-    // ==========================
     // Number of grid points in z
-    int m_nz_lsm = 30;
+    int m_nz_lsm = 1;
 
     // Size of grid spacing in z
-    amrex::Real m_dz_lsm = 0.1; // 3 [m] below surface
+    amrex::Real m_dz_lsm = 1.0;
 
-    // Specific heat
-    amrex::Real m_cp_soil =  1.26e6; // [J/m^3 K]
+    // LSM data variables
+    amrex::Array<FabPtr, LsmData_NOAHMP::NumVars> lsm_fab_data;
 
-    // Conductivity
-    amrex::Real m_k_soil = 0.2; // dry soil [W/m K]
+    // LSM data variables
+    amrex::Array<FabPtr, LsmFlux_NOAHMP::NumVars> lsm_fab_flux;
 
-    // Theta Dirichlet value at lowest point below surface
-    amrex::Real m_theta_dir = 400.0; // [K]
+    // Vector to store NoahmpIO objects at a level
+    NoahmpIO_vector noahmpio_vect;
 
-    // Thermal diffusivity
-    amrex::Real m_d_soil = m_k_soil / m_cp_soil; // [m^2/s]
-
-   // Vector to store NoahmpIO objects at a level
-   NoahmpIO_vector noahmpio_vect;
-
-   int m_plot_int_1 = -1;
+    // Plot frequency
+    int m_plot_int_1 = -1;
 };
 #endif

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -13,30 +13,37 @@ using namespace amrex;
 /* Initialize lsm data structures */
 void
 NOAHMP::Init (const int& lev,
-            const MultiFab& cons_in,
-            const Geometry& geom,
-            const Real& dt)
+              const MultiFab& cons_in,
+              const Geometry& geom,
+              const Real& dt)
 {
 
-    m_dt = dt;
+    m_dt   = dt;
     m_geom = geom;
 
     Box domain = geom.Domain();
     khi_lsm    = domain.smallEnd(2) - 1;
 
-    LsmVarMap.resize(m_lsm_size);
-    LsmVarMap = {LsmVar_NOAHMP::t_sfc, LsmVar_NOAHMP::sfc_emis,
-                 LsmVar_NOAHMP::sfc_alb_dir_vis, LsmVar_NOAHMP::sfc_alb_dir_nir,
-                 LsmVar_NOAHMP::sfc_alb_dif_vis, LsmVar_NOAHMP::sfc_alb_dif_nir,
-                 LsmVar_NOAHMP::sw_flux_dn , LsmVar_NOAHMP::lw_flux_dn };
+    LsmDataMap.resize(m_lsm_data_size);
+    LsmDataMap = {LsmData_NOAHMP::t_sfc          , LsmData_NOAHMP::sfc_emis       ,
+                  LsmData_NOAHMP::sfc_alb_dir_vis, LsmData_NOAHMP::sfc_alb_dir_nir,
+                  LsmData_NOAHMP::sfc_alb_dif_vis, LsmData_NOAHMP::sfc_alb_dif_nir,
+                  LsmData_NOAHMP::sw_flux_dn     , LsmData_NOAHMP::lw_flux_dn     };
+    LsmDataName.resize(m_lsm_data_size);
+    LsmDataName = {"t_sfc"          , "sfc_emis"        ,
+                  "sfc_alb_dir_vis" , "sfc_alb_dir_nir" ,
+                  "sfc_alb_dif_vis" , "sfc_alb_dif_nir" ,
+                   "sw_flux_dn"     , "lw_flux_dn"      };
 
-    LsmVarName.resize(m_lsm_size);
-    LsmVarName = {"t_sfc"      , "sfc_emis"   ,
-                  "sfc_alb_dir_vis", "sfc_alb_dir_nir",
-                  "sfc_alb_dif_vis", "sfc_alb_dif_nir",
-                  "sw_flux_dn" , "lw_flux_dn" };
 
-    amrex::ParmParse pp("erf");
+    LsmFluxMap.resize(m_lsm_flux_size);
+    LsmFluxMap = {LsmFlux_NOAHMP::q_flux         , LsmFlux_NOAHMP::t_flux         ,
+                  LsmFlux_NOAHMP::tau13          , LsmFlux_NOAHMP::tau23          };
+    LsmFluxName.resize(m_lsm_flux_size);
+    LsmFluxName = {"t_flux"         , "q_flux"         ,
+                   "tau13"          , "tau23"          };
+
+    ParmParse pp("erf");
     pp.query("plot_int_1" , m_plot_int_1);
 
     // NOTE: All boxes in ba extend from zlo to zhi, so this transform is valid.
@@ -63,31 +70,35 @@ NOAHMP::Init (const int& lev,
     lsm_rb.setHi(2,lsm_z_hi); lsm_rb.setLo(2,lsm_z_lo);
     m_lsm_geom.define( ba_lsm.minimalBox(), lsm_rb, m_geom.Coord(), m_geom.isPeriodic() );
 
-    // Create the data and fluxes
-    for (auto ivar = 0; ivar < LsmVar_NOAHMP::NumVars; ++ivar) {
+    // Create the data
+    for (auto ivar = 0; ivar < LsmData_NOAHMP::NumVars; ++ivar) {
         // State vars are CC
-        lsm_fab_vars[ivar] = std::make_shared<MultiFab>(ba_lsm, dm, 1, ng);
+        lsm_fab_data[ivar] = std::make_shared<MultiFab>(ba_lsm, dm, 1, ng);
 
         // NOTE: Radiation steps first so we set values
         //       to reasonable initialization for coupling
         Real val_to_set = 0.0;
-        if (ivar == LsmVar_NOAHMP::t_sfc) {
+        if (ivar == LsmData_NOAHMP::t_sfc) {
             val_to_set = 300.0;
-        } else if (ivar == LsmVar_NOAHMP::sfc_emis) {
+        } else if (ivar == LsmData_NOAHMP::sfc_emis) {
             val_to_set = 0.9;
-        } else if ((ivar>=LsmVar_NOAHMP::sfc_alb_dir_vis) && (ivar<=LsmVar_NOAHMP::sfc_alb_dif_nir)) {
+        } else if ( (ivar>=LsmData_NOAHMP::sfc_alb_dir_vis) &&
+                    (ivar<=LsmData_NOAHMP::sfc_alb_dif_nir) ) {
             val_to_set = 0.06;
         } else {
             val_to_set = 0.0;
         }
-        lsm_fab_vars[ivar]->setVal(val_to_set);
+        lsm_fab_data[ivar]->setVal(val_to_set);
+    }
 
-        // Fluxes are nodal in z
-        lsm_fab_flux[ivar] = std::make_shared<MultiFab>(convert(ba_lsm, IntVect(0,0,1)), dm, 1, IntVect(0,0,0));
+    // Create the fluxes
+    for (auto ivar = 0; ivar < LsmFlux_NOAHMP::NumVars; ++ivar) {
+        // NOTE: Fluxes are CC with ghost cells for averaging
+        lsm_fab_flux[ivar] = std::make_shared<MultiFab>(ba_lsm, dm, 1, IntVect(1,1,0));
         lsm_fab_flux[ivar]->setVal(0.);
     }
 
-    amrex::Print() << "Noah-MP initialization started" << std::endl;
+    Print() << "Noah-MP initialization started" << std::endl;
 
     // Set noahmpio_vect to the size of local blocks (boxes)
     noahmpio_vect.resize(cons_in.local_size(), lev);
@@ -95,10 +106,10 @@ NOAHMP::Init (const int& lev,
     // Iterate over multifab and noahmpio object together. Multifabs is
     // used to extract size of blocks and set bounds for noahmpio objects.
     int idb = 0;
-    for (amrex::MFIter mfi(cons_in, false); mfi.isValid(); ++mfi, ++idb) {
+    for (MFIter mfi(cons_in, false); mfi.isValid(); ++mfi, ++idb) {
 
         // Get bounds for the tile
-        const amrex::Box& bx = mfi.tilebox();
+        const Box& bx = mfi.tilebox();
 
         // Check if tile is at the lower boundary in lower z direction
         if (bx.smallEnd(2) == domain.smallEnd(2)) {
@@ -116,10 +127,10 @@ NOAHMP::Init (const int& lev,
             noahmpio->ScalarInitDefault();
 
             // Store the rank of process for noahmp
-            noahmpio->rank = amrex::ParallelDescriptor::MyProc();
+            noahmpio->rank = ParallelDescriptor::MyProc();
 
             // Store parallel communicator for noahmp
-            noahmpio->comm = MPI_Comm_c2f(amrex::ParallelDescriptor::Communicator());
+            noahmpio->comm = MPI_Comm_c2f(ParallelDescriptor::Communicator());
 
             // Read namelist.erf file. This file contains
             // noahmpio specific parameters and is read by
@@ -136,9 +147,9 @@ NOAHMP::Init (const int& lev,
             // This will be changed later if we want to do special memory
             // management for expensive use cases.
             noahmpio->xstart = bx.smallEnd(0);
-            noahmpio->xend = bx.bigEnd(0);
+            noahmpio->xend   = bx.bigEnd(0);
             noahmpio->ystart = bx.smallEnd(1);
-            noahmpio->yend = bx.bigEnd(1);
+            noahmpio->yend   = bx.bigEnd(1);
 
             // Domain bounds
             noahmpio->ids = noahmpio->xstart;
@@ -181,65 +192,73 @@ NOAHMP::Init (const int& lev,
             noahmpio->InitMain();
 
             // Write initial plotfile for land with the tag 0
-            amrex::Print() << "Noah-MP writing lnd.nc file at lev: " << lev << std::endl;
+            Print() << "Noah-MP writing lnd.nc file at lev: " << lev << std::endl;
             noahmpio->WriteLand(0);
         }
   }
 
-  amrex::Print() << "Noah-MP initialization completed" << std::endl;
+  Print() << "Noah-MP initialization completed" << std::endl;
 
 };
 
 void
 NOAHMP::Advance_With_State (const int& lev,
-                          MultiFab& cons_in,
-                          MultiFab& xvel_in,
-                          MultiFab& yvel_in,
-                          MultiFab* hfx3_out,
-                          MultiFab* qfx3_out,
-                          const amrex::Real& dt,
-                          const int& nstep) {
+                            MultiFab& cons_in,
+                            MultiFab& xvel_in,
+                            MultiFab& yvel_in,
+                            MultiFab* /*hfx3_out*/,
+                            MultiFab* /*qfx3_out*/,
+                            const amrex::Real& dt,
+                            const int& nstep)
+{
 
     Box domain = m_geom.Domain();
 
-    amrex::Print () << "Noah-MP driver started at time step: " << nstep+1 << std::endl;
+    Print () << "Noah-MP driver started at time step: " << nstep+1 << std::endl;
 
     // Loop over blocks to copy forcing data to Noahmp, drive the land model,
     // and copy data back to ERF Multifabs.
     int idb = 0;
-    for (amrex::MFIter mfi(cons_in, false); mfi.isValid(); ++mfi, ++idb) {
+    for (MFIter mfi(cons_in, false); mfi.isValid(); ++mfi, ++idb) {
 
-        const amrex::Box& bx = mfi.tilebox();
+        const Box& bx = mfi.tilebox();
 
         // Check if tile is at the lower boundary in lower z direction
         if (bx.smallEnd(2) == domain.smallEnd(2)) {
 
             NoahmpIO_type* noahmpio = &noahmpio_vect[idb];
 
-            const amrex::Array4<const amrex::Real>& U_PHY = xvel_in.const_array(mfi);
-            const amrex::Array4<const amrex::Real>& V_PHY = yvel_in.const_array(mfi);
-            const amrex::Array4<const amrex::Real>& QV_TH = cons_in.const_array(mfi);
-            const amrex::Array4<const amrex::Real>& SWDOWN = lsm_fab_vars[LsmVar_NOAHMP::sw_flux_dn]->const_array(mfi);
-            const amrex::Array4<const amrex::Real>& GLW = lsm_fab_vars[LsmVar_NOAHMP::lw_flux_dn]->const_array(mfi);
+            const Array4<const Real>& U_PHY  = xvel_in.const_array(mfi);
+            const Array4<const Real>& V_PHY  = yvel_in.const_array(mfi);
+            const Array4<const Real>& QV_TH  = cons_in.const_array(mfi);
 
-            amrex::Array4<amrex::Real> TSK = lsm_fab_vars[LsmVar_NOAHMP::t_sfc]->array(mfi);
-            amrex::Array4<amrex::Real> EMISS = lsm_fab_vars[LsmVar_NOAHMP::sfc_emis]->array(mfi);
-            amrex::Array4<amrex::Real> ALBSFCDIR_VIS = lsm_fab_vars[LsmVar_NOAHMP::sfc_alb_dir_vis]->array(mfi);
-            amrex::Array4<amrex::Real> ALBSFCDIR_NIR = lsm_fab_vars[LsmVar_NOAHMP::sfc_alb_dir_nir]->array(mfi);
-            amrex::Array4<amrex::Real> ALBSFCDIF_VIS = lsm_fab_vars[LsmVar_NOAHMP::sfc_alb_dif_vis]->array(mfi);
-            amrex::Array4<amrex::Real> ALBSFCDIF_NIR = lsm_fab_vars[LsmVar_NOAHMP::sfc_alb_dif_nir]->array(mfi);
-            amrex::Array4<amrex::Real> SHBXY = hfx3_out->array(mfi);
-            amrex::Array4<amrex::Real> EVBXY = qfx3_out->array(mfi);
+            // Into NOAH-MP
+            const Array4<const Real>& SWDOWN = lsm_fab_data[LsmData_NOAHMP::sw_flux_dn]->const_array(mfi);
+            const Array4<const Real>& GLW    = lsm_fab_data[LsmData_NOAHMP::lw_flux_dn]->const_array(mfi);
+
+            // Out of NOAH-MP
+            Array4<Real> TSK           = lsm_fab_data[LsmData_NOAHMP::t_sfc]->array(mfi);
+            Array4<Real> EMISS         = lsm_fab_data[LsmData_NOAHMP::sfc_emis]->array(mfi);
+            Array4<Real> ALBSFCDIR_VIS = lsm_fab_data[LsmData_NOAHMP::sfc_alb_dir_vis]->array(mfi);
+            Array4<Real> ALBSFCDIR_NIR = lsm_fab_data[LsmData_NOAHMP::sfc_alb_dir_nir]->array(mfi);
+            Array4<Real> ALBSFCDIF_VIS = lsm_fab_data[LsmData_NOAHMP::sfc_alb_dif_vis]->array(mfi);
+            Array4<Real> ALBSFCDIF_NIR = lsm_fab_data[LsmData_NOAHMP::sfc_alb_dif_nir]->array(mfi);
+
+            // NOTE: Need to expose stresses and get stresses from NOAHMP
+            Array4<Real> q_flux_arr    = lsm_fab_flux[LsmFlux_NOAHMP::q_flux]->array(mfi);
+            Array4<Real> t_flux_arr    = lsm_fab_flux[LsmFlux_NOAHMP::t_flux]->array(mfi);
+            //Array4<Real> tau13_arr     = lsm_fab_flux[LsmFlux_NOAHMP::tau13]->array(mfi);
+            //Array4<Real> tau23_arr     = lsm_fab_flux[LsmFlux_NOAHMP::tau23]->array(mfi);
 
             // Copy forcing data from ERF to Noahmp.
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int ) noexcept
             {
-                noahmpio->U_PHY(i,1,j) = 0.5*(U_PHY(i,j,0)+U_PHY(i+1,j,0));
-                noahmpio->V_PHY(i,1,j) = 0.5*(V_PHY(i,j,0)+V_PHY(i,j+1,0));
-                noahmpio->T_PHY(i,1,j) = QV_TH(i,j,0,RhoTheta_comp)/QV_TH(i,j,0,Rho_comp);
+                noahmpio->U_PHY(i,1,j)   = 0.5*(U_PHY(i,j,0)+U_PHY(i+1,j  ,0));
+                noahmpio->V_PHY(i,1,j)   = 0.5*(V_PHY(i,j,0)+V_PHY(i  ,j+1,0));
+                noahmpio->T_PHY(i,1,j)   = QV_TH(i,j,0,RhoTheta_comp)/QV_TH(i,j,0,Rho_comp);
                 noahmpio->QV_CURR(i,1,j) = QV_TH(i,j,0,RhoQ1_comp)/QV_TH(i,j,0,Rho_comp);
-                noahmpio->SWDOWN(i,j) = SWDOWN(i,j,0);
-                noahmpio->GLW(i,j) = GLW(i,j,0);
+                noahmpio->SWDOWN(i,j)    = SWDOWN(i,j,0);
+                noahmpio->GLW(i,j)       = GLW(i,j,0);
             });
 
             // Call the noahmpio driver code. This runs the land model forcing for
@@ -250,10 +269,10 @@ NOAHMP::Advance_With_State (const int& lev,
             // Copy forcing data from Noahmp to ERF
             ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int ) noexcept
             {
-                SHBXY(i,j,0) = noahmpio->SHBXY(i,j);
-                EVBXY(i,j,0) = noahmpio->EVBXY(i,j);
-                TSK(i,j,0) = noahmpio->TSK(i,j);
-                EMISS(i,j,0) = noahmpio->EMISS(i,j);
+                q_flux_arr(i,j,0) = noahmpio->SHBXY(i,j);
+                t_flux_arr(i,j,0) = noahmpio->EVBXY(i,j);
+                TSK(i,j,0)        = noahmpio->TSK(i,j);
+                EMISS(i,j,0)      = noahmpio->EMISS(i,j);
                 ALBSFCDIR_VIS(i,j,0) = noahmpio->ALBSFCDIRXY(i,1,j);
                 ALBSFCDIR_NIR(i,j,0) = noahmpio->ALBSFCDIRXY(i,2,j);
                 ALBSFCDIF_VIS(i,j,0) = noahmpio->ALBSFCDIFXY(i,1,j);

--- a/Source/LandSurfaceModel/Null/ERF_NullSurf.H
+++ b/Source/LandSurfaceModel/Null/ERF_NullSurf.H
@@ -70,15 +70,33 @@ class NullSurf {
     Lsm_Data_Size () { return NullSurf::m_lsm_size; }
 
     virtual
+    int
+    Lsm_Flux_Size () { return NullSurf::m_lsm_size; }
+
+    virtual
     std::string
-    Lsm_VarName (const int& /*varIdx*/)
+    Lsm_DataName (const int& /*varIdx*/)
     {
-        return varname;
+        return dataname;
+    }
+
+    virtual
+    std::string
+    Lsm_FluxName (const int& /*varIdx*/)
+    {
+        return fluxname;
     }
 
     virtual
     int
-    Lsm_VarIndex (std::string /*varname*/)
+    Lsm_DataIndex (std::string /*varname*/)
+    {
+        return (-1);
+    }
+
+    virtual
+    int
+    Lsm_FluxIndex (std::string /*varname*/)
     {
         return (-1);
     }
@@ -86,6 +104,7 @@ class NullSurf {
  private:
     int m_lsm_size = 1;
     amrex::Geometry m_lsm_geom;
-    std::string varname = " ";
+    std::string dataname = " ";
+    std::string fluxname = " ";
 };
 #endif

--- a/Source/LandSurfaceModel/SLM/ERF_SLM.H
+++ b/Source/LandSurfaceModel/SLM/ERF_SLM.H
@@ -100,7 +100,7 @@ public:
 
     // Get variable names
     std::string
-    Lsm_VarName (const int& varIdx) override
+    Lsm_DataName (const int& varIdx) override
     {
         int lsmIdx = LsmVarMap[varIdx];
         AMREX_ALWAYS_ASSERT(lsmIdx < SLM::m_lsm_size && lsmIdx>=0);

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -18,7 +18,7 @@ void ERF::advance_radiation (int lev,
         Vector<std::string> lsm_input_names = rad[lev]->get_lsm_input_varnames();
         Vector<MultiFab*> lsm_input_ptrs(lsm_input_names.size(),nullptr);
         for (int i(0); i<lsm_input_ptrs.size(); ++i) {
-            int varIdx = lsm.Get_VarIdx(lev,lsm_input_names[i]);
+            int varIdx = lsm.Get_DataIdx(lev,lsm_input_names[i]);
             lsm_input_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
         }
 
@@ -26,7 +26,7 @@ void ERF::advance_radiation (int lev,
         Vector<std::string> lsm_output_names = rad[lev]->get_lsm_output_varnames();
         Vector<MultiFab*> lsm_output_ptrs(lsm_output_names.size(),nullptr);
         for (int i(0); i<lsm_output_ptrs.size(); ++i) {
-            int varIdx = lsm.Get_VarIdx(lev,lsm_output_names[i]);
+            int varIdx = lsm.Get_DataIdx(lev,lsm_output_names[i]);
             lsm_output_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
         }
 


### PR DESCRIPTION
# Overview
Noah-MP now stores the `t_flux, q_flux, tau13, & tau23` fluxes for coupling. Those fluxes are used by the SurfaceLayer class when available.

## Notes
The `tau` stresses need to be exposed on the NoahMP side @akashdhruv, otherwise the simulation will be `FreeSlip` at the bottom wall.