### PR TITLE
Shoc Coupling

### DIFF
--- a/Exec/DevTests/Shoc/ERF_Prob.H
+++ b/Exec/DevTests/Shoc/ERF_Prob.H
@@ -6,44 +6,49 @@
 #include "AMReX_REAL.H"
 
 #include "ERF_ProbCommon.H"
-#include "ERF_EOS.H"
 
 struct ProbParm : ProbParmDefaults {
-    // background conditions
-    // if init_type != "" then these are perturbations and should be 0
-    amrex::Real T_0 = 300.0;
-    amrex::Real U_0 = 0.0;
-    amrex::Real V_0 = 0.0;
-    amrex::Real W_0 = 0.0;
+  amrex::Real rho_0 = 0.0;
+  amrex::Real T_0   = 0.0;
+  amrex::Real A_0   = 1.0;
+  amrex::Real KE_0  = 0.1;  // initialize to calculated rho_hse times input KE
+  amrex::Real rhoKE_0 = -1; // alternatively, initialize to specified (rho*KE)
 
-    // center of thermal perturbation
-    amrex::Real x_c = 0.0;
-    amrex::Real y_c = 0.0;
-    amrex::Real z_c = 0.0;
+  amrex::Real KE_decay_height = -1;
+  amrex::Real KE_decay_order  =  1;
 
-    // radial extent of thermal perturbation
-    amrex::Real x_r = 0.0;
-    amrex::Real y_r = 0.0;
-    amrex::Real z_r = 0.0;
+  amrex::Real U_0 = 0.0;
+  amrex::Real V_0 = 0.0;
+  amrex::Real W_0 = 0.0;
 
-    // perturbation temperature
-    amrex::Real T_pert = -15.0;
-    bool T_pert_is_airtemp = true; // T_pert input is air temperature
-    bool perturb_rho = true; // not rho*theta (i.e., p is constant); otherwise perturb rho*theta
+  // random initial perturbations (legacy code)
+  amrex::Real U_0_Pert_Mag = 0.0;
+  amrex::Real V_0_Pert_Mag = 0.0;
+  amrex::Real W_0_Pert_Mag = 0.0;
+  amrex::Real T_0_Pert_Mag = 0.0; // perturbation to rho*Theta
+  bool pert_rhotheta = true;
 
-    // Moist bubble params
-    bool do_moist_bubble = false;
-    amrex::Real theta_pert  = 2.0;
-    amrex::Real qt_init     = 0.02;
-    amrex::Real eq_pot_temp = 320.0;
+  // divergence-free initial perturbations
+  amrex::Real pert_deltaU = 0.0;
+  amrex::Real pert_deltaV = 0.0;
+  amrex::Real pert_periods_U = 5.0;
+  amrex::Real pert_periods_V = 5.0;
+  amrex::Real pert_ref_height = 100.0;
+
+  // helper vars
+  amrex::Real aval;
+  amrex::Real bval;
+  amrex::Real ufac;
+  amrex::Real vfac;
 }; // namespace ProbParm
 
 class Problem : public ProblemBase
 {
 public:
-    Problem();
+    Problem(const amrex::Real* problo, const amrex::Real* probhi);
 
-#include "Prob/ERF_InitDensityHSEDry.H"
+#include "Prob/ERF_InitConstantDensityHSE.H"
+#include "Prob/ERF_InitRayleighDamping.H"
 
     void init_custom_pert (
         const amrex::Box&  bx,
@@ -65,135 +70,11 @@ public:
         amrex::Array4<amrex::Real const> const& mf_v,
         const SolverChoice& sc) override;
 
-    void erf_init_dens_hse_moist (amrex::MultiFab& rho_hse,
-                                  std::unique_ptr<amrex::MultiFab>& z_phys_nd,
-                                  amrex::Geometry const& geom) override;
-
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real compute_theta (const amrex::Real T_b, const amrex::Real p_b);
-
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real compute_temperature (const amrex::Real p_b);
-
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real compute_F_for_temp(const amrex::Real T_b, const amrex::Real p_b);
-
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real compute_p_k (amrex::Real& p_k,
-                             const amrex::Real p_k_minus_1,
-                             amrex::Real& theta_k,
-                             amrex::Real& rho_k,
-                             amrex::Real& q_v_k,
-                             amrex::Real& T_dp,
-                             amrex::Real& T_b,
-                             const amrex::Real dz,
-                             const amrex::Real rho_k_minus_1);
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    amrex::Real compute_F (const amrex::Real& p_k,
-                           const amrex::Real& p_k_minus_1,
-                           amrex::Real &theta_k,
-                           amrex::Real& rho_k,
-                           amrex::Real& q_v_k,
-                           amrex::Real& T_dp,
-                           amrex::Real& T_b,
-                           const amrex::Real& dz,
-                           const amrex::Real& rho_k_minus_1);
-
-    AMREX_FORCE_INLINE
-    AMREX_GPU_HOST_DEVICE
-    void compute_rho (const amrex::Real& pressure,
-                      amrex::Real &theta,
-                      amrex::Real& rho,
-                      amrex::Real& q_v,
-                      amrex::Real& T_dp,
-                      amrex::Real& T_b);
-
-  void init_isentropic_hse_no_terrain(amrex::Real *theta,
-                                        amrex::Real* r,
-                                        amrex::Real* p,
-                                        amrex::Real *q_v,
-                                        const amrex::Real& dz,
-                                        const int& khi);
-
-#include "Prob/ERF_InitRayleighDamping.H"
-
 protected:
-    std::string name() override { return "Bubble"; }
+    std::string name() override { return "SHOC"; }
 
 private:
     ProbParm parms;
 };
