### PR TITLE
Fix upwind real bcs.

### DIFF
--- a/Source/BoundaryConditions/ERF_BoundaryConditionsRealbdy.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsRealbdy.cpp
@@ -380,16 +380,27 @@ ERF::fill_from_realbdy_upwind (const Vector<MultiFab*>& mfs,
                     const Array4<Real>& u_arr = mf_u.array(mfi);
                     const Array4<Real>& v_arr = mf_v.array(mfi);
 
+                    auto lb_u = lbound(u_arr); lb_u.x += ngvect_vels[0]; lb_u.y += ngvect_vels[1];
+                    auto ub_u = ubound(u_arr); ub_u.x -= ngvect_vels[0]; ub_u.y -= ngvect_vels[1];
+                    auto lb_v = lbound(v_arr); lb_v.x += ngvect_vels[0]; lb_v.y += ngvect_vels[1];
+                    auto ub_v = ubound(v_arr); ub_v.x -= ngvect_vels[0]; ub_v.y -= ngvect_vels[1];
+
                     // NOTE: Xlo/hi boxes own corner cells (Ylo/hi)
                     ParallelFor(bx_xlo, bx_xhi,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
+                        // Limit for BDY FAB data
                         int ii = std::max(i , dom_lo.x);
                         int jj = std::max(j , dom_lo.y);
                             jj = std::min(jj, dom_hi.y);
-                        if ( (u_arr(dom_lo.x,jj,k) >= 0.0) ||
-                             ((jj == dom_lo.y) && (v_arr(ii,dom_lo.y  ,k) >= 0.0)) ||
-                             ((jj == dom_hi.y) && (v_arr(ii,dom_hi.y+1,k) <= 0.0)) ) {
+
+                        // Limit for u_arr and v_arr
+                        int ju = std::min(std::max(j, lb_u.y), ub_u.y);
+                        int iv = std::min(std::max(i, lb_v.x), ub_v.x);
+
+                        if ( (u_arr(dom_lo.x,ju,k) >= 0.0) ||
+                             ((jj == dom_lo.y) && (v_arr(iv,dom_lo.y  ,k) >= 0.0)) ||
+                             ((jj == dom_hi.y) && (v_arr(iv,dom_hi.y+1,k) <= 0.0)) ) {
                             dest_arr(i,j,k,comp_idx) = oma   * bdatxlo_n  (ii,jj,k,0)
                                                      + alpha * bdatxlo_np1(ii,jj,k,0);
                             if (var_idx == Vars::cons) {
@@ -401,12 +412,18 @@ ERF::fill_from_realbdy_upwind (const Vector<MultiFab*>& mfs,
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
+                        // Limit for BDY FAB data
                         int ii = std::min(i , dom_hi.x);
                         int jj = std::max(j , dom_lo.y);
                             jj = std::min(jj, dom_hi.y);
-                        if ( (u_arr(dom_hi.x+1,jj,k) <= 0.0) ||
-                             ((jj == dom_lo.y) && (v_arr(ii,dom_lo.y  ,k) >= 0.0)) ||
-                             ((jj == dom_hi.y) && (v_arr(ii,dom_hi.y+1,k) <= 0.0)) ) {
+
+                        // Limit for u_arr and v_arr
+                        int ju = std::min(std::max(j, lb_u.y), ub_u.y);
+                        int iv = std::min(std::max(i, lb_v.x), ub_v.x);
+
+                        if ( (u_arr(dom_hi.x+1,ju,k) <= 0.0) ||
+                             ((jj == dom_lo.y) && (v_arr(iv,dom_lo.y  ,k) >= 0.0)) ||
+                             ((jj == dom_hi.y) && (v_arr(iv,dom_hi.y+1,k) <= 0.0)) ) {
                             dest_arr(i,j,k,comp_idx) = oma   * bdatxhi_n  (ii,jj,k,0)
                                                      + alpha * bdatxhi_np1(ii,jj,k,0);
                             if (var_idx == Vars::cons) {
@@ -423,8 +440,13 @@ ERF::fill_from_realbdy_upwind (const Vector<MultiFab*>& mfs,
                     ParallelFor(bx_ylo, bx_yhi,
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
+                        // Limit for BDY FAB data
                         int jj = std::max(j, dom_lo.y);
-                        if (v_arr(i,dom_lo.y,k) >= 0.0) {
+
+                        // Limit for v_arr
+                        int iv = std::min(std::max(i, lb_v.x), ub_v.x);
+
+                        if (v_arr(iv,dom_lo.y,k) >= 0.0) {
                             dest_arr(i,j,k,comp_idx) = oma   * bdatylo_n  (i,jj,k,0)
                                                      + alpha * bdatylo_np1(i,jj,k,0);
                             if (var_idx == Vars::cons) {
@@ -436,8 +458,13 @@ ERF::fill_from_realbdy_upwind (const Vector<MultiFab*>& mfs,
                     },
                     [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
+                        // Limit for BDY FAB data
                         int jj = std::min(j, dom_hi.y);
-                        if (v_arr(i,dom_hi.y+1,k) <= 0.0) {
+
+                        // Limit for v_arr
+                        int iv = std::min(std::max(i, lb_v.x), ub_v.x);
+
+                        if (v_arr(iv,dom_hi.y+1,k) <= 0.0) {
                             dest_arr(i,j,k,comp_idx) = oma   * bdatyhi_n  (i,jj,k,0)
                                                      + alpha * bdatyhi_np1(i,jj,k,0);
                             if (var_idx == Vars::cons) {


### PR DESCRIPTION
## Notes
The `ii/jj` are limited on the domain, so they are valid to use with FAB data that exists everywhere. However, using those indices with `u_arr/v_arr` in the upwind BCs will lead to out of bounds errors when checking the sign of the velocity. Using limiters now to keep the indices bounded within the valid box of the variable.

## Testing
This bug was revealed by the Tornado case with UPW Real BCs and multiple ranks. Can confirm this case now runs in debug with the current PR.