### PR TITLE
Fix Cmake Compile on Perlmutter

### DIFF
--- a/Build/cmake_cuda_perlmutter.sh
+++ b/Build/cmake_cuda_perlmutter.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Example CMake config script for an OSX laptop with OpenMPI
+
+cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
+      -DCMAKE_PREFIX_PATH:PATH=${CUDA_HOME}/../../ \
+      -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DERF_DIM:STRING=3 \
+      -DERF_ENABLE_MPI:BOOL=ON \
+      -DERF_ENABLE_CUDA:BOOL=ON \
+      -DERF_ENABLE_NVHPC:BOOL=ON \
+      -DERF_ENABLE_TESTS:BOOL=ON \
+      -DERF_ENABLE_FCOMPARE:BOOL=ON \
+      -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+      .. && make -j8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,27 @@ if(ERF_ENABLE_MORR_FORT OR ERF_ENABLE_NOAHMP)
 else()
   project(ERF CXX C)
 endif()
+
+# Find NVHPC package and create aliases if needed
+if(ERF_ENABLE_CUDA AND ERF_ENABLE_NVHPC)
+  find_package(NVHPC REQUIRED COMPONENTS MATH CUDA)
+  function(create_cuda_alias nvhpc_target cuda_name)
+    if(TARGET NVHPC::${nvhpc_target} AND NOT TARGET CUDA::${cuda_name})
+      add_library(CUDA::${cuda_name} ALIAS NVHPC::${nvhpc_target})
+      message(STATUS " Created alias: CUDA::${cuda_name} -> NVHPC::${nvhpc_target}")
+    elseif(NOT TARGET NVHPC::${nvhpc_target})
+      message(WARNING "X Cannot create alias CUDA::${cuda_name}: NVHPC::${nvhpc_target} not found")
+  endif()
+  endfunction()
+  create_cuda_alias(CUBLAS cublas)
+  create_cuda_alias(CUBLAS_STATIC cublas_static)
+  create_cuda_alias(CURAND curand)
+  create_cuda_alias(CURAND_STATIC curand_static)
+  create_cuda_alias(CUSPARSE cusparse)
+  create_cuda_alias(CUSPARSE_STATIC cusparse_static)
+endif()
+
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake")
 include(CMakePackageConfigHelpers)
 
@@ -34,6 +55,7 @@ option(ERF_ENABLE_OPENMP "Enable OpenMP" OFF)
 option(ERF_ENABLE_CUDA "Enable CUDA" OFF)
 option(ERF_ENABLE_HIP  "Enable HIP" OFF)
 option(ERF_ENABLE_SYCL "Enable SYCL" OFF)
+option(ERF_ENABLE_NVHPC "Enable NVHPC" OFF)
 
 #Options for NOAH-MP
 option(ERF_ENABLE_NOAHMP "Enable Noah-MP" OFF)


### PR DESCRIPTION
# Issue
On Perlmutter, `NVHPC` provides the math libraries that are often provided by the `CUDAToolkit` --- i.e., curand, cuspares, etc. Since the libraries are not in the default $CUDA_HOME/lib64 location, the cmake build on this system has been failing.


## Solution
1. Find the `NVHPC` package with hints to its location coming from the `cmake_prefix_path = ${CUDA_HOME}/../../`. Note, one can also export `NVHPC_DIR` to achieve the same thing.
2. Modify the `NVHPC::CURAND` targets to have an alias of `CUDA::curand` since amrex sets the latter as the linking library. 
3. Only do the above work if `ERF_ENABLE_CUDA` and `ERF_ENABLE_NVHPC`


## Follow up
The solution provided here (from @jmsexton03) works but we will assess if a more general approach is possible or if a PR to AMReX is warranted.