-
-/*
- * Calculate perturbation to potential temperature or density at a
- * given (x,y,z). If the perturb_rho flag is set, then rho is perturbed,
- * and pressure is not (rho*theta is constant); otherwise, rho is
- * constant and rho*theta is perturbed
- *
- * Note: the input p_hse and r_hse should be in HSE given an appropriate
- * background flow initialization.
- */
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-void
-perturb_rho_theta (const amrex::Real x,
-                   const amrex::Real y,
-                   const amrex::Real z,
-                   const amrex::Real p_hse,
-                   const amrex::Real r_hse,
-                   const ProbParm pp,
-                   const amrex::Real rdOcp,
-                   amrex::Real& rho,
-                   amrex::Real& rhotheta)
-{
-    // Perturbation air temperature
-    // - The bubble is either cylindrical (for 2-D problems, if two
-    //   radial extents are specified) or an ellipsoid (if all three
-    //   radial extents are specified).
-    amrex::Real L = 0.0;
-    if (pp.x_r > 0) L += std::pow((x - pp.x_c)/pp.x_r, 2);
-    if (pp.y_r > 0) L += std::pow((y - pp.y_c)/pp.y_r, 2);
-    if (pp.z_r > 0) L += std::pow((z - pp.z_c)/pp.z_r, 2);
-    L = std::sqrt(L);
-    amrex::Real dT;
-    if (L > 1.0) {
-        dT = 0.0;
-    }
-    else {
-        dT = pp.T_pert * std::pow(cos(PI*L/2.0),2);
-    }
-
-    // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
-    const amrex::Real Tbar_hse = p_hse / (R_d * r_hse);
-
-    // Note: theta_perturbed is theta PLUS perturbation in theta
-    amrex::Real theta_perturbed;
-    if (pp.T_pert_is_airtemp) {
-        // dT is air temperature
-        theta_perturbed = (Tbar_hse + dT)*std::pow(p_0/p_hse, rdOcp);
-    } else {
-        // dT is potential temperature
-        theta_perturbed = Tbar_hse*std::pow(p_0/p_hse, rdOcp) + dT;
-    }
-
-    if (pp.perturb_rho)
-    {
-        // this version perturbs rho but not p (i.e., rho*theta)
-        // - hydrostatic rebalance is needed (TODO: is this true?)
-        // - this is the approach taken in the density current problem
-        rhotheta = 0.0; // i.e., hydrostatically balanced pressure stays const
-        rho = getRhoThetagivenP(p_hse) / theta_perturbed - r_hse;
-    }
-    else
-    {
-        // this version perturbs rho*theta (i.e., p) but not rho
-        rho = 0.0; // i.e., hydrostatically balanced density stays const
-        rhotheta = r_hse * theta_perturbed - getRhoThetagivenP(p_hse);
-    }
-}
 
 #endif

--- a/Exec/DevTests/Shoc/ERF_Prob.cpp
+++ b/Exec/DevTests/Shoc/ERF_Prob.cpp
@@ -1,423 +1,216 @@
 #include "ERF_Prob.H"
-#include "ERF_MicrophysicsUtils.H"
-#include "ERF_Constants.H"
-#include "ERF_EOS.H"
+#include "AMReX_Random.H"
 
 using namespace amrex;
 
 std::unique_ptr<ProblemBase>
-amrex_probinit(
-    const amrex_real* /*problo*/,
-    const amrex_real* /*probhi*/)
+amrex_probinit(const amrex_real* problo, const amrex_real* probhi)
 {
-    return std::make_unique<Problem>();
+    return std::make_unique<Problem>(problo, probhi);
 }
 
