### PR TITLE
Lmask Indexing

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1097,7 +1097,7 @@ ERF::InitData_post ()
                                sst_lev[lev], tsk_lev[lev],
                                m_SurfaceLayer, low_data_zlo,
                                vars_new[lev][Vars::cons], *mf_PSFC[lev],
-                               solverChoice.rdOcp, lmask_lev[lev][itime], use_moist);
+                               solverChoice.rdOcp, lmask_lev[lev][0], use_moist);
             } // itime
         }
 #endif

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -920,7 +920,7 @@ ERF::init_from_wrfinput (int lev,
                            sst_lev[lev], tsk_lev[lev],
                            m_SurfaceLayer, low_data_zlo,
                            lev_new[Vars::cons], *mf_PSFC[lev],
-                           l_rdOcp, lmask_lev[lev][itime], use_moist);
+                           l_rdOcp, lmask_lev[lev][0], use_moist);
         }
     } // lev == 0 && nc_low_file exists
 }

--- a/Source/TimeIntegration/ERF_SlowRhsPre.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPre.cpp
@@ -206,6 +206,14 @@ void erf_slow_rhs_pre (int level, int finest_level,
         if (solverChoice.use_shoc) {
             // Zero out the surface stresses of tau13/tau23
             shoc_lev->set_diff_stresses();
+        } else if (l_use_SurfLayer) {
+            // Set surface shear stresses, update heat and moisture fluxes
+            // (fluxes will be later applied in the diffusion source update)
+            Vector<const MultiFab*> mfs = {&S_data[IntVars::cons], &xvel, &yvel, &zvel};
+            SurfLayer->impose_SurfaceLayer_bcs(level, mfs, Tau_lev,
+                                               Hfx1, Hfx2, Hfx3,
+                                               Q1fx1, Q1fx2, Q1fx3,
+                                               &z_phys_nd);
         }
 #else
         // This is computed pre step in Advance if we use SHOC

--- a/Source/TimeIntegration/ERF_TimeStep.cpp
+++ b/Source/TimeIntegration/ERF_TimeStep.cpp
@@ -98,7 +98,7 @@ ERF::timeStep (int lev, Real time, int /*iteration*/)
                                sst_lev[lev], tsk_lev[lev],
                                m_SurfaceLayer, low_data_zlo,
                                S_new, *mf_PSFC[lev],
-                               solverChoice.rdOcp, lmask_lev[lev][itime], use_moist);
+                               solverChoice.rdOcp, lmask_lev[lev][0], use_moist);
             }
         } // itime
     } // have nc_low_file && lev == 0


### PR DESCRIPTION
## Notes
`lmask_lev` is not read in over `ntimes` when initializing from wrfinput, but is with the metgrid pathway. In this PR, the time index is set to `0` when passing lmask to the routine that sets sst and tsk. This avoids overrunning the lmask_lev vector when using the wrinput pathway. Also, minor modifications for SHOC when a user has compiled with support but is not using the physics package.