### PR TITLE
EB: DEBUG -- Apply FillBoundary for S_new at slow_rhs_fun_post.

### DIFF
--- a/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
@@ -142,7 +142,7 @@
 
             // FillBoundary is needed to get momenta in grown boxes for advection flux calculation,
             // and subsequently, flux interpolation.
-            for (int i = 0; i <= AMREX_SPACEDIM; ++i) {
+            for (int i = 1; i <= AMREX_SPACEDIM; ++i) {
                 S_new[i].FillBoundary(fine_geom.periodicity());
             }
 

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
@@ -139,6 +139,13 @@
                     }
                 }
             }
+
+            // FillBoundary is needed to get momenta in grown boxes for adevection flux calculation,
+            // and subsequently, flux interpolation.
+            for (int i = 0; i <= AMREX_SPACEDIM; ++i) {
+                S_new[i].FillBoundary(fine_geom.periodicity());
+            }
+
         } // EB
 
         // Apply boundary conditions on all the state variables that have been updated

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
@@ -140,7 +140,7 @@
                 }
             }
 
-            // FillBoundary is needed to get momenta in grown boxes for adevection flux calculation,
+            // FillBoundary is needed to get momenta in grown boxes for advection flux calculation,
             // and subsequently, flux interpolation.
             for (int i = 0; i <= AMREX_SPACEDIM; ++i) {
                 S_new[i].FillBoundary(fine_geom.periodicity());


### PR DESCRIPTION
This PR fixes a bug that caused different RHS values at grid boundaries. For `terrain_type==EB`, the advection fluxes are computed on a one-cell-wider box to allow flux interpolation. As a result, we need `FillBoundary` at the end of each RK stage. (There may be a more efficient approach to avoid the extra `FillBoundary`, but I apply this to patch the grid boundary for now.) I confirmed the consistency between `np=1` and `np=4` with `fcompare`.