### PR TITLE
Improved representation of stratification in Smagorinsky

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1006,10 +1006,9 @@ List of Parameters
 | **erf.Cs**                       | Constant           | Real                | 0.0          |
 |                                  | Smagorinsky coeff. |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
-| **erf.use_smag_stratification**  | Enable             | Boolean             | true         |
-|                                  | stratification     |                     |              |
-|                                  | effects (dry and   |                     |              |
-|                                  | moist) in          |                     |              |
+| **erf.use_moist_Ri_correction**  | Apply moist        | Boolean             | false        |
+|                                  | Richardson number  |                     |              |
+|                                  | limiter to the     |                     |              |
 |                                  | Smagorinsky model  |                     |              |
 +----------------------------------+--------------------+---------------------+--------------+
 | **erf.Ck**                       | Constant           | Real                | 0.1          |

--- a/Docs/sphinx_doc/theory/DNSvsLES.rst
+++ b/Docs/sphinx_doc/theory/DNSvsLES.rst
@@ -179,15 +179,14 @@ When :math:`Ri_{eff} \leq 0`, stratification is unstable and the standard Smagor
 
 **Implementation Control**
 
-The enhanced moist Smagorinsky formulation can be controlled via the input parameter:
+The moist Richardson number limiter can be enabled via the input parameter:
 
 .. code-block:: none
 
-    erf.use_smag_stratification = true   # Enhanced moist Smagorinsky (default)
-    erf.use_smag_stratification = false  # Standard Smagorinsky
+    erf.use_moist_Ri_correction = true   # Apply moist Richardson number limiter
+    erf.use_moist_Ri_correction = false  # Standard Smagorinsky
 
-When disabled, the model reverts to the standard Smagorinsky formulation with :math:`\ell_m = \Delta`,
-providing backwards compatibility and enabling direct comparison between approaches.
+When disabled, the model reverts to the standard Smagorinsky formulation with :math:`\ell_m = \Delta`.
 
 Deardorff Model
 ~~~~~~~~~~~~~~~

--- a/Exec/DevTests/Tornado/inputs_tornado_wrf_files_PBL_Smag2d
+++ b/Exec/DevTests/Tornado/inputs_tornado_wrf_files_PBL_Smag2d
@@ -61,7 +61,7 @@ prob.KE_decay_order  = 3
 
 erf.les_type = "Smagorinsky2D"
 erf.Cs = 0.02
-erf.use_smag_stratification = false
+erf.use_moist_Ri_correction = false
 erf.mix_isotropic = false
 
 #erf.les_type  = "Deardorff"

--- a/Exec/DevTests/Tornado/inputs_tornado_wrf_files_Radiation
+++ b/Exec/DevTests/Tornado/inputs_tornado_wrf_files_Radiation
@@ -61,7 +61,7 @@ prob.KE_decay_order  = 3
 
 erf.les_type = "Smagorinsky2D"
 erf.Cs = 0.02
-erf.use_smag_stratification = false
+erf.use_moist_Ri_correction = false
 erf.mix_isotropic = false
 
 #erf.les_type  = "Deardorff"

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -196,6 +196,13 @@ public:
 
     query_one_or_per_level(pp, "mix_isotropic", mix_isotropic, lev, max_level);
     query_one_or_per_level(pp, "use_smag_stratification", use_smag_stratification, lev, max_level);
+    query_one_or_per_level(pp, "use_moist_Ri_correction", use_moist_Ri_correction, lev, max_level);
+    query_one_or_per_level(pp, "Ri_crit", Ri_crit, lev, max_level);
+
+    if (use_smag_stratification && use_moist_Ri_correction) {
+        amrex::Abort("Cannot enable both use_smag_stratification (deprecated) and use_moist_Ri_correction. "
+                     "Please use only use_moist_Ri_correction for moist stability corrections.");
+    }
 
     // Set common flags
     use_kturb =
