### PR TITLE
[Hurricane] Hurricane diagnostics

### DIFF
--- a/Docs/sphinx_doc/theory/HindCast.rst
+++ b/Docs/sphinx_doc/theory/HindCast.rst
@@ -23,8 +23,9 @@ This folder contains examples for hurricane simulations from real weather data.
    - For ERA5 data see the README section `here <https://github.com/erf-model/erftools/tree/main/notebooks/era5>`_.
    - For GFS data see the README section `here <https://github.com/erf-model/erftools/tree/main/notebooks/gfs>`_.
 
-2. From the step above, copy the ``Output/HindCastBoundaryDataDir`` directory to the directory
-   where ERF will be run. This is the boundary data for the lateral forcing of large-scale meteorology.
+2. From the step above, copy the `Output/ERA5Data_3D` (`Output/GFSData_3D` for GFS) directory to the directory
+   where ERF will be run. This is the boundary data for the lateral forcing of large-scale meteorology. Set the
+   inputs option `erf.hindcast_boundary_data_dir = ERA5Data_3D`.
 
 3. The Python script also outputs the domain size to be used in the ``inputs`` file for the ERF run.
    For example::
@@ -33,10 +34,10 @@ This folder contains examples for hurricane simulations from real weather data.
        geometry.prob_hi  =   2593434.0  2328015.0 25000.0
 
 4. Copy the initial condition file to the ERF run directory. This can be the first file in the
-   ``HindCastBoundaryDataDir``. It can also be a file that was generated at the same time as the first file in
-   ``HindCastBoundaryDataDir``. For example, the initial condition can be from ERA5 data, but the
+   ``hindcast_boundary_data_dir``. It can also be a file that was generated at the same time as the first file in
+   ``hindcast_boundary_data_dir``. For example, the initial condition can be from ERA5 data, but the
    boundary data can be from GFS data. However, the initial condition and the very first file in
-   ``HindCastBoundaryDataDir`` should correspond to the same date and geographical area.
+   ``hindcast_boundary_data_dir`` should correspond to the same date and geographical area.
 
 5. Run ERF.
 
@@ -66,7 +67,7 @@ The following are the inputs required for hindcast simulations.
     zhi.type = "SlipWall"
 
     // Lateral forcing with reanalysis/forecast data
-    erf.hindcast_boundary_data_dir = "WeatherData"
+    erf.hindcast_boundary_data_dir = "ERA5Data_3D"
     erf.hindcast_lateral_forcing = true
     // Sponge strength
     erf.hindcast_lateral_sponge_strength = 0.3
@@ -80,3 +81,7 @@ The following are the inputs required for hindcast simulations.
     erf.hindcast_zhi_sponge_strength = 0.3
     // Sponge length of 5 km
     erf.hindcast_zhi_sponge_length = 5000.0
+
+    // Coriolis force
+    erf.use_coriolis = true
+    erf.coriolis_3d = true

--- a/Docs/sphinx_doc/theory/HindCast.rst
+++ b/Docs/sphinx_doc/theory/HindCast.rst
@@ -23,9 +23,9 @@ This folder contains examples for hurricane simulations from real weather data.
    - For ERA5 data see the README section `here <https://github.com/erf-model/erftools/tree/main/notebooks/era5>`_.
    - For GFS data see the README section `here <https://github.com/erf-model/erftools/tree/main/notebooks/gfs>`_.
 
-2. From the step above, copy the `Output/ERA5Data_3D` (`Output/GFSData_3D` for GFS) directory to the directory
+2. From the step above, copy the ``Output/ERA5Data_3D`` (``Output/GFSData_3D`` for GFS) directory to the directory
    where ERF will be run. This is the boundary data for the lateral forcing of large-scale meteorology. Set the
-   inputs option `erf.hindcast_boundary_data_dir = ERA5Data_3D`.
+   inputs option ``erf.hindcast_boundary_data_dir = ERA5Data_3D``.
 
 3. The Python script also outputs the domain size to be used in the ``inputs`` file for the ERF run.
    For example::

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -1003,7 +1003,7 @@ struct SolverChoice {
     amrex::Real hindcast_zhi_sponge_strength = -1.0, hindcast_zhi_sponge_length = -1.0;
     bool hindcast_zhi_sponge_damping = false;
 
-    bool io_hurricane_eye_tracker = true;
+    bool io_hurricane_eye_tracker = false;
     amrex::Real hurricane_eye_latitude = -1e10, hurricane_eye_longitude = -1e10;
 };
 #endif

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -599,6 +599,18 @@ struct SolverChoice {
             }
         }
 
+        pp.query("io_hurricane_eye_tracker", io_hurricane_eye_tracker);
+        if(io_hurricane_eye_tracker) {
+            pp.query("hurricane_eye_latitude", hurricane_eye_latitude);
+            pp.query("hurricane_eye_longitude", hurricane_eye_longitude);
+            if(hurricane_eye_latitude == -1e10 or hurricane_eye_longitude == -1e10) {
+                amrex::Abort("ERROR: You are using 'erf.io_hurricane_eye_tracker' to write out the files that track the eye of the hurricane"
+                              " but have not provided the initial location of the eye of the hurricane to be tracked. There has to be two"
+                              " options in the inputs - erf.hurricane_eye_latitude and erf.hurricane_eye_longitude that gives an approximate"
+                              " location of the eye in the initial condition");
+            }
+        }
+
         check_params(max_level);
     }
 
