### PR TITLE
Fix Advection Typo

### DIFF
--- a/Source/Advection/ERF_AdvectionSrcForScalars.H
+++ b/Source/Advection/ERF_AdvectionSrcForScalars.H
@@ -36,7 +36,6 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         const int prim_index = cons_index - 1;
         amrex::Real interpy(0.);
         interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ));
-
         (flx_arr[1])(i,j,k) = avg_ymom(i,j,k) * interpy;
     });
     amrex::ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept

--- a/Source/Advection/ERF_AdvectionSrcForState.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForState.cpp
@@ -278,7 +278,7 @@ AdvectionSrcForScalars (const Box& bx,
               ( (flx_arr[1])(i,j+1,k) - (flx_arr[1])(i,j,k) ) * dyInv +
               ( (flx_arr[2])(i,j,k+1) - (flx_arr[2])(i,j,k) ) * dzInv );
         } else {
-            advectionSrc(i,j,k) = 0.;
+            advectionSrc(i,j,k,cons_index) = 0.;
         }
     });
 


### PR DESCRIPTION
## Note
This PR should not affect the output since a negative detJ is not physical. However, the ncomp input must be specified otherwise the array4 defaults to 0 (rho component).