### PR TITLE
Add many more plot2d vars; new `erf.init_tke_from_ustar` param

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -429,6 +429,50 @@ Output Options for 3D plotfiles
 |                             |                  |
 +-----------------------------+------------------+
 
+
+Output Options for 3D plotfiles
+-------------------------------
+
++-------------------+----------------------------+
+| Parameter         | Definition                 |
+|                   |                            |
++===================+============================+
+| **z_surf**        | Surface elevation          |
++-------------------+----------------------------+
+| **landmask**      | Land-sea mask              |
+|                   | (land=1, sea=0)            |
++-------------------+----------------------------+
+| **mapfac**        | Map factors                |
++-------------------+----------------------------+
+| **lat_m**         | Latitude (at unstaggered   |
+|                   | "mass" points)             |
++-------------------+----------------------------+
+| **u_star**        | Friction velocity          |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **t_star**        | Temperature scale          |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **q_star**        | Humidity scale             |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **Olen**          | Obukhov length             |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **pblh**          | Diagnosed PBL height       |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **t_surf**        | Surface temperature        |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **q_surf**        | Surface humidity           |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+| **z0**            | Roughness height           |
+|                   | (with SurfaceLayer only)   |
++-------------------+----------------------------+
+
+
 Examples of Usage
 -----------------
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -447,6 +447,12 @@ public:
                        const FluxIter& most_flux,
                        bool is_land);
 
+  void init_tke_from_ustar (const int& lev,
+                            amrex::MultiFab& cons,
+                            const std::unique_ptr<amrex::MultiFab>& z_phys_cc,
+                            const amrex::Real tkefac = 1.0,
+                            const amrex::Real zi = 700.0);
+
   void impose_SurfaceLayer_bcs (const int& lev,
                                 amrex::Vector<const amrex::MultiFab*> mfs,
                                 amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -449,9 +449,9 @@ public:
 
   void init_tke_from_ustar (const int& lev,
                             amrex::MultiFab& cons,
-                            const std::unique_ptr<amrex::MultiFab>& z_phys_cc,
+                            const std::unique_ptr<amrex::MultiFab>& z_phys_nd,
                             const amrex::Real tkefac = 1.0,
-                            const amrex::Real zi = 700.0);
+                            const amrex::Real zscale = 700.0);
 
   void impose_SurfaceLayer_bcs (const int& lev,
                                 amrex::Vector<const amrex::MultiFab*> mfs,

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -237,11 +237,14 @@ SurfaceLayer::compute_fluxes (const int& lev,
                 (!is_land && lmask_arr(i,j,k) == 0))
             {
                 most_flux.iterate_flux(i, j, k, max_iters,
-                                       z0_arr, umm_arr, tm_arr, tvm_arr, qvm_arr,
-                                       u_star_arr, w_star_arr,           // to be updated
-                                       t_star_arr, q_star_arr,           // to be updated
-                                       t_surf_arr, q_surf_arr, olen_arr, // to be updated
-                                       pblh_arr, Hwave_arr, Lwave_arr, eta_arr);
+                                       z0_arr,                              // updated if(!is_land)
+                                       umm_arr, tm_arr, tvm_arr, qvm_arr,
+                                       u_star_arr,                          // updated
+                                       w_star_arr,                          // updated if(m_include_wstar)
+                                       t_star_arr, q_star_arr,              // updated
+                                       t_surf_arr, q_surf_arr, olen_arr,    // updated
+                                       pblh_arr,                            // updated if(m_include_wstar)
+                                       Hwave_arr, Lwave_arr, eta_arr);
             }
         });
     }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -698,9 +698,9 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
 
     constexpr Real small = 0.01;
 
-    for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+    for (MFIter mfi(cons); mfi.isValid(); ++mfi)
     {
-        Box gtbx = mfi.growntilebox();
+        Box gtbx = mfi.tilebox();
 
         auto const& u_star_arr = u_star[lev]->const_array(mfi);
         auto const& z_phys_arr = z_phys_nd->const_array(mfi);

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -687,9 +687,9 @@ SurfaceLayer::compute_pblh (const int& lev,
 void
 SurfaceLayer::init_tke_from_ustar (const int& lev,
                                    MultiFab& cons,
-                                   const std::unique_ptr<MultiFab>& z_phys_cc,
+                                   const std::unique_ptr<MultiFab>& z_phys_nd,
                                    const Real tkefac,
-                                   const Real zi)
+                                   const Real zscale)
 {
     Print() << "Initializing TKE from surface layer ustar on level " << lev << std::endl;
 
@@ -709,10 +709,12 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
             Real rho = cons_arr(i, j, k, Rho_comp);
             Real ust = u_star_arr(i, j, 0);
             Real tke0 = tkefac * ust * ust; // surface value
+            Real zagl = Compute_Zrel_AtCellCenter(i, j, k, z_phys_arr);
 
-            // linearly tapering profile
+            // linearly tapering profile --  following WRF, approximate top of
+            // PBL as ustar * zscale
             cons_arr(i, j, k, RhoKE_comp) = rho * tke0 * std::max(
-                (ust * zi - z_phys_arr(i,j,k)) / (std::max(ust, small) * zi),
+                (ust * zscale - zagl) / (std::max(ust, small) * zscale),
                 small);
         });
     }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -685,6 +685,41 @@ SurfaceLayer::compute_pblh (const int& lev,
 }
 
 void