@@ -990,5 +1002,8 @@ struct SolverChoice {
     amrex::Real hindcast_lateral_sponge_strength = -1.0, hindcast_lateral_sponge_length = -1.0;
     amrex::Real hindcast_zhi_sponge_strength = -1.0, hindcast_zhi_sponge_length = -1.0;
     bool hindcast_zhi_sponge_damping = false;
+
+    bool io_hurricane_eye_tracker = true;
+    amrex::Real hurricane_eye_latitude = -1e10, hurricane_eye_longitude = -1e10;
 };
 #endif

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -151,13 +151,24 @@ public:
 
     // Hurricane track line output as VTKPolyline
     amrex::Vector<std::array<amrex::Real, 2>> hurricane_track_xy;
+    amrex::Vector<std::array<amrex::Real, 2>> hurricane_eye_track_xy,
+                                              hurricane_eye_track_latlon,
+                                              hurricane_maxvel_vs_time,
+                                              hurricane_tracker_circle;
     amrex::Vector<amrex::MultiFab> weather_forecast_data_1, weather_forecast_data_2;
     amrex::Vector<amrex::Vector<amrex::MultiFab>> forecast_state_1,
                                                   forecast_state_2,
                                                   forecast_state_interp;
     std::string MakeVTKFilename(int nstep);
+    std::string MakeVTKFilename_TrackerCircle(int nstep);
+    std::string MakeVTKFilename_EyeTracker_xy(int nstep);
+    std::string MakeFilename_EyeTracker_latlon(int nstep);
+    std::string MakeFilename_EyeTracker_maxvel(int nstep);
     void WriteVTKPolyline(const std::string& filename,
                           amrex::Vector<std::array<amrex::Real, 2>>& points_xy);
+
+    void WriteLinePlot(const std::string& filename,
+                       amrex::Vector<std::array<amrex::Real, 2>>& points_xy);
 
     // Initialize multilevel data
     void InitData ();

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -22,6 +22,7 @@
 #include "ERF_ReadFromWRFInput.H"
 #include "ERF_ReadFromWRFBdy.H"
 #endif
+#include "ERF_HurricaneDiagnostics.H"
 
 using namespace amrex;
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -833,6 +833,47 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
             }
         }
     }
