### PR TITLE
Option for file name digits in plotfile and checkpoint file

### DIFF
--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -668,6 +668,8 @@ struct SolverChoice {
             }
         }
 
+        pp.query("file_name_digits", file_name_digits);
+
         check_params(max_level);
     }
 
@@ -1075,5 +1077,7 @@ struct SolverChoice {
 
     bool io_hurricane_eye_tracker = false;
     amrex::Real hurricane_eye_latitude = -1e10, hurricane_eye_longitude = -1e10;
+
+    int file_name_digits = 5;
 };
 #endif

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -35,7 +35,8 @@ ERF::WriteCheckpointFile () const
     // etc.                these subdirectories will hold the MultiFab data at each level of refinement
 
     // checkpoint file name, e.g., chk00010
-    const std::string& checkpointname = Concatenate(check_file,istep[0],5);
+    int file_name_digits = solverChoice.file_name_digits;
+    const std::string& checkpointname = Concatenate(check_file,istep[0],file_name_digits);
 
     Print() << "Writing native checkpoint " << checkpointname << "\n";
 

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1506,16 +1506,18 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
     std::string plotfilenameU;
     std::string plotfilenameV;
     std::string plotfilenameW;
+
+    int file_name_digits = solverChoice.file_name_digits;
     if (which == 1) {
-       plotfilename = Concatenate(plot3d_file_1, istep[0], 5);
-       plotfilenameU = Concatenate(plot3d_file_1+"U", istep[0], 5);
-       plotfilenameV = Concatenate(plot3d_file_1+"V", istep[0], 5);
-       plotfilenameW = Concatenate(plot3d_file_1+"W", istep[0], 5);
+       plotfilename = Concatenate(plot3d_file_1, istep[0], file_name_digits);
+       plotfilenameU = Concatenate(plot3d_file_1+"U", istep[0], file_name_digits);
+       plotfilenameV = Concatenate(plot3d_file_1+"V", istep[0], file_name_digits);
+       plotfilenameW = Concatenate(plot3d_file_1+"W", istep[0], file_name_digits);
     } else if (which == 2) {
-       plotfilename = Concatenate(plot3d_file_2, istep[0], 5);
-       plotfilenameU = Concatenate(plot3d_file_2+"U", istep[0], 5);
-       plotfilenameV = Concatenate(plot3d_file_2+"V", istep[0], 5);
-       plotfilenameW = Concatenate(plot3d_file_2+"W", istep[0], 5);
+       plotfilename = Concatenate(plot3d_file_2, istep[0], file_name_digits);
+       plotfilenameU = Concatenate(plot3d_file_2+"U", istep[0], file_name_digits);
+       plotfilenameV = Concatenate(plot3d_file_2+"V", istep[0], file_name_digits);
+       plotfilenameW = Concatenate(plot3d_file_2+"W", istep[0], file_name_digits);
     }
 
     // LSM writes it's own data
@@ -2301,11 +2303,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 
     } // lev
 
+    int file_name_digits = solverChoice.file_name_digits;
     std::string plotfilename;
     if (which == 1) {
-       plotfilename = Concatenate(plot2d_file_1, istep[0], 5);
+       plotfilename = Concatenate(plot2d_file_1, istep[0], file_name_digits);
     } else if (which == 2) {
-       plotfilename = Concatenate(plot2d_file_2, istep[0], 5);
+       plotfilename = Concatenate(plot2d_file_2, istep[0], file_name_digits);
     }
 
     Vector<Geometry> my_geom(finest_level+1);


### PR DESCRIPTION
This PR adds an inputs option to change the number of digits appended to the plot files and checkpoint file names. The default is set to 5. The input option is for eg. `erf.file_name_digits = 6`.