### PR TITLE
Correct Diffusion dz at Top W/ Stretched Grid

### DIFF
--- a/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
@@ -74,7 +74,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 #include "ERF_DiffSetup.H"
 
     int klo = domain.smallEnd(2);
-    int khi = domain.bigEnd(2) + 1;
+    int khi = domain.bigEnd(2);
     auto dz_ptr = stretched_dz_d.data();
 
     for (int n(0); n<num_comp; ++n) {
@@ -170,7 +170,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 Real dzk_inv;
                 if (k==klo) {
                     dzk_inv =  1.0 / dz_ptr[k];
-                } else if (k==khi) {
+                } else if (k==(khi+1)) {
                     dzk_inv =  1.0 / dz_ptr[k-1];
                 } else {
                     dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
@@ -282,7 +282,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 Real dzk_inv;
                 if (k==klo) {
                     dzk_inv =  1.0 / dz_ptr[k];
-                } else if (k==khi) {
+                } else if (k==(khi+1)) {
                     dzk_inv =  1.0 / dz_ptr[k-1];
                 } else {
                     dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
@@ -391,7 +391,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 Real dzk_inv;
                 if (k==klo) {
                     dzk_inv =  1.0 / dz_ptr[k];
-                } else if (k==khi) {
+                } else if (k==(khi+1)) {
                     dzk_inv =  1.0 / dz_ptr[k-1];
                 } else {
                     dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
@@ -497,7 +497,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 Real dzk_inv;
                 if (k==klo) {
                     dzk_inv =  1.0 / dz_ptr[k];
-                } else if (k==khi) {
+                } else if (k==(khi+1)) {
                     dzk_inv =  1.0 / dz_ptr[k-1];
                 } else {
                     dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);

--- a/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
@@ -73,6 +73,8 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
 #include "ERF_DiffSetup.H"
 
+    int klo = domain.smallEnd(2);
+    int khi = domain.bigEnd(2) + 1;
     auto dz_ptr = stretched_dz_d.data();
 
     for (int n(0); n<num_comp; ++n) {
@@ -165,7 +167,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
-                Real dzk_inv = (k == 0) ? 1.0 / dz_ptr[k] : 2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                Real dzk_inv;
+                if (k==klo) {
+                    dzk_inv =  1.0 / dz_ptr[k];
+                } else if (k==khi) {
+                    dzk_inv =  1.0 / dz_ptr[k-1];
+                } else {
+                    dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
 
@@ -270,7 +279,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
-                Real dzk_inv = (k == 0) ? 1.0 / dz_ptr[k] : 2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                Real dzk_inv;
+                if (k==klo) {
+                    dzk_inv =  1.0 / dz_ptr[k];
+                } else if (k==khi) {
+                    dzk_inv =  1.0 / dz_ptr[k-1];
+                } else {
+                    dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
 
@@ -372,7 +388,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
-                Real dzk_inv = (k == 0) ? 1.0 / dz_ptr[k] : 2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                Real dzk_inv;
+                if (k==klo) {
+                    dzk_inv =  1.0 / dz_ptr[k];
+                } else if (k==khi) {
+                    dzk_inv =  1.0 / dz_ptr[k-1];
+                } else {
+                    dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
 
@@ -471,7 +494,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
-                Real dzk_inv = (k == 0) ? 1.0 / dz_ptr[k] : 2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                Real dzk_inv;
+                if (k==klo) {
+                    dzk_inv =  1.0 / dz_ptr[k];
+                } else if (k==khi) {
+                    dzk_inv =  1.0 / dz_ptr[k-1];
+                } else {
+                    dzk_inv =  2.0 / (dz_ptr[k] + dz_ptr[k-1]);
+                }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
 


### PR DESCRIPTION
## Notes
The `stretched_dz` is at `CC` and is the size of the domain. When computing diffusive fluxes, we operate on the w-faces. We therefore, must use one-sided diffs at the top and bottom to obtain dz.