+
+    if(solverChoice.io_hurricane_eye_tracker and (nstep == 0 or (nstep+1)%m_plot3d_int_1 == 0)) {
+        int levc=finest_level;
+
+        HurricaneEyeTracker(levc,
+                            geom[levc],
+                            vars_new[levc],
+                            solverChoice.moisture_type,
+                            solverChoice.hindcast_lateral_forcing? &forecast_state_interp[levc] : nullptr,
+                            solverChoice.hurricane_eye_latitude,
+                            solverChoice.hurricane_eye_longitude,
+                            hurricane_eye_track_xy,
+                            hurricane_eye_track_latlon,
+                            hurricane_tracker_circle);
+
+        MultiFab& U_new = vars_new[levc][Vars::xvel];
+        MultiFab& V_new = vars_new[levc][Vars::yvel];
+        MultiFab& W_new = vars_new[levc][Vars::zvel];
+
+        MultiFab mf_cc_vel(grids[levc], dmap[levc], AMREX_SPACEDIM, IntVect(0,0,0));
+        average_face_to_cellcenter(mf_cc_vel,0,{AMREX_D_DECL(&U_new,&V_new,&W_new)},0);
+
+        HurricaneMaxVelTracker(levc,
+                               geom[levc],
+                               mf_cc_vel,
+                               t_new[0],
+                               hurricane_eye_track_xy,
+                               hurricane_maxvel_vs_time);
+
+        std::string filename_tracker = MakeVTKFilename_TrackerCircle(nstep);
+        std::string filename_xy = MakeVTKFilename_EyeTracker_xy(nstep);
+        std::string filename_latlon = MakeFilename_EyeTracker_latlon(nstep);
+        std::string filename_maxvel = MakeFilename_EyeTracker_maxvel(nstep);
+        if (ParallelDescriptor::IOProcessor()) {
+            WriteVTKPolyline(filename_tracker, hurricane_tracker_circle);
+            WriteVTKPolyline(filename_xy, hurricane_eye_track_xy);
+            WriteLinePlot(filename_latlon, hurricane_eye_track_latlon);
+            WriteLinePlot(filename_maxvel, hurricane_maxvel_vs_time);
+        }
+    }
+
 } // post_timestep
 
 // This is called from main.cpp and handles all initialization, whether from start or restart

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -838,8 +838,7 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
     if(solverChoice.io_hurricane_eye_tracker and (nstep == 0 or (nstep+1)%m_plot3d_int_1 == 0)) {
         int levc=finest_level;
 
-        HurricaneEyeTracker(levc,
-                            geom[levc],
+        HurricaneEyeTracker(geom[levc],
                             vars_new[levc],
                             solverChoice.moisture_type,
                             solverChoice.hindcast_lateral_forcing? &forecast_state_interp[levc] : nullptr,
@@ -856,8 +855,7 @@ ERF::post_timestep (int nstep, Real time, Real dt_lev0)
         MultiFab mf_cc_vel(grids[levc], dmap[levc], AMREX_SPACEDIM, IntVect(0,0,0));
         average_face_to_cellcenter(mf_cc_vel,0,{AMREX_D_DECL(&U_new,&V_new,&W_new)},0);
 
-        HurricaneMaxVelTracker(levc,
-                               geom[levc],
+        HurricaneMaxVelTracker(geom[levc],
                                mf_cc_vel,
                                t_new[0],
                                hurricane_eye_track_xy,

--- a/Source/IO/ERF_Write1DProfiles.cpp
+++ b/Source/IO/ERF_Write1DProfiles.cpp
@@ -589,6 +589,82 @@ ERF::MakeVTKFilename(int nstep) {
     return oss.str();
 }
 
+std::string
+ERF::MakeVTKFilename_TrackerCircle(int nstep) {
+    // Ensure output directory exists
+    const std::string dir = "Output_HurricaneTracker/tracker_circle";
+    if (!fs::exists(dir)) {
+        fs::create_directories(dir);
+    }
+
+    // Construct filename with zero-padded step
+    std::ostringstream oss;
+    if(nstep==0){
+        oss << dir << "/hurricane_tracker_circle_" << std::setw(7) << std::setfill('0') << nstep << ".vtk";
+    } else {
+        oss << dir << "/hurricane_tracker_circle_" << std::setw(7) << std::setfill('0') << nstep+1 << ".vtk";
+    }
+
+    return oss.str();
+}
+
+std::string
+ERF::MakeVTKFilename_EyeTracker_xy(int nstep) {
+    // Ensure output directory exists
+    const std::string dir = "Output_HurricaneTracker/xy";
+    if (!fs::exists(dir)) {
+        fs::create_directories(dir);
+    }
+
+    // Construct filename with zero-padded step
+    std::ostringstream oss;
+    if(nstep==0){
+        oss << dir << "/hurricane_track_xy_" << std::setw(7) << std::setfill('0') << nstep << ".vtk";
+    } else {
+        oss << dir << "/hurricane_track_xy_" << std::setw(7) << std::setfill('0') << nstep+1 << ".vtk";
+    }
+
+    return oss.str();
+}
+
+std::string
+ERF::MakeFilename_EyeTracker_latlon(int nstep) {
+    // Ensure output directory exists
+    const std::string dir = "Output_HurricaneTracker/latlon";
+    if (!fs::exists(dir)) {
+        fs::create_directories(dir);
+    }
+
+    // Construct filename with zero-padded step
+    std::ostringstream oss;
+    if(nstep==0){
+        oss << dir << "/hurricane_track_latlon" << std::setw(7) << std::setfill('0') << nstep << ".txt";
+    } else {
+        oss << dir << "/hurricane_track_latlon" << std::setw(7) << std::setfill('0') << nstep+1 << ".txt";
+    }
+
+    return oss.str();
+}
+
+std::string
+ERF::MakeFilename_EyeTracker_maxvel(int nstep) {
+    // Ensure output directory exists
+    const std::string dir = "Output_HurricaneTracker/maxvel";
+    if (!fs::exists(dir)) {
+        fs::create_directories(dir);
+    }
+
+    // Construct filename with zero-padded step
+    std::ostringstream oss;
+    if(nstep==0){
+        oss << dir << "/hurricane_maxvel_" << std::setw(7) << std::setfill('0') << nstep << ".txt";
+    } else {
+        oss << dir << "/hurricane_maxvel_" << std::setw(7) << std::setfill('0') << nstep+1 << ".txt";
+    }
+
+    return oss.str();
+}
+
 void
 ERF::WriteVTKPolyline(const std::string& filename,
                       Vector<std::array<Real, 2>>& points_xy)
@@ -636,3 +712,24 @@ ERF::WriteVTKPolyline(const std::string& filename,
     vtkfile.close();
 }
 
+void
+ERF::WriteLinePlot(const std::string& filename,
+                   Vector<std::array<Real, 2>>& points_xy)
+{
+    std::ofstream ofs(filename);
+    if (!ofs.is_open()) {
+        amrex::Print() << "Error: Could not open file " << filename << " for writing.\n";
+        return;
+    }
+
+    ofs << std::setprecision(10) << std::scientific;
+    ofs << "# x y\n";
+
+    for (const auto& p : points_xy) {
+        ofs << p[0] << " " << p[1] << "\n";
+    }
+
+    ofs.close();
+
+    amrex::Print() << "Line plot data written to " << filename << "\n";
+}

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -61,8 +61,8 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     global_i_min = local_i_min;
     global_j_min = local_j_min;
 
-    ParallelDescriptor::Bcast(&global_i_min, 1, owner_rank);
-    ParallelDescriptor::Bcast(&global_j_min, 1, owner_rank);
+    amrex::ParallelDescriptor::Bcast(&global_i_min, 1, owner_rank);
+    amrex::ParallelDescriptor::Bcast(&global_j_min, 1, owner_rank);
 
     if (rank == 0) {
         amrex::Print() << "Global minimum distance to hurricane eye (k=0): "
@@ -95,8 +95,8 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     // Synchronize to ensure the owner has computed values
     amrex::Gpu::synchronize();
 
-    ParallelDescriptor::Bcast(&eye_lat, 1, owner_rank);
-    ParallelDescriptor::Bcast(&eye_lon, 1, owner_rank);
+    amrex::ParallelDescriptor::Bcast(&eye_lat, 1, owner_rank);
+    amrex::ParallelDescriptor::Bcast(&eye_lon, 1, owner_rank);
 
     const auto dx = geom.CellSizeArray();
     const auto prob_lo = geom.ProbLoArray();

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -1,0 +1,342 @@
+#ifndef ERF_HURRICANE_DIAGNOSTICS_H_
+#define ERF_HURRICANE_DIAGNOSTICS_H_
+
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_ParallelReduce.H>
+#include <limits>
+
+#include "ERF_DataStruct.H"
+
+/**
+ * Routines to compute hurricane diagnostics
+ */
+#include <AMReX.H>
+#include <mpi.h>
+
+//---------------------------------------------------------------------
+// Returns the global minimum distance and corresponding (i,j) indices.
+//--i-------------------------------------------------------------------
+
+// For MPI_MINLOC reduction
+struct {
+    amrex::Real value;
+    int rank;
+    } in, out;
+
+void ComputeGlobalMinLocation(const amrex::Geometry& geom,
+                              const amrex::Vector<amrex::MultiFab>& S_data,
+                              const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                              amrex::Real* d_val_min_ptr,
+                              int* d_i_min_ptr,
+                              int* d_j_min_ptr,
+                              amrex::Real& global_val_min,
+                              int& global_i_min,
+                              int& global_j_min, 
+                              amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                              amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
+{
+    // Host mirrors
+    amrex::Real h_val_min;
+    int h_i_min, h_j_min;
+
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_val_min_ptr, d_val_min_ptr + 1, &h_val_min);
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_i_min_ptr, d_i_min_ptr + 1, &h_i_min);
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_j_min_ptr, d_j_min_ptr + 1, &h_j_min);
+    amrex::Gpu::synchronize();
+
+
+    amrex::Real local_val_min = h_val_min;
+    int local_i_min = h_i_min;
+    int local_j_min = h_j_min;
+
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    in.value = local_val_min;
+    in.rank  = rank;
+
+    // Find rank that holds the global minimum
+    MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MINLOC, MPI_COMM_WORLD);
+
+    global_val_min = out.value;
+    int owner_rank = out.rank;
+
+    // Broadcast the indices from the rank that owns the minimum
+    global_i_min = local_i_min;
+    global_j_min = local_j_min;
+
+    MPI_Bcast(&global_i_min, 1, MPI_INT, owner_rank, MPI_COMM_WORLD);
+    MPI_Bcast(&global_j_min, 1, MPI_INT, owner_rank, MPI_COMM_WORLD);
+
+    if (rank == 0) {
+        amrex::Print() << "Global minimum distance to hurricane eye (k=0): "
+                       << global_val_min << " at (i,j) = ("
+                       << global_i_min << ", " << global_j_min << ")\n";
+    }
+
+    amrex::Gpu::DeviceScalar<amrex::Real> d_eye_lat(0.0), d_eye_lon(0.0);
+
+    amrex::Real* d_eye_lat_ptr = d_eye_lat.dataPtr();
+    amrex::Real* d_eye_lon_ptr = d_eye_lon.dataPtr();
+
+    // On owner_rank, compute eye_lat and eye_lon
+    if (rank == owner_rank) {
+        for (amrex::MFIter mfi(S_data[IntVars::cons]); mfi.isValid(); ++mfi) {
+            const amrex::Box& box = mfi.validbox();
+            const auto latlon_arr = (*forecast_state_at_lev)[4].array(mfi);
+            amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                if (i == global_i_min && j == global_j_min && k == 0) {
+                    *d_eye_lat_ptr = latlon_arr(i,j,k,0);
+                    *d_eye_lon_ptr = latlon_arr(i,j,k,1);
+                }
+            });
+        }
+    }
+
+    amrex::Real eye_lat = d_eye_lat.dataValue();
+    amrex::Real eye_lon = d_eye_lon.dataValue();
+
+    // Synchronize to ensure the owner has computed values
+    amrex::Gpu::synchronize();
+
+    // Broadcast to all ranks
+    MPI_Bcast(&eye_lat, 1, MPI_DOUBLE, owner_rank, MPI_COMM_WORLD);
+    MPI_Bcast(&eye_lon, 1, MPI_DOUBLE, owner_rank, MPI_COMM_WORLD);
+
+    const auto dx = geom.CellSizeArray();
+    const auto prob_lo = geom.ProbLoArray(); 
+
+    amrex::Real eye_x =  prob_lo[0] + (global_i_min+0.5)*dx[0];
+    amrex::Real eye_y =  prob_lo[1] + (global_j_min+0.5)*dx[1];
+ 
+    hurricane_eye_track_xy.push_back({eye_x, eye_y});
+    hurricane_eye_track_latlon.push_back({eye_lat, eye_lon});
+}
+
+void
+HurricaneTrackerCircle (const amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                        amrex::Vector<std::array<amrex::Real, 2>>& hurricane_tracker_circle)
+{
+    // Check that there is at least one eye position
+    if (hurricane_eye_track_xy.empty()) return;
+
+    // Get the last known (x, y) position of the eye
+    const auto [x_last, y_last] = hurricane_eye_track_xy.back();
+
+    // Define circle properties
+    const int n_points = 100;        // number of points on the circle
+    const amrex::Real radius = 200e3; // radius in meters (example: 50 km)
+
+    // Clear previous points and reserve space
+    hurricane_tracker_circle.clear();
+    hurricane_tracker_circle.reserve(n_points);
+
+    // Fill the circle points
+    for (int i = 0; i < n_points; ++i) {
+        amrex::Real theta = 2.0 * M_PI * i / n_points;
+        amrex::Real x = x_last + radius * std::cos(theta);
+        amrex::Real y = y_last + radius * std::sin(theta);
+        hurricane_tracker_circle.push_back({x, y});
+    }
+}
+
+void HurricaneEyeTrackerInitial (const int levc,
+                          const amrex::Geometry& geom,
+                          const amrex::Vector<amrex::MultiFab>& S_data,
+                          MoistureType moisture_type,
+                          const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon,
+                          const amrex::Real& hurricane_eye_latitude,
+                          const amrex::Real& hurricane_eye_longitude)
+{
+    amrex::Gpu::DeviceScalar<amrex::Real> d_val_min(1e10);
+    amrex::Gpu::DeviceScalar<int> d_i_min(-1), d_j_min(-1);
+
+    amrex::Real* d_val_min_ptr = d_val_min.dataPtr();
+    int* d_i_min_ptr = d_i_min.dataPtr();
+    int* d_j_min_ptr = d_j_min.dataPtr();
+
+    for (amrex::MFIter mfi(S_data[IntVars::cons]); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        const auto latlon_arr = (*forecast_state_at_lev)[4].array(mfi);
+
+        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            if (k==0) {
+
+                amrex::Real dlat = latlon_arr(i,j,k,0) - hurricane_eye_latitude;
+                amrex::Real dlon = latlon_arr(i,j,k,1) - hurricane_eye_longitude;
+                amrex::Real dist = std::sqrt(dlat*dlat + dlon*dlon);
+                // Atomic min using device pointer from DeviceVector
+                amrex::Real old = amrex::Gpu::Atomic::Min(&d_val_min_ptr[0], dist);
+                //amrex::Gpu::Atomic::Min(&d_val_min_ptr[0], dist);
+                if (dist < old) {
+                    // We are the new minimum; record indices
+                    d_i_min_ptr[0] = i;
+                    d_j_min_ptr[0] = j;
+                }
+            }
+        });
+    }
+
+    amrex::Real global_val_min;
+    int global_i_min, global_j_min;
+
+    ComputeGlobalMinLocation(geom, S_data, forecast_state_at_lev,
+                             d_val_min_ptr, d_i_min_ptr, d_j_min_ptr,
+                             global_val_min, global_i_min, global_j_min, 
+                             hurricane_eye_track_xy,
+                             hurricane_eye_track_latlon);
+}
+
+void HurricaneEyeTrackerNotInitial (const int levc,
+                          const amrex::Geometry& geom,
+                          const amrex::Vector<amrex::MultiFab>& S_data,
+                          MoistureType moisture_type,
+                          const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
+{
+
+    if (hurricane_eye_track_xy.empty()) {
+        amrex::Print() << "Error: hurricane_eye_track_xy is empty!\n";
+        amrex::Abort("Attempted to access hurricane_eye_track_xy[0]");
+    }
+
+    amrex::Real tmp_x_eye = hurricane_eye_track_xy.back()[0];
+    amrex::Real tmp_y_eye = hurricane_eye_track_xy.back()[1];
+
+    if(amrex::ParallelDescriptor::IOProcessor()){
+        std::cout << "The value of x y are " << tmp_x_eye << " " << tmp_y_eye << std::endl;
+    }
+   
+    amrex::Gpu::DeviceScalar<amrex::Real> d_val_min(1e10);
+    amrex::Gpu::DeviceScalar<int> d_i_min(-1), d_j_min(-1);
+
+    amrex::Real* d_val_min_ptr = d_val_min.dataPtr();
+    int* d_i_min_ptr = d_i_min.dataPtr();
+    int* d_j_min_ptr = d_j_min.dataPtr();
+ 
+    bool use_moisture = (moisture_type != MoistureType::None);
+    const int ncomp = S_data[IntVars::cons].nComp();
+
+    const auto dx = geom.CellSizeArray();
+    const auto prob_lo = geom.ProbLoArray();    
+
+    for (amrex::MFIter mfi(S_data[IntVars::cons]); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        const amrex::Array4<amrex::Real const>& S_arr = S_data[IntVars::cons].const_array(mfi);
+
+        amrex::ParallelFor(box,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+            if(k==0) {
+                amrex::Real x =  prob_lo[0] + (i+0.5)*dx[0];
+                amrex::Real y =  prob_lo[1] + (j+0.5)*dx[1];
+                amrex::Real dist = std::sqrt((x-tmp_x_eye)*(x-tmp_x_eye) + (y-tmp_y_eye)*(y-tmp_y_eye));
+                if(dist < 200e3) {
+                    amrex::Real qv_for_p = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : 0;
+                    const amrex::Real rhotheta = S_arr(i,j,k,RhoTheta_comp);
+                    amrex::Real pressure = getPgivenRTh(rhotheta,qv_for_p);
+                    amrex::Real old = amrex::Gpu::Atomic::Min(&d_val_min_ptr[0], pressure);
+                    //amrex::Gpu::Atomic::Min(&d_val_min_ptr[0], dist);
+                    if (old > pressure) {
+                        // We are the new minimum; record indices
+                        d_i_min_ptr[0] = i;
+                        d_j_min_ptr[0] = j;
+                    }
+                }
+            }
+        });
+    }
+
+    amrex::Real global_val_min;
+    int global_i_min, global_j_min;
+
+    ComputeGlobalMinLocation(geom, S_data, forecast_state_at_lev,
+                             d_val_min_ptr, d_i_min_ptr, d_j_min_ptr,
+                             global_val_min, global_i_min, global_j_min,
+                             hurricane_eye_track_xy,
+                             hurricane_eye_track_latlon);
+}
+
+void HurricaneEyeTracker (const int levc,
+				          const amrex::Geometry& geom,
+                   		  const amrex::Vector<amrex::MultiFab>& S_data,
+                          MoistureType moisture_type,
+                 		  const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                          const amrex::Real& hurricane_eye_latitude,
+                          const amrex::Real& hurricane_eye_longitude,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon,
+                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_tracker_circle)
+{
+    static bool is_start = true;
+    if(is_start){
+        HurricaneEyeTrackerInitial(levc, geom, S_data, moisture_type, 
+                                   forecast_state_at_lev, hurricane_eye_track_xy,
+                                   hurricane_eye_track_latlon, 
+                                   hurricane_eye_latitude, hurricane_eye_longitude);
+        is_start = false;
+    } else {
+        HurricaneEyeTrackerNotInitial(levc, geom, S_data, moisture_type, 
+                                      forecast_state_at_lev, hurricane_eye_track_xy,
+                                      hurricane_eye_track_latlon);
+    }
+    HurricaneTrackerCircle(hurricane_eye_track_xy, hurricane_tracker_circle);
+}
+
+void 
+HurricaneMaxVelTracker(const int levc,
+                       const amrex::Geometry& geom,
+                       const amrex::MultiFab& mf_cc_vel,
+                       const amrex::Real& time,
+                       const amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                       amrex::Vector<std::array<amrex::Real, 2>>& hurricane_maxvel_vs_time) 
+{
+    const int ncomp = AMREX_SPACEDIM;
+
+    amrex::Real* d_val_max_ptr;
+    amrex::Gpu::DeviceVector<amrex::Real> d_val_max(1, -1.0e30);
+    d_val_max_ptr = d_val_max.data();
+
+    const auto [x_last, y_last] = hurricane_eye_track_xy.back();
+    const auto dx = geom.CellSizeArray();
+    const auto prob_lo = geom.ProbLoArray();
+
+    amrex::Real x_eye = x_last;
+    amrex::Real y_eye = y_last;
+
+    for (amrex::MFIter mfi(mf_cc_vel); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        const auto& vel_arr = mf_cc_vel.const_array(mfi);
+
+        amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            amrex::Real x = prob_lo[0] + (i+0.5)*dx[0];
+            amrex::Real y = prob_lo[1] + (j+0.5)*dx[1];
+            amrex::Real dist = std::sqrt((x-x_eye)*(x-x_eye) + 
+                                         (y-y_eye)*(y-y_eye));
+            if(k==1 && dist < 200e3) {
+                amrex::Real velmag = 0.0;
+                for (int comp = 0; comp < ncomp; ++comp) {
+                    amrex::Real vel = vel_arr(i, j, k, comp);
+                    velmag += vel * vel;
+                }
+                velmag = std::sqrt(velmag)*3.6; // km/hr
+                amrex::Gpu::Atomic::Max(&d_val_max_ptr[0], velmag);
+            }
+        });
+    }
+
+    amrex::Gpu::synchronize();
+
+    amrex::Real h_val_max_local = -1.0e30;
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_val_max.begin(), d_val_max.end(), &h_val_max_local);
+
+    amrex::Real h_val_max_global = -1.0e30;
+    MPI_Allreduce(&h_val_max_local, &h_val_max_global, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+
+    amrex::Real time_in_hrs = time / 3600.0;
+    hurricane_maxvel_vs_time.push_back({time_in_hrs, h_val_max_global});
+}
+
+#endif

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -11,7 +11,6 @@
 /**
  * Routines to compute hurricane diagnostics
  */