-Problem::Problem()
+Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
 {
   // Parse params
   ParmParse pp("prob");
+  pp.query("rho_0", parms.rho_0);
   pp.query("T_0", parms.T_0);
+  pp.query("A_0", parms.A_0);
+  pp.query("KE_0", parms.KE_0);
+  pp.query("rhoKE_0", parms.rhoKE_0);
+  pp.query("KE_decay_height", parms.KE_decay_height);
+  pp.query("KE_decay_order", parms.KE_decay_order);
+
   pp.query("U_0", parms.U_0);
   pp.query("V_0", parms.V_0);
   pp.query("W_0", parms.W_0);
-  pp.query("x_c", parms.x_c);
-  pp.query("y_c", parms.y_c);
-  pp.query("z_c", parms.z_c);
-  pp.query("x_r", parms.x_r);
-  pp.query("y_r", parms.y_r);
-  pp.query("z_r", parms.z_r);
-  pp.query("T_pert", parms.T_pert);
-  pp.query("T_pert_is_airtemp", parms.T_pert_is_airtemp);
-  pp.query("perturb_rho", parms.perturb_rho);
+  pp.query("U_0_Pert_Mag", parms.U_0_Pert_Mag);
+  pp.query("V_0_Pert_Mag", parms.V_0_Pert_Mag);
+  pp.query("W_0_Pert_Mag", parms.W_0_Pert_Mag);
+  pp.query("T_0_Pert_Mag", parms.T_0_Pert_Mag);
+  pp.query("pert_rhotheta", parms.pert_rhotheta);
 
-  pp.query("do_moist_bubble", parms.do_moist_bubble);
-  pp.query("theta_pert", parms.theta_pert);
-  pp.query("qt_init", parms.qt_init);
-  pp.query("eq_pot_temp", parms.eq_pot_temp);
+  pp.query("pert_deltaU", parms.pert_deltaU);
+  pp.query("pert_deltaV", parms.pert_deltaV);
+  pp.query("pert_periods_U", parms.pert_periods_U);
+  pp.query("pert_periods_V", parms.pert_periods_V);
+  pp.query("pert_ref_height", parms.pert_ref_height);
+  parms.aval = parms.pert_periods_U * 2.0 * PI / (probhi[1] - problo[1]);
+  parms.bval = parms.pert_periods_V * 2.0 * PI / (probhi[0] - problo[0]);
+  parms.ufac = parms.pert_deltaU * std::exp(0.5) / parms.pert_ref_height;
+  parms.vfac = parms.pert_deltaV * std::exp(0.5) / parms.pert_ref_height;
 
   init_base_parms(parms.rho_0, parms.T_0);
 }
 
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real compute_saturation_pressure (const Real T_b)
-{
-    return erf_esatw(T_b)*100.0;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real compute_relative_humidity ()
-{
-    return 1.0;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real vapor_mixing_ratio (const Real p_b, const Real T_b, const Real RH)
-{
-    Real p_s = compute_saturation_pressure(T_b);
-    Real p_v = compute_vapor_pressure(p_s, RH);
-    Real q_v = Rd_on_Rv*p_v/(p_b - p_v);
-    return q_v;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real Problem::compute_F_for_temp(const Real T_b, const Real p_b)
-{
-    Real q_t = parms.qt_init;
-    Real fac = Cp_d + Cp_l*q_t;
-    Real RH  = compute_relative_humidity();
-    Real q_v = vapor_mixing_ratio(p_b, T_b, RH);
-    Real p_s = compute_saturation_pressure(T_b);
-    Real p_v = compute_vapor_pressure(p_s, RH);
-    return  parms.eq_pot_temp - T_b*std::pow((p_b - p_v)/p_0, -R_d/fac)*std::exp(L_v*q_v/(fac*T_b));
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real Problem::compute_temperature (const Real p_b)
-{
-    Real T_b = 200.0, delta_T; // Initial guess
-    for(int iter=0; iter<20; iter++)
-    {
-        Real F         = compute_F_for_temp(T_b, p_b);
-        Real F_plus_dF = compute_F_for_temp(T_b+1e-10, p_b);
-        Real F_prime   = (F_plus_dF - F)/1e-10;
-        delta_T = -F/F_prime;
-        T_b = T_b + delta_T;
-    }
-
-    if(std::fabs(delta_T) > 1e-8){
-         amrex::Abort("Newton Raphson for temperature could not converge");
-    }
-
-    return T_b;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real compute_dewpoint_temperature (const Real T_b, const Real RH)
-{
-    Real T_dp, gamma, T;
-    T = T_b - 273.15;
-
-    Real b = 18.678, c = 257.14, d = 234.5;
-    gamma = log(RH*exp((b - T/d)*T/(c + T)));
-
-    T_dp = c*gamma/(b - gamma);
-
-    return T_dp;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-void Problem::compute_rho (const Real& pressure, Real& theta, Real& rho, Real& q_v, Real& T_dp, Real& T_b)
-{
-    T_b     = compute_temperature(pressure);
-
-    theta   = getThgivenTandP(T_b, pressure, (R_d/Cp_d));
-
-    Real RH = compute_relative_humidity();
-    q_v     = vapor_mixing_ratio(pressure, T_b, RH);
-
-    rho     = getRhogivenTandPress(T_b, pressure, q_v);
-    rho     = rho*(1.0 + parms.qt_init); // q_t = 0.02 a given constant for this test case
-
-    T_dp    = compute_dewpoint_temperature(T_b, RH);
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real Problem::compute_F (const Real& p_k, const Real& p_k_minus_1, Real &theta_k, Real& rho_k, Real& q_v_k,
-                         Real& T_dp, Real& T_b, const Real& dz, const Real& rho_k_minus_1)
-{
-    Real F;
-
-    if(rho_k_minus_1 == 0.0) // This loop is for the first point above the ground
-    {
-        compute_rho(p_k, theta_k, rho_k, q_v_k, T_dp, T_b);
-        F = p_k - p_k_minus_1 + rho_k*CONST_GRAV*dz/2.0;
-    }
-    else
-    {
-        compute_rho(p_k, theta_k, rho_k, q_v_k, T_dp, T_b);
-        F = p_k - p_k_minus_1 + rho_k_minus_1*CONST_GRAV*dz/2.0 + rho_k*CONST_GRAV*dz/2.0;
-    }
-
-    return F;
-}
-
-AMREX_FORCE_INLINE
-AMREX_GPU_HOST_DEVICE
-Real Problem::compute_p_k (Real &p_k, const Real p_k_minus_1, Real &theta_k, Real& rho_k, Real& q_v_k,
-                           Real& T_dp, Real& T_b, const Real dz, const Real rho_k_minus_1)
-{
-    Real delta_p_k;
-
-    for(int iter=0; iter<20; iter++)
-    {
-        Real F         = compute_F(p_k, p_k_minus_1, theta_k, rho_k, q_v_k, T_dp, T_b, dz, rho_k_minus_1);
-        Real F_plus_dF = compute_F(p_k+1e-10, p_k_minus_1, theta_k, rho_k, q_v_k, T_dp, T_b, dz, rho_k_minus_1);
-        Real F_prime   = (F_plus_dF - F)/1e-10;
-        delta_p_k = -F/F_prime;
-        p_k            = p_k + delta_p_k;
-    }
-
-    if(std::fabs(delta_p_k) > 1e-8){
-        amrex::Abort("Newton Raphson for pressure could not converge");
-    }
-
-    return p_k;
-}
-
-void
-Problem::init_isentropic_hse_no_terrain(Real *theta, Real* r, Real* p, Real *q_v,
-                                        const Real& dz,
-                                        const int& khi)
-{
-    Real T_b, T_dp;
-
-    // Compute the quantities at z = 0.5*dz (first cell center)
-    p[0] = p_0;
-    compute_p_k(p[0], p_0, theta[0], r[0], q_v[0], T_dp, T_b, dz, 0.0);
-
-    for (int k=1;k<=khi;k++){
-        p[k] = p[k-1];
-        compute_p_k(p[k], p[k-1], theta[k], r[k], q_v[k], T_dp, T_b, dz, r[k-1]);
-    }
-
-    r[khi+1] = r[khi];
-}
-
-void
-Problem::erf_init_dens_hse_moist (MultiFab& rho_hse,
-                                  std::unique_ptr<MultiFab>& /*z_phys_nd*/,
-                                  Geometry const& geom)
-{
-    const Real dz        = geom.CellSize()[2];
-    const int khi        = geom.Domain().bigEnd()[2];
-
-    // These are at cell centers (unstaggered)
-    Vector<Real> h_r(khi+2);
-    Vector<Real> h_p(khi+2);
-    Vector<Real> h_t(khi+2);
-    Vector<Real> h_q_v(khi+2);
-
-    Gpu::DeviceVector<Real> d_r(khi+2);
-
-    init_isentropic_hse_no_terrain(h_t.data(), h_r.data(),h_p.data(), h_q_v.data(), dz, khi);
-
-    Gpu::copyAsync(Gpu::hostToDevice, h_r.begin(), h_r.end(), d_r.begin());
-
-    Real* r = d_r.data();
-
-#ifdef _OPENMP
-#pragma omp parallel if (Gpu::notInLaunchRegion())
-#endif
-    for ( MFIter mfi(rho_hse,TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.growntilebox(1);
-        const Array4<Real> rho_hse_arr   = rho_hse[mfi].array();
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            int kk = std::max(k,0);
-            rho_hse_arr(i,j,k) = r[kk];
-        });
-    } // mfi
-}
-
-
 void
 Problem::init_custom_pert(
-    const Box& bx,
-    const Box& xbx,
-    const Box& ybx,
-    const Box& zbx,
-    Array4<Real const> const& /*state*/,
-    Array4<Real      > const& state_pert,
-    Array4<Real      > const& x_vel_pert,
-    Array4<Real      > const& y_vel_pert,
-    Array4<Real      > const& z_vel_pert,
-    Array4<Real      > const& r_hse,
-    Array4<Real      > const& p_hse,
-    Array4<Real const> const& /*z_nd*/,
-    Array4<Real const> const& /*z_cc*/,
-    GeometryData const& geomdata,
-    Array4<Real const> const& /*mf_m*/,
-    Array4<Real const> const& /*mf_u*/,
-    Array4<Real const> const& /*mf_v*/,
+    const amrex::Box&  bx,
+    const amrex::Box& xbx,
+    const amrex::Box& ybx,
+    const amrex::Box& zbx,
+    amrex::Array4<amrex::Real const> const& /*state*/,
+    amrex::Array4<amrex::Real      > const& state_pert,
+    amrex::Array4<amrex::Real      > const& x_vel_pert,
+    amrex::Array4<amrex::Real      > const& y_vel_pert,
+    amrex::Array4<amrex::Real      > const& z_vel_pert,
+    amrex::Array4<amrex::Real      > const& r_hse,
+    amrex::Array4<amrex::Real      > const& /*p_hse*/,
+    amrex::Array4<amrex::Real const> const& z_nd,
+    amrex::Array4<amrex::Real const> const& z_cc,
+    amrex::GeometryData const& geomdata,
+    amrex::Array4<amrex::Real const> const& /*mf_m*/,
+    amrex::Array4<amrex::Real const> const& /*mf_u*/,
+    amrex::Array4<amrex::Real const> const& /*mf_v*/,
     const SolverChoice& sc)
 {
-    const int khi = geomdata.Domain().bigEnd()[2];
-
     const bool use_moisture = (sc.moisture_type != MoistureType::None);
 
-    AMREX_ALWAYS_ASSERT(bx.length()[2] == khi+1);
-
-    const Real dz        = geomdata.CellSize()[2];
-    const Real rdOcp     = sc.rdOcp;
-
-    amrex::Print() << "Bubble delta T = " << parms.T_pert << " K" << std::endl;
-    amrex::Print() << "  centered at ("
-                   << parms.x_c << " " << parms.y_c << " " << parms.z_c << ")" << std::endl;
-    amrex::Print() << "  with extent ("
-                   << parms.x_r << " " << parms.y_r << " " << parms.z_r << ")" << std::endl;
-
-    if (parms.T_0 <= 0)
-    {
-        amrex::Print() << "Ignoring parms.T_0 = " << parms.T_0
-                       << ", background fields should have been initialized with erf.init_type"
+    if (parms.KE_decay_height > 0) {
+        amrex::Print() << "Initial KE profile (order " << parms.KE_decay_order
+                       << ") will extend up to " << parms.KE_decay_height
                        << std::endl;
     }
 
-    if (parms.do_moist_bubble) {
-        Vector<Real> h_r(khi+2);
-        Vector<Real> h_p(khi+2);
-        Vector<Real> h_t(khi+2);
-        Vector<Real> h_q_v(khi+2);
-
-        Gpu::DeviceVector<Real> d_r(khi+2);
-        Gpu::DeviceVector<Real> d_p(khi+2);
-        Gpu::DeviceVector<Real> d_t(khi+2);
-        Gpu::DeviceVector<Real> d_q_v(khi+2);
-
-        init_isentropic_hse_no_terrain(h_t.data(), h_r.data(),h_p.data(),h_q_v.data(),dz, khi);
-
-        Gpu::copyAsync(Gpu::hostToDevice, h_r.begin(), h_r.end(), d_r.begin());
-        Gpu::copyAsync(Gpu::hostToDevice, h_p.begin(), h_p.end(), d_p.begin());
-        Gpu::copyAsync(Gpu::hostToDevice, h_t.begin(), h_t.end(), d_t.begin());
-        Gpu::copyAsync(Gpu::hostToDevice, h_q_v.begin(), h_q_v.end(), d_q_v.begin());
-
-        Real* theta_back   = d_t.data();
-        Real* p_back   = d_p.data();
-        Real* q_v_back = d_q_v.data();
-
-
-        const Real x_c = parms.x_c, y_c = parms.y_c, z_c = parms.z_c;
-        const Real x_r = parms.x_r, y_r = parms.y_r, z_r = parms.z_r;
-        const Real theta_pert = parms.theta_pert;
-
-        int moisture_type = 1;
-
-        if(sc.moisture_type == MoistureType::SAM) {
-            moisture_type = 1;
-        } else if(sc.moisture_type == MoistureType::SAM_NoIce ||
-                  sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
-            moisture_type = 2;
+    if (parms.pert_ref_height > 0) {
+        if ((parms.pert_deltaU != 0.0) || (parms.pert_deltaV != 0.0)) {
+            amrex::Print() << "Adding divergence-free perturbations "
+                           << parms.pert_deltaU << " " << parms.pert_deltaV
+                           << std::endl;
         }
-
-        ParallelFor(bx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k)
-        {
-            // Geometry (note we must include these here to get the data on device)
-            const auto prob_lo         = geomdata.ProbLo();
-            const auto dx              = geomdata.CellSize();
-            const amrex::Real x        = prob_lo[0] + (i + 0.5) * dx[0];
-            const amrex::Real y        = prob_lo[1] + (j + 0.5) * dx[1];
-            const amrex::Real z        = prob_lo[2] + (k + 0.5) * dx[2];
-
-            Real rad, delta_theta, theta_total, rho, RH;
-
-            // Introduce the warm bubble. Assume that the bubble is pressure matched with the background
-            rad = 0.0;
-            if (x_r > 0) rad += std::pow((x - x_c)/x_r, 2);
-            if (y_r > 0) rad += std::pow((y - y_c)/y_r, 2);
-            if (z_r > 0) rad += std::pow((z - z_c)/z_r, 2);
-            rad = std::sqrt(rad);
-
-            if(rad <= 1.0){
-                delta_theta = theta_pert*std::pow(cos(PI*rad/2.0),2);
+        if (parms.U_0_Pert_Mag != 0.0) {
+            amrex::Print() << "Adding random x-velocity perturbations" << std::endl;
+        }
+        if (parms.V_0_Pert_Mag != 0.0) {
+            amrex::Print() << "Adding random y-velocity perturbations" << std::endl;
+        }
+        if (parms.T_0_Pert_Mag != 0.0) {
+            if (parms.pert_rhotheta) {
+                amrex::Print() << "Adding random rho*theta perturbations" << std::endl;
+            } else {
+                amrex::Print() << "Adding random theta perturbations" << std::endl;
             }
-            else{
-                delta_theta = 0.0;
-            }
+        }
+    }
 
-            theta_total  = theta_back[k]*(delta_theta/300.0 + 1);
-            Real T = getTgivenPandTh(p_back[k], theta_total, (R_d/Cp_d));
-            rho    = p_back[k]/(R_d*T*(1.0 + (R_v/R_d)*q_v_back[k]));
-            RH     = compute_relative_humidity();
-            Real q_v_hot = vapor_mixing_ratio(p_back[k], T, RH);
+  ParallelForRNG(bx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+    // Geometry
+    const Real* prob_lo = geomdata.ProbLo();
+    const Real* prob_hi = geomdata.ProbHi();
+    const Real* dx = geomdata.CellSize();
+    const Real x = prob_lo[0] + (i + 0.5) * dx[0];
+    const Real y = prob_lo[1] + (j + 0.5) * dx[1];
+    const Real z = (z_cc) ? z_cc(i,j,k) : prob_lo[2] + (k + 0.5) * dx[2];
 
-            // Compute background quantities
-            Real T_back   = getTgivenPandTh(p_back[k], theta_back[k], (R_d/Cp_d));
-            Real rho_back = p_back[k]/(R_d*T_back*(1.0 + (R_v/R_d)*q_v_back[k]));
+    // Define a point (xc,yc,zc) at the center of the domain
+    const Real xc = 0.5 * (prob_lo[0] + prob_hi[0]);
+    const Real yc = 0.5 * (prob_lo[1] + prob_hi[1]);
+    const Real zc = 0.5 * (prob_lo[2] + prob_hi[2]);
 
-            // This version perturbs rho but not p
-            state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*theta_back[k]*(1.0 + (R_v/R_d)*q_v_back[k]);
-            state_pert(i, j, k, Rho_comp)      = rho - rho_back*(1.0 + parms_d.qt_init);
+    const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
-            // Set scalar = 0 everywhere
-            state_pert(i, j, k, RhoScalar_comp) = 0.0;
+    // Add temperature perturbations
+    if ((z <= parms_d.pert_ref_height) && (parms_d.T_0_Pert_Mag != 0.0)) {
+        Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
+        state_pert(i, j, k, RhoTheta_comp) = (rand_double*2.0 - 1.0)*parms_d.T_0_Pert_Mag;
+        if (!parms_d.pert_rhotheta) {
+            // we're perturbing theta, not rho*theta
+            state_pert(i, j, k, RhoTheta_comp) *= r_hse(i,j,k);
+        }
+    }
 
-            // mean states
-            state_pert(i, j, k, RhoQ1_comp) = rho*q_v_hot;
-            state_pert(i, j, k, RhoQ2_comp) = rho*(parms_d.qt_init - q_v_hot);
+    // Set scalar = A_0*exp(-10r^2), where r is distance from center of domain
+    state_pert(i, j, k, RhoScalar_comp) = parms_d.A_0 * exp(-10.*r*r);
 
-            // Cold microphysics are present
-            int nstate = state_pert.ncomp;
-            if (nstate == NVAR_max) {
-                Real omn;
-                if(moisture_type == 1) {
-                    omn = std::max(0.0,std::min(1.0,(T-tbgmin)*a_bg));
-                } else if(moisture_type == 2) {
-                    omn = 1.0;
-                } else {
-                    omn = 0.0;
-                    Abort("Bubble/ERF_Prob.cpp: invalid moisture type specified");
-                }
-                Real qn  = state_pert(i, j, k, RhoQ2_comp);
-                state_pert(i, j, k, RhoQ2_comp) = qn * omn;
-                state_pert(i, j, k, RhoQ3_comp) = qn * (1.0-omn);
-            }
-        });
-    } else {
-        ParallelFor(bx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-        {
-            // Geometry (note we must include these here to get the data on device)
-            const auto prob_lo         = geomdata.ProbLo();
-            const auto dx              = geomdata.CellSize();
+    // Set an initial value for SGS KE
+    if (state_pert.nComp() > RhoKE_comp) {
+        // Deardorff
+        if (parms_d.rhoKE_0 > 0) {
+            state_pert(i, j, k, RhoKE_comp) = parms_d.rhoKE_0;
+        } else {
+            state_pert(i, j, k, RhoKE_comp) = r_hse(i,j,k) * parms_d.KE_0;
+        }
+        if (parms_d.KE_decay_height > 0) {
+            // scale initial SGS kinetic energy with height
+            state_pert(i, j, k, RhoKE_comp) *= max(
+                std::pow(1 - min(z/parms_d.KE_decay_height,1.0), parms_d.KE_decay_order),
+                1e-12);
+        }
+    }
 
-            const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-            const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-            const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+    if (use_moisture) {
+        state_pert(i, j, k, RhoQ1_comp) = 0.0;
+        state_pert(i, j, k, RhoQ2_comp) = 0.0;
+    }
+  });
 
-            perturb_rho_theta(x, y, z, p_hse(i,j,k), r_hse(i,j,k),
-                              parms_d, rdOcp,
-                              state_pert(i, j, k, Rho_comp),
-                              state_pert(i, j, k, RhoTheta_comp));
-
-            state_pert(i, j, k, RhoScalar_comp) = 0.0;
-
-            if (use_moisture) {
-                state_pert(i, j, k, RhoQ1_comp) = 0.0;
-                state_pert(i, j, k, RhoQ2_comp) = 0.0;
-            }
-        });
-    } // do_moist_bubble
-
-    const Real u0 = parms.U_0;
-    const Real v0 = parms.V_0;
-    const Real w0 = parms.W_0;
+  // Set the x-velocity
+  ParallelForRNG(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+    const Real* prob_lo = geomdata.ProbLo();
+    const Real* dx = geomdata.CellSize();
+    const Real y = prob_lo[1] + (j + 0.5) * dx[1];
+    const Real z = (z_nd) ? 0.25*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+                                 + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
+                               : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    x_vel_pert(i, j, k) = parms_d.U_0;
+    if ((z <= parms_d.pert_ref_height) && (parms_d.U_0_Pert_Mag != 0.0))
     {
-        x_vel_pert(i, j, k) = u0;
-    });
+        Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
+        Real x_vel_prime = (rand_double*2.0 - 1.0)*parms_d.U_0_Pert_Mag;
+        x_vel_pert(i, j, k) += x_vel_prime;
+    }
+    if (parms_d.pert_deltaU != 0.0)
+    {
+        const amrex::Real yl = y - prob_lo[1];
+        const amrex::Real zl = z / parms_d.pert_ref_height;
+        const amrex::Real damp = std::exp(-0.5 * zl * zl);
+        x_vel_pert(i, j, k) += parms_d.ufac * damp * z * std::cos(parms_d.aval * yl);
+    }
+  });
+
+  // Set the y-velocity
+  ParallelForRNG(ybx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+    const Real* prob_lo = geomdata.ProbLo();
+    const Real* dx = geomdata.CellSize();
+    const Real x = prob_lo[0] + (i + 0.5) * dx[0];
+    const Real z = (z_nd) ? 0.25*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+                                 + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
+                               : prob_lo[2] + (k + 0.5) * dx[2];
 
     // Set the y-velocity
-    ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    y_vel_pert(i, j, k) = parms_d.V_0;
+    if ((z <= parms_d.pert_ref_height) && (parms_d.V_0_Pert_Mag != 0.0))
     {
-        y_vel_pert(i, j, k) = v0;
-    });
+        Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
+        Real y_vel_prime = (rand_double*2.0 - 1.0)*parms_d.V_0_Pert_Mag;
+        y_vel_pert(i, j, k) += y_vel_prime;
+    }
+    if (parms_d.pert_deltaV != 0.0)
+    {
+        const amrex::Real xl = x - prob_lo[0];
+        const amrex::Real zl = z / parms_d.pert_ref_height;
+        const amrex::Real damp = std::exp(-0.5 * zl * zl);
+        y_vel_pert(i, j, k) += parms_d.vfac * damp * z * std::cos(parms_d.bval * xl);
+    }
+  });
+
+  // Set the z-velocity
+  ParallelForRNG(zbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+    const int dom_lo_z = geomdata.Domain().smallEnd()[2];
+    const int dom_hi_z = geomdata.Domain().bigEnd()[2];
 
     // Set the z-velocity
-    ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    if (k == dom_lo_z || k == dom_hi_z+1)
     {
-        z_vel_pert(i, j, k) = w0;
-    });
-
-    Gpu::streamSynchronize();
+        z_vel_pert(i, j, k) = 0.0;
+    }
+    else if (parms_d.W_0_Pert_Mag != 0.0)
+    {
+        Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
+        Real z_vel_prime = (rand_double*2.0 - 1.0)*parms_d.W_0_Pert_Mag;
+        z_vel_pert(i, j, k) = parms_d.W_0 + z_vel_prime;
+    }
+  });
 }

