### PR TITLE
2D Output Vars

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -869,7 +869,7 @@ private:
 
     amrex::Vector<std::unique_ptr<IRadiation>> rad; // Radiation model at each level
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> qheating_rates;  // radiation heating rate source terms (SW, LW)
-
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> rad_fluxes;      // radiation fluxes (SW up/dn, LW up/dn)
 #ifdef ERF_USE_SHOC
     amrex::Vector<std::unique_ptr<SHOCInterface>> shoc_interface; // SHOC model at each level
 #endif
@@ -1136,7 +1136,8 @@ private:
     const amrex::Vector<std::string> derived_names_2d {
         "z_surf", "landmask", "mapfac", "lat_m", "lon_m",
         "u_star", "w_star", "t_star", "q_star", "Olen", "pblh",
-        "t_surf", "q_surf", "z0"
+        "t_surf", "q_surf", "z0", "OLR", "sens_flux", "laten_flux",
+        "surf_pres"
     };
 
     // algorithm choices

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -166,6 +166,7 @@ ERF::ERF_shared ()
 #endif
 
     qheating_rates.resize(nlevs_max);
+    rad_fluxes.resize(nlevs_max);
     sw_lw_fluxes.resize(nlevs_max);
     solar_zenith.resize(nlevs_max);
 

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -382,10 +382,12 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     //*********************************************************
     // Radiation heating source terms
     //*********************************************************
-    if (solverChoice.rad_type != RadiationType::None || solverChoice.lsm_type != LandSurfaceType::None)
+    if (solverChoice.rad_type != RadiationType::None)
     {
-        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, ngrow_state);
+        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, 0);
+        rad_fluxes[lev]     = std::make_unique<MultiFab>(ba, dm, 4, 0);
         qheating_rates[lev]->setVal(0.);
+        rad_fluxes[lev]->setVal(0.);
     }
 
     //*********************************************************
@@ -407,8 +409,8 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
         }
         BoxArray m_ba(std::move(m_bl));
 
-        sw_lw_fluxes[lev] = std::make_unique<MultiFab>(m_ba, dm, 6, ngrow_state); // DIR/DIF VIS/NIR (4), NET SW (1), LW (1)
-        solar_zenith[lev] = std::make_unique<MultiFab>(m_ba, dm, 1, ngrow_state);
+        sw_lw_fluxes[lev] = std::make_unique<MultiFab>(m_ba, dm, 6, 0); // DIR/DIF VIS/NIR (4), NET SW (1), LW (1)
+        solar_zenith[lev] = std::make_unique<MultiFab>(m_ba, dm, 1, 0);
 
         sw_lw_fluxes[lev]->setVal(0.);
         solar_zenith[lev]->setVal(0.);

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1935,6 +1935,10 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         // Set all components to zero in case they aren't defined below
         mf[lev].setVal(0.0);
 
+        // Expose domain khi and klo at each level
+        int klo = geom[lev].Domain().smallEnd(2);
+        int khi = geom[lev].Domain().bigEnd(2);
+
         if (containerHasElement(plot_var_names, "z_surf")) {
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -2204,6 +2208,87 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             }
             mf_comp++;
         } // z0
+
+        if (containerHasElement(plot_var_names, "OLR")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (solverChoice.rad_type != RadiationType::None) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& olr    = rad_fluxes[lev]->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = olr(i, j, khi, 2);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // OLR
+
+        if (containerHasElement(plot_var_names, "sens_flux")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (SFS_hfx3_lev[lev]) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& hfx_arr = SFS_hfx3_lev[lev]->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = hfx_arr(i, j, klo);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // sens_flux
+
+        if (containerHasElement(plot_var_names, "laten_flux")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (SFS_hfx3_lev[lev]) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& qfx_arr = SFS_q1fx3_lev[lev]->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = qfx_arr(i, j, klo);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999,mf_comp,1,0);
+            }
+            mf_comp++;
+        } // laten_flux
+
+        if (containerHasElement(plot_var_names, "surf_pres")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            bool moist = (solverChoice.moisture_type != MoistureType::None);
+            for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                const auto& derdat   = mf[lev].array(mfi);
+                const auto& cons_arr = vars_new[lev][Vars::cons].const_array(mfi);
+                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    auto rt = cons_arr(i,j,klo,RhoTheta_comp);
+                    auto qv = (moist) ? cons_arr(i,j,klo,RhoQ1_comp)/cons_arr(i,j,klo,Rho_comp)
+                                      : 0.0;
+                    derdat(i, j, k, mf_comp) = getPgivenRTh(rt, qv);
+                });
+            }
+            mf_comp++;
+        } // surf_pres
+
     } // lev
 
     std::string plotfilename;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -99,6 +99,7 @@ public:
          amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
          amrex::Vector<amrex::MultiFab*>& lsm_output_ptrs,
          amrex::MultiFab* qheating_rates,
+         amrex::MultiFab* rad_fluxes,
          amrex::MultiFab* z_phys,
          amrex::MultiFab* lat_ptr,
          amrex::MultiFab* lon_ptr) override