-#include <AMReX.H>
 
 struct {
     amrex::Real value;

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -43,14 +43,16 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     int local_i_min = h_i_min;
     int local_j_min = h_j_min;
 
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int rank = amrex::ParallelDescriptor::MyProc();
 
     in.value = local_val_min;
     in.rank  = rank;
 
-    // Find rank that holds the global minimum
-    MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MINLOC, MPI_COMM_WORLD);
+    #ifdef AMREX_USE_MPI
+        MPI_Allreduce(&in, &out, 1, MPI_DOUBLE_INT, MPI_MINLOC, MPI_COMM_WORLD);
+    #else
+        out = in;
+    #endif
 
     global_val_min = out.value;
     int owner_rank = out.rank;
@@ -59,8 +61,8 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     global_i_min = local_i_min;
     global_j_min = local_j_min;
 
-    MPI_Bcast(&global_i_min, 1, MPI_INT, owner_rank, MPI_COMM_WORLD);
-    MPI_Bcast(&global_j_min, 1, MPI_INT, owner_rank, MPI_COMM_WORLD);
+    ParallelDescriptor::Bcast(&global_i_min, 1, owner_rank);
+    ParallelDescriptor::Bcast(&global_j_min, 1, owner_rank);
 
     if (rank == 0) {
         amrex::Print() << "Global minimum distance to hurricane eye (k=0): "
@@ -93,9 +95,8 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     // Synchronize to ensure the owner has computed values
     amrex::Gpu::synchronize();
 
-    // Broadcast to all ranks
-    MPI_Bcast(&eye_lat, 1, MPI_DOUBLE, owner_rank, MPI_COMM_WORLD);
-    MPI_Bcast(&eye_lon, 1, MPI_DOUBLE, owner_rank, MPI_COMM_WORLD);
+    ParallelDescriptor::Bcast(&eye_lat, 1, owner_rank);
+    ParallelDescriptor::Bcast(&eye_lon, 1, owner_rank);
 
     const auto dx = geom.CellSizeArray();
     const auto prob_lo = geom.ProbLoArray();
@@ -321,7 +322,12 @@ HurricaneMaxVelTracker(const amrex::Geometry& geom,
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_val_max.begin(), d_val_max.end(), &h_val_max_local);
 
     amrex::Real h_val_max_global = -1.0e30;
-    MPI_Allreduce(&h_val_max_local, &h_val_max_global, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+     #ifdef AMREX_USE_MPI
+        MPI_Allreduce(&h_val_max_local, &h_val_max_global, 1, MPI_DOUBLE, MPI_MAX, MPI_COMM_WORLD);
+        h_val_max_global = h_val_max_local;
+    #else
+        h_val_max_global = h_val_max_local;
+    #endif
 
     amrex::Real time_in_hrs = time / 3600.0;
     hurricane_maxvel_vs_time.push_back({time_in_hrs, h_val_max_global});

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -12,6 +12,10 @@
  * Routines to compute hurricane diagnostics
  */
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 struct {
     amrex::Real value;
     int rank;

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -32,7 +32,7 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
                               int* d_j_min_ptr,
                               amrex::Real& global_val_min,
                               int& global_i_min,
-                              int& global_j_min, 
+                              int& global_j_min,
                               amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
                               amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
 {
@@ -105,11 +105,11 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     MPI_Bcast(&eye_lon, 1, MPI_DOUBLE, owner_rank, MPI_COMM_WORLD);
 
     const auto dx = geom.CellSizeArray();
-    const auto prob_lo = geom.ProbLoArray(); 
+    const auto prob_lo = geom.ProbLoArray();
 
     amrex::Real eye_x =  prob_lo[0] + (global_i_min+0.5)*dx[0];
     amrex::Real eye_y =  prob_lo[1] + (global_j_min+0.5)*dx[1];
- 
+
     hurricane_eye_track_xy.push_back({eye_x, eye_y});
     hurricane_eye_track_latlon.push_back({eye_lat, eye_lon});
 }
@@ -185,7 +185,7 @@ void HurricaneEyeTrackerInitial (const int levc,
 
     ComputeGlobalMinLocation(geom, S_data, forecast_state_at_lev,
                              d_val_min_ptr, d_i_min_ptr, d_j_min_ptr,
-                             global_val_min, global_i_min, global_j_min, 
+                             global_val_min, global_i_min, global_j_min,
                              hurricane_eye_track_xy,
                              hurricane_eye_track_latlon);
 }
@@ -210,19 +210,19 @@ void HurricaneEyeTrackerNotInitial (const int levc,
     if(amrex::ParallelDescriptor::IOProcessor()){
         std::cout << "The value of x y are " << tmp_x_eye << " " << tmp_y_eye << std::endl;
     }
-   
+
     amrex::Gpu::DeviceScalar<amrex::Real> d_val_min(1e10);
     amrex::Gpu::DeviceScalar<int> d_i_min(-1), d_j_min(-1);
 
     amrex::Real* d_val_min_ptr = d_val_min.dataPtr();
     int* d_i_min_ptr = d_i_min.dataPtr();
     int* d_j_min_ptr = d_j_min.dataPtr();
- 
+
     bool use_moisture = (moisture_type != MoistureType::None);
     const int ncomp = S_data[IntVars::cons].nComp();
 
     const auto dx = geom.CellSizeArray();
-    const auto prob_lo = geom.ProbLoArray();    
+    const auto prob_lo = geom.ProbLoArray();
 
     for (amrex::MFIter mfi(S_data[IntVars::cons]); mfi.isValid(); ++mfi) {
         const amrex::Box& box = mfi.validbox();
@@ -260,10 +260,10 @@ void HurricaneEyeTrackerNotInitial (const int levc,
 }
 
 void HurricaneEyeTracker (const int levc,
-				          const amrex::Geometry& geom,
-                   		  const amrex::Vector<amrex::MultiFab>& S_data,
+                          const amrex::Geometry& geom,
+                             const amrex::Vector<amrex::MultiFab>& S_data,
                           MoistureType moisture_type,
-                 		  const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                           const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
                           const amrex::Real& hurricane_eye_latitude,
                           const amrex::Real& hurricane_eye_longitude,
                           amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
@@ -272,26 +272,26 @@ void HurricaneEyeTracker (const int levc,
 {
     static bool is_start = true;
     if(is_start){
-        HurricaneEyeTrackerInitial(levc, geom, S_data, moisture_type, 
+        HurricaneEyeTrackerInitial(levc, geom, S_data, moisture_type,
                                    forecast_state_at_lev, hurricane_eye_track_xy,
-                                   hurricane_eye_track_latlon, 
+                                   hurricane_eye_track_latlon,
                                    hurricane_eye_latitude, hurricane_eye_longitude);
         is_start = false;
     } else {
-        HurricaneEyeTrackerNotInitial(levc, geom, S_data, moisture_type, 
+        HurricaneEyeTrackerNotInitial(levc, geom, S_data, moisture_type,
                                       forecast_state_at_lev, hurricane_eye_track_xy,
                                       hurricane_eye_track_latlon);
     }
     HurricaneTrackerCircle(hurricane_eye_track_xy, hurricane_tracker_circle);
 }
 
-void 
+void
 HurricaneMaxVelTracker(const int levc,
                        const amrex::Geometry& geom,
                        const amrex::MultiFab& mf_cc_vel,
                        const amrex::Real& time,
                        const amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
-                       amrex::Vector<std::array<amrex::Real, 2>>& hurricane_maxvel_vs_time) 
+                       amrex::Vector<std::array<amrex::Real, 2>>& hurricane_maxvel_vs_time)
 {
     const int ncomp = AMREX_SPACEDIM;
 
@@ -313,7 +313,7 @@ HurricaneMaxVelTracker(const int levc,
         amrex::ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             amrex::Real x = prob_lo[0] + (i+0.5)*dx[0];
             amrex::Real y = prob_lo[1] + (j+0.5)*dx[1];
-            amrex::Real dist = std::sqrt((x-x_eye)*(x-x_eye) + 
+            amrex::Real dist = std::sqrt((x-x_eye)*(x-x_eye) +
                                          (y-y_eye)*(y-y_eye));
             if(k==1 && dist < 200e3) {
                 amrex::Real velmag = 0.0;

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -12,7 +12,6 @@
  * Routines to compute hurricane diagnostics
  */
 #include <AMReX.H>
-#include <mpi.h>
 
 struct {
     amrex::Real value;

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -14,11 +14,6 @@
 #include <AMReX.H>
 #include <mpi.h>
 
-//---------------------------------------------------------------------
-// Returns the global minimum distance and corresponding (i,j) indices.
-//--i-------------------------------------------------------------------
-
-// For MPI_MINLOC reduction
 struct {
     amrex::Real value;
     int rank;
@@ -36,7 +31,6 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
                               amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
                               amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
 {
-    // Host mirrors
     amrex::Real h_val_min;
     int h_i_min, h_j_min;
 
@@ -44,7 +38,6 @@ void ComputeGlobalMinLocation(const amrex::Geometry& geom,
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_i_min_ptr, d_i_min_ptr + 1, &h_i_min);
     amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_j_min_ptr, d_j_min_ptr + 1, &h_j_min);
     amrex::Gpu::synchronize();
-
 
     amrex::Real local_val_min = h_val_min;
     int local_i_min = h_i_min;

--- a/Source/Utils/ERF_HurricaneDiagnostics.H
+++ b/Source/Utils/ERF_HurricaneDiagnostics.H
@@ -141,15 +141,13 @@ HurricaneTrackerCircle (const amrex::Vector<std::array<amrex::Real, 2>>& hurrica
     }
 }
 
-void HurricaneEyeTrackerInitial (const int levc,
-                          const amrex::Geometry& geom,
-                          const amrex::Vector<amrex::MultiFab>& S_data,
-                          MoistureType moisture_type,
-                          const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
-                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
-                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon,
-                          const amrex::Real& hurricane_eye_latitude,
-                          const amrex::Real& hurricane_eye_longitude)
+void HurricaneEyeTrackerInitial (const amrex::Geometry& geom,
+                                 const amrex::Vector<amrex::MultiFab>& S_data,
+                                 const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                                 amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                                 amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon,
+                                 const amrex::Real& hurricane_eye_latitude,
+                                 const amrex::Real& hurricane_eye_longitude)
 {
     amrex::Gpu::DeviceScalar<amrex::Real> d_val_min(1e10);
     amrex::Gpu::DeviceScalar<int> d_i_min(-1), d_j_min(-1);
@@ -190,13 +188,12 @@ void HurricaneEyeTrackerInitial (const int levc,
                              hurricane_eye_track_latlon);
 }
 
-void HurricaneEyeTrackerNotInitial (const int levc,
-                          const amrex::Geometry& geom,
-                          const amrex::Vector<amrex::MultiFab>& S_data,
-                          MoistureType moisture_type,
-                          const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
-                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
-                          amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
+void HurricaneEyeTrackerNotInitial (const amrex::Geometry& geom,
+                                    const amrex::Vector<amrex::MultiFab>& S_data,
+                                    MoistureType moisture_type,
+                                    const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                                    amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
+                                    amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_latlon)
 {
 
     if (hurricane_eye_track_xy.empty()) {
@@ -259,11 +256,10 @@ void HurricaneEyeTrackerNotInitial (const int levc,
                              hurricane_eye_track_latlon);
 }
 
-void HurricaneEyeTracker (const int levc,
-                          const amrex::Geometry& geom,
-                             const amrex::Vector<amrex::MultiFab>& S_data,
+void HurricaneEyeTracker (const amrex::Geometry& geom,
+                          const amrex::Vector<amrex::MultiFab>& S_data,
                           MoistureType moisture_type,
-                           const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
+                          const amrex::Vector<amrex::MultiFab>* forecast_state_at_lev,
                           const amrex::Real& hurricane_eye_latitude,
                           const amrex::Real& hurricane_eye_longitude,
                           amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,
@@ -272,13 +268,13 @@ void HurricaneEyeTracker (const int levc,
 {
     static bool is_start = true;
     if(is_start){
-        HurricaneEyeTrackerInitial(levc, geom, S_data, moisture_type,
+        HurricaneEyeTrackerInitial(geom, S_data,
                                    forecast_state_at_lev, hurricane_eye_track_xy,
                                    hurricane_eye_track_latlon,
                                    hurricane_eye_latitude, hurricane_eye_longitude);
         is_start = false;
     } else {
-        HurricaneEyeTrackerNotInitial(levc, geom, S_data, moisture_type,
+        HurricaneEyeTrackerNotInitial(geom, S_data, moisture_type,
                                       forecast_state_at_lev, hurricane_eye_track_xy,
                                       hurricane_eye_track_latlon);
     }
@@ -286,8 +282,7 @@ void HurricaneEyeTracker (const int levc,
 }
 
 void
-HurricaneMaxVelTracker(const int levc,
-                       const amrex::Geometry& geom,
+HurricaneMaxVelTracker(const amrex::Geometry& geom,
                        const amrex::MultiFab& mf_cc_vel,
                        const amrex::Real& time,
                        const amrex::Vector<std::array<amrex::Real, 2>>& hurricane_eye_track_xy,

--- a/Source/Utils/Make.package
+++ b/Source/Utils/Make.package
@@ -16,6 +16,8 @@ CEXE_headers += ERF_MoistUtils.H
 CEXE_headers += ERF_SatMethods.H
 CEXE_headers += ERF_WaterVaporSaturation.H
 CEXE_headers += ERF_DirectionSelector.H
+CEXE_headers += ERF_StormDiagnostics.H
+CEXE_headers += ERF_HurricaneDiagnostics.H
 
 CEXE_sources += ERF_AverageDown.cpp
 CEXE_sources += ERF_ChopGrids.cpp


### PR DESCRIPTION
This PR adds routines for hurricane diagnostics such as hurricane track (in both xy and lat-lon formats), max wind speed and the tracking circle. The following options are needed for the diagnostics to be written.
```
erf.hurricane_eye_tracker = true
erf.hurricane_eye_latitude = 29.5; # deg N
erf.hurricane_eye_longitude = -72.0; # deg W
```
The user has to specify an approximate location of the hurricane eye for the initial condition in latitude-longitude format. The output is written (with the same frequency as the plotfiles) into a folder `Output_HurricaneTracker` that has 4 folders:
 
`latlon` - contains the hurricane eye track in latitude-longitude format
`maxvel` - contains the max wind speed of the hurricane with time
`tracker_circle` - contains the circle that tracks the hurricane (centered at the eye with 200 km radius)
`xy` - contains the hurricane eye track in xy format


The animation below shows the tracking of hurricane Henri for 3 days. The tracking circle, eye track and NOAA forecast cone are shown. The images show the comparison of tracks between ERF, WRF and the actual track, and the max wind speed comparison.

![output-ezgif com-crop (1)](https://github.com/user-attachments/assets/a2a54eb2-879b-4422-9d97-609a4ffbad92) <img width="426" height="349" alt="image" src="https://github.com/user-attachments/assets/5914f868-e3bb-4f6b-a084-83b882a4bef7" />

<img width="846" height="334" alt="Screen Shot 2025-10-10 at 12 53 55 PM" src="https://github.com/user-attachments/assets/82c368e5-a6bf-4d7f-897c-bb87a94523dd" />
