### PR TITLE
No Condensation W/ Shoc

### DIFF
--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -54,10 +54,11 @@ public:
     Define (SolverChoice& sc) override
     {
         m_fac_cond = lcond / sc.c_p;
-        m_fac_fus = lfus / sc.c_p;
-        m_fac_sub = lsub / sc.c_p;
-        m_gOcp = CONST_GRAV / sc.c_p;
-        m_axis = sc.ave_plane;
+        m_fac_fus  = lfus / sc.c_p;
+        m_fac_sub  = lsub / sc.c_p;
+        m_gOcp     = CONST_GRAV / sc.c_p;
+        m_axis     = sc.ave_plane;
+        m_do_cond  = (!sc.use_shoc);
     }
 
     // init
@@ -159,6 +160,7 @@ private:
     amrex::Real m_fac_fus;
     amrex::Real m_fac_sub;
     amrex::Real m_gOcp;
+    bool m_do_cond;
 
     // Pointer to terrain data
     amrex::MultiFab* m_z_phys_nd;

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -10,7 +10,8 @@ using namespace amrex;
  */
 void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 {
-    auto tabs  = mic_fab_vars[MicVar_Kess::tabs];
+    bool do_cond = m_do_cond;
+    auto tabs    = mic_fab_vars[MicVar_Kess::tabs];
     if (solverChoice.moisture_type == MoistureType::Kessler){
         auto dz = m_geom.CellSize(2);
         auto domain = m_geom.Domain();
@@ -75,17 +76,17 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 Real fac = (L_v/Cp_d)*dtqsat;
 
                 // If water vapor content exceeds saturation value, then vapor condenses to water and latent heat is released, increasing temperature
-                if (qv_array(i,j,k) > qsat) {
+                if ( (qv_array(i,j,k) > qsat) && do_cond ) {
                     dq_vapor_to_clwater = std::min(qv_array(i,j,k), (qv_array(i,j,k)-qsat)/(1.0 + fac));
                 }
 
                 // If water vapor is less than the saturated value, then the cloud water can evaporate,
                 // leading to evaporative cooling and reducing temperature
-                if (qv_array(i,j,k) < qsat && qc_array(i,j,k) > 0.0) {
+                if ( (qv_array(i,j,k) < qsat) && (qc_array(i,j,k) > 0.0) && do_cond ) {
                     dq_clwater_to_vapor = std::min(qc_array(i,j,k), (qsat - qv_array(i,j,k))/(1.0 + fac));
                 }
 
-                if (qp_array(i,j,k) > 0.0 && qv_array(i,j,k) < qsat) {
+                if (( qp_array(i,j,k) > 0.0) && (qv_array(i,j,k) < qsat) ) {
                     Real C = 1.6 + 124.9*std::pow(0.001*rho_array(i,j,k)*qp_array(i,j,k),0.2046);
                     dq_rain_to_vapor = 1.0/(0.001*rho_array(i,j,k))*(1.0 - qv_array(i,j,k)/qsat)*C*std::pow(0.001*rho_array(i,j,k)*qp_array(i,j,k),0.525)/
                         (5.4e5 + 2.55e6/(pressure*qsat))*dtn;
@@ -247,8 +248,8 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
     }
 
 
-    if (solverChoice.moisture_type == MoistureType::Kessler_NoRain){
-
+    if (solverChoice.moisture_type == MoistureType::Kessler_NoRain) {
+        if (!do_cond) { return; }
         // get the temperature, density, theta, qt and qc from input
         for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -503,6 +503,9 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Morrison::Advance (const amrex::Real& dt_advance,
                        const SolverChoice& sc)
     {
+        // Expose for GPU
+        bool do_cond = m_do_cond;
+
         // Store timestep
         amrex::Real dt = dt_advance;
 
@@ -1855,9 +1858,11 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
                 pcc = -dumqc / dt;
               }
 
+              if (!do_cond) { pcc = 0.0; }
+
               // Update tendencies
               morr_arr(i,j,k,MORRInd::qv3dten) -= pcc;
-              morr_arr(i,j,k,MORRInd::t3dten) += pcc * morr_arr(i,j,k,MORRInd::xxlv) / morr_arr(i,j,k,MORRInd::cpm);
+              morr_arr(i,j,k,MORRInd::t3dten)  += pcc * morr_arr(i,j,k,MORRInd::xxlv) / morr_arr(i,j,k,MORRInd::cpm);
               morr_arr(i,j,k,MORRInd::qc3dten) += pcc;
             } else { //cold
               //......................................................................

--- a/Source/Microphysics/Morrison/ERF_Morrison.H
+++ b/Source/Microphysics/Morrison/ERF_Morrison.H
@@ -76,6 +76,7 @@ public:
         m_gOcp     = CONST_GRAV / sc.c_p;
         m_axis     = sc.ave_plane;
         m_rdOcp    = sc.rdOcp;
+        m_do_cond  = (!sc.use_shoc);
     }
 
     // init
@@ -292,6 +293,7 @@ private:
     amrex::Real m_fac_sub;
     amrex::Real m_gOcp;
     amrex::Real m_rdOcp;
+    bool m_do_cond;
 
     // Pointer to terrain data
     amrex::MultiFab* m_z_phys_nd;

--- a/Source/Microphysics/SAM/ERF_CloudSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_CloudSAM.cpp
@@ -11,6 +11,7 @@ using namespace amrex;
 void
 SAM::Cloud (const SolverChoice& sc)
 {
+    if (!do_cond) { return; }
 
     constexpr Real an = 1.0/(tbgmax-tbgmin);
     constexpr Real bn = tbgmin*an;

--- a/Source/Microphysics/SAM/ERF_CloudSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_CloudSAM.cpp
@@ -11,7 +11,7 @@ using namespace amrex;
 void
 SAM::Cloud (const SolverChoice& sc)
 {
-    if (!do_cond) { return; }
+    if (!m_do_cond) { return; }
 
     constexpr Real an = 1.0/(tbgmax-tbgmin);
     constexpr Real bn = tbgmin*an;

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -83,6 +83,7 @@ public:
         m_gOcp     = CONST_GRAV / sc.c_p;
         m_axis     = sc.ave_plane;
         m_rdOcp    = sc.rdOcp;
+        m_do_cond  = (!sc.use_shoc);
     }
 
     // init
@@ -307,6 +308,7 @@ private:
     amrex::Real m_fac_sub;
     amrex::Real m_gOcp;
     amrex::Real m_rdOcp;
+    bool m_do_cond;
 
     // Pointer to terrain data
     amrex::MultiFab* m_z_phys_nd;

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.H
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.H
@@ -58,6 +58,7 @@ public:
     {
         m_fac_cond = lcond / sc.c_p;
         m_rdOcp    = sc.rdOcp;
+        m_do_cond  = (!sc.use_shoc);
     }
 
     // init
@@ -203,7 +204,8 @@ private:
 
     // constants
     amrex::Real m_fac_cond;
-    amrex::Real m_rdOcp ;
+    amrex::Real m_rdOcp;
+    bool m_do_cond;
 
     // independent variables
     amrex::Array<FabPtr, MicVar_SatAdj::NumVars> mic_fab_vars;

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
@@ -7,6 +7,8 @@ using namespace amrex;
  */
 void SatAdj::AdvanceSatAdj (const SolverChoice& /*solverChoice*/)
 {
+    if (!m_do_cond) { return; }
+
     auto tabs  = mic_fab_vars[MicVar_SatAdj::tabs];
 
     // Expose for GPU


### PR DESCRIPTION
## Notes
The `use_shoc` flag is passed to the microphysics modules to determine whether condensation/evaporation of cloud water should be done.