### PR TITLE
Adding scripts for compiling with SHOC with CUDA on Perlmutter

### DIFF
--- a/Build/GNU_Ekat/eamxx_clone.sh
+++ b/Build/GNU_Ekat/eamxx_clone.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Set path to ERF
-${ERF_DIR:=/home/ERF}
+ERF_DIR="${ERF_DIR:-/home/ERF}"
 
 # Set the path to external in ERF
 EXT_DIR=${ERF_DIR}/external

--- a/Build/build_erf_with_shoc_cuda_Perlmutter.sh
+++ b/Build/build_erf_with_shoc_cuda_Perlmutter.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+# 1. Resolve ERF_DIR to the repo root (one level up from this script)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+export ERF_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "ERF_DIR set to: $ERF_DIR"
+
+# 2. Source EKAT setup
+echo "Sourcing EKAT setup..."
+source "$ERF_DIR/Build/GNU_Ekat/eamxx_clone.sh"
+
+# 3. Prepare build directory
+echo "Preparing build directory..."
+mkdir -p "$ERF_DIR/build"
+cp "$ERF_DIR/Build/cmake_with_shoc_cuda_Perlmutter.sh" "$ERF_DIR/build/"
+
+# 4. Move into build directory
+cd "$ERF_DIR/build"
+
+# 5. Run cmake setup
+echo "Running cmake_with_shoc_cuda_Perlmutter.sh..."
+source cmake_with_shoc_cuda_Perlmutter.sh

--- a/Build/build_erf_with_shoc_cuda_Perlmutter.sh
+++ b/Build/build_erf_with_shoc_cuda_Perlmutter.sh
@@ -8,9 +8,13 @@ export ERF_DIR="$(dirname "$SCRIPT_DIR")"
 
 echo "ERF_DIR set to: $ERF_DIR"
 
-# 2. Source EKAT setup
-echo "Sourcing EKAT setup..."
+E3SM_DIR="$ERF_DIR/external/E3SM"
+if [ ! -d "$E3SM_DIR" ]; then
+echo "external/E3SM folder not found, running eamxx_clone.sh..."
 source "$ERF_DIR/Build/GNU_Ekat/eamxx_clone.sh"
+else
+echo "external/E3SM folder already exists, skipping clone."
+fi
 
 # 3. Prepare build directory
 echo "Preparing build directory..."

--- a/Build/cmake_with_shoc_cuda_Perlmutter.sh
+++ b/Build/cmake_with_shoc_cuda_Perlmutter.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# Example CMake config script for an OSX laptop with OpenMPI
-
 cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
       -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
       -DCMAKE_BUILD_TYPE:STRING=Release \

--- a/Build/cmake_with_shoc_cuda_Perlmutter.sh
+++ b/Build/cmake_with_shoc_cuda_Perlmutter.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Example CMake config script for an OSX laptop with OpenMPI
+
+cmake -DCMAKE_INSTALL_PREFIX:PATH=./install \
+      -DMPIEXEC_PREFLAGS:STRING=--oversubscribe \
+      -DCMAKE_BUILD_TYPE:STRING=Release \
+      -DERF_DIM:STRING=3 \
+      -DERF_ENABLE_MPI:BOOL=ON \
+      -DERF_ENABLE_TESTS:BOOL=ON \
+      -DERF_ENABLE_EKAT:BOOL=ON \
+      -DERF_ENABLE_SHOC:BOOL=ON \
+      -DERF_ENABLE_FCOMPARE:BOOL=ON \
+      -DERF_ENABLE_DOCUMENTATION:BOOL=OFF \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=ON \
+      -DERF_ENABLE_CUDA:BOOL=ON \
+      -DKokkos_ENABLE_CUDA=ON \
+      -DKokkos_ENABLE_CUDA_LAMBDA=ON \
+      -DKokkos_ARCH_AMPERE80=ON \
+      -DCMAKE_CXX_STANDARD=17 \
+      -DCMAKE_CXX_STANDARD_REQUIRED=ON \
+      -DKokkos_ENABLE_CXX17=ON \
+      -DCMAKE_CUDA_STANDARD=17 \
+      -DCMAKE_CUDA_STANDARD_REQUIRED=ON \
+      -DKokkos_ENABLE_CUDA_RELOCATABLE_DEVICE_CODE=ON \
+      -DCMAKE_CXX_COMPILER=CC \
+      -DCMAKE_C_COMPILER=cc \
+      -DCMAKE_CUDA_COMPILER=nvcc \
+      -DCMAKE_CUDA_FLAGS="-I$CRAY_MPICH_DIR/include -L$CRAY_MPICH_DIR/lib " \
+      -DMPI_CXX_INCLUDE_PATH=$CRAY_MPICH_DIR/include \
+      -DMPI_CXX_LIBRARIES=$CRAY_MPICH_DIR/lib/libmpi.so \
+      -DMPI_LIBRARY="$CRAY_MPICH_DIR/lib/libmpi.so" \
+      -DCUDA_LIBRARY_DIRS=/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/math_libs/12.4/targets/x86_64-linux/lib \
+      -DCUDAToolkit_ROOT=/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/cuda/12.4 \
+      -DCUDA_curand_LIBRARY=/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/math_libs/12.4/targets/x86_64-linux/lib/libcurand.so \
+      -DCUDA_cusparse_LIBRARY=/opt/nvidia/hpc_sdk/Linux_x86_64/24.5/math_libs/12.4/targets/x86_64-linux/lib/libcusparse.so \
+      .. && make -j8


### PR DESCRIPTION
This PR adds Perlmutter-specific scripts for compiling ERF with SHOC with CUDA. The steps to compile are

```
cd ERF
source Build/build_erf_with_shoc_cuda_Perlmutter.sh
```

The executables will be in `ERF/build/Exec` in the respective folders. The time taken for this configuration step on Perlmutter is about 30 min.