--- a/Exec/DevTests/Shoc/inputs_shoc
+++ b/Exec/DevTests/Shoc/inputs_shoc
@@ -4,8 +4,6 @@ max_step  = 1
 
 amrex.fpe_trap_invalid = 1
 
-erf.use_shoc = 1
-
 fabarray.mfiter_tile_size = 1024 1024 1024
 
 # PROBLEM SIZE & GEOMETRY
@@ -35,7 +33,7 @@ erf.check_int       = 100       # number of timesteps between checkpoints
 # PLOTFILES
 erf.plot_file_1     = plt        # prefix of plotfile name
 erf.plot_int_1      = 100        # number of timesteps between plotfiles
-erf.plot_vars_1     = density rhotheta rhoQ1 rhoQ2 rhoadv_0 x_velocity y_velocity z_velocity pressure theta scalar temp pres_hse dens_hse pert_pres pert_dens eq_pot_temp qt qv qc qrain
+erf.plot_vars_1     = density rhotheta rhoQ1 rhoQ2 rhoadv_0 x_velocity y_velocity z_velocity pressure theta scalar temp KE Kmv Khv pres_hse dens_hse pert_pres pert_dens qt qv qc qrain
 
 # SOLVER CHOICES
 erf.use_gravity          = true
@@ -49,8 +47,9 @@ erf.moistscal_horiz_adv_type = "Upwind_3rd"
 erf.moistscal_vert_adv_type  = "Upwind_3rd"       
 
 # PHYSICS OPTIONS