@@ -106,7 +107,7 @@ public:
         set_grids(level, step, time, dt, ba, geom,
                   cons_in, lsm_fluxes, lsm_zenith,
                   lsm_input_ptrs, qheating_rates,
-                  z_phys, lat_ptr, lon_ptr);
+                  rad_fluxes, z_phys, lat_ptr, lon_ptr);
         rad_run_impl(lsm_output_ptrs);
     }
 
@@ -123,6 +124,7 @@ public:
                amrex::MultiFab* lsm_zenith,
                amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
                amrex::MultiFab* qheating_rates,
+               amrex::MultiFab* rad_fluxes,
                amrex::MultiFab* z_phys,
                amrex::MultiFab* lat,
                amrex::MultiFab* lon);
@@ -252,6 +254,9 @@ private:
 
     // Pointer to the radiation source terms
     amrex::MultiFab* m_qheating_rates = nullptr;
+
+    // Pointer to the radiation fluxes
+    amrex::MultiFab* m_rad_fluxes = nullptr;
 
     // Pointer to the terrain heights
     amrex::MultiFab* m_z_phys = nullptr;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -142,6 +142,7 @@ Radiation::set_grids (int& level,
                       MultiFab* lsm_zenith,
                       Vector<MultiFab*>& lsm_input_ptrs,
                       MultiFab* qheating_rates,
+                      MultiFab* rad_fluxes,
                       MultiFab* z_phys,
                       MultiFab* lat,
                       MultiFab* lon)
@@ -157,6 +158,7 @@ Radiation::set_grids (int& level,
     m_lsm_fluxes     = lsm_fluxes;
     m_lsm_zenith     = lsm_zenith;
     m_qheating_rates = qheating_rates;
+    m_rad_fluxes     = rad_fluxes;
     m_z_phys         = z_phys;
     m_lat            = lat;
     m_lon            = lon;
@@ -614,6 +616,9 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
     auto sfc_flux_dir_nir_d = sfc_flux_dir_nir;
     auto sfc_flux_dif_vis_d = sfc_flux_dif_vis;
     auto sfc_flux_dif_nir_d = sfc_flux_dif_nir;
+    auto sw_flux_up_d = sw_flux_up;
+    auto sw_flux_dn_d = sw_flux_dn;
+    auto lw_flux_up_d = lw_flux_up;
     auto lw_flux_dn_d = lw_flux_dn;
     auto mu0_d = mu0;
 
@@ -625,6 +630,7 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
         const int jmin       = vbx.smallEnd(1);
         const int offset     = m_col_offsets[mfi.index()];
         const Array4<Real>& q_arr = m_qheating_rates->array(mfi);
+        const Array4<Real>& f_arr = m_rad_fluxes->array(mfi);
         ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // map [i,j,k] 0-based to [icol, ilay] 0-based
@@ -639,6 +645,12 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
             Real iexner = 1./getExnergivenP(Real(p_lay_d(icol,ilay)), R_d/Cp_d);
             q_arr(i,j,k,0) *= iexner;
             q_arr(i,j,k,1) *= iexner;
+
+            // Populate the fluxes
+            f_arr(i,j,k,0) = sw_flux_up_d(icol,ilay);
+            f_arr(i,j,k,1) = sw_flux_dn_d(icol,ilay);
+            f_arr(i,j,k,2) = lw_flux_up_d(icol,ilay);
+            f_arr(i,j,k,3) = lw_flux_dn_d(icol,ilay);
         });
         if (m_lsm_fluxes) {
             const Array4<Real>& lsm_arr =  m_lsm_fluxes->array(mfi);

--- a/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
@@ -35,6 +35,7 @@ public:
          amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
          amrex::Vector<amrex::MultiFab*>& lsm_output_ptrs,
          amrex::MultiFab* qheating_rates,
+         amrex::MultiFab* rad_fluxes,
          amrex::MultiFab* z_phys,
          amrex::MultiFab* lat,
          amrex::MultiFab* lon) = 0;

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -36,7 +36,7 @@ void ERF::advance_radiation (int lev,
                       cons.boxArray(), geom[lev], &(cons),
                       sw_lw_fluxes[lev].get(), solar_zenith[lev].get(),
                       lsm_input_ptrs, lsm_output_ptrs,
-                      qheating_rates[lev].get(), z_phys_nd[lev].get()   ,
-                      lat_ptr, lon_ptr);
+                      qheating_rates[lev].get(), rad_fluxes[lev].get(),
+                      z_phys_nd[lev].get()     , lat_ptr, lon_ptr);
     }
 }


### PR DESCRIPTION
## Summary
Adding the `OLR, sens_flux, laten_flux, and surf_pres` to the 2D output var options. Also, ghost cells were removed when not necessary and the qheating rates should only be allocated when radiation is used.

To enable, add to an inputs file:
```
erf.plot2d_file_1    = plt2d
erf.plot2d_int_1     = 1
erf.plot2d_vars_1    = OLR sens_flux laten_flux surf_pres