### PR TITLE
Stress Rotations

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -487,7 +487,9 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             Box bxxy = convert(bx, IntVect(1,1,0));
             ParallelFor(bxxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real stresst = -cons_arr(i,j,k,Rho_comp)*u_star_arr(i,j,k)*u_star_arr(i,j,k);
+                Real stresst = flux_comp.compute_u_flux(i, j, k,
+                                                       cons_arr, velx_arr, vely_arr,
+                                                       umm_arr, um_arr, u_star_arr);
                 rotate_stress_tensor(i, j, k, stresst, dxInv, zphys_arr,
                                      velx_arr, vely_arr, velz_arr,
                                      t11_arr, t22_arr, t33_arr,

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -441,43 +441,29 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             });
         } // custom
 
-        // Rho*u flux
-        //============================================================================
-        Box bxx = surroundingNodes(bx,0);
-        ParallelFor(bxx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-        {
-            // Valid tau13 from LSM and over land
-            Real stressx;
-            int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
-            if (lsm_tau13_arr && is_land) {
-                stressx = lsm_tau13_arr(i,j,k);
-            } else {
-                stressx = flux_comp.compute_u_flux(i, j, k,
-                                                   cons_arr, velx_arr, vely_arr,
-                                                   umm_arr, um_arr, u_star_arr);
+        if (!rotate) {
+            // Rho*u flux
+            //============================================================================
+            Box bxx = surroundingNodes(bx,0);
+            ParallelFor(bxx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                // Valid tau13 from LSM and over land
+                Real stressx;
+                int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+                if (lsm_tau13_arr && is_land) {
+                    stressx = lsm_tau13_arr(i,j,k);
+                } else {
+                    stressx = flux_comp.compute_u_flux(i, j, k,
+                                                       cons_arr, velx_arr, vely_arr,
+                                                       umm_arr, um_arr, u_star_arr);
+                }
 
-
-            }
-
-            // Do stress rotations?
-            if (rotate) {
-                rotate_stress_tensor(i, j, k, stressx, dxInv, zphys_arr,
-                                     velx_arr, vely_arr, velz_arr,
-                                     t11_arr, t22_arr, t33_arr,
-                                     t12_arr, t21_arr,
-                                     t13_arr, t31_arr,
-                                     t23_arr, t32_arr);
-            } else {
                 t13_arr(i,j,k) = stressx;
                 if (t31_arr) { t31_arr(i,j,k) = stressx; }
-            }
+            });
 
-        });
-
-        // Rho*v flux
-        //============================================================================
-        // NOTE: One stress rotation for ALL the stress components
-        if (!rotate) {
+            // Rho*v flux
+            //============================================================================
             Box bxy = surroundingNodes(bx,1);
             ParallelFor(bxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
@@ -494,6 +480,20 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
 
                 t23_arr(i,j,k) = stressy;
                 if (t32_arr) { t32_arr(i,j,k) = stressy; }
+            });
+        } else {
+            // All fluxes with rotation
+            //============================================================================
+            Box bxxy = convert(bx, IntVect(1,1,0));
+            ParallelFor(bxxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            {
+                Real stresst = -cons_arr(i,j,k,Rho_comp)*u_star_arr(i,j,k)*u_star_arr(i,j,k);
+                rotate_stress_tensor(i, j, k, stresst, dxInv, zphys_arr,
+                                     velx_arr, vely_arr, velz_arr,
+                                     t11_arr, t22_arr, t33_arr,
+                                     t12_arr, t21_arr,
+                                     t13_arr, t31_arr,
+                                     t23_arr, t32_arr);
             });
         }
     } // mfiter