-erf.les_type        = "None"
-erf.pbl_type        = "None"
+erf.les_type        = "Smagorinsky2D"
+erf.Cs = 0.1
+erf.pbl_type        = "SHOC"
 erf.moisture_model  = "Kessler"
 
 erf.molec_diff_type   = "ConstantAlpha"
@@ -62,3 +61,7 @@ erf.alpha_C           = 0.0
 erf.init_type = "input_sounding"
 erf.input_sounding_file = "input_sounding_moist"
 erf.sounding_type = Ideal
+
+prob.KE_0            = 0.4
+prob.KE_decay_height = 1000.
+prob.KE_decay_order  = 2

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -519,13 +519,8 @@ struct SolverChoice {
             }
         }
 
-        // Are we using SHOC?
-        pp.query("use_shoc", use_shoc);
-#ifndef ERF_USE_SHOC
-        if (use_shoc) {
-            amrex::Abort("You set use_shoc to true but didn't build with SHOC; you must rebuild the executable");
-        }
-#endif
+        // Are we using SHOC? (test on compilation done in turb struct)
+        if (turbChoice[0].pbl_type == PBLType::SHOC) { use_shoc = true; }
 
         // Which type of multilevel coupling
         coupling_type = CouplingType::TwoWay; // Default

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -134,7 +134,7 @@ public:
           pp, "mrf_moistvars", mrf_moistvars, lev, max_level);
       } else if (pbl_type == PBLType::SHOC) {
 #ifndef ERF_USE_SHOC
-          Abort("You set use_shoc to true but didn't build with SHOC; you must rebuild the executable");
+          amrex::Abort("You set use_shoc to true but didn't build with SHOC; you must rebuild the executable");
 #endif
       }
     }

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -7,7 +7,7 @@ AMREX_ENUM(LESType, None, Smagorinsky, Smagorinsky2D, Deardorff);
 
 AMREX_ENUM(RANSType, None, kEqn);
 
