### PR TITLE
SHOC Permute K

### DIFF
--- a/Exec/DevTests/Shoc/inputs_shoc
+++ b/Exec/DevTests/Shoc/inputs_shoc
@@ -68,7 +68,6 @@ erf.moistscal_vert_adv_type  = "Upwind_3rd_SL"
 # PHYSICS OPTIONS
 erf.les_type        = "Smagorinsky2D"
 erf.Cs              = 0.17
-#erf.les_type        = "Smagorinsky"
 erf.pbl_type        = "SHOC"
 erf.moisture_model  = "Kessler"
 

--- a/Exec/DevTests/Shoc/inputs_shoc
+++ b/Exec/DevTests/Shoc/inputs_shoc
@@ -7,8 +7,8 @@ amrex.fpe_trap_invalid = 1
 fabarray.mfiter_tile_size = 1024 1024 1024
 
 # PROBLEM SIZE & GEOMETRY
-geometry.prob_extent = 400.0 400.0  2000.0
-amr.n_cell           = 4     4      200
+geometry.prob_extent = 4000.0 4000.0  2000.0
+amr.n_cell           = 4      4       200
     
 geometry.is_periodic = 1 1 0
 
@@ -26,7 +26,7 @@ erf.most.zref   = 10.0
 zhi.type = "SlipWall"
 
 # TIME STEP CONTROL
-erf.fixed_dt = 0.1
+erf.fixed_dt = 1.0
 erf.fixed_mri_dt_ratio = 6
 
 # DIAGNOSTICS & VERBOSITY
@@ -50,9 +50,9 @@ erf.plot_vars_1     = density rhotheta rhoQ1 rhoQ2 rhoadv_0 x_velocity y_velocit
 erf.use_gravity     = true
 erf.abl_driver_type = "GeostrophicWind"
 erf.abl_geo_forcing = 7.0 -5.5 0.0
-#erf.use_coriolis    = true
-#erf.latitude        = 90.
-#erf.rotational_time_period = 86164.0900027328
+erf.use_coriolis    = true
+erf.latitude        = 90.
+erf.rotational_time_period = 86164.0900027328
 
 erf.four_stream_radiation              = true
 erf.add_custom_w_subsidence            = true
@@ -68,6 +68,7 @@ erf.moistscal_vert_adv_type  = "Upwind_3rd_SL"
 # PHYSICS OPTIONS
 erf.les_type        = "Smagorinsky2D"
 erf.Cs              = 0.17
+#erf.les_type        = "Smagorinsky"
 erf.pbl_type        = "SHOC"
 erf.moisture_model  = "Kessler"
 

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.H
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.H
@@ -215,8 +215,8 @@ protected:
 
             wpthlp_sfc(i) = (surf_sens_flux(i)/(cpair*rrho_i(i,nlevi_v)[nlevi_p]))*inv_exner_int_surf;
             wprtp_sfc(i)  = surf_evap(i)/rrho_i(i,nlevi_v)[nlevi_p];
-            upwp_sfc(i) = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
-            vpwp_sfc(i) = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
+            upwp_sfc(i)   = surf_mom_flux(i,0)/rrho_i(i,nlevi_v)[nlevi_p];
+            vpwp_sfc(i)   = surf_mom_flux(i,1)/rrho_i(i,nlevi_v)[nlevi_p];
         } // operator
 
         // Local variables

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -507,7 +507,7 @@ SHOCInterface::kokkos_buffers_to_mf ()
     //=======================================================
     auto horiz_wind_d = horiz_wind;
     //auto sgs_buoy_flux_d = sgs_buoy_flux;
-    auto tk_d = tk;
+    //auto tk_d = tk;
     //auto cldfrac_liq_d = cldfrac_liq;
     auto tke_d = tke;
     auto qc_d = qc;
@@ -516,7 +516,7 @@ SHOCInterface::kokkos_buffers_to_mf ()
     //=======================================================
     //auto pblh_d = pblh;
     //auto inv_qc_relvar_d = inv_qc_relvar;
-    auto tkh_d = tkh;
+    //auto tkh_d = tkh;
     //auto w_sec_d = w_sec;
     //auto cldfrac_liq_prev_d = cldfrac_liq_prev;
     //auto ustar_d = ustar;

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -193,7 +193,7 @@ SHOCInterface::alloc_buffers ()
     surf_evap        = view_1d("Sfc evap"          , m_num_cols);
     T_mid            = view_2d("T_mid"             , m_num_cols, m_num_layers  );
     qv               = view_2d("Qv"                , m_num_cols, m_num_layers  );
-    if (apply_tms) { surf_drag_coeff_tms = view_1d("surf_drag_coeff"   , m_num_cols); }
+    surf_drag_coeff_tms = view_1d("surf_drag_coeff", m_num_cols);
 
     // Input data structures
     //=======================================================
@@ -378,6 +378,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
         const int nx     = vbx.length(0);
         const int imin   = vbx.smallEnd(0);
         const int jmin   = vbx.smallEnd(1);
+        const int kmax   = vbx.bigEnd(2);
         const int offset = m_col_offsets[mfi.index()];
         const Array4<const Real>& cons_arr = m_cons->const_array(mfi);
 
@@ -396,9 +397,10 @@ SHOCInterface::mf_to_kokkos_buffers ()
                                                           Array4<const Real>{};
         ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
+            // NOTE: k gets permuted with ilay
             // map [i,j,k] 0-based to [icol, ilay] 0-based
             const int icol   = (j-jmin)*nx + (i-imin) + offset;
-            const int ilay   = k;
+            const int ilay   = kmax - k;
 
             // EOS input (at CC)
             Real r  = cons_arr(i,j,k,Rho_comp);
@@ -433,6 +435,14 @@ SHOCInterface::mf_to_kokkos_buffers ()
             Real w_limited = std::copysign(std::max(std::fabs(w_cc),1.0e-6),w_cc);
 
 
+            // Input/Output data structures
+            //=======================================================
+            horiz_wind_d(icol,0,ilay)  = 0.5 * (u_arr(i,j,k) + u_arr(i+1,j  ,k));
+            horiz_wind_d(icol,1,ilay)  = 0.5 * (v_arr(i,j,k) + v_arr(i  ,j+1,k));
+            cldfrac_liq_d(icol,ilay)   = (qc>0.0) ? 1. : 0.;
+            tke_d(icol,ilay)           = std::max(cons_arr(i,j,k,RhoKE_comp)/r, 0.0);
+            qc_d(icol,ilay)            = qc;
+
             // Interface data structures
             //=======================================================
             // eamxx_common_physics_functions_impl.hpp: calculate_vertical_velocity
@@ -443,10 +453,14 @@ SHOCInterface::mf_to_kokkos_buffers ()
                 // Unit conversion to W/m^2 (eamxx_shoc_process_interface.cpp L62)
                 surf_sens_flux_d(icol)   = hfx3_arr(i,j,k) * r * Cp_d;
                 surf_evap(icol)          = (moist) ? qfx3_arr(i,j,k) : 0.0;
+                // Back out the drag coeff
+                Real wsp = sqrt( horiz_wind_d(icol,0,ilay)[0]*horiz_wind_d(icol,0,ilay)[0]
+                               + horiz_wind_d(icol,1,ilay)[0]*horiz_wind_d(icol,1,ilay)[0] );
+                surf_drag_coeff_tms_d(icol) = surf_mom_flux_d(icol,0) /
+                                              (-r * wsp * horiz_wind_d(icol,0,ilay)[0]);
             }
             T_mid_d(icol,ilay)          = getTgivenRandRTh(r, rt, qv);
             qv_d(icol,ilay)             = qv;
-            surf_drag_coeff_tms_d(icol) = 0.0;
 
             // Input data structures
             //=======================================================
@@ -457,7 +471,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             // Enforce the grid spacing
             dz_d(icol,ilay) = delz;
             // Geopotential
-            phis_d(icol)             = CONST_GRAV * z;
+            phis_d(icol)    = CONST_GRAV * z;
 
             if (ilay==(nlay-1)) {
                 Real r_hi  = cons_arr(i,j,k+1,Rho_comp);
@@ -468,14 +482,6 @@ SHOCInterface::mf_to_kokkos_buffers ()
                 qv_avg = 0.5 * (qv + qv_hi);
                 p_int_d(icol,ilay+1) = getPgivenRTh(rt_avg, qv_avg);
             }
-
-            // Input/Output data structures
-            //=======================================================
-            horiz_wind_d(icol,0,ilay)  = 0.5 * (u_arr(i,j,k) + u_arr(i+1,j  ,k));
-            horiz_wind_d(icol,1,ilay)  = 0.5 * (v_arr(i,j,k) + v_arr(i  ,j+1,k));
-            cldfrac_liq_d(icol,ilay)   = (qc>0.0) ? 1. : 0.;
-            tke_d(icol,ilay)           = std::max(cons_arr(i,j,k,RhoKE_comp)/r, 0.0);
-            qc_d(icol,ilay)            = qc;
         });
     }
 }
@@ -501,7 +507,7 @@ SHOCInterface::kokkos_buffers_to_mf ()
     //=======================================================
     auto horiz_wind_d = horiz_wind;
     //auto sgs_buoy_flux_d = sgs_buoy_flux;
-    //auto tk_d = tk;
+    auto tk_d = tk;
     //auto cldfrac_liq_d = cldfrac_liq;
     auto tke_d = tke;
     auto qc_d = qc;
@@ -510,7 +516,7 @@ SHOCInterface::kokkos_buffers_to_mf ()
     //=======================================================
     //auto pblh_d = pblh;
     //auto inv_qc_relvar_d = inv_qc_relvar;
-    //auto tkh_d = tkh;
+    auto tkh_d = tkh;
     //auto w_sec_d = w_sec;
     //auto cldfrac_liq_prev_d = cldfrac_liq_prev;
     //auto ustar_d = ustar;
@@ -522,6 +528,7 @@ SHOCInterface::kokkos_buffers_to_mf ()
         const int nx     = vbx.length(0);
         const int imin   = vbx.smallEnd(0);
         const int jmin   = vbx.smallEnd(1);
+        const int kmax   = vbx.bigEnd(2);
         const int offset = m_col_offsets[mfi.index()];
 
         const Array4<Real>& cons_arr = m_cons->array(mfi);
@@ -538,9 +545,10 @@ SHOCInterface::kokkos_buffers_to_mf ()
 
         ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
+            // NOTE: k gets permuted with ilay
             // map [i,j,k] 0-based to [icol, ilay] 0-based
             const int icol   = (j-jmin)*nx + (i-imin) + offset;
-            const int ilay   = k;
+            const int ilay   = kmax - k;
 
             // Density at CC
             Real r  = cons_arr(i,j,k,Rho_comp);
@@ -813,7 +821,7 @@ SHOCInterface::initialize_impl ()
     const auto default_policy = TPF::get_default_team_policy(m_num_cols, nlev_packs);
     workspace_mgr.setup(m_buffer.wsm_data, nlevi_packs, 14+(n_wind_slots+n_trac_slots), default_policy);
 
-    // NOTE: FIX ME!
+    // NOTE: Vertical indices were permuted, so top and bottom are correct
     // Maximum number of levels in pbl from surface
     const int ntop_shoc = 0;
     const int nbot_shoc = m_num_layers;


### PR DESCRIPTION
## Notes
Shoc assumes the BCs are imposed at the top of the domain. We now permute the `k` index when moving to and from `ilay` so that we obtain the expected column ordering. This now develops a nice boundary layer near the surface.