--- a/Source/Utils/ERF_TerrainMetrics.H
+++ b/Source/Utils/ERF_TerrainMetrics.H
@@ -664,8 +664,9 @@ rotate_stress_tensor (const int& i,
     amrex::Array2D<amrex::Real,0,2,0,2> R_mat;
 
     // Metric data
-    amrex::Real h_xi  = Compute_h_xi_AtIface(i, j, klo, dxInv, zphys_arr);
-    amrex::Real h_eta = Compute_h_eta_AtIface(i, j, klo, dxInv, zphys_arr);
+    amrex::Real h_xi   = Compute_h_xi_AtIface(i, j, klo, dxInv, zphys_arr);
+    amrex::Real h_eta  = Compute_h_eta_AtIface(i, j, klo, dxInv, zphys_arr);
+    amrex::Real h_zeta = Compute_h_zeta_AtIface(i, j, klo, dxInv, zphys_arr);
 
     // Populate the normal vector
     amrex::Real Inormn = 1./std::sqrt(1.0 + h_xi*h_xi + h_eta*h_eta);
@@ -692,7 +693,7 @@ rotate_stress_tensor (const int& i,
     // Populate the a_hat vector
     a_hat(0) =   n_hat(1)*u_t_hat(2) - n_hat(2)*u_t_hat(1);
     a_hat(1) = -(n_hat(0)*u_t_hat(2) - n_hat(2)*u_t_hat(0));
-    a_hat(2) =   n_hat(1)*u_t_hat(1) - n_hat(1)*u_t_hat(0);
+    a_hat(2) =   n_hat(0)*u_t_hat(1) - n_hat(1)*u_t_hat(0);
 
     // Copy column vectors into R_mat
     int jrow;
@@ -709,18 +710,26 @@ rotate_stress_tensor (const int& i,
         R_mat(icol,jrow) = n_hat(icol);
     }
 
-    // Assign the stresses
-    tau11_arr(i,j,klo) = 2.0*R_mat(0,0)*R_mat(2,0)*flux;
-    tau22_arr(i,j,klo) = 2.0*R_mat(0,1)*R_mat(2,1)*flux;
-    tau33_arr(i,j,klo) = 2.0*R_mat(0,2)*R_mat(2,2)*flux;
+    // Body-fixed tau
+    amrex::Real T11    = 2.0*R_mat(0,0)*R_mat(2,0)*flux;
+    amrex::Real T22    = 2.0*R_mat(0,1)*R_mat(2,1)*flux;
+    amrex::Real T33    = 2.0*R_mat(0,2)*R_mat(2,2)*flux;
+    amrex::Real T12    = (R_mat(0,0)*R_mat(2,1) + R_mat(2,0)*R_mat(0,1))*flux;
+    amrex::Real T13    = (R_mat(0,0)*R_mat(2,2) + R_mat(0,2)*R_mat(2,0))*flux;
+    amrex::Real T23    = (R_mat(0,1)*R_mat(2,2) + R_mat(0,2)*R_mat(2,1))*flux;
 
-    tau12_arr(i,j,klo) = (R_mat(0,0)*R_mat(2,1) + R_mat(2,0)*R_mat(0,1))*flux;
-    tau21_arr(i,j,klo) = tau12_arr(i,j,klo);
+    // Rotated stress fluxes
+    tau11_arr(i,j,klo) = h_zeta*T11;
+    tau22_arr(i,j,klo) = h_zeta*T22;
+    tau33_arr(i,j,klo) = -h_xi*T13 - h_eta*T23 + T33;
 
-    tau13_arr(i,j,klo) = (R_mat(0,0)*R_mat(2,2) + R_mat(0,2)*R_mat(2,0))*flux;
-    tau31_arr(i,j,klo) = tau13_arr(i,j,klo);
+    tau12_arr(i,j,klo) = h_zeta*T12;
+    tau21_arr(i,j,klo) = tau21_arr(i,j,klo);
 
-    tau23_arr(i,j,klo) = (R_mat(0,1)*R_mat(2,2) + R_mat(0,2)*R_mat(2,1))*flux;
-    tau32_arr(i,j,klo) = tau23_arr(i,j,klo);
+    tau13_arr(i,j,klo) = -h_xi*T11 - h_eta*T12 + T13;
+    tau31_arr(i,j,klo) = h_zeta*T13;
+
+    tau23_arr(i,j,klo) = -h_xi*T12 - h_eta*T22 + T23;
+    tau32_arr(i,j,klo) = h_zeta*T23;
 }
 #endif

--- a/Source/Utils/ERF_TerrainMetrics.H
+++ b/Source/Utils/ERF_TerrainMetrics.H
@@ -670,13 +670,13 @@ rotate_stress_tensor (const int& i,
 
     // Populate the normal vector
     amrex::Real Inormn = 1./std::sqrt(1.0 + h_xi*h_xi + h_eta*h_eta);
-    n_hat(0) = -Inormn*h_xi; n_hat(1) = -Inormn*h_eta; n_hat(2) = Inormn;
+    n_hat(0) = Inormn*h_xi; n_hat(1) = Inormn*h_eta; n_hat(2) = -Inormn;
 
     // Populate the tangent vectors
     amrex::Real Inorm1 = 1./std::sqrt(1.0 + h_xi*h_xi);
     amrex::Real Inorm2 = 1./std::sqrt(1.0 + h_eta*h_eta);
-    t_hat_1(0) = Inorm1;      t_hat_2(1) = Inorm2;
-    t_hat_1(2) = Inorm1*h_xi; t_hat_2(2) = Inorm2*h_eta;
+    t_hat_1(0) = -Inorm1;      t_hat_2(1) = -Inorm2;
+    t_hat_1(2) = -Inorm1*h_xi; t_hat_2(2) = -Inorm2*h_eta;
 
     // Populate the u_t vector
     amrex::Real Norm_u_t = 0.0;


### PR DESCRIPTION
## Notes
This PR fixes the cross product in the stress rotation function (for SurfaceLayer with terrain) and writes rotated fluxes (which are not symmetric). This uses the stress tensor closure from  Sullivan's 2014 paper (Appendix A):


<img width="530" height="71" alt="image" src="https://github.com/user-attachments/assets/618044ba-edda-44cc-a4ca-83406841652f" />

However, in the code, we are writing into the `tau` data structures that hold the viscous fluxes, which include metric terms from the divergence rotation:

<img width="332" height="101" alt="image" src="https://github.com/user-attachments/assets/29278a12-7056-42b1-a76d-779708e065d6" />

### Reminder
There is a sign convention flip with the normal and tangent vectors in the stress rotation code. This flip produced the correct sign for the vertical fluxes (originally the tau23 flux was the incorrect sign).