@@ -239,7 +246,11 @@ public:
         amrex::Print() << "    Using Smagorinsky LES model at level " << lev << std::endl;
       }
       if (use_smag_stratification) {
-        amrex::Print() << "    Smagorinsky accounts for moist stratification" << std::endl;
+        amrex::Print() << "    Smagorinsky accounts for moist stratification (DEPRECATED - use use_moist_Ri_correction instead)" << std::endl;
+      }
+      if (use_moist_Ri_correction) {
+        amrex::Print() << "    Smagorinsky uses moist Richardson number correction with Ri_crit = "
+                       << Ri_crit << std::endl;
       }
     } else if (les_type == LESType::Deardorff) {
       amrex::Print() << "    Using Deardorff LES model at level " << lev << std::endl;
@@ -379,8 +390,11 @@ public:
   // Anistropic length scales
   bool mix_isotropic = true;
 
-  // Use the stratification adjustment for the Smagorinsky Scheme
-  bool use_smag_stratification = true;
+  // Use the stratification adjustment for the Smagorinsky Scheme (deprecated)
+  bool use_smag_stratification = false;
+
+  bool use_moist_Ri_correction = false;
+  amrex::Real Ri_crit = 0.25;
 
   // RANS type
   RANSType rans_type;

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -195,14 +195,8 @@ public:
     query_one_or_per_level(pp, "theta_ref", theta_ref, lev, max_level);
 
     query_one_or_per_level(pp, "mix_isotropic", mix_isotropic, lev, max_level);
-    query_one_or_per_level(pp, "use_smag_stratification", use_smag_stratification, lev, max_level);
     query_one_or_per_level(pp, "use_moist_Ri_correction", use_moist_Ri_correction, lev, max_level);
     query_one_or_per_level(pp, "Ri_crit", Ri_crit, lev, max_level);
-
-    if (use_smag_stratification && use_moist_Ri_correction) {
-        amrex::Abort("Cannot enable both use_smag_stratification (deprecated) and use_moist_Ri_correction. "
-                     "Please use only use_moist_Ri_correction for moist stability corrections.");
-    }
 
     // Set common flags
     use_kturb =
@@ -244,9 +238,6 @@ public:
         amrex::Print() << "    Using 2D Smagorinsky LES model at level " << lev << std::endl;
       } else {
         amrex::Print() << "    Using Smagorinsky LES model at level " << lev << std::endl;
-      }
-      if (use_smag_stratification) {
-        amrex::Print() << "    Smagorinsky accounts for moist stratification (DEPRECATED - use use_moist_Ri_correction instead)" << std::endl;
       }
       if (use_moist_Ri_correction) {
         amrex::Print() << "    Smagorinsky uses moist Richardson number correction with Ri_crit = "
@@ -301,8 +292,7 @@ public:
       }
     }
 
