### PR TITLE
RRTMGP Memory Reduction

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -389,10 +389,10 @@ rrtmgp_main (const int ncol, const int nlay,
              real1d_k& t_sfc      , real2d_k& emis_sfc   , real1d_k& lw_src,
              real2d_k& lwp, real2d_k& iwp,
              real2d_k& rel, real2d_k& rei, real2d_k& cldfrac,
-             real3d_k& aer_tau_sw, real3d_k& aer_ssa_sw, real3d_k& aer_asm_sw,
-             real3d_k& aer_tau_lw,
-             real3d_k& cld_tau_sw_bnd, real3d_k& cld_tau_lw_bnd,
-             real3d_k& cld_tau_sw_gpt, real3d_k& cld_tau_lw_gpt,
+             real3d_k& /*aer_tau_sw*/, real3d_k& /*aer_ssa_sw*/, real3d_k& /*aer_asm_sw*/,
+             real3d_k& /*aer_tau_lw*/,
+             real3d_k& /*cld_tau_sw_bnd*/, real3d_k& /*cld_tau_lw_bnd*/,
+             real3d_k& /*cld_tau_sw_gpt*/, real3d_k& /*cld_tau_lw_gpt*/,
              real2d_k& sw_flux_up, real2d_k& sw_flux_dn, real2d_k& sw_flux_dn_dir,
              real2d_k& lw_flux_up, real2d_k& lw_flux_dn,
              real2d_k& sw_clnclrsky_flux_up, real2d_k& sw_clnclrsky_flux_dn, real2d_k& sw_clnclrsky_flux_dn_dir,
@@ -457,6 +457,7 @@ rrtmgp_main (const int ncol, const int nlay,
     optical_props1_t aerosol_lw;
     aerosol_sw.init(k_dist_sw_k->get_band_lims_wavenumber());
     aerosol_sw.alloc_2str(ncol, nlay);
+    /*
     Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ncol, nlay, nswbands}),
                          KOKKOS_LAMBDA (int icol, int ilay, int ibnd)
     {
@@ -464,13 +465,16 @@ rrtmgp_main (const int ncol, const int nlay,
         aerosol_sw.ssa(icol,ilay,ibnd) = aer_ssa_sw(icol,ilay,ibnd);
         aerosol_sw.g  (icol,ilay,ibnd) = aer_asm_sw(icol,ilay,ibnd);
     });
+    */
     aerosol_lw.init(k_dist_lw_k->get_band_lims_wavenumber());
     aerosol_lw.alloc_1scl(ncol, nlay);
+    /*
     Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ncol, nlay, nlwbands}),
                          KOKKOS_LAMBDA (int icol, int ilay, int ibnd)
     {
         aerosol_lw.tau(icol,ilay,ibnd) = aer_tau_lw(icol,ilay,ibnd);
     });
+    */
 
     // Convert cloud physical properties to optical properties for input to RRTMGP
     optical_props2_t clouds_sw = get_cloud_optics_sw(ncol, nlay,
@@ -479,8 +483,8 @@ rrtmgp_main (const int ncol, const int nlay,
     optical_props1_t clouds_lw = get_cloud_optics_lw(ncol, nlay,
                                                      *cloud_optics_lw_k, *k_dist_lw_k,
                                                      lwp, iwp, rel, rei);
-    Kokkos::deep_copy(cld_tau_sw_bnd, clouds_sw.tau);
-    Kokkos::deep_copy(cld_tau_lw_bnd, clouds_lw.tau);
+    //Kokkos::deep_copy(cld_tau_sw_bnd, clouds_sw.tau);
+    //Kokkos::deep_copy(cld_tau_lw_bnd, clouds_lw.tau);
 
     // Do subcolumn sampling to map bands -> gpoints based on cloud fraction and overlap assumption;
     // This implements the Monte Carlo Independing Column Approximation by mapping only a single
@@ -493,6 +497,7 @@ rrtmgp_main (const int ncol, const int nlay,
     auto clouds_lw_gpt = get_subsampled_clouds(ncol, nlay, nlwbands, nlwgpts,
                                                clouds_lw, *k_dist_lw_k, cldfrac, p_lay);
 
+    /*
     // Copy cloud properties to outputs (is this needed, or can we just use pointers?)
     // Alternatively, just compute and output a subcolumn cloud mask
     Kokkos::parallel_for(Kokkos::MDRangePolicy<Kokkos::Rank<3>>({0, 0, 0}, {ncol, nlay, nswgpts}),
@@ -505,6 +510,7 @@ rrtmgp_main (const int ncol, const int nlay,
     {
         cld_tau_lw_gpt(icol,ilay,igpt) = clouds_lw_gpt.tau(icol,ilay,igpt);
     });
+    */
 
   // Do shortwave
   rrtmgp_sw(ncol, nlay,

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -100,13 +100,13 @@ public:
          amrex::Vector<amrex::MultiFab*>& lsm_output_ptrs,
          amrex::MultiFab* qheating_rates,
          amrex::MultiFab* z_phys,
-         amrex::MultiFab* lat,
-         amrex::MultiFab* lon) override
+         amrex::MultiFab* lat_ptr,
+         amrex::MultiFab* lon_ptr) override
     {
         set_grids(level, step, time, dt, ba, geom,
                   cons_in, lsm_fluxes, lsm_zenith,
                   lsm_input_ptrs, qheating_rates,
-                  z_phys, lat, lon);
+                  z_phys, lat_ptr, lon_ptr);
         rad_run_impl(lsm_output_ptrs);
     }
 

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -305,6 +305,7 @@ Radiation::alloc_buffers ()
     // 2d size (ncol, nlwbands)
     emis_sfc    = real2d_k("emis_sfc", m_ncol, m_nlwbands);
 
+    /*
     // 3d size (ncol, nlay, n[sw,lw]bands)
     aero_tau_sw = real3d_k("aero_tau_sw", m_ncol, m_nlay, m_nswbands);
     aero_ssa_sw = real3d_k("aero_ssa_sw", m_ncol, m_nlay, m_nswbands);
@@ -318,6 +319,7 @@ Radiation::alloc_buffers ()
     // 3d size (ncol, nlay, n[sw,lw]gpts)
     cld_tau_sw_gpt = real3d_k("cld_tau_sw_gpt", m_ncol, m_nlay, m_nswgpts);
     cld_tau_lw_gpt = real3d_k("cld_tau_lw_gpt", m_ncol, m_nlay, m_nlwgpts);
+    */
 }
 
 void
@@ -409,6 +411,7 @@ Radiation::dealloc_buffers ()
     // 2d size (ncol, nlwbands)
     emis_sfc = real2d_k();
 
+    /*
     // 3d size (ncol, nlay, n[sw,lw]bands)
     aero_tau_sw = real3d_k();
     aero_ssa_sw = real3d_k();
@@ -422,6 +425,7 @@ Radiation::dealloc_buffers ()
     // 3d size (ncol, nlay, n[sw,lw]gpts)
     cld_tau_sw_gpt = real3d_k();
     cld_tau_lw_gpt = real3d_k();
+    */
 }
 
 


### PR DESCRIPTION
## Notes
The following PR removes unnecessary 3d data structures from the `ERF_Radiation` interface that are for passing in/out optical properties. The list is provided below:

1. aero_tau/ssa/g_sw
2. aero_tau_lw 
3. cld_tau_sw_bnd 
4. cld_tau_lw_bnd
5. cld_tau_sw_gpt
6. cld_tau_lw_gpt

For now, the allocations are commented out and the copies to/from the E3SM port are also commented out.