### PR TITLE
Add `erf.most.ignore_sst` option

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -223,6 +223,10 @@ public:
       } else {
           amrex::Abort("Undefined MOST roughness type for sea!");
       }
+
+      // use skin temperature instead of sea-surface temperature
+      // (wrfinput data may have lower resolution SST data)
+      pp.query("most.ignore_sst", m_ignore_sst);
   } // constructor
 
   void make_SurfaceLayer_at_level (const int& lev,
@@ -410,9 +414,22 @@ public:
           // extended lambda capture) Note that land temp will be set from m_tsk_lev
           //      while sea temp will be set from m_sst_lev
           theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
+
+          // Pathways in fill_tsurf_with_sst_and_tsk
+          bool use_tsk = (m_tsk_lev[lev][0]);
+          amrex::Print() << "Using MOST with specified surface temperature ";
+          if (use_tsk) {
+              amrex::Print() << "(land: TSK, ";
+          } else {
+              amrex::Print() << "(land: T0, ";
+          }
+          if (use_tsk && m_ignore_sst) {
+              amrex::Print() << "sea: TSK)" << std::endl;
+          } else {
+              amrex::Print() << "sea: SST)" << std::endl;
+              AMREX_ALWAYS_ASSERT(m_sst_lev[lev][0]);
+          }
       }
-
-
   }
 
   void
@@ -622,6 +639,8 @@ private:
   bool use_moisture;
   bool m_has_lsm_tsurf  = false;
   int  m_lsm_tsurf_indx = -1;
+
+  bool m_ignore_sst = false;
 
   MOSTAverage m_ma;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> u_star;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -543,6 +543,7 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
     Real lst = default_land_surf_temp;
 
     bool use_tsk = (m_tsk_lev[lev][0]);
+    bool ignore_sst = m_ignore_sst;
 
     // Populate t_surf
     for (MFIter mfi(*t_surf[lev]); mfi.isValid(); ++mfi)
@@ -562,7 +563,7 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
             ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 int is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
-                if (!is_land && !m_ignore_sst) {
+                if (!is_land && !ignore_sst) {
                     t_surf_arr(i,j,k) = oma   * sst_lo_arr(i,j,k)
                                       + alpha * sst_hi_arr(i,j,k);
                 } else {

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -562,7 +562,7 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
             ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 int is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
-                if (!is_land) {
+                if (!is_land && !m_ignore_sst) {
                     t_surf_arr(i,j,k) = oma   * sst_lo_arr(i,j,k)
                                       + alpha * sst_hi_arr(i,j,k);
                 } else {


### PR DESCRIPTION
When using `erf.init_type = wrfinput` to initialize ERF from existing WRF data, the `SST` field in wrfinput_d0* may be lower resolution than `TSK` and—worse yet—have zeros in locations where `LANDMASK==0`.  Not surprisingly, this can lead to nonphysical results.

This option gives a workaround, to use the `TSK` field to set the surface temperature on land and water (assuming `TSK` is valid everywhere).