-AMREX_ENUM(PBLType, None, MYJ, MYNN25, MYNNEDMF, YSU, MRF);
+AMREX_ENUM(PBLType, None, MYJ, MYNN25, MYNNEDMF, YSU, MRF, SHOC);
 
 AMREX_ENUM(StratType, theta, thetav, thetal);
 
@@ -132,6 +132,10 @@ public:
         query_one_or_per_level(pp, "pbl_mrf_sf", pbl_mrf_sf, lev, max_level);
         query_one_or_per_level(
           pp, "mrf_moistvars", mrf_moistvars, lev, max_level);
+      } else if (pbl_type == PBLType::SHOC) {
+#ifndef ERF_USE_SHOC
+          Abort("You set use_shoc to true but didn't build with SHOC; you must rebuild the executable");
+#endif
       }
     }
 
@@ -196,7 +200,7 @@ public:
     use_tke =
       ((les_type == LESType::Deardorff) || (rans_type == RANSType::kEqn) ||
        (pbl_type == PBLType::MYJ)       || (pbl_type == PBLType::MYNN25) ||
-       (pbl_type == PBLType::MYNNEDMF));
+       (pbl_type == PBLType::MYNNEDMF)  || (pbl_type == PBLType::SHOC));
 
     // Validate inputs
     if (les_type == LESType::Smagorinsky) {

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -368,10 +368,16 @@ public:
 
 #ifdef ERF_USE_SHOC
     void compute_shoc_tendencies (int lev,
-                                  amrex::MultiFab& cons,
-                                  amrex::MultiFab& xvel,
-                                  amrex::MultiFab& yvel,
-                                  amrex::MultiFab& zvel,
+                                  amrex::MultiFab* cons,
+                                  amrex::MultiFab* xvel,
+                                  amrex::MultiFab* yvel,
+                                  amrex::MultiFab* zvel,
+                                  amrex::MultiFab* tau13,
+                                  amrex::MultiFab* tau23,
+                                  amrex::MultiFab* hfx3,
+                                  amrex::MultiFab* qfx3,
+                                  amrex::MultiFab* eddyDiffs,
+                                  amrex::MultiFab* z_phys_nd,
                                   const amrex::Real& dt_advance);
 #endif
 

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -472,10 +472,16 @@ ERF::update_diffusive_arrays (int lev, const BoxArray& ba, const DistributionMap
         Tau[lev][TauType::tau12] = std::make_unique<MultiFab>( ba12, dm, 1, IntVect(1,1,1) );
         Tau[lev][TauType::tau13] = std::make_unique<MultiFab>( ba13, dm, 1, IntVect(1,1,1) );
         Tau[lev][TauType::tau23] = std::make_unique<MultiFab>( ba23, dm, 1, IntVect(1,1,1) );
+        Tau[lev][TauType::tau12]->setVal(0.);
+        Tau[lev][TauType::tau13]->setVal(0.);
+        Tau[lev][TauType::tau23]->setVal(0.);
         if (l_use_terrain) {
             Tau[lev][TauType::tau21] = std::make_unique<MultiFab>( ba12, dm, 1, IntVect(1,1,1) );
             Tau[lev][TauType::tau31] = std::make_unique<MultiFab>( ba13, dm, 1, IntVect(1,1,1) );
             Tau[lev][TauType::tau32] = std::make_unique<MultiFab>( ba23, dm, 1, IntVect(1,1,1) );
+            Tau[lev][TauType::tau21]->setVal(0.);
+            Tau[lev][TauType::tau31]->setVal(0.);
+            Tau[lev][TauType::tau32]->setVal(0.);
         } else {
             Tau[lev][TauType::tau21] = nullptr;
             Tau[lev][TauType::tau31] = nullptr;

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.H
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.H
@@ -76,6 +76,11 @@ public:
                amrex::MultiFab* xvel,
                amrex::MultiFab* yvel,
                amrex::MultiFab* zvel,
+               amrex::MultiFab* tau13,
+               amrex::MultiFab* tau23,
+               amrex::MultiFab* hfx3,
+               amrex::MultiFab* qfx3,
+               amrex::MultiFab* eddyDiffs,
                amrex::MultiFab* z_phys);
 
     // Initialize the implementation
@@ -107,7 +112,8 @@ public:
     kokkos_buffers_to_mf ();
 
     // The name of the subcomponent
-    std::string name () const { return "shoc"; }
+    std::string
+    name () const { return "shoc"; }
 
 #ifndef KOKKOS_ENABLE_CUDA
   // Cuda requires methods enclosing __device__ lambda's to be public
@@ -515,21 +521,26 @@ protected:
 #endif
 
     // Update flux (if necessary)
-    void check_flux_state_consistency (const double dt);
+    void
+    check_flux_state_consistency (const double dt);
 
     // Apply TMS drag coeff to shoc_main inputs (if necessary)
-    void apply_turbulent_mountain_stress ();
+    void
+    apply_turbulent_mountain_stress ();
 
 protected:
 
     // SHOC updates the 'tracers' group.
-    void set_computed_group_impl ();
+    void
+    set_computed_group_impl ();
 
     // Computes total number of bytes needed for local variables
-    size_t requested_buffer_size_in_bytes () const;
+    size_t
+    requested_buffer_size_in_bytes () const;
 
     // Set local variables
-    void init_buffers ();
+    void
+    init_buffers ();
 
     // Offsets for MultiFab <-> KOKKOS transfer
     amrex::Vector<int> m_col_offsets;
@@ -560,9 +571,18 @@ protected:
     amrex::MultiFab* m_cons = nullptr;
 
     // Pointer to the FC velocity vars
-    amrex::MultiFab* m_xvel = nullptr;
-    amrex::MultiFab* m_yvel = nullptr;
-    amrex::MultiFab* m_zvel = nullptr;
+    amrex::MultiFab* m_xvel  = nullptr;
+    amrex::MultiFab* m_yvel  = nullptr;
+    amrex::MultiFab* m_zvel  = nullptr;
+
+    // Pointer to the surface stresses
+    amrex::MultiFab* m_tau13 = nullptr;
+    amrex::MultiFab* m_tau23 = nullptr;
+    amrex::MultiFab* m_hfx3  = nullptr;
+    amrex::MultiFab* m_qfx3  = nullptr;
+
+    // Pointer to the diffusion coeffs
+    amrex::MultiFab* m_mu    = nullptr;
 
     // Pointer to the terrain heights
     amrex::MultiFab* m_z_phys = nullptr;

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -82,17 +82,24 @@ SHOCInterface::SHOCInterface (const int& lev,
 
 void
 ERF::compute_shoc_tendencies (int lev,
-                              MultiFab& cons,
-                              MultiFab& xvel,
-                              MultiFab& yvel,
-                              MultiFab& zvel,
+                              MultiFab* cons,
+                              MultiFab* xvel,
+                              MultiFab* yvel,
+                              MultiFab* zvel,
+                              MultiFab* tau13,
+                              MultiFab* tau23,
+                              MultiFab* hfx3,
+                              MultiFab* qfx3,
+                              MultiFab* eddyDiffs,
+                              MultiFab* z_phys_nd,
                               const Real& dt_advance)
 {
     Print() << "Advancing SHOC at level: " << lev << " ...";
 
-    shoc_interface[lev]->set_grids(lev, cons.boxArray(), Geom(lev),
-                                   &cons, &xvel, &yvel, &zvel,
-                                   z_phys_nd[lev].get());
+    shoc_interface[lev]->set_grids(lev, cons->boxArray(), Geom(lev),
+                                   cons , xvel , yvel, zvel,
+                                   tau13, tau23, hfx3, qfx3,
+                                   eddyDiffs, z_phys_nd);
 
     shoc_interface[lev]->initialize_impl();
     shoc_interface[lev]->run_impl(dt_advance);
@@ -110,6 +117,11 @@ SHOCInterface::set_grids (int& level,
                           MultiFab* xvel,
                           MultiFab* yvel,
                           MultiFab* zvel,
+                          MultiFab* tau13,
+                          MultiFab* tau23,
+                          MultiFab* hfx3,
+                          MultiFab* qfx3,
+                          MultiFab* eddyDiffs,
                           MultiFab* z_phys)
 {
     // Set data members that may change
@@ -119,6 +131,11 @@ SHOCInterface::set_grids (int& level,
     m_xvel    = xvel;
     m_yvel    = yvel;
     m_zvel    = zvel;
+    m_tau13   = tau13;
+    m_tau23   = tau23;
+    m_hfx3    = hfx3;
+    m_qfx3    = qfx3;
+    m_mu      = eddyDiffs;
     m_z_phys  = z_phys;
 
     // Ensure the boxes span klo -> khi
@@ -351,9 +368,18 @@ SHOCInterface::mf_to_kokkos_buffers ()
         const int jmin   = vbx.smallEnd(1);
         const int offset = m_col_offsets[mfi.index()];
         const Array4<const Real>& cons_arr = m_cons->const_array(mfi);
+
         const Array4<const Real>& u_arr    = m_xvel->const_array(mfi);
         const Array4<const Real>& v_arr    = m_yvel->const_array(mfi);
         const Array4<const Real>& w_arr    = m_zvel->const_array(mfi);
+
+        const Array4<const Real>& t13_arr   = m_tau13->const_array(mfi);
+        const Array4<const Real>& t23_arr   = m_tau23->const_array(mfi);
+        const Array4<const Real>& hfx3_arr  = m_hfx3->const_array(mfi);
+        const Array4<const Real>& qfx3_arr  = m_qfx3->const_array(mfi);
+
+        const Array4<const Real>& mu_arr    = m_mu->const_array(mfi);
+
         const Array4<const Real>& z_arr    = (m_z_phys) ? m_z_phys->const_array(mfi) :
                                                           Array4<const Real>{};
         ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
@@ -390,18 +416,20 @@ SHOCInterface::mf_to_kokkos_buffers ()
                                          + (z_arr(i  ,j+1,k+1) - z_arr(i  ,j+1,k))
                                          + (z_arr(i+1,j+1,k+1) - z_arr(i+1,j+1,k)) ) : dz;
 
-            // W at cc (cannot be 0)
+            // W at cc (cannot be 0?; inspection of shoc code...)
             Real w_cc = 0.5 * (w_arr(i,j,k) + w_arr(i,j,k+1));
-            Real w_limited = std::copysign(std::max(std::fabs(w_cc),0.001),w_cc);
+            Real w_limited = std::copysign(std::max(std::fabs(w_cc),1.0e-6),w_cc);
 
             // Interface data structures
             //=======================================================
             // Physics functions calculate_vertical_velocity
-            omega_d(icol,ilay)          = w_limited * r * CONST_GRAV;
-            surf_sens_flux_d(icol)      = 0.0;
-            surf_mom_flux_d(icol,0)     = 0.0;
-            surf_mom_flux_d(icol,1)     = 0.0;
-            surf_evap(icol)             = 0.0;
+            omega_d(icol,ilay)           = w_limited * r * CONST_GRAV;
+            if (k==0) {
+                surf_mom_flux_d(icol,0)  = 0.5 * (t13_arr(i,j,k) + t13_arr(i+1,j  ,k));
+                surf_mom_flux_d(icol,1)  = 0.5 * (t23_arr(i,j,k) + t23_arr(i  ,j+1,k));
+                surf_sens_flux_d(icol)   = hfx3_arr(i,j,k);
+                surf_evap(icol)          = (moist) ? qfx3_arr(i,j,k) : 0.0;
+            }
             T_mid_d(icol,ilay)          = getTgivenRandRTh(r, rt, qv);
             qv_d(icol,ilay)             = qv;
             surf_drag_coeff_tms_d(icol) = 0.0;
@@ -412,6 +440,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             p_int_d(icol,ilay)       = getPgivenRTh(rt_avg, qv_avg);
             // Physics functions calculate_density
             pseudo_dens_d(icol,ilay) = r * CONST_GRAV * delz;
+            // Geopotential
             phis_d(icol)             = CONST_GRAV * z;
 
             if (ilay==(nlay-1)) {
@@ -428,8 +457,9 @@ SHOCInterface::mf_to_kokkos_buffers ()
             //=======================================================
             horiz_wind_d(icol,0,ilay)  = 0.5 * (u_arr(i,j,k) + u_arr(i+1,j  ,k));
             horiz_wind_d(icol,1,ilay)  = 0.5 * (v_arr(i,j,k) + v_arr(i  ,j+1,k));
+            // NOTE: Fix me
             sgs_buoy_flux_d(icol,ilay) = 0.0;
-            tk_d(icol,ilay)            = 0.0;
+            tk_d(icol,ilay)            = mu_arr(i,j,k,EddyDiff::Mom_v);
             cldfrac_liq_d(icol,ilay)   = (qc>0.0) ? 1. : 0.;
             tke_d(icol,ilay)           = std::max(cons_arr(i,j,k,RhoKE_comp)/r, 0.0);
             qc_d(icol,ilay)            = qc;
@@ -440,7 +470,87 @@ SHOCInterface::mf_to_kokkos_buffers ()
 
 void
 SHOCInterface::kokkos_buffers_to_mf ()
-{}
+{
+    //
+    // Expose for device capture
+    //
+
+    // Interface data structures
+    //=======================================================
+    auto T_mid_d = T_mid;
+    auto qv_d = qv;
+
+    // Input data structures
+    //=======================================================
+    auto p_mid_d = p_mid;
+
+    // Input/Output data structures
+    //=======================================================
+    auto horiz_wind_d = horiz_wind;
+    //auto sgs_buoy_flux_d = sgs_buoy_flux;
+    auto tk_d = tk;
+    //auto cldfrac_liq_d = cldfrac_liq;
+    auto tke_d = tke;
+    auto qc_d = qc;
+
+    // Output data structures
+    //=======================================================
+    //auto pblh_d = pblh;
+    //auto inv_qc_relvar_d = inv_qc_relvar;
+    auto tkh_d = tkh;
+    //auto w_sec_d = w_sec;
+    //auto cldfrac_liq_prev_d = cldfrac_liq_prev;
+    //auto ustar_d = ustar;
+    //auto obklen_d = obklen;
+
+    bool moist = (m_cons->nComp() > RhoQ1_comp);
+    for (MFIter mfi(*m_cons); mfi.isValid(); ++mfi) {
+        const auto& vbx  = mfi.validbox();
+        const int nx     = vbx.length(0);
+        const int imin   = vbx.smallEnd(0);
+        const int jmin   = vbx.smallEnd(1);
+        const int offset = m_col_offsets[mfi.index()];
+
+        const Array4<Real>& cons_arr = m_cons->array(mfi);
+
+        const Array4<Real>& u_arr    = m_xvel->array(mfi);
+        const Array4<Real>& v_arr    = m_yvel->array(mfi);
+
+        const Array4<Real>& mu_arr   = m_mu->array(mfi);
+
+        ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        {
+            // map [i,j,k] 0-based to [icol, ilay] 0-based
+            const int icol   = (j-jmin)*nx + (i-imin) + offset;
+            const int ilay   = k;
+
+            // Density at CC
+            Real r  = cons_arr(i,j,k,Rho_comp);
+
+            // Theta at CC
+            Real Th = getThgivenTandP(T_mid_d(icol,ilay)[0], p_mid_d(icol,ilay)[0], R_d/Cp_d);
+
+            // Interface data structures
+            //=======================================================
+            if (moist) { cons_arr(i,j,k,RhoQ1_comp) = r * qv_d(icol,ilay)[0]; }
+            cons_arr(i,j,k,RhoTheta_comp) = r * Th;
+
+            // Input/Output data structures
+            //=======================================================
+            // NOTE: Fix averaging for U/V and account for the CC box being looped over
+            u_arr(i,j,k) = horiz_wind_d(icol,0,ilay)[0];
+            v_arr(i,j,k) = horiz_wind_d(icol,1,ilay)[0];
+            mu_arr(i,j,k,EddyDiff::Mom_v) = tk_d(icol,ilay)[0];
+            cons_arr(i,j,k,RhoKE_comp) = std::max(r*tke_d(icol,ilay)[0],0.0);
+            if (moist) { cons_arr(i,j,k,RhoQ2_comp) = r * qc_d(icol,ilay)[0]; }
+
+            // Output data structures
+            //=======================================================
+            mu_arr(i,j,k,EddyDiff::Theta_v) = tkh_d(icol,ilay)[0];
+        });
+    }
+
+}
 
 
 size_t SHOCInterface::requested_buffer_size_in_bytes() const

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -149,7 +149,11 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
     // Update the "old" state using SHOC
     // **************************************************************************************
     if (solverChoice.use_shoc) {
-        compute_shoc_tendencies(lev, S_old, U_old, V_old, W_old, dt_lev);
+        compute_shoc_tendencies(lev, &S_old, &U_old, &V_old, &W_old,
+                                Tau[lev][TauType::tau13].get(), Tau[lev][TauType::tau23].get(),
+                                SFS_hfx3_lev[lev].get()       , SFS_q1fx3_lev[lev].get()      ,
+                                eddyDiffs_lev[lev].get()      , z_phys_nd[lev].get()          ,
+                                dt_lev);
     }
 #endif
 


### PR DESCRIPTION
# Goal
This PR hooks up the variables we may want back from SHOC into the ERF dycore. This ran in debug but there is more work to be done that is outlined below.

## Notes
1. SHOC is now a PBL scheme that requires the use of the TKE equation. 
2. We need to verify all the variables we want back from SHOC.
3. We should understand what and how some vars are updated. For example, is temperature modified from macrophysics and we can use that to get an updated theta (as is done now)? Has implicit vertical diffusion been done for momentum? Do we need to avoid vertical diffusion in our dycore? 
4. Ordering with respect to the turbulent diffusivities. We call SHOC before we compute the turbulent diffusivities so we overwrite what would be copied back into mu_mom/theta_v. This can be fixed easily but we need to answer the above questions first. 