### PR TITLE
Implicit Diffusion Checks

### DIFF
--- a/Source/DataStructs/ERF_DiffStruct.H
+++ b/Source/DataStructs/ERF_DiffStruct.H
@@ -36,10 +36,10 @@ struct DiffChoice {
         }
 
         if (molec_diff_type != MolecDiffType::None) {
-            pp.query("alpha_T", alpha_T);
-            pp.query("alpha_C", alpha_C);
-            pp.query("dynamic_viscosity", dynamic_viscosity);
-            pp.query("rho0_trans", rho0_trans);
+            if(pp.query("alpha_T", alpha_T)) { AMREX_ALWAYS_ASSERT(alpha_T > 0.); }
+            if(pp.query("alpha_C", alpha_C)) { AMREX_ALWAYS_ASSERT(alpha_C > 0.); }
+            if(pp.query("dynamic_viscosity", dynamic_viscosity)) { AMREX_ALWAYS_ASSERT(dynamic_viscosity > 0.); }
+            if(pp.query("rho0_trans", rho0_trans)) { AMREX_ALWAYS_ASSERT(rho0_trans > 0.); }
             pp.query("eb_diff_constraint_x", eb_diff_constraint_x);
             pp.query("eb_diff_constraint_y", eb_diff_constraint_y);
             pp.query("eb_diff_constraint_z", eb_diff_constraint_z);
@@ -81,7 +81,7 @@ struct DiffChoice {
     }
 
     // Molecular transport model
-    MolecDiffType molec_diff_type = MolecDiffType::Constant;
+    MolecDiffType molec_diff_type = MolecDiffType::None;
 
     // Diffusive/viscous coefficients [m2/s]
     amrex::Real alpha_T = 0.0;

--- a/Source/DataStructs/ERF_DiffStruct.H
+++ b/Source/DataStructs/ERF_DiffStruct.H
@@ -40,6 +40,7 @@ struct DiffChoice {
             if(pp.query("alpha_C", alpha_C)) { AMREX_ALWAYS_ASSERT(alpha_C > 0.); }
             if(pp.query("dynamic_viscosity", dynamic_viscosity)) { AMREX_ALWAYS_ASSERT(dynamic_viscosity > 0.); }
             if(pp.query("rho0_trans", rho0_trans)) { AMREX_ALWAYS_ASSERT(rho0_trans > 0.); }
+            AMREX_ALWAYS_ASSERT( (alpha_T > 0.) || (alpha_C > 0.) || (dynamic_viscosity > 0.));
             pp.query("eb_diff_constraint_x", eb_diff_constraint_x);
             pp.query("eb_diff_constraint_y", eb_diff_constraint_y);
             pp.query("eb_diff_constraint_z", eb_diff_constraint_z);

--- a/Source/TimeIntegration/ERF_Implicit.H
+++ b/Source/TimeIntegration/ERF_Implicit.H
@@ -16,7 +16,7 @@
                 const bool l_use_SurfLayer = (m_SurfaceLayer != nullptr);
                 const BCRec* bc_ptr_h = domain_bcs_type.data();
 
-                const bool l_use_turb       = solverChoice.turbChoice[level].use_kturb;
+                const bool l_use_turb = solverChoice.turbChoice[level].use_kturb;
 
                 std::unique_ptr<MultiFab> dflux_z;
                 dflux_z = std::make_unique<MultiFab>(convert(ba,IntVect(0,0,1)), dm, 1, 0);

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
@@ -159,7 +159,9 @@
 #endif
                          fr_as_crse, fr_as_fine);
 
-        if (solverChoice.vert_implicit_fac[nrk] && solverChoice.implicit_before_substep) {
+        if (solverChoice.vert_implicit_fac[nrk]  &&
+            solverChoice.implicit_before_substep &&
+            l_use_diff) {
             MultiFab scratch(S_data[IntVars::cons].boxArray(),S_data[IntVars::cons].DistributionMap(), 2,
                              S_data[IntVars::cons].nGrowVect());
             MultiFab::Copy(scratch, S_old[IntVars::cons], 0, 0, 2, S_data[IntVars::cons].nGrowVect()); // scratch := S_old (for both)

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -159,8 +159,10 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
 
         const GpuArray<Real, AMREX_SPACEDIM> dxInv = fine_geom.InvCellSizeArray();
 
-        if (solverChoice.vert_implicit_fac[nrk] && !solverChoice.implicit_before_substep &&
-            fast_step == n_sub-1)
+        if (solverChoice.vert_implicit_fac[nrk]   &&
+            !solverChoice.implicit_before_substep &&
+            (fast_step == n_sub-1)                &&
+            l_use_diff)
         {
             MultiFab scratch(S_data[IntVars::cons], make_alias, 0, 2);
 #include "ERF_Implicit.H"


### PR DESCRIPTION
## Summary
- Modify default molecular diffusivity model to be `None`, this is consistent with the other default values
- If a molecular diffusivity model is specified, assert that the parsed value is greater than 0.
- If a molecular diffusivity model is specified, assert one diffusion coefficient is greater than 0.
- Test on `l_use_diff` to enter the implicit diffusion routines.