-    if ((les_type  == LESType::Deardorff)                              ||
-        (les_type  == LESType::Smagorinsky && use_smag_stratification) ||
+    if ((les_type  == LESType::Deardorff) ||
         (rans_type == RANSType::kEqn)) {
       if (theta_ref > 0) {
         amrex::Print() << "    reference theta         : " << theta_ref << std::endl;
@@ -389,9 +379,6 @@ public:
 
   // Anistropic length scales
   bool mix_isotropic = true;
-
-  // Use the stratification adjustment for the Smagorinsky Scheme (deprecated)
-  bool use_smag_stratification = false;
 
   bool use_moist_Ri_correction = false;
   amrex::Real Ri_crit = 0.25;

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -66,15 +66,9 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
         bool l_has_yvel = (yvel != nullptr);
         bool l_has_moisture = (moisture_indices.qv >= 0);
 
-        // Legacy stratification approach (deprecated, for backward compatibility)
-        const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        bool l_use_moisture_legacy = (moisture_indices.qv > 0);
-        int  l_rho_qv_comp  = moisture_indices.qv;
-        bool l_use_smag_stratification = turbChoice.use_smag_stratification;
-
-    #ifdef _OPENMP
-    #pragma omp parallel if (Gpu::notInLaunchRegion())
-    #endif
+#ifdef _OPENMP
+#pragma omp parallel if (Gpu::notInLaunchRegion())
+#endif
         for (MFIter mfi(eddyViscosity,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
             Box bxcc  = mfi.growntilebox(1) & domain;
@@ -145,26 +139,6 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                     Real S2_vert = ComputeVerticalShear2(i, j, k, dzInv, u_arr, v_arr);
                     Real Ri_moist = ComputeRichardson(N2_moist, S2_vert);
                     stability_factor = StabilityFunction(Ri_moist, l_Ri_crit);
-                }
-
-                else if (l_use_smag_stratification) {
-                    Real inv_theta = (use_ref_theta) ? 1.0 / turbChoice.theta_ref
-                                                     : cell_data(i,j,k,Rho_comp) /
-                                                       cell_data(i,j,k,RhoTheta_comp);
-                    Real stratification = ComputeStratificationForSmagorinsky(
-                        i, j, k, cell_data, dzInv, l_abs_g, inv_theta,
-                        l_use_moisture_legacy, l_rho_qv_comp, moisture_indices);
-
-                    Real mixing_length = Delta;
-                    if (stratification > 1e-10 && strain_rate_magnitude > 1e-10) {
-                        Real velocity_scale = strain_rate_magnitude * Delta;
-                        Real buoyancy_length = std::sqrt((velocity_scale * velocity_scale) / stratification);
-                        mixing_length = amrex::min(Delta, buoyancy_length);
-                        mixing_length = amrex::max(mixing_length, 0.001 * Delta);
-                    }
-
-                    Real CsDeltaSqr_legacy = Cs * Cs * mixing_length * mixing_length;
-                    nu_turb_base_v = CsDeltaSqr_legacy * strain_rate_magnitude;
                 }
 
                 if (isotropic) {

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -7,6 +7,7 @@
 #include "ERF_TileNoZ.H"
 #include "ERF_TerrainMetrics.H"
 #include "ERF_MoistUtils.H"
+#include "ERF_RichardsonNumber.H"
 
 using namespace amrex;
 
@@ -23,16 +24,20 @@ using namespace amrex;
  * @param[in]  geom problem geometry
  * @param[in]  mapfac map factors
  * @param[in]  turbChoice container with turbulence parameters
+ * @param[in]  xvel x-direction velocity (for moist Ri correction)
+ * @param[in]  yvel y-direction velocity (for moist Ri correction)
  */
 void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                                    const MultiFab& cons_in, MultiFab& eddyViscosity,
                                    MultiFab& Hfx1, MultiFab& Hfx2, MultiFab& Hfx3, MultiFab& Diss,
-                                   const Geometry& geom, bool use_terrain_fitted_coords,
-                                   Vector<std::unique_ptr<MultiFab>>& mapfac,
-                                   const std::unique_ptr<MultiFab>& z_phys_nd,
-                                   const TurbChoice& turbChoice, const Real const_grav,
-                                   std::unique_ptr<SurfaceLayer>& /*SurfLayer*/,
-                                   const MoistureComponentIndices& moisture_indices)
+                                  const Geometry& geom, bool use_terrain_fitted_coords,
+                                  Vector<std::unique_ptr<MultiFab>>& mapfac,
+                                  const std::unique_ptr<MultiFab>& z_phys_nd,
+                                  const TurbChoice& turbChoice, const Real const_grav,
+                                  std::unique_ptr<SurfaceLayer>& /*SurfLayer*/,
+                                  const MoistureComponentIndices& moisture_indices,
+                                  const MultiFab* xvel,
+                                  const MultiFab* yvel)
 {
     const GpuArray<Real, AMREX_SPACEDIM> cellSizeInv = geom.InvCellSizeArray();
     const Box& domain = geom.Domain();
@@ -53,10 +58,17 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
         Real Cs = turbChoice.Cs;
         bool smag2d = turbChoice.smag2d;
 
-        // Define variables that need to be captured in the lambda
+        // Define variables required inside device lambdas (scalars only)
         Real l_abs_g = const_grav;
+        Real l_Ri_crit = turbChoice.Ri_crit;
+        bool l_use_moist_Ri = turbChoice.use_moist_Ri_correction;
+        bool l_has_xvel = (xvel != nullptr);
+        bool l_has_yvel = (yvel != nullptr);
+        bool l_has_moisture = (moisture_indices.qv >= 0);
+
+        // Legacy stratification approach (deprecated, for backward compatibility)
         const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        bool l_use_moisture = (moisture_indices.qv > 0);
+        bool l_use_moisture_legacy = (moisture_indices.qv > 0);
         int  l_rho_qv_comp  = moisture_indices.qv;
         bool l_use_smag_stratification = turbChoice.use_smag_stratification;
 
@@ -65,14 +77,12 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
     #endif
         for (MFIter mfi(eddyViscosity,TilingIfNotGPU()); mfi.isValid(); ++mfi)
         {
-            // NOTE: This gets us the lateral ghost cells for lev>0; which
-            //       have been filled from FP Two Levels.
             Box bxcc  = mfi.growntilebox(1) & domain;
             const Array4<Real>& mu_turb = eddyViscosity.array(mfi);
             const Array4<Real>& hfx_x   = Hfx1.array(mfi);
             const Array4<Real>& hfx_y   = Hfx2.array(mfi);
             const Array4<Real>& hfx_z   = Hfx3.array(mfi);
-            const Array4<Real const > &cell_data = cons_in.array(mfi);
+            const Array4<Real const >& cell_data = cons_in.array(mfi);
             Array4<Real const> tau11 = Tau_lev[TauType::tau11]->array(mfi);
             Array4<Real const> tau22 = Tau_lev[TauType::tau22]->array(mfi);
             Array4<Real const> tau33 = Tau_lev[TauType::tau33]->array(mfi);
@@ -83,10 +93,13 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
             Array4<Real const> mf_v = mapfac[MapFacType::v_y]->const_array(mfi);
             Array4<Real const> z_nd_arr = z_phys_nd->const_array(mfi);
 
+            Array4<Real const> u_arr = (l_has_xvel) ? xvel->const_array(mfi) : Array4<Real const>{};
+            Array4<Real const> v_arr = (l_has_yvel) ? yvel->const_array(mfi) : Array4<Real const>{};
+
             ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // =====================================================================
-                // STRAIN RATE CALCULATION
+                // 1. STRAIN RATE MAGNITUDE CALCULATION
                 // =====================================================================
                 Real SmnSmn;
                 if (smag2d) {
@@ -94,9 +107,10 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 } else {
                     SmnSmn = ComputeSmnSmn(i,j,k,tau11,tau22,tau33,tau12,tau13,tau23);
                 }
+                Real strain_rate_magnitude = std::sqrt(2.0 * SmnSmn);
 
                 // =====================================================================
-                // GRID SCALE CALCULATION
+                // 2. GRID SCALE CALCULATION (filter width Δ)
                 // =====================================================================
                 Real dxInv = cellSizeInv[0];
                 Real dyInv = cellSizeInv[1];
@@ -111,68 +125,61 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                     Real cellVolMsf = 1.0 / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
                     Delta = std::cbrt(cellVolMsf);
                     DeltaH = Delta;
-                } else { // separate horizontal/vertical length scales
-                    // Typically, dx and dy >> dz
-                    // If using enhanced Smagorinsky, dz is the more meaningful grid scale
+                } else {
                     Delta = 1.0 / dzInv;
                     DeltaH = std::sqrt(1.0 / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
                 }
 
-                // =====================================================================
-                // MIXING LENGTH CALCULATION: STANDARD vs ADJUSTED
-                // =====================================================================
-                Real mixing_length;
+                Real rho = cell_data(i, j, k, Rho_comp);
+                Real CsDeltaSqr_h = Cs * Cs * DeltaH * DeltaH;
+                Real CsDeltaSqr_v = Cs * Cs * Delta * Delta;
 
-                if (l_use_smag_stratification) {
-                    // ENHANCED SMAGORINSKY: Our moist stratification approach
+                Real nu_turb_base_h = CsDeltaSqr_h * strain_rate_magnitude;
+                Real nu_turb_base_v = CsDeltaSqr_v * strain_rate_magnitude;
+
+                Real stability_factor = 1.0;
+
+                if (l_use_moist_Ri && l_has_moisture && l_has_xvel && l_has_yvel) {
+                    Real N2_moist = ComputeMoistN2(i, j, k, dzInv, l_abs_g,
+                                                   cell_data, moisture_indices);
+                    Real S2_vert = ComputeVerticalShear2(i, j, k, dzInv, u_arr, v_arr);
+                    Real Ri_moist = ComputeRichardson(N2_moist, S2_vert);
+                    stability_factor = StabilityFunction(Ri_moist, l_Ri_crit);
+                }
+
+                else if (l_use_smag_stratification) {
                     Real inv_theta = (use_ref_theta) ? 1.0 / turbChoice.theta_ref
                                                      : cell_data(i,j,k,Rho_comp) /
                                                        cell_data(i,j,k,RhoTheta_comp);
                     Real stratification = ComputeStratificationForSmagorinsky(
                         i, j, k, cell_data, dzInv, l_abs_g, inv_theta,
-                        l_use_moisture, l_rho_qv_comp, moisture_indices);
+                        l_use_moisture_legacy, l_rho_qv_comp, moisture_indices);
 
-                    // Stability-limited mixing length
-                    mixing_length = Delta;
-                    if (stratification > 1e-10) {
-                        Real strain_rate_magnitude = std::sqrt(2.0 * SmnSmn);
-                        if (strain_rate_magnitude > 1e-10) {
-                            Real velocity_scale = strain_rate_magnitude * Delta;
-                            Real buoyancy_length = std::sqrt(velocity_scale * velocity_scale / stratification);
-
-                            mixing_length = amrex::min(Delta, buoyancy_length);
-                            mixing_length = amrex::max(mixing_length, 0.001 * Delta);
-                        }
+                    Real mixing_length = Delta;
+                    if (stratification > 1e-10 && strain_rate_magnitude > 1e-10) {
+                        Real velocity_scale = strain_rate_magnitude * Delta;
+                        Real buoyancy_length = std::sqrt((velocity_scale * velocity_scale) / stratification);
+                        mixing_length = amrex::min(Delta, buoyancy_length);
+                        mixing_length = amrex::max(mixing_length, 0.001 * Delta);
                     }
 
-                } else {
-                    // STANDARD SMAGORINSKY: Grid-scale mixing length only
-                    mixing_length = Delta;  // Always use grid scale
+                    Real CsDeltaSqr_legacy = Cs * Cs * mixing_length * mixing_length;
+                    nu_turb_base_v = CsDeltaSqr_legacy * strain_rate_magnitude;
                 }
-
-                // =====================================================================
-                // EDDY VISCOSITY CALCULATION (same for standard/enhanced)
-                // =====================================================================
-                Real CsDeltaSqr = Cs * Cs * mixing_length * mixing_length;
 
                 if (isotropic) {
-                    mu_turb(i, j, k, EddyDiff::Mom_h) = CsDeltaSqr * cell_data(i, j, k, Rho_comp) * std::sqrt(2.0*SmnSmn);
-                    mu_turb(i, j, k, EddyDiff::Mom_v) = mu_turb(i, j, k, EddyDiff::Mom_h);
-
-                } else { // anisotropic or smag2d
-                    Real CsDeltaHSqr = Cs * Cs * DeltaH * DeltaH;
-                    mu_turb(i, j, k, EddyDiff::Mom_h) = CsDeltaHSqr * cell_data(i, j, k, Rho_comp) * std::sqrt(2.0*SmnSmn);
-                    mu_turb(i, j, k, EddyDiff::Mom_v) = CsDeltaSqr  * cell_data(i, j, k, Rho_comp) * std::sqrt(2.0*SmnSmn);
+                    mu_turb(i, j, k, EddyDiff::Mom_h) = rho * nu_turb_base_h * stability_factor;
+                    mu_turb(i, j, k, EddyDiff::Mom_v) = rho * nu_turb_base_v * stability_factor;
+                } else {
+                    mu_turb(i, j, k, EddyDiff::Mom_h) = rho * nu_turb_base_h;
+                    mu_turb(i, j, k, EddyDiff::Mom_v) = rho * nu_turb_base_v * stability_factor;
                 }
 
-                // =====================================================================
-                // HEAT FLUX CALCULATION
-                // =====================================================================
                 Real dtheta_dz = 0.5 * ( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
                                        - cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dzInv;
                 hfx_x(i,j,k) = 0.0;
                 hfx_y(i,j,k) = 0.0;
-                hfx_z(i,j,k) = -inv_Pr_t*mu_turb(i,j,k,EddyDiff::Mom_v) * dtheta_dz;
+                hfx_z(i,j,k) = -inv_Pr_t * mu_turb(i,j,k,EddyDiff::Mom_v) * dtheta_dz;
             });
         }
     }
@@ -636,7 +643,8 @@ void ComputeTurbulentViscosity (Real dt,
                                      Hfx1, Hfx2, Hfx3, Diss,
                                      geom, use_terrain_fitted_coords,
                                      mapfac, z_phys_nd, turbChoice, const_grav,
-                                     SurfLayer, solverChoice.moisture_indices);
+                                     SurfLayer, solverChoice.moisture_indices,
+                                     &xvel, &yvel);
     }
 
     if (turbChoice.rans_type != RANSType::None) {

--- a/Source/Diffusion/ERF_EddyViscosity.H
+++ b/Source/Diffusion/ERF_EddyViscosity.H
@@ -38,6 +38,25 @@ ComputeTurbulentViscosity (amrex::Real dt,
                            const amrex::BCRec* bc_ptr,
                            bool vert_only = false);
 
+void
+ComputeTurbulentViscosityLES (amrex::Vector<std::unique_ptr<amrex::MultiFab>>& Tau_lev,
+                              const amrex::MultiFab& cons_in,
+                              amrex::MultiFab& eddyViscosity,
+                              amrex::MultiFab& Hfx1,
+                              amrex::MultiFab& Hfx2,
+                              amrex::MultiFab& Hfx3,
+                              amrex::MultiFab& Diss,
+                              const amrex::Geometry& geom,
+                              bool use_terrain_fitted_coords,
+                              amrex::Vector<std::unique_ptr<amrex::MultiFab>>& mapfac,
+                              const std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                              const TurbChoice& turbChoice,
+                              const amrex::Real const_grav,
+                              std::unique_ptr<SurfaceLayer>& SurfLayer,
+                              const MoistureComponentIndices& moisture_indices,
+                              const amrex::MultiFab* xvel = nullptr,
+                              const amrex::MultiFab* yvel = nullptr);
+
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
 amrex::Real

--- a/Source/Diffusion/ERF_RichardsonNumber.H
+++ b/Source/Diffusion/ERF_RichardsonNumber.H
@@ -142,26 +142,17 @@ ComputeMoistN2(int i, int j, int k,
     amrex::Real dtheta_dz;
 
     if (saturated && qc_index >= 0) {
-        amrex::Real theta_l =
-            GetLiquidWaterPotentialTemperature(cell_data(i,j,k,rhoTheta_comp) / rho,
-                                               cell_data(i,j,k,qv_index) / rho,
-                                               cell_data(i,j,k,qc_index) / rho);
-        amrex::Real theta_l_kp1 =
-            GetLiquidWaterPotentialTemperature(cell_data(i,j,k+1,rhoTheta_comp) / cell_data(i,j,k+1,rho_comp),
-                                               cell_data(i,j,k+1,qv_index) / cell_data(i,j,k+1,rho_comp),
-                                               cell_data(i,j,k+1,qc_index) / cell_data(i,j,k+1,rho_comp));
-        amrex::Real theta_l_km1 =
-            GetLiquidWaterPotentialTemperature(cell_data(i,j,k-1,rhoTheta_comp) / cell_data(i,j,k-1,rho_comp),
-                                               cell_data(i,j,k-1,qv_index) / cell_data(i,j,k-1,rho_comp),
-                                               cell_data(i,j,k-1,qc_index) / cell_data(i,j,k-1,rho_comp));
+        amrex::Real theta_l    = GetThetal(i, j, k  , cell_data, moisture_indices);
+        amrex::Real theta_l_kp1= GetThetal(i, j, k+1, cell_data, moisture_indices);
+        amrex::Real theta_l_km1= GetThetal(i, j, k-1, cell_data, moisture_indices);
 
         inv_theta = 1.0 / theta_l;
         dtheta_dz = 0.5 * (theta_l_kp1 - theta_l_km1) * dzInv;
 
     } else if (qv_index >= 0) {
-        amrex::Real theta_v = GetThetavGivenRhoRhoTheta(cell_data, i, j, k);
-        amrex::Real theta_v_kp1 = GetThetavGivenRhoRhoTheta(cell_data, i, j, k+1);
-        amrex::Real theta_v_km1 = GetThetavGivenRhoRhoTheta(cell_data, i, j, k-1);
+        amrex::Real theta_v    = GetThetav(i, j, k  , cell_data, moisture_indices);
+        amrex::Real theta_v_kp1= GetThetav(i, j, k+1, cell_data, moisture_indices);
+        amrex::Real theta_v_km1= GetThetav(i, j, k-1, cell_data, moisture_indices);
 
         inv_theta = 1.0 / theta_v;
         dtheta_dz = 0.5 * (theta_v_kp1 - theta_v_km1) * dzInv;

--- a/Source/Diffusion/ERF_RichardsonNumber.H
+++ b/Source/Diffusion/ERF_RichardsonNumber.H
@@ -1,0 +1,266 @@
+/** \file ERF_RichardsonNumber.H
+ *
+ * Functions for computing moist Richardson number and Mason (1989) stability function
+ * for Smagorinsky turbulence closure with conditional instability correction.
+ *
+ * PHYSICAL BACKGROUND:
+ * -------------------
+ * In cloud-resolving simulations, standard Smagorinsky models overpredict turbulent
+ * mixing in conditionally unstable regions (cloud updrafts) where buoyancy-driven
+ * instability occurs. This module implements the moist Richardson number correction
+ * following Mason (1989) and Stevens et al. (2005) for marine stratocumulus.
+ *
+ * KEY EQUATIONS:
+ * --------------
+ * 1. Moist Brunt-Väisälä frequency:
+ *    N²_moist = (g/θ_v) * ∂θ_v/∂z  (unsaturated)
+ *    N²_moist = (g/θ_l) * ∂θ_l/∂z  (saturated, in clouds)
+ *
+ * 2. Moist Richardson number:
+ *    Ri_moist = N²_moist / S²_vert
+ *    where S²_vert = (∂u/∂z)² + (∂v/∂z)²
+ *
+ * 3. Mason (1989) stability function:
+ *    f(Ri) = 0                        if Ri ≥ Ri_crit (complete suppression)
+ *          = sqrt(1 - Ri/Ri_crit)     if 0 < Ri < Ri_crit (partial suppression)
+ *          = 1                        if Ri ≤ 0 (no suppression, unstable/neutral)
+ *
+ * 4. Corrected vertical eddy viscosity:
+ *    μ_t,v = ρ(C_s·Δ)²|S| · f(Ri_moist)
+ *
+ * PHYSICAL INTERPRETATION:
+ * ------------------------
+ * - In cloud updrafts: ∂θ_l/∂z < 0 → Ri < 0 → f(Ri) = 1.0 → full mixing (correct!)
+ * - In stable regions: ∂θ_v/∂z > 0 → Ri > 0 → f(Ri) < 1.0 → reduced mixing
+ * - In neutral regions: Ri ≈ 0 → f(Ri) ≈ 1.0 → standard Smagorinsky
+ *
+ * CUDA-CONSERVATIVE DESIGN:
+ * --------------------------
+ * - All functions are explicit device functions (not lambdas)
+ * - Use simple scalar parameters (no struct captures in device context)
+ * - Geometry passed via local scalars (dzInv), not complex objects
+ * - Reuse existing ERF GetThetav/GetThetal from ERF_MoistUtils.H
+ *
+ * REFERENCES:
+ * -----------
+ * - Mason, P. J. (1989): Large-eddy simulation of the convective atmospheric boundary
+ *   layer. J. Atmos. Sci., 46, 1492-1516.
+ * - Stevens et al. (2005): Evaluation of large-eddy simulations via observations of
+ *   nocturnal marine stratocumulus. Mon. Wea. Rev., 133, 1443-1462.
+ * - Smagorinsky, J. (1963): General circulation experiments with the primitive equations.
+ *   Mon. Wea. Rev., 91, 99-164.
+ */
+
+#ifndef ERF_RICHARDSON_NUMBER_H_
+#define ERF_RICHARDSON_NUMBER_H_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+#include <cmath>
+#include "ERF_Constants.H"
+#include "ERF_IndexDefines.H"
+#include "ERF_DataStruct.H"
+#include "ERF_MoistUtils.H"
+
+/**
+ * Check if grid cell is saturated based on cloud liquid water content.
+ *
+ * @param[in] i,j,k  cell indices
+ * @param[in] cell_data  conserved state (ρ, ρθ, ρq_v, ρq_c, etc.)
+ * @param[in] moisture_indices  indices for moisture species
+ * @return true if saturated (q_c > 1e-8 kg/kg), false otherwise
+ *
+ * PHYSICAL JUSTIFICATION: Threshold of 1e-8 kg/kg (0.01 g/kg) is typical
+ * for distinguishing cloudy from clear regions in LES. Below this threshold,
+ * condensate is negligible and air is effectively unsaturated.
+ */
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+bool
+IsSaturated(int i, int j, int k,
+            const amrex::Array4<const amrex::Real>& cell_data,
+            int qc_index)
+{
+    if (qc_index >= 0) {
+        amrex::Real rho = cell_data(i, j, k, Rho_comp);
+        amrex::Real qc = cell_data(i, j, k, qc_index) / rho;
+        return (qc > 1.0e-8);  // 0.01 g/kg threshold
+    }
+    return false;
+}
+
+/**
+ * Compute moist Brunt-Väisälä frequency squared (N²_moist).
+ *
+ * @param[in] i,j,k  cell indices
+ * @param[in] dzInv  inverse vertical grid spacing (1/Δz) [1/m]
+ * @param[in] const_grav  gravitational acceleration g [m/s²]
+ * @param[in] cell_data  conserved state
+ * @param[in] moisture_indices  moisture species indices
+ * @return N²_moist [1/s²]
+ *
+ * PHYSICS:
+ * --------
+ * Uses centered finite differences: ∂/∂z ≈ (f_{k+1} - f_{k-1}) / (2Δz)
+ *
+ * Unsaturated: N² = (g/θ_v) · ∂θ_v/∂z
+ *   where θ_v = θ(1 + 0.61q_v - q_c) accounts for vapor buoyancy and condensate loading
+ *
+ * Saturated: N² = (g/θ_l) · ∂θ_l/∂z
+ *   where θ_l = θ - (L_v/c_p·Π)·q_c is the liquid water potential temperature
+ *
+ * CONDITIONAL INSTABILITY:
+ * ------------------------
+ * In cloud updrafts, ∂θ_l/∂z can be **negative** due to release of latent heat
+ * during ascent. This gives N² < 0, which is physically correct for convective
+ * instability and should enhance (not suppress) mixing.
+ *
+ * UNITS:
+ * ------
+ * Input: dzInv [1/m], const_grav [m/s²], θ [K]
+ * Output: N² [1/s²]
+ */
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+ComputeMoistN2(int i, int j, int k,
+               amrex::Real dzInv,
+               amrex::Real const_grav,
+               const amrex::Array4<const amrex::Real>& cell_data,
+               const MoistureComponentIndices& moisture_indices)
+{
+    const int rho_comp       = Rho_comp;
+    const int rhoTheta_comp  = RhoTheta_comp;
+    const int qv_index = moisture_indices.qv;
+    const int qc_index = moisture_indices.qc;
+
+    amrex::Real rho = cell_data(i, j, k, rho_comp);
+
+    bool saturated = IsSaturated(i, j, k, cell_data, qc_index);
+
+    amrex::Real inv_theta;
+    amrex::Real dtheta_dz;
+
+    if (saturated && qc_index >= 0) {
+        amrex::Real theta_l =
+            GetLiquidWaterPotentialTemperature(cell_data(i,j,k,rhoTheta_comp) / rho,
+                                               cell_data(i,j,k,qv_index) / rho,
+                                               cell_data(i,j,k,qc_index) / rho);
+        amrex::Real theta_l_kp1 =
+            GetLiquidWaterPotentialTemperature(cell_data(i,j,k+1,rhoTheta_comp) / cell_data(i,j,k+1,rho_comp),
+                                               cell_data(i,j,k+1,qv_index) / cell_data(i,j,k+1,rho_comp),
+                                               cell_data(i,j,k+1,qc_index) / cell_data(i,j,k+1,rho_comp));
+        amrex::Real theta_l_km1 =
+            GetLiquidWaterPotentialTemperature(cell_data(i,j,k-1,rhoTheta_comp) / cell_data(i,j,k-1,rho_comp),
+                                               cell_data(i,j,k-1,qv_index) / cell_data(i,j,k-1,rho_comp),
+                                               cell_data(i,j,k-1,qc_index) / cell_data(i,j,k-1,rho_comp));
+
+        inv_theta = 1.0 / theta_l;
+        dtheta_dz = 0.5 * (theta_l_kp1 - theta_l_km1) * dzInv;
+
+    } else if (qv_index >= 0) {
+        amrex::Real theta_v = GetThetavGivenRhoRhoTheta(cell_data, i, j, k);
+        amrex::Real theta_v_kp1 = GetThetavGivenRhoRhoTheta(cell_data, i, j, k+1);
+        amrex::Real theta_v_km1 = GetThetavGivenRhoRhoTheta(cell_data, i, j, k-1);
+
+        inv_theta = 1.0 / theta_v;
+        dtheta_dz = 0.5 * (theta_v_kp1 - theta_v_km1) * dzInv;
+
+    } else {
+        amrex::Real theta = cell_data(i, j, k, rhoTheta_comp) / rho;
+        amrex::Real theta_kp1 = cell_data(i, j, k+1, rhoTheta_comp) / cell_data(i, j, k+1, rho_comp);
+        amrex::Real theta_km1 = cell_data(i, j, k-1, rhoTheta_comp) / cell_data(i, j, k-1, rho_comp);
+
+        inv_theta = 1.0 / theta;
+        dtheta_dz = 0.5 * (theta_kp1 - theta_km1) * dzInv;
+    }
+
+    return const_grav * inv_theta * dtheta_dz;
+}
+
+/**
+ * Compute vertical shear squared (S²_vert).
+ *
+ * @param[in] i,j,k cell indices
+ * @param[in] dzInv inverse vertical grid spacing (1/Δz) [1/m]
+ * @param[in] u face-centered x-velocity (u) array with ngrow≥1 in z
+ * @param[in] v face-centered y-velocity (v) array with ngrow≥1 in z
+ * @return S²_vert = (∂u/∂z)² + (∂v/∂z)² [1/s²]
+ *
+ * DISCRETIZATION:
+ * ---------------
+ * ERF uses Arakawa C-grid:
+ *   u defined at (i+1/2, j, k)  (x-faces)
+ *   v defined at (i, j+1/2, k)  (y-faces)
+ *   w defined at (i, j, k+1/2)  (z-faces)
+ *   cell centers at (i, j, k)
+ *
+ * To get shear at cell center (i,j,k), interpolate velocities to center then difference:
+ *   ∂u/∂z|_{i,j,k} ≈ (u_{i,j,k+1} - u_{i,j,k-1}) / (2Δz)
+ *   where u_{i,j,k} = 0.5 * (u_{i-1/2,j,k} + u_{i+1/2,j,k})
+ *
+ * UNITS:
+ * ------
+ * Input: dzInv [1/m], u, v [m/s]
+ * Output: S²_vert [1/s²]
+ */
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+ComputeVerticalShear2(int i, int j, int k,
+                      amrex::Real dzInv,
+                      const amrex::Array4<const amrex::Real>& u,
+                      const amrex::Array4<const amrex::Real>& v)
+{
+    amrex::Real u_c_km1 = 0.5 * (u(i, j, k-1) + u(i+1, j, k-1));
+    amrex::Real u_c_kp1 = 0.5 * (u(i, j, k+1) + u(i+1, j, k+1));
+
+    amrex::Real v_c_km1 = 0.5 * (v(i, j, k-1) + v(i, j+1, k-1));
+    amrex::Real v_c_kp1 = 0.5 * (v(i, j, k+1) + v(i, j+1, k+1));
+
+    amrex::Real du_dz = 0.5 * (u_c_kp1 - u_c_km1) * dzInv;
+    amrex::Real dv_dz = 0.5 * (v_c_kp1 - v_c_km1) * dzInv;
+
+    amrex::Real S2_vert = du_dz * du_dz + dv_dz * dv_dz;
+
+    return S2_vert;
+}
+
+/**
+ * Compute moist Richardson number.
+ *
+ * @param[in] N2_moist  moist Brunt-Väisälä frequency squared [1/s²]
+ * @param[in] S2_vert   vertical wind shear squared [1/s²]
+ * @return Ri_moist = N²_moist / S²_vert [dimensionless]
+ */
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+ComputeRichardson(amrex::Real N2_moist, amrex::Real S2_vert)
+{
+    amrex::Real S2_safe = amrex::max(S2_vert, 1.0e-10);
+    return N2_moist / S2_safe;
+}
+
+/**
+ * Mason (1989) stability function for turbulent mixing suppression.
+ *
+ * @param[in] Ri  gradient Richardson number [dimensionless]
+ * @param[in] Ri_crit  critical Richardson number (default 0.25)
+ * @return f(Ri) ∈ [0, 1] [dimensionless]
+ */
+AMREX_GPU_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+StabilityFunction(amrex::Real Ri, amrex::Real Ri_crit)
+{
+    if (Ri >= Ri_crit) {
+        return 0.0;
+    } else if (Ri > 0.0) {
+        return std::sqrt(1.0 - Ri / Ri_crit);
+    } else {
+        return 1.0;
+    }
+}
+
+#endif // ERF_RICHARDSON_NUMBER_H_


### PR DESCRIPTION
# Replace `use_smag_stratification` with Moist Richardson Number Correction

## Summary

This PR removes the deprecated `use_smag_stratification` flag and replaces it with a cleaner **moist Richardson number limiter** (`use_moist_Ri_correction`) based on Mason (1989). Instead of adjusting the mixing length, the new approach applies a stability function directly to the vertical eddy viscosity.

## Key Changes

### Mathematical Approach
**Old:** Adjust mixing length based on stratification: `l_m = min(Δ, sqrt(u'²/N²))`  
**New:** Apply stability function to viscosity: `ν_t,v = ρ(C_s·Δ)²|S| · f(Ri_moist)`

Where `f(Ri) = sqrt(1 - Ri/Ri_crit)` for 0 < Ri < Ri_crit, providing smooth suppression in stable regions and full mixing (f=1) in unstable/neutral conditions.

### Code Changes

1. **New input parameters** (`ERF_TurbStruct.H`):
   - `erf.use_moist_Ri_correction` (Boolean, default=false) — replaces `use_smag_stratification`
   - `erf.Ri_crit` (Real, default=0.25) — critical Richardson number

2. **Simplified Smagorinsky implementation** (`ERF_ComputeTurbulentViscosity.cpp`):
   - Removed complex mixing length adjustment logic
   - Streamlined calculation: grid scale → base viscosity → stability correction
   - Added velocity fields (xvel, yvel) to function signature for shear calculation

3. **New header** (`ERF_RichardsonNumber.H`):
   - `ComputeMoistN2()` — Brunt-Väisälä frequency using θ_v (clear) or θ_l (cloudy)
   - `ComputeVerticalShear2()` — vertical wind shear with C-grid interpolation
   - `StabilityFunction()` — Mason (1989) stability function

4. **Updated documentation**:
   - `Docs/sphinx_doc/Inputs.rst` — parameter table
   - `Docs/sphinx_doc/theory/DNSvsLES.rst` — theory section
   - Tornado test input files updated

## Breaking Changes

Users must update input files:
- `erf.use_smag_stratification = true` → `erf.use_moist_Ri_correction = true`
- `erf.use_smag_stratification = false` → `erf.use_moist_Ri_correction = false`

Default is now `false` (standard Smagorinsky) for backward compatibility.

## References

- Mason, P. J. (1989): *J. Atmos. Sci.*, **46**, 1492-1516
- Stevens, B., et al. (2005): *Mon. Wea. Rev.*, **133**, 1443-1462