+SurfaceLayer::init_tke_from_ustar (const int& lev,
+                                   MultiFab& cons,
+                                   const std::unique_ptr<MultiFab>& z_phys_cc,
+                                   const Real tkefac,
+                                   const Real zi)
+{
+    Print() << "Initializing TKE from surface layer ustar on level " << lev << std::endl;
+
+    constexpr Real small = 0.01;
+
+    for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+    {
+        Box gtbx = mfi.growntilebox();
+
+        auto const& u_star_arr = u_star[lev]->const_array(mfi);
+        auto const& z_phys_arr = z_phys_cc->const_array(mfi);
+
+        auto const& cons_arr   = cons.array(mfi);
+
+        ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        {
+            Real rho = cons_arr(i, j, k, Rho_comp);
+            Real ust = u_star_arr(i, j, 0);
+            Real tke0 = tkefac * ust * ust; // surface value
+
+            // linearly tapering profile
+            cons_arr(i, j, k, RhoKE_comp) = rho * tke0 * std::max(
+                (ust * zi - z_phys_arr(i,j,k)) / (std::max(ust, small) * zi),
+                small);
+        });
+    }
+}
+
+
+void
 SurfaceLayer::read_custom_roughness (const int& lev,
                                      const std::string& fname)
 {

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -700,7 +700,7 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
         Box gtbx = mfi.growntilebox();
 
         auto const& u_star_arr = u_star[lev]->const_array(mfi);
-        auto const& z_phys_arr = z_phys_cc->const_array(mfi);
+        auto const& z_phys_arr = z_phys_nd->const_array(mfi);
 
         auto const& cons_arr   = cons.array(mfi);
 

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -202,6 +202,10 @@ public:
        (pbl_type == PBLType::MYJ)       || (pbl_type == PBLType::MYNN25) ||
        (pbl_type == PBLType::MYNNEDMF)  || (pbl_type == PBLType::SHOC));
 
+    if (use_tke) {
+        query_one_or_per_level(pp, "init_tke_from_ustar", init_tke_from_ustar, lev, max_level);
+    }
+
     // Validate inputs
     if (les_type == LESType::Smagorinsky) {
       if (Cs == 0) {
@@ -379,7 +383,7 @@ public:
   PBLType pbl_type;
 
   MYNNLevel25 pbl_mynn;
-  MYNNLevel2 pbl_mynn_level2; // for filtering
+  MYNNLevel2 pbl_mynn_level2; // limiting in the decaying turbulence regime
 
   // Common Flags
   bool use_kturb = false; // Any turbulence modeling?
@@ -387,8 +391,13 @@ public:
     false; // Any microscale turbulence modeling (LES, RANS) with TKE closure?
            // Then need to populate SmnSmn_lev for production term.
   bool use_pbl_tke =
-    false; // Any mesoscale  turbulence modeling (PBL) with TKE closure?
+    false; // Any mesoscale turbulence modeling (PBL) with TKE closure?
   bool use_tke = false; // Any TKE closure (meso or microscale)?
+
+  // Initialize TKE/QKE with linear profiles whose surface values are a
+  // function of the friction velocity calculated by the surface layer scheme
+  // (e.g., as done in MYNN-EDMF)
+  bool init_tke_from_ustar = false;
 
   // Model coefficients - YSU
   // TODO: Add parmparse for all of these above

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -699,6 +699,7 @@ private:
 
     // set which variables and derived quantities go into plotfiles
     void setPlotVariables (const std::string& pp_plot_var_names, amrex::Vector<std::string>& plot_var_names);
+    void setPlotVariables2D (const std::string& pp_plot_var_names, amrex::Vector<std::string>& plot_var_names);
     // append variables to plot
     void appendPlotVariables (const std::string& pp_plot_var_names, amrex::Vector<std::string>& plot_var_names);
 
@@ -1120,6 +1121,13 @@ private:
 #endif
                                                     ,"qsrc_sw", "qsrc_lw"
                                                    };
+
+    // **************************************************************************************
+    // NOTE: The order of variable names here **MUST MATCH THE ORDER** in IO/ERF_Plotfile.cpp
+    // **************************************************************************************
+    const amrex::Vector<std::string> derived_names_2d {
+        "mapfac", "lat_m", "lon_m"
+    };
 
     // algorithm choices
     static SolverChoice solverChoice;

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -1126,7 +1126,7 @@ private:
     // NOTE: The order of variable names here **MUST MATCH THE ORDER** in IO/ERF_Plotfile.cpp
     // **************************************************************************************
     const amrex::Vector<std::string> derived_names_2d {
-        "mapfac", "lat_m", "lon_m"
+        "z_surf", "mapfac", "lat_m", "lon_m"
     };
 
     // algorithm choices

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -1126,7 +1126,9 @@ private:
     // NOTE: The order of variable names here **MUST MATCH THE ORDER** in IO/ERF_Plotfile.cpp
     // **************************************************************************************
     const amrex::Vector<std::string> derived_names_2d {
-        "z_surf", "mapfac", "lat_m", "lon_m"
+        "z_surf", "landmask", "mapfac", "lat_m", "lon_m",
+        "u_star", "w_star", "t_star", "q_star", "Olen", "pblh",
+        "t_surf", "q_surf", "z0"
     };
 
     // algorithm choices

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -209,8 +209,8 @@ ERF::ERF_shared ()
 
     const std::string& pv3d_1 = "plot_vars_1"  ; setPlotVariables(pv3d_1,plot3d_var_names_1);
     const std::string& pv3d_2 = "plot_vars_2"  ; setPlotVariables(pv3d_2,plot3d_var_names_2);
-    const std::string& pv2d_1 = "plot2d_vars_1"; setPlotVariables(pv2d_1,plot2d_var_names_1);
-    const std::string& pv2d_2 = "plot2d_vars_2"; setPlotVariables(pv2d_2,plot2d_var_names_2);
+    const std::string& pv2d_1 = "plot2d_vars_1"; setPlotVariables2D(pv2d_1,plot2d_var_names_1);
+    const std::string& pv2d_2 = "plot2d_vars_2"; setPlotVariables2D(pv2d_2,plot2d_var_names_2);
 
     // This is only used when we have mesh_type == MeshType::StretchedDz
     stretched_dz_h.resize(nlevs_max);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1561,7 +1561,7 @@ ERF::InitData_post ()
                         const Real B1 = solverChoice.turbChoice[lev].pbl_mynn.B1;
                         qkefac = 1.5 * std::pow(B1, 2.0/3.0);
                     }
-                    m_SurfaceLayer->init_tke_from_ustar(lev, vars_new[lev][Vars::cons], z_phys_cc[lev], qkefac);
+                    m_SurfaceLayer->init_tke_from_ustar(lev, vars_new[lev][Vars::cons], z_phys_nd[lev], qkefac);
                 }
             }
         }

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1550,6 +1550,19 @@ ERF::InitData_post ()
                 m_SurfaceLayer->update_pblh(lev, vars_new, z_phys_cc[lev].get(),
                                             solverChoice.moisture_indices);
                 m_SurfaceLayer->update_fluxes(lev, time, vars_new[lev][Vars::cons], z_phys_nd[lev]);
+
+                // Initialize tke(x,y,z) as a function of u*(x,y)
+                if (solverChoice.turbChoice[lev].init_tke_from_ustar) {
+                    Real qkefac = 1.0;
+                    if (solverChoice.turbChoice[lev].pbl_type == PBLType::MYNN25 ||
+                        solverChoice.turbChoice[lev].pbl_type == PBLType::MYNNEDMF)
+                    {
+                        // https://github.com/NCAR/MYNN-EDMF/blob/90f36c25259ec1960b24325f5b29ac7c5adeac73/module_bl_mynnedmf.F90#L1325-L1333
+                        const Real B1 = solverChoice.turbChoice[lev].pbl_mynn.B1;
+                        qkefac = 1.5 * std::pow(B1, 2.0/3.0);
+                    }
+                    m_SurfaceLayer->init_tke_from_ustar(lev, vars_new[lev][Vars::cons], z_phys_cc[lev], qkefac);
+                }
             }
         }
     } // end if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::surface_layer)

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1949,6 +1949,22 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             mf_comp++;
         }
 
+        if (containerHasElement(plot_var_names, "landmask")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                const Array4<Real>& derdat = mf[lev].array(mfi);
+                const Array4<const int>& lmask_arr = lmask_lev[lev][0]->const_array(mfi);
+                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                   derdat(i, j, k, mf_comp) = lmask_arr(i, j, 0);
+                });
+            }
+            mf_comp++;
+        }
+
         if (containerHasElement(plot_var_names, "mapfac")) {
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -2004,9 +2020,189 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             mf_comp++;
 
         } // lon_m
-    }
 
-    // mf[0].setVal(1.0);
+        ///////////////////////////////////////////////////////////////////////
+        // These quantities are diagnosed by the surface layer
+        if (containerHasElement(plot_var_names, "u_star")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_u_star(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // ustar
+
+        if (containerHasElement(plot_var_names, "w_star")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_w_star(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // wstar
+
+        if (containerHasElement(plot_var_names, "t_star")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_t_star(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // tstar
+
+        if (containerHasElement(plot_var_names, "q_star")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_q_star(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // qstar
+
+        if (containerHasElement(plot_var_names, "Olen")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_olen(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // Olen
+
+        if (containerHasElement(plot_var_names, "pblh")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_pblh(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // pblh
+
+        if (containerHasElement(plot_var_names, "t_surf")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_t_surf(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // tsurf
+
+        if (containerHasElement(plot_var_names, "q_surf")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_q_surf(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // qsurf
+
+        if (containerHasElement(plot_var_names, "z0")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& ustar  = m_SurfaceLayer->get_z0(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // z0
+    } // lev
 
     std::string plotfilename;
     if (which == 1) {

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1,6 +1,7 @@
 #include "ERF.H"
 #include "ERF_SrcHeaders.H"
 #include "ERF_StormDiagnostics.H"
+#include "ERF_TerrainMetrics.H"
 
 using namespace amrex;
 
@@ -1931,6 +1932,22 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 
         // Set all components to zero in case they aren't defined below
         mf[lev].setVal(0.0);
+
+        if (containerHasElement(plot_var_names, "z_surf")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                const Array4<Real>& derdat = mf[lev].array(mfi);
+                const Array4<const Real>& z_phys_arr = z_phys_nd[lev]->const_array(mfi);
+                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                   derdat(i, j, k, mf_comp) = Compute_Z_AtWFace(i, j, 0, z_phys_arr);
+                });
+            }
+            mf_comp++;
+        }
 
         if (containerHasElement(plot_var_names, "mapfac")) {
 #ifdef _OPENMP

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -177,6 +177,49 @@ ERF::setPlotVariables (const std::string& pp_plot_var_names, Vector<std::string>
         }
     }
 #endif
+
+    plot_var_names = tmp_plot_names;
+}
+
+void
+ERF::setPlotVariables2D (const std::string& pp_plot_var_names, Vector<std::string>& plot_var_names)
+{
+    ParmParse pp(pp_prefix);
+
+    if (pp.contains(pp_plot_var_names.c_str()))
+    {
+        std::string nm;
+
+        int nPltVars = pp.countval(pp_plot_var_names.c_str());
+
+        for (int i = 0; i < nPltVars; i++)
+        {
+            pp.get(pp_plot_var_names.c_str(), nm, i);
+
+            // Add the named variable to our list of plot variables
+            // if it is not already in the list
+            if (!containerHasElement(plot_var_names, nm)) {
+                plot_var_names.push_back(nm);
+            }
+        }
+    } else {
+        //
+        // The default is to add none of the variables to the list
+        //
+        plot_var_names.clear();
+    }
+
+    // Get state variables in the same order as we define them,
+    // since they may be in any order in the input list
+    Vector<std::string> tmp_plot_names;
+
+    // 2D plot variables
+    for (int i = 0; i < derived_names_2d.size(); ++i) {
+        if (containerHasElement(plot_var_names, derived_names_2d[i]) ) {
+            tmp_plot_names.push_back(derived_names_2d[i]);
+        }
+    }
+
     plot_var_names = tmp_plot_names;
 }
 

--- a/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
@@ -219,15 +219,17 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             Real qe2 = mynn.B1 * Lm*Lm * SM2 * (1.0-Rf) * shearProd;
             Real qe  = (qe2 < 0.0) ? 0.0 : std::sqrt(qe2);
 
-            // Level 2 limiting (Helfand and Labraga 1988)
+            // Level 2 limiting intrdocued by Helfand and Labraga 1988 (NN09, Eqn. 42)
             Real alphac  = (qvel(i,j,k) >= qe) ? 1.0 : qvel(i,j,k) / (qe + eps);
-#ifdef EXTRA_MYNN25_CHECKS
+//#if EXTRA_MYNN25_CHECKS
+#if 0
             Real Ri = -GH/(GM+level2.eps);
-            if (alphac < 1 && (Ri > 1 || Ri < -1)) {
-                Warning("Level 2 limiting being applied with Ri out of expected range");
-                //AllPrint() << "alphac"<<IntVect(i,j,k)<<"= " << alphac
-                //    << " Ri,SM2,SH2= " << Ri << " " << SM2 << " " << level2.calc_SH(Rf)
-                //    << std::endl;
+            if (alphac < 1) {
+                AllPrint() << "Level 2 limter at " << IntVect(i,j,k) << " :"
+                    << " ustar= " << u_star_arr(i,j,0)
+                    << " alphac= " << alphac
+                    << " Ri,SM2,SH2= " << Ri << " " << SM2 << " " << level2.calc_SH(Rf)
+                    << std::endl;
             }
 #endif
 
@@ -238,7 +240,7 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             // Clip SM, SH following WRF
             SM = amrex::min(amrex::max(SM, mynn.SMmin), mynn.SMmax);
             SH = amrex::min(amrex::max(SH, mynn.SHmin), mynn.SHmax);
-#ifdef EXTRA_MYNN25_CHECKS
+#if EXTRA_MYNN25_CHECKS
             if (SM == mynn.SMmin) {
                 Warning("SM clipped at min val");
             } else if (SM == mynn.SMmax) {

--- a/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
@@ -223,9 +223,10 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             Real alphac  = (qvel(i,j,k) >= qe) ? 1.0 : qvel(i,j,k) / (qe + eps);
 //#if EXTRA_MYNN25_CHECKS
 #if 0
+            // VERY verbose diagnostic
             Real Ri = -GH/(GM+level2.eps);
             if (alphac < 1) {
-                AllPrint() << "Level 2 limter at " << IntVect(i,j,k) << " :"
+                AllPrint() << "Level 2 limiter at " << IntVect(i,j,k) << " :"
                     << " ustar= " << u_star_arr(i,j,0)
                     << " alphac= " << alphac
                     << " Ri,SM2,SH2= " << Ri << " " << SM2 << " " << level2.calc_SH(Rf)

--- a/Source/PBL/ERF_MYNNStruct.H
+++ b/Source/PBL/ERF_MYNNStruct.H
@@ -23,7 +23,7 @@ struct MYNNLevel25 {
     {
         amrex::Real alphac2 = alphac * alphac;
 
-        // Compute non-dimensional parameters (notation follows NN09)
+        // Compute non-dimensional parameters (notation follows NN09, Eqns. 33-37)
         amrex::Real Phi1 = 1.0  -  3.0 * alphac2 * A2 * B2 * (1-C3) * GH;
         amrex::Real Phi2 = 1.0  -  9.0 * alphac2 * A1 * A2 * (1-C2) * GH;
         amrex::Real Phi3 = Phi1 +  9.0 * alphac2 * A2 * A2 * (1-C2) * (1-C5) * GH;
@@ -31,10 +31,10 @@ struct MYNNLevel25 {
         amrex::Real Phi5 =         6.0 * alphac2 * A1 * A1 * GM;
 
         // Compute level 2.5 stability functions
-        amrex::Real D = Phi2*Phi4 + Phi5*Phi3;
-        SM = alphac * A1 * (Phi3 - 3*C1*Phi4) / D;
-        SH = alphac * A2 * (Phi2 + 3*C1*Phi5) / D;
-        SQ = SQfac * SM;
+        amrex::Real D = Phi2*Phi4 + Phi5*Phi3;      // NN09 Eqn. 31
+        SM = alphac * A1 * (Phi3 - 3*C1*Phi4) / D;  // NN09 Eqn. 27
+        SH = alphac * A2 * (Phi2 + 3*C1*Phi5) / D;  // NN09 Eqn. 28
+        SQ = SQfac * SM;                            // NN09 Eqn. 67
     }
 
     // Closure coefficients (from Nakanishi & Niino 2009 [NN09])


### PR DESCRIPTION
* New vars include `ustar`, `wstar`, `tstar`, `qstar`, `z0`, etc from the surface layer.
* Create separate variable list for 2D vars
* `erf.init_tke_from_ustar` will take the initially diagnosed ustar and generate a linearly decaying (and horizontally varying) QKE profile following MYNN-EDMF (https://github.com/NCAR/MYNN-EDMF/blob/90f36c25259ec1960b24325f5b29ac7c5adeac73/module_bl_mynnedmf.F90#L1325-L1333)