### PR TITLE
FillPatcher Domain BCs

### DIFF
--- a/Source/BoundaryConditions/ERF_FillPatcher.H
+++ b/Source/BoundaryConditions/ERF_FillPatcher.H
@@ -13,13 +13,16 @@ public:
                     amrex::Geometry const& fgeom,
                     amrex::BoxArray const& cba, amrex::DistributionMapping const& cdm,
                     amrex::Geometry const& cgeom,
-                    int nghost, int nghost_set, int ncomp, amrex::InterpBase* interp);
+                    int nghost, int nghost_set, int ncomp,
+                    bool real_bc,
+                    amrex::InterpBase* interp);
 
     void Define (amrex::BoxArray const& fba, amrex::DistributionMapping const& fdm,
                  amrex::Geometry const& fgeom,
                  amrex::BoxArray const& cba, amrex::DistributionMapping const& cdm,
                  amrex::Geometry const& cgeom,
                  int nghost, int nghost_set, int ncomp,
+                 bool real_bc,
                  amrex::InterpBase* interp);
 
     void BuildMask (amrex::BoxArray const& fba, int nghost, int nghost_set);
@@ -65,6 +68,7 @@ private:
     int m_nghost;
     int m_nghost_subset;
     int m_ncomp;
+    bool m_real_bc;
     amrex::InterpBase* m_interp;
     amrex::IntVect m_ratio;
     std::unique_ptr<amrex::MultiFab> m_cf_crse_data_old;

--- a/Source/BoundaryConditions/ERF_FillPatcher.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatcher.cpp
@@ -156,6 +156,10 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
     Box fdomain = m_fgeom.Domain();
     fdomain.convert(fba.ixType());
 
+    // NOTE: If periodic, we should fill at the domain boundary
+    //       even if we don't have real bcs.
+    auto f_per = m_fgeom.periodicity();
+
     // Grow the complement boxes and trim with the bounding box
     Vector<Box>& com_bl_v = com_bl.data();
     for (int i(0); i<com_bl.size(); ++i) {
@@ -170,10 +174,11 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
         //       on a domain wall where BCs should be used.
         if (!m_real_bc) {
             for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
-                bool is_node = (fba.ixType()[idim] == IndexType::NODE);
-                if ( (bx.bigEnd(idim) == fdomain.smallEnd(idim)) && is_node) {
+                bool is_node     = (fba.ixType()[idim] == IndexType::NODE);
+                bool is_periodic = f_per.isPeriodic(idim);
+                if ( (bx.bigEnd(idim) == fdomain.smallEnd(idim)) && is_node && !is_periodic) {
                     bx.growHi(idim,-1);
-                } else if ( (bx.smallEnd(idim) == fdomain.bigEnd(idim)) && is_node) {
+                } else if ( (bx.smallEnd(idim) == fdomain.bigEnd(idim)) && is_node && !is_periodic) {
                     bx.growLo(idim,-1);
                 }
             }

--- a/Source/BoundaryConditions/ERF_FillPatcher.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatcher.cpp
@@ -151,13 +151,11 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
         }
     }
 
-    // NOTE: Ensure we don't touch a domain boundary
-    // Trim the fine domain to not include boundary faces
+    // Get the fine domain
     Box fdomain = m_fgeom.Domain();
     fdomain.convert(fba.ixType());
 
-    // NOTE: If periodic, we should fill at the domain boundary
-    //       even if we don't have real bcs.
+    // Get the periodicity
     auto f_per = m_fgeom.periodicity();
 
     // Grow the complement boxes and trim with the bounding box
@@ -185,6 +183,44 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
         }
     }
 
+    // NOTE: Fill periodic BCs when we can.
+    //       The above will NOT trim the complement
+    //       with periodic BCs. Therefore, the domain
+    //       boundary will not be filled with the mask.
+    //       Thus, the default mask (FillSet) would
+    //       result.
+    int dir = -1;
+    int ind_lo = -1;
+    int ind_hi = -1;
+    bool periodic_and_node = false;
+    for (int idim(0); idim<AMREX_SPACEDIM; ++idim) {
+        dir = idim;
+        ind_lo = fdomain.smallEnd(idim);
+        ind_hi = fdomain.bigEnd(idim);
+        periodic_and_node = ( (fba.ixType()[idim] == IndexType::NODE) && f_per.isPeriodic(idim) );
+        if (periodic_and_node) { break; }
+    }
+    BoxList bl_hi, bl_lo, per_bl;
+    if (periodic_and_node) {
+        for (int ibx(0); ibx<fba.size(); ++ibx) {
+            Box fbx = fba[ibx];
+            if (fbx.smallEnd(dir) == fdomain.smallEnd(dir)) {
+                bl_lo.push_back(makeSlab(fbx,dir,ind_lo));
+            }
+            if (fbx.bigEnd(dir) == fdomain.bigEnd(dir)) {
+                bl_hi.push_back(makeSlab(fbx,dir,ind_lo));
+            }
+        }
+        for (auto const& bl : bl_lo) {
+            for (auto const& bh : bl_hi) {
+                Box per_un = bl & bh;
+                if (per_un.ok()) {
+                    per_bl.push_back(per_un);
+                }
+            }
+        }
+    }
+
     // Do second complement with the grown boxes
     com_ba.define(std::move(com_bl));
     com_ba.complementIn(com_bl, fba_bnd);
@@ -200,6 +236,28 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
             {
                 mask_arr(i,j,k) = mask_val;
             });
+        }
+    }
+
+    // Correct the periodic planes if needed
+    if (per_bl.size() > 0) {
+        for (MFIter mfi(*m_cf_mask); mfi.isValid(); ++mfi) {
+            const Box& vbx = mfi.validbox();
+            const Array4<int>& mask_arr = m_cf_mask->array(mfi);
+
+            for (auto const& b : per_bl) {
+                Box per_bx_lo = vbx & b;
+                Box per_bx_hi = makeSlab(per_bx_lo,dir,ind_hi);
+                ParallelFor(per_bx_lo, per_bx_hi,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    mask_arr(i,j,k) = mask_val;
+                },
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                {
+                    mask_arr(i,j,k) = mask_val;
+                });
+            }
         }
     }
 }

--- a/Source/BoundaryConditions/ERF_FillPatcher.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatcher.cpp
@@ -22,8 +22,9 @@ ERFFillPatcher::ERFFillPatcher (BoxArray const& fba, DistributionMapping const& 
                                 Geometry const& fgeom,
                                 BoxArray const& cba, DistributionMapping const& cdm,
                                 Geometry const& cgeom,
-                                int nghost, int nghost_set,
-                                int ncomp, InterpBase* interp)
+                                int nghost, int nghost_set, int ncomp,
+                                bool real_bc,
+                                InterpBase* interp)
     : m_fba(fba),
       m_cba(cba),
       m_fdm(fdm),
@@ -37,7 +38,7 @@ ERFFillPatcher::ERFFillPatcher (BoxArray const& fba, DistributionMapping const& 
     m_crse_times.resize(2);
 
     // Define the coarse and fine MFs
-    Define(fba, fdm, fgeom, cba, cdm, cgeom,nghost, nghost_set, ncomp, interp);
+    Define(fba, fdm, fgeom, cba, cdm, cgeom,nghost, nghost_set, ncomp, real_bc, interp);
 }
 
 
@@ -58,8 +59,9 @@ void ERFFillPatcher::Define (BoxArray const& fba, DistributionMapping const& fdm
                              Geometry const& fgeom,
                              BoxArray const& cba, DistributionMapping const& cdm,
                              Geometry const& cgeom,
-                             int nghost, int nghost_set,
-                             int ncomp, InterpBase* interp)
+                             int nghost, int nghost_set, int ncomp,
+                             bool real_bc,
+                             InterpBase* interp)
 {
     AMREX_ALWAYS_ASSERT(nghost <= 0);
     AMREX_ALWAYS_ASSERT(nghost_set <= 0);
@@ -68,9 +70,10 @@ void ERFFillPatcher::Define (BoxArray const& fba, DistributionMapping const& fdm
     // Set data members
     m_fba = fba; m_cba = cba;
     m_fdm = fdm; m_cdm = cdm;
-    m_fgeom  = fgeom;  m_cgeom = cgeom;
-    m_nghost = nghost; m_nghost_subset = nghost_set;
-    m_ncomp  = ncomp;  m_interp = interp;
+    m_fgeom   = fgeom;  m_cgeom = cgeom;
+    m_nghost  = nghost; m_nghost_subset = nghost_set;
+    m_ncomp   = ncomp;  m_interp = interp;
+    m_real_bc = real_bc;
 
     // Delete old MFs if they exist
     if (m_cf_crse_data_old) m_cf_crse_data_old.reset();
@@ -148,14 +151,34 @@ void ERFFillPatcher::BuildMask (BoxArray const& fba,
         }
     }
 
+    // NOTE: Ensure we don't touch a domain boundary
+    // Trim the fine domain to not include boundary faces
+    Box fdomain = m_fgeom.Domain();
+    fdomain.convert(fba.ixType());
+
     // Grow the complement boxes and trim with the bounding box
     Vector<Box>& com_bl_v = com_bl.data();
     for (int i(0); i<com_bl.size(); ++i) {
         Box& bx = com_bl_v[i];
         bx.grow(box_grow_vect);
         bx &= fba_bnd;
-    }
 
+        // NOTE: Without real_bcs, if the complement box coincides
+        //       with the domain boundary, we must trim it so that
+        //       the second complement (where the mask is set) includes
+        //       the domain boundary. This ensures we don't do a FillSet
+        //       on a domain wall where BCs should be used.
+        if (!m_real_bc) {
+            for (int idim = 0; idim < AMREX_SPACEDIM; ++idim) {
+                bool is_node = (fba.ixType()[idim] == IndexType::NODE);
+                if ( (bx.bigEnd(idim) == fdomain.smallEnd(idim)) && is_node) {
+                    bx.growHi(idim,-1);
+                } else if ( (bx.smallEnd(idim) == fdomain.bigEnd(idim)) && is_node) {
+                    bx.growLo(idim,-1);
+                }
+            }
+        }
+    }
 
     // Do second complement with the grown boxes
     com_ba.define(std::move(com_bl));

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2606,16 +2606,20 @@ ERF::Construct_ERFFillPatchers (int lev)
 
     FPr_c.emplace_back(ba_fine, dm_fine, geom[lev]  ,
                        ba_crse, dm_crse, geom[lev-1],
-                       -cf_width, -cf_set_width, ncomp, &cell_cons_interp);
+                       -cf_width, -cf_set_width, ncomp, solverChoice.use_real_bcs,
+                       &cell_cons_interp);
     FPr_u.emplace_back(convert(ba_fine, IntVect(1,0,0)), dm_fine, geom[lev]  ,
                        convert(ba_crse, IntVect(1,0,0)), dm_crse, geom[lev-1],
-                       -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                       -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                       &face_cons_linear_interp);
     FPr_v.emplace_back(convert(ba_fine, IntVect(0,1,0)), dm_fine, geom[lev]  ,
                        convert(ba_crse, IntVect(0,1,0)), dm_crse, geom[lev-1],
-                       -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                       -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                       &face_cons_linear_interp);
     FPr_w.emplace_back(convert(ba_fine, IntVect(0,0,1)), dm_fine, geom[lev]  ,
                        convert(ba_crse, IntVect(0,0,1)), dm_crse, geom[lev-1],
-                       -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                       -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                       &face_cons_linear_interp);
 }
 
 void
@@ -2632,16 +2636,20 @@ ERF::Define_ERFFillPatchers (int lev)
 
     FPr_c[lev-1].Define(ba_fine, dm_fine, geom[lev]  ,
                         ba_crse, dm_crse, geom[lev-1],
-                        -cf_width, -cf_set_width, ncomp, &cell_cons_interp);
+                        -cf_width, -cf_set_width, ncomp, solverChoice.use_real_bcs,
+                        &cell_cons_interp);
     FPr_u[lev-1].Define(convert(ba_fine, IntVect(1,0,0)), dm_fine, geom[lev]  ,
                         convert(ba_crse, IntVect(1,0,0)), dm_crse, geom[lev-1],
-                        -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                        -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                        &face_cons_linear_interp);
     FPr_v[lev-1].Define(convert(ba_fine, IntVect(0,1,0)), dm_fine, geom[lev]  ,
                         convert(ba_crse, IntVect(0,1,0)), dm_crse, geom[lev-1],
-                        -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                        -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                        &face_cons_linear_interp);
     FPr_w[lev-1].Define(convert(ba_fine, IntVect(0,0,1)), dm_fine, geom[lev]  ,
                         convert(ba_crse, IntVect(0,0,1)), dm_crse, geom[lev-1],
-                        -cf_width, -cf_set_width, 1, &face_cons_linear_interp);
+                        -cf_width, -cf_set_width, 1, solverChoice.use_real_bcs,
+                        &face_cons_linear_interp);
 }
 
 #ifdef ERF_USE_MULTIBLOCK


### PR DESCRIPTION
## Notes
This PR modifies the `FillPatcher` class to avoid conflicts with AMR simulations that DO NOT use real boundary conditions. Specifically, without real bcs, we do not want to fill fine boxes that coincide with a domain boundary; this would enforce interpolated coarse data as opposed to the true BC.