### PR TITLE
replace dx(2) by dzmin in microphysics

### DIFF
--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -633,6 +633,11 @@ ERF::init_zphys (int lev, Real time)
         } // lev == 0
 
     } // init_type
+
+    // Compute the min dz and pass to the micro model
+    Real dz_min = get_dzmin_terrain(*z_phys_nd[lev]);
+    ParallelDescriptor::ReduceRealMin(dz_min);
+    micro->Set_dzmin (lev, dz_min);
 }
 
 void
@@ -668,7 +673,13 @@ ERF::remake_zphys (int lev, Real /*time*/, std::unique_ptr<MultiFab>& temp_zphys
         terrain_blanking[lev]->setVal(1.0);
         MultiFab::Subtract(*terrain_blanking[lev], EBFactory(lev).getVolFrac(), 0, 0, 1, z_phys_nd[lev]->nGrowVect());
     }
+
+    // Compute the min dz and pass to the micro model
+    Real dz_min = get_dzmin_terrain(*z_phys_nd[lev]);
+    ParallelDescriptor::ReduceRealMin(dz_min);
+    micro->Set_dzmin (lev, dz_min);
 }
+
 void
 ERF::update_terrain_arrays (int lev)
 {

--- a/Source/Microphysics/ERF_EulerianMicrophysics.H
+++ b/Source/Microphysics/ERF_EulerianMicrophysics.H
@@ -144,6 +144,13 @@ public:
         m_moist_model[a_lev]->GetPlotVar(a_name, a_mf);
     }
 
+    /*! \brief Populates dz_min in micro model for precipitation */
+    virtual void Set_dzmin (const int a_lev,
+                            const amrex::Real dz_min) const override
+    {
+        m_moist_model[a_lev]->Set_dzmin(dz_min);
+    }
+
 protected:
 
     /*! \brief Create and set the specified moisture model */

--- a/Source/Microphysics/ERF_LagrangianMicrophysics.H
+++ b/Source/Microphysics/ERF_LagrangianMicrophysics.H
@@ -173,10 +173,10 @@ public:
     }
 
      /*! \brief Populates dz_min in micro model for precipitation */
-    virtual void Set_dzmin (const int a_lev,
+    virtual void Set_dzmin (const int /*a_lev*/,
                             const amrex::Real dz_min) const override
     {
-        m_moist_model[a_lev]->Set_dzmin(dz_min);
+        m_moist_model->Set_dzmin(dz_min);
     }
 
 protected:

--- a/Source/Microphysics/ERF_LagrangianMicrophysics.H
+++ b/Source/Microphysics/ERF_LagrangianMicrophysics.H
@@ -172,6 +172,13 @@ public:
         m_moist_model->GetPlotVar(a_name, a_mf);
     }
 
+     /*! \brief Populates dz_min in micro model for precipitation */
+    virtual void Set_dzmin (const int a_lev,
+                            const amrex::Real dz_min) const override
+    {
+        m_moist_model[a_lev]->Set_dzmin(dz_min);
+    }
+
 protected:
 
     /*! \brief Create and set the specified moisture model */

--- a/Source/Microphysics/ERF_Microphysics.H
+++ b/Source/Microphysics/ERF_Microphysics.H
@@ -82,6 +82,9 @@ public:
                              amrex::MultiFab& a_mf,
                              const int a_lev) const = 0;
 
+    /*! \brief Import minimum dz at this level */
+    virtual void Set_dzmin (const amrex::Real dz_min);
+
     /*! \brief query if a specified moisture model is Eulerian or Lagrangian */
     static MoistureModelType modelType (const MoistureType a_moisture_type)
     {

--- a/Source/Microphysics/ERF_Microphysics.H
+++ b/Source/Microphysics/ERF_Microphysics.H
@@ -83,7 +83,8 @@ public:
                              const int a_lev) const = 0;
 
     /*! \brief Import minimum dz at this level */
-    virtual void Set_dzmin (const amrex::Real dz_min);
+    virtual void Set_dzmin (const int lev,
+                            const amrex::Real dz_min) const = 0;
 
     /*! \brief query if a specified moisture model is Eulerian or Lagrangian */
     static MoistureModelType modelType (const MoistureType a_moisture_type)

--- a/Source/Microphysics/Kessler/ERF_InitKessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_InitKessler.cpp
@@ -1,7 +1,6 @@
 #include <AMReX_GpuContainers.H>
 #include "ERF_Kessler.H"
 #include "ERF_IndexDefines.H"
-#include "ERF_PlaneAverage.H"
 #include "ERF_EOS.H"
 #include "ERF_TileNoZ.H"
 
@@ -54,6 +53,12 @@ void Kessler::Init (const MultiFab& cons_in,
         zlo  = lo.z;
         zhi  = hi.z;
     }
+}
+
+void
+Kessler::Set_dzmin (const Real dz_min)
+{
+    m_dzmin = dz_min;
 }
 
 /**

--- a/Source/Microphysics/Kessler/ERF_InitKessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_InitKessler.cpp
@@ -55,11 +55,6 @@ void Kessler::Init (const MultiFab& cons_in,
     }
 }
 
-void
-Kessler::Set_dzmin (const Real dz_min)
-{
-    m_dzmin = dz_min;
-}
 
 /**
  * Initializes the Microphysics module.

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -70,6 +70,10 @@ public:
           std::unique_ptr<amrex::MultiFab>& z_phys_nd,
           std::unique_ptr<amrex::MultiFab>& detJ_cc) override;
 
+    // Import minimum dz at this level
+    void
+    Set_dzmin (const amrex::Real dz_min);
+
     // Copy state into micro vars
     void
     Copy_State_to_Micro (const amrex::MultiFab& cons_in) override;
@@ -148,6 +152,9 @@ private:
 
     // timestep
     amrex::Real dt;
+
+    // Minimum dz at this level
+    amrex::Real m_dzmin;
 
     // number of vertical levels
     int nlev, zlo, zhi;

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -72,7 +72,10 @@ public:
 
     // Import minimum dz at this level
     void
-    Set_dzmin (const amrex::Real dz_min);
+    Set_dzmin (const amrex::Real dz_min) override
+    {
+        m_dzmin = dz_min;
+    }
 
     // Copy state into micro vars
     void

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -12,8 +12,8 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 {
     bool do_cond = m_do_cond;
     auto tabs    = mic_fab_vars[MicVar_Kess::tabs];
-    if (solverChoice.moisture_type == MoistureType::Kessler){
-        auto dz = m_geom.CellSize(2);
+    if (solverChoice.moisture_type == MoistureType::Kessler)
+    {
         auto domain = m_geom.Domain();
         int k_lo = domain.smallEnd(2);
         int k_hi = domain.bigEnd(2);
@@ -24,7 +24,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
         fz.define(convert(ba, IntVect(0,0,1)), dm, 1, 0); // No ghost cells
 
         Real dtn  = dt;
-        Real coef = dtn/dz;
+        Real coef = dtn/m_dzmin;
 
         // Saturation and evaporation calculations go first
         for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {

--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -73,8 +73,6 @@ Morrison::Init (const MultiFab& cons_in,
         rho1d.resize({zlo}, {zhi});
         pres1d.resize({zlo}, {zhi});
         tabs1d.resize({zlo}, {zhi});
-        gamaz.resize({zlo}, {zhi});
-        zmid.resize({zlo}, {zhi});
     }
 
 #ifdef ERF_USE_MORR_FORT
@@ -88,6 +86,11 @@ Morrison::Init (const MultiFab& cons_in,
 #endif
 }
 
+void
+Morrison::Set_dzmin (const Real dz_min)
+{
+    m_dzmin = dz_min;
+}
 
 /**
  * Initializes the Microphysics module.
@@ -151,9 +154,6 @@ Morrison::Copy_State_to_Micro (const MultiFab& cons_in)
 
 void Morrison::Compute_Coefficients ()
 {
-    auto dz   = m_geom.CellSize(2);
-    auto lowz = m_geom.ProbLo(2);
-
     auto accrrc_t  = accrrc.table();
     auto accrsi_t  = accrsi.table();
     auto accrsc_t  = accrsc.table();
@@ -170,9 +170,6 @@ void Morrison::Compute_Coefficients ()
     auto rho1d_t  = rho1d.table();
     auto pres1d_t = pres1d.table();
     auto tabs1d_t = tabs1d.table();
-
-    auto gamaz_t  = gamaz.table();
-    auto zmid_t   = zmid.table();
 
     Real gam3  = erf_gammafff(3.0             );
     Real gamr1 = erf_gammafff(3.0+b_rain      );
@@ -222,8 +219,6 @@ void Morrison::Compute_Coefficients ()
         //       not affect results since evporation requires snow/graupel to be present
         //       and thus T<273.16
         tabs1d_t(k)   = std::min(getTgivenRandRTh(rho_dptr[k], RhoTheta, qv_dptr[k]),273.16);
-        zmid_t(k)     = lowz + (k+0.5)*dz;
-        gamaz_t(k)    = gOcp*zmid_t(k);
     });
 
     if(round(gam3) != 2) {

--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -86,11 +86,6 @@ Morrison::Init (const MultiFab& cons_in,
 #endif
 }
 
-void
-Morrison::Set_dzmin (const Real dz_min)
-{
-    m_dzmin = dz_min;
-}
 
 /**
  * Initializes the Microphysics module.

--- a/Source/Microphysics/Morrison/ERF_Morrison.H
+++ b/Source/Microphysics/Morrison/ERF_Morrison.H
@@ -90,7 +90,10 @@ public:
 
     // Import minimum dz at this level
     void
-    Set_dzmin (const amrex::Real dz_min);
+    Set_dzmin (const amrex::Real dz_min) override
+    {
+        m_dzmin = dz_min;
+    }
 
     // Copy state into micro vars
     void

--- a/Source/Microphysics/Morrison/ERF_Morrison.H
+++ b/Source/Microphysics/Morrison/ERF_Morrison.H
@@ -88,6 +88,10 @@ public:
           std::unique_ptr<amrex::MultiFab>& z_phys_nd,
           std::unique_ptr<amrex::MultiFab>& detJ_cc) override;
 
+    // Import minimum dz at this level
+    void
+    Set_dzmin (const amrex::Real dz_min);
+
     // Copy state into micro vars
     void
     Copy_State_to_Micro (const amrex::MultiFab& cons_in) override;
@@ -295,6 +299,9 @@ private:
     amrex::Real m_rdOcp;
     bool m_do_cond;
 
+    // Minimum dz at this level
+    amrex::Real m_dzmin;
+
     // Pointer to terrain data
     amrex::MultiFab* m_z_phys_nd;
     amrex::MultiFab* m_detJ_cc;
@@ -323,8 +330,5 @@ private:
     amrex::TableData<amrex::Real, 1> qt1d;
     amrex::TableData<amrex::Real, 1> qv1d;
     amrex::TableData<amrex::Real, 1> qn1d;
-
-    amrex::TableData<amrex::Real, 1> gamaz;
-    amrex::TableData<amrex::Real, 1> zmid; // mid value of vertical coordinate in physical domain
 };
 #endif

--- a/Source/Microphysics/Null/ERF_NullMoist.H
+++ b/Source/Microphysics/Null/ERF_NullMoist.H
@@ -84,6 +84,11 @@ public:
         amrex::Abort("NullMoist::GetPlotVar() should never be called.");
     }
 
+    virtual
+    void
+    Set_dzmin (const amrex::Real /*dz_min*/) { }
+
+
 private:
     int m_qmoist_size = 0;
     int m_qstate_moist_size = 0;

--- a/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
+++ b/Source/Microphysics/Null/ERF_NullMoistLagrangian.H
@@ -57,6 +57,10 @@ public:
              const amrex::Vector<std::unique_ptr<amrex::MultiFab>>&, /* terrain */
              const amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2>& ) { }
 
+    virtual
+    void
+    Set_dzmin (const amrex::Real /*dz_min*/) { }
+
 protected:
 
 private:

--- a/Source/Microphysics/SAM/ERF_IceFall.cpp
+++ b/Source/Microphysics/SAM/ERF_IceFall.cpp
@@ -14,9 +14,8 @@ void SAM::IceFall (const SolverChoice& sc) {
        sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce)
       return;
 
-    Real dz   = m_geom.CellSize(2);
     Real dtn  = dt;
-    Real coef = dtn/dz;
+    Real coef = dtn/m_dzmin;
 
     auto domain = m_geom.Domain();
     int k_lo = domain.smallEnd(2);

--- a/Source/Microphysics/SAM/ERF_InitSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_InitSAM.cpp
@@ -75,11 +75,6 @@ SAM::Init (const MultiFab& cons_in,
     }
 }
 
-void
-SAM::Set_dzmin (const Real dz_min)
-{
-    m_dzmin = dz_min;
-}
 
 /**
  * Initializes the Microphysics module.

--- a/Source/Microphysics/SAM/ERF_InitSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_InitSAM.cpp
@@ -72,11 +72,14 @@ SAM::Init (const MultiFab& cons_in,
         rho1d.resize({zlo}, {zhi});
         pres1d.resize({zlo}, {zhi});
         tabs1d.resize({zlo}, {zhi});
-        gamaz.resize({zlo}, {zhi});
-        zmid.resize({zlo}, {zhi});
     }
 }
 
+void
+SAM::Set_dzmin (const Real dz_min)
+{
+    m_dzmin = dz_min;
+}
 
 /**
  * Initializes the Microphysics module.
@@ -138,9 +141,6 @@ SAM::Copy_State_to_Micro (const MultiFab& cons_in)
 
 void SAM::Compute_Coefficients ()
 {
-    auto dz   = m_geom.CellSize(2);
-    auto lowz = m_geom.ProbLo(2);
-
     auto accrrc_t  = accrrc.table();
     auto accrsi_t  = accrsi.table();
     auto accrsc_t  = accrsc.table();
@@ -157,9 +157,6 @@ void SAM::Compute_Coefficients ()
     auto rho1d_t  = rho1d.table();
     auto pres1d_t = pres1d.table();
     auto tabs1d_t = tabs1d.table();
-
-    auto gamaz_t  = gamaz.table();
-    auto zmid_t   = zmid.table();
 
     Real gam3  = erf_gammafff(3.0             );
     Real gamr1 = erf_gammafff(3.0+b_rain      );
@@ -209,8 +206,6 @@ void SAM::Compute_Coefficients ()
         //       not affect results since evporation requires snow/graupel to be present
         //       and thus T<273.16
         tabs1d_t(k)   = std::min(getTgivenRandRTh(rho_dptr[k], RhoTheta, qv_dptr[k]),273.16);
-        zmid_t(k)     = lowz + (k+0.5)*dz;
-        gamaz_t(k)    = gOcp*zmid_t(k);
     });
 
     if(round(gam3) != 2) {

--- a/Source/Microphysics/SAM/ERF_PrecipFall.cpp
+++ b/Source/Microphysics/SAM/ERF_PrecipFall.cpp
@@ -27,9 +27,8 @@ SAM::PrecipFall (const SolverChoice& sc)
     Real vsnow = (a_snow*gams3/6.0)*pow((PI*rhos*nzeros),-csnow);
     Real vgrau = (a_grau*gamg3/6.0)*pow((PI*rhog*nzerog),-cgrau);
 
-    auto dz   = m_geom.CellSize(2);
     Real dtn  = dt;
-    Real coef = dtn/dz;
+    Real coef = dtn/m_dzmin;
 
     auto domain = m_geom.Domain();
     int k_lo = domain.smallEnd(2);

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -95,6 +95,10 @@ public:
           std::unique_ptr<amrex::MultiFab>& z_phys_nd,
           std::unique_ptr<amrex::MultiFab>& detJ_cc) override;
 
+    // Import minimum dz at this level
+    void
+    Set_dzmin (const amrex::Real dz_min);
+
     // Copy state into micro vars
     void
     Copy_State_to_Micro (const amrex::MultiFab& cons_in) override;
@@ -310,6 +314,9 @@ private:
     amrex::Real m_rdOcp;
     bool m_do_cond;
 
+    // Minimum dz at this level
+    amrex::Real m_dzmin;
+
     // Pointer to terrain data
     amrex::MultiFab* m_z_phys_nd;
     amrex::MultiFab* m_detJ_cc;
@@ -338,8 +345,5 @@ private:
     amrex::TableData<amrex::Real, 1> qt1d;
     amrex::TableData<amrex::Real, 1> qv1d;
     amrex::TableData<amrex::Real, 1> qn1d;
-
-    amrex::TableData<amrex::Real, 1> gamaz;
-    amrex::TableData<amrex::Real, 1> zmid; // mid value of vertical coordinate in physical domain
 };
 #endif

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -97,7 +97,10 @@ public:
 
     // Import minimum dz at this level
     void
-    Set_dzmin (const amrex::Real dz_min);
+    Set_dzmin (const amrex::Real dz_min) override
+    {
+        m_dzmin = dz_min;
+    }
 
     // Copy state into micro vars
     void

--- a/Source/Utils/ERF_TerrainMetrics.H
+++ b/Source/Utils/ERF_TerrainMetrics.H
@@ -18,24 +18,30 @@ init_default_zphys (int lev, const amrex::Geometry& geom,
  */
 
 // Declare functions for ERF.cpp
-void init_zlevels (amrex::Vector<amrex::Vector<amrex::Real>> & zlevels_stag,
-                   amrex::Vector<amrex::Vector<amrex::Real>> & stretched_dz_h,
-                   amrex::Vector<amrex::Gpu::DeviceVector<amrex::Real>> & stretched_dz_d,
-                   amrex::Vector<amrex::Geometry> const& geom,
-                   amrex::Vector<amrex::IntVect>  const& ref_ratio,
-                   const amrex::Real grid_stretching_ratio,
-                   const amrex::Real zsurf,
-                   const amrex::Real dz0);
+void
+init_zlevels (amrex::Vector<amrex::Vector<amrex::Real>>& zlevels_stag,
+              amrex::Vector<amrex::Vector<amrex::Real>>& stretched_dz_h,
+              amrex::Vector<amrex::Gpu::DeviceVector<amrex::Real>>& stretched_dz_d,
+              amrex::Vector<amrex::Geometry> const& geom,
+              amrex::Vector<amrex::IntVect>  const& ref_ratio,
+              const amrex::Real grid_stretching_ratio,
+              const amrex::Real zsurf,
+              const amrex::Real dz0);
 
-void make_terrain_fitted_coords (int lev, const amrex::Geometry& geom,
-                                 amrex::MultiFab& z_phys_nd,
-                                 amrex::Vector<amrex::Real> const& z_levels_h,
-                                 amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2>& phys_bc_type);
+void
+make_terrain_fitted_coords (int lev, const amrex::Geometry& geom,
+                            amrex::MultiFab& z_phys_nd,
+                            amrex::Vector<amrex::Real> const& z_levels_h,
+                            amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2>& phys_bc_type);
 
-void init_which_terrain_grid (int lev, const amrex::Geometry& geom,
-                              amrex::MultiFab& z_phys_nd,
-                              amrex::Vector<amrex::Real> const& z_levels_h);
+void
+init_which_terrain_grid (int lev, const amrex::Geometry& geom,
+                         amrex::MultiFab& z_phys_nd,
+                         amrex::Vector<amrex::Real> const& z_levels_h);
 
+// Compute the min dz at cell center with terrain
+amrex::Real
+get_dzmin_terrain (amrex::MultiFab& z_phys_nd);
 
 //*****************************************************************************************
 // Compute terrain metric terms at cell-center

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -640,3 +640,24 @@ make_zcc (const Geometry& geom,
     }
     z_phys_cc.FillBoundary(geom.periodicity());
 }
+
+
+/**
+ * Computation min dz at cell-center
+ */
+Real
+get_dzmin_terrain (MultiFab& z_phys_nd)
+{
+    auto const& ma_z_nd_arr = z_phys_nd.const_arrays();
+    GpuTuple<Real> min = ParReduce(TypeList<ReduceOpMin>{},
+                                   TypeList<Real>{},
+                                   z_phys_nd, IntVect(0),
+                                   [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                                   -> GpuTuple<Real>
+                                   {
+                                       amrex::Real dz = Compute_Z_AtWFace(i,j,k+1,ma_z_nd_arr[box_no]) -
+                                                        Compute_Z_AtWFace(i,j,k  ,ma_z_nd_arr[box_no]);
+                                       return { dz };
+                                   });
+    return (get<0>(min) + std::numeric_limits<amrex::Real>::epsilon());
+}


### PR DESCRIPTION
## NOTES
The microphysics model does substepping for the advection of precipitating components. The `dz` used for that substepping calculation was based upon a fixed grid spacing. This PR introduces a parreduce routine for computing the min `dz`, with terrain, on each rank. This value is then reduced across ranks and passed to the microphysics model.