### PR TITLE
Start_DateTime Specification Fix

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -819,11 +819,8 @@ ERF::InitData_pre ()
     }
 
     if (restart_chkfile.empty()) {
-
         // Start simulation from the beginning
-        const Real time = start_time;
-        InitFromScratch(time);
-
+        InitFromScratch(0.0);
     } else {
         // For initialization this is done in init_only; it is done here for restart
         init_bcs();

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -156,7 +156,7 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
         if ( (solverChoice.init_type == InitType::WRFInput) || (solverChoice.init_type == InitType::Metgrid) )
         {
             AMREX_ALWAYS_ASSERT(solverChoice.terrain_type == TerrainType::StaticFittedMesh);
-            init_only(lev, start_time);
+            init_only(lev, time);
             init_zphys(lev, time);
             update_terrain_arrays(lev);
             make_physbcs(lev);
@@ -165,7 +165,7 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
             update_terrain_arrays(lev);
             // Note that for init_type != InitType::WRFInput and != InitType::Metgrid,
             // make_physbcs is called inside init_only
-            init_only(lev, start_time);
+            init_only(lev, time);
         }
     } else {
         // if restarting and nudging from input sounding, load the input sounding files


### PR DESCRIPTION
## Issue Summary
If the `start_datetime` input is specified for a run that is not initialized from a NC file, then the total time passed around is `2X` what it should be. The issue arises from the following call structure:

1.  ReadParams parses the `start_datetime`
2. InitFromScratch is called with `start_datetime`
3. Init_only is called with `start_datetime` and thus sets `t_new[lev] = start_datetime`
4. Evolve adds `cur_time + start_datetime` where `cur_time = t_new[lev]`