### PR TITLE
RRTMGP -> NOAHMP Coupling

### DIFF
--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
@@ -28,6 +28,7 @@ namespace LsmData_NOAHMP {
          sfc_alb_dir_nir,
          sfc_alb_dif_vis,
          sfc_alb_dif_nir,
+         cos_zenith_angle,
          sw_flux_dn,
          lw_flux_dn,
          NumVars

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -30,10 +30,11 @@ NOAHMP::Init (const int& lev,
                   LsmData_NOAHMP::sfc_alb_dif_vis, LsmData_NOAHMP::sfc_alb_dif_nir,
                   LsmData_NOAHMP::sw_flux_dn     , LsmData_NOAHMP::lw_flux_dn     };
     LsmDataName.resize(m_lsm_data_size);
-    LsmDataName = {"t_sfc"          , "sfc_emis"        ,
-                  "sfc_alb_dir_vis" , "sfc_alb_dir_nir" ,
-                  "sfc_alb_dif_vis" , "sfc_alb_dif_nir" ,
-                   "sw_flux_dn"     , "lw_flux_dn"      };
+    LsmDataName = {"t_sfc"          , "sfc_emis"         ,
+                   "sfc_alb_dir_vis" , "sfc_alb_dir_nir" ,
+                   "sfc_alb_dif_vis" , "sfc_alb_dif_nir" ,
+                   "cos_zenith_angle", "sw_flux_dn"      ,
+                   "lw_flux_dn"      };
 
 
     LsmFluxMap.resize(m_lsm_flux_size);
@@ -208,7 +209,7 @@ NOAHMP::Advance_With_State (const int& lev,
                             MultiFab& yvel_in,
                             MultiFab* /*hfx3_out*/,
                             MultiFab* /*qfx3_out*/,
-                            const amrex::Real& dt,
+                            const Real& dt,
                             const int& nstep)
 {
 
@@ -284,5 +285,5 @@ NOAHMP::Advance_With_State (const int& lev,
             }
         }
     }
-    amrex::Print () << "Noah-MP driver completed" << std::endl;
+    Print () << "Noah-MP driver completed" << std::endl;
 };

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -241,7 +241,7 @@ private:
                                                     "sfc_alb_dif_vis", "sfc_alb_dif_nir"};
 
     // List of output parameter names
-    amrex::Vector<std::string> m_lsm_output_names = {"sw_flux_dn", "lw_flux_dn"};
+    amrex::Vector<std::string> m_lsm_output_names = {"cos_zenith_angle", "sw_flux_dn", "lw_flux_dn"};
 
     // T surf if no LSM is available
     amrex::Real m_rad_t_sfc = -1;
@@ -364,7 +364,6 @@ private:
     real1d_k o3_lay;
 
     // 1d size (ncol)
-    real1d_k cosine_zenith;
     real1d_k mu0;
     real1d_k sfc_alb_dir_vis;
     real1d_k sfc_alb_dir_nir;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -213,7 +213,6 @@ Radiation::alloc_buffers ()
     Kokkos::deep_copy(o3_lay, o3_lay_h);
 
     // 1d size (ncol)
-    cosine_zenith    = real1d_k("cosine_zenith"   , m_ncol);
     mu0              = real1d_k("mu0"             , m_ncol);
     sfc_alb_dir_vis  = real1d_k("sfc_alb_dir_vis" , m_ncol);
     sfc_alb_dir_nir  = real1d_k("sfc_alb_dir_nir" , m_ncol);
@@ -316,7 +315,6 @@ Radiation::dealloc_buffers ()
     o3_lay = real1d_k();
 
     // 1d size (ncol)
-    cosine_zenith    = real1d_k();
     mu0              = real1d_k();
     sfc_alb_dir_vis  = real1d_k();
     sfc_alb_dir_nir  = real1d_k();
@@ -669,14 +667,25 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
             auto rrtmgp_for_fill = rrtmgp_out_vars[ivar];
             if (lsm_output_ptrs[ivar]) {
                 const Array4<Real>& lsm_out_arr = lsm_output_ptrs[ivar]->array(mfi);
-                ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                {
-                    // map [i,j,k] 0-based to [icol, ilay] 0-based
-                    const int icol   = (j-jmin)*nx + (i-imin) + offset;
+                if (ivar==0) {
+                    ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    {
+                        // map [i,j,k] 0-based to [icol, ilay] 0-based
+                        const int icol   = (j-jmin)*nx + (i-imin) + offset;
 
-                    // export the desired variable at surface
-                    lsm_out_arr(i,j,k) = rrtmgp_for_fill(icol,0);
-                });
+                        // export the desired variable at surface
+                        lsm_out_arr(i,j,k) = mu0_d(icol);
+                    });
+                } else {
+                    ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    {
+                        // map [i,j,k] 0-based to [icol, ilay] 0-based
+                        const int icol   = (j-jmin)*nx + (i-imin) + offset;
+
+                        // export the desired variable at surface
+                        lsm_out_arr(i,j,k) = rrtmgp_for_fill(icol,0);
+                    });
+                } // ivar
             } // valid ptr
         } // ivar
     }// mfi


### PR DESCRIPTION
## Notes
This PR adds the cosine zenith angle to the output variable list from RRTMGP to NOAHMP. This was tested for compilation and the `cos_zenith_angle` in NOAHMP must be hooked up to the NOAHMP driver.