### PR TITLE
Make max_step more user friendly

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -986,7 +986,7 @@ private:
     // runtime parameters
 
     // Maximum number of steps
-    int max_step = std::numeric_limits<int>::max();
+    int max_step = -1;
 
     // Start and stop times
     static amrex::Real start_time;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1836,6 +1836,9 @@ ERF::ReadParameters ()
     {
         ParmParse pp;  // Traditionally, max_step and stop_time do not have prefix.
         pp.query("max_step", max_step);
+        if (max_step < 0) {
+            max_step = std::numeric_limits<int>::max();
+        }
 
         std::string start_datetime, stop_datetime;
         if (pp.query("start_datetime", start_datetime)) {


### PR DESCRIPTION
Previously, if `max_step = -1` was set in the input file, it would overwrite the default numerical upper limit and the main timeStep loop would never be entered inside Evolve(). 