### PR TITLE
Add a couple more timestepping diagnostic outputs, another w-damping formulation

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1421,9 +1421,36 @@ List of Parameters
 |                            | CFL for w-damping to be applied, |                   |             |
 |                            | if ``erf.w_damping`` is true     |                   |             |
 +----------------------------+----------------------------------+-------------------+-------------+
-| **erf.w_damping_coeff**    | w-damping coefficient (m/s)      | Real              | 0.3         |
+| **erf.w_damping_const**    | w-damping coefficient (m/s2)     | Real              | -1          |
++----------------------------+----------------------------------+-------------------+-------------+
+| **erf.w_damping_coeff**    | w-damping coefficient (-)        | Real              | -1          |
 +----------------------------+----------------------------------+-------------------+-------------+
 
+If ``erf.w_damping`` is true, then either ``erf.w_damping_const`` or ``erf.w_damping_coeff`` must
+be specified. For WRF-like damping, set ``erf.w_damping_const = 0.3`` to give
+
+.. math::
+
+   f_d = - \rho\,\text{sgn}(w)\,(C-C_{crit}) \cdot \gamma,
+
+where :math:`\gamma` is a constant damping coefficient with units of m/s2 and the advective Courant
+number is :math:`C = |w|\Delta t / \Delta z`.
+
+If ``erf.w_damping_coeff`` is specified instead, then
+
+.. math::
+
+   f_d = - \rho\,\text{sgn}(w)\,(|w|-w_{crit}) \cdot \frac{\alpha}{\Delta t},
+
+where :math:`\alpha` is a dimensionless damping factor and :math:`w_{crit} = C_{crit} \Delta z / \Delta t`.
+This is equivalent to:
+
+.. math::
+
+   f_d = - \rho\,\text{sgn}(w)\,(C-C_{crit}) \cdot \alpha \frac{\Delta z}{(\Delta t)^2}.
+
+This approach gives a damping coefficient that is sensitive to the vertical grid spacing and
+robustly damps towards the critical Courant number.
 
 
 Initialization

--- a/Source/DataStructs/ERF_DampingStruct.H
+++ b/Source/DataStructs/ERF_DampingStruct.H
@@ -50,7 +50,12 @@ struct DampingChoice {
         // Include vertical-velocity damping to improve robustness
         pp.query("w_damping", w_damping);
         pp.query("w_damping_cfl", w_damping_cfl);
+        pp.query("w_damping_const", w_damping_const);
         pp.query("w_damping_coeff", w_damping_coeff);
+
+        if (w_damping && (w_damping_const < 0 && w_damping_coeff < 0)) {
+            amrex::Abort("Need to specify vertical damping coefficient w_damping_const (like WRF) or w_damping_coeff (~ dz/dt**2)");
+        }
     }
 
     void display()
@@ -67,7 +72,13 @@ struct DampingChoice {
         } else {
             amrex::Print() << " None" << std::endl;
         }
-        amrex::Print() << "w damping                   : " << w_damping << std::endl;
+
+        amrex::Print() << "w damping                   : " << w_damping;
+        if (w_damping_const > 0) {
+            amrex::Print() << " (coeff = " << w_damping_const << ")" << std::endl;
+        } else {
+            amrex::Print() << " (coeff = " << w_damping_coeff << " * dz/dt**2)" << std::endl;
+        }
     }
 
     bool        rayleigh_damp_U        = false;
@@ -79,8 +90,12 @@ struct DampingChoice {
     amrex::Real rayleigh_ztop;
 
     bool        w_damping              = false;
-    amrex::Real w_damping_cfl          = 1.0; // from WRF manual -- note that WRF w_crit_cfl=1.2 by default
-    amrex::Real w_damping_coeff        = 0.3; // damping coefficient [m/s2]
+    amrex::Real w_damping_cfl          = 1.0; // from WRF manual -- WRF source code has default
+                                              //   w_crit_cfl=1.2
+    amrex::Real w_damping_const        = -1;  // damping coefficient -- to used a constant value
+                                              //   (WRF uses 0.3 m/s2), set to a positive value;
+                                              //   otherwise, the damping coefficient will be
+    amrex::Real w_damping_coeff        = -1;  //   grid-dependent: coeff * dz/dt**2
 
     // Molecular transport model
     RayleighDampingType rayleigh_damping_type = RayleighDampingType::SlowExplicit;

--- a/Source/DataStructs/ERF_DampingStruct.H
+++ b/Source/DataStructs/ERF_DampingStruct.H
@@ -79,8 +79,8 @@ struct DampingChoice {
     amrex::Real rayleigh_ztop;
 
     bool        w_damping              = false;
-    amrex::Real w_damping_cfl          = 1.0;
-    amrex::Real w_damping_coeff        = 0.3; // damping coefficient [m/s]
+    amrex::Real w_damping_cfl          = 1.0; // from WRF manual -- note that WRF w_crit_cfl=1.2 by default
+    amrex::Real w_damping_coeff        = 0.3; // damping coefficient [m/s2]
 
     // Molecular transport model
     RayleighDampingType rayleigh_damping_type = RayleighDampingType::SlowExplicit;

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -362,6 +362,8 @@ struct SolverChoice {
             }
         }
 
+        pp.query("substepping_diag", substepping_diag);
+
         pp.query("beta_s", beta_s);
 
 
@@ -925,6 +927,9 @@ struct SolverChoice {
 
     amrex::Vector<SubsteppingType> substepping_type;
     amrex::Vector<int> anelastic;
+
+    // do some extra CFL diagnostics for compressible with substepping
+    bool substepping_diag = false;
 
     // time off-centering coefficient, > 0 for forward weighting (i.e., bias
     // towards the future time step)

--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -96,7 +96,6 @@ void make_mom_sources (Real time,
     //    8. Forest canopy
     //    9. Immersed forcing
     //   10. Constant mass flux
-    //   11. Vertical-velocity damping
     // *****************************************************************************
     // NOTE: buoyancy is now computed in a separate routine - it should not appear here
     // *****************************************************************************
@@ -831,60 +830,5 @@ void make_mom_sources (Real time,
             });
         }
 
-        // *****************************************************************************
-        // 11. Add w-damping
-        // *****************************************************************************
-        bool        w_damping       = solverChoice.dampingChoice.w_damping;
-        amrex::Real w_damping_coeff = solverChoice.dampingChoice.w_damping_coeff;
-        amrex::Real cflw_lim        = solverChoice.dampingChoice.w_damping_cfl;
-
-        if (w_damping && is_slow_step) {
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                Real dzInv;
-                if (z_nd_arr) {
-                    // average z_nd to face then diff
-                    if (k == domain.smallEnd(2)) {
-                        dzInv = 4.0 / (
-                            z_nd_arr(i  ,j  ,k+1) - z_nd_arr(i  ,j  ,k)
-                          + z_nd_arr(i+1,j  ,k+1) - z_nd_arr(i+1,j  ,k)
-                          + z_nd_arr(i  ,j+1,k+1) - z_nd_arr(i  ,j+1,k)
-                          + z_nd_arr(i+1,j+1,k+1) - z_nd_arr(i+1,j+1,k) );
-                    } else if (k == domain.bigEnd(2)+1) {
-                        dzInv = 4.0 / (
-                            z_nd_arr(i  ,j  ,k) - z_nd_arr(i  ,j  ,k-1)
-                          + z_nd_arr(i+1,j  ,k) - z_nd_arr(i+1,j  ,k-1)
-                          + z_nd_arr(i  ,j+1,k) - z_nd_arr(i  ,j+1,k-1)
-                          + z_nd_arr(i+1,j+1,k) - z_nd_arr(i+1,j+1,k-1) );
-                    } else {
-                        // dz = 0.5 * (dz[i,j,k] + dz[i,j,k+1])
-                        //    = 0.5 * (z_nd_face[i,j,k+1] - z_nd_face[i,j,k-1])
-                        dzInv = 8.0 / (
-                            z_nd_arr(i  ,j  ,k+1) - z_nd_arr(i  ,j  ,k-1)
-                          + z_nd_arr(i+1,j  ,k+1) - z_nd_arr(i+1,j  ,k-1)
-                          + z_nd_arr(i  ,j+1,k+1) - z_nd_arr(i  ,j+1,k-1)
-                          + z_nd_arr(i+1,j+1,k+1) - z_nd_arr(i+1,j+1,k-1) );
-                    }
-                } else {
-                    dzInv = dxInv[2];
-                }
-
-                Real rho_on_w_face = 0.5 * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
-                Real wmag = std::abs(rho_w(i,j,k) / rho_on_w_face);
-
-                Real cflw = wmag * dt * dzInv;
-                if (cflw > cflw_lim) {
-#ifdef AMREX_USE_GPU
-                    AMREX_DEVICE_PRINTF("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f\n",
-                           i,j,k, cflw, cflw_lim);
-#else
-                    printf("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f\n",
-                           i,j,k, cflw, cflw_lim);
-#endif
-                    Real sgn_w = (rho_w(i,j,k) > 0) ? 1.0 : -1.0;
-                    zmom_src_arr(i, j, k) -= rho_on_w_face * sgn_w * w_damping_coeff * (cflw - cflw_lim);
-                }
-            });
-        }
     } // mfi
 }

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -77,10 +77,11 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
     bool l_substepping = (solverChoice.substepping_type[level] == SubsteppingType::Implicit);
     int  l_anelastic   = solverChoice.anelastic[level];
 
-    bool l_substepping_diag = (verbose && l_substepping && !l_anelastic && solverChoice.substepping_diag);
+    bool l_comp_substepping_diag = (verbose && l_substepping && !l_anelastic && solverChoice.substepping_diag);
 
     Real estdt_comp_inv;
     Real estdt_vert_comp_inv;
+    Real estdt_vert_lowM_inv;
 
     if (l_substepping && (nxc==1) && (nyc==1)) {
         // SCM -- should not depend on dx or dy; force minimum number of substeps
@@ -205,33 +206,6 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
            });
            return new_comp_dt;
        });
-
-       if (l_substepping_diag) {
-           estdt_vert_comp_inv = ReduceMax(S_new, ccvel, 0,
-           [=] AMREX_GPU_HOST_DEVICE (Box const& b,
-                                      Array4<Real const> const& s,
-                                      Array4<Real const> const& u) -> Real
-           {
-               Real new_comp_dt = -1.e100;
-               amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
-               {
-                   {
-                       const Real rho      = s(i, j, k, Rho_comp);
-                       const Real rhotheta = s(i, j, k, RhoTheta_comp);
-
-                       // NOTE: even when moisture is present,
-                       //       we only use the partial pressure of the dry air
-                       //       to compute the soundspeed
-                       Real pressure = getPgivenRTh(rhotheta);
-                       Real c = std::sqrt(Gamma * pressure / rho);
-
-                       // Look at z-direction only
-                       new_comp_dt = amrex::max(((amrex::Math::abs(u(i,j,k,2))+c)*dzinv   ), new_comp_dt);
-                   }
-               });
-               return new_comp_dt;
-           });
-       }
     } // not EB
 
     ParallelDescriptor::ReduceRealMax(estdt_comp_inv);
@@ -254,6 +228,50 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
      ParallelDescriptor::ReduceRealMax(estdt_lowM_inv);
      if (estdt_lowM_inv > 0.0_rt)
          estdt_lowM = cfl / estdt_lowM_inv;
+
+     // Additional vertical diagnostics
+     if (l_comp_substepping_diag) {
+         estdt_vert_comp_inv = ReduceMax(S_new, ccvel, 0,
+         [=] AMREX_GPU_HOST_DEVICE (Box const& b,
+                                    Array4<Real const> const& s,
+                                    Array4<Real const> const& u) -> Real
+         {
+             Real new_comp_dt = -1.e100;
+             amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
+             {
+                 {
+                     const Real rho      = s(i, j, k, Rho_comp);
+                     const Real rhotheta = s(i, j, k, RhoTheta_comp);
+
+                     // NOTE: even when moisture is present,
+                     //       we only use the partial pressure of the dry air
+                     //       to compute the soundspeed
+                     Real pressure = getPgivenRTh(rhotheta);
+                     Real c = std::sqrt(Gamma * pressure / rho);
+
+                     // Look at z-direction only
+                     new_comp_dt = amrex::max((amrex::Math::abs(u(i,j,k,2)) + c) * dzinv, new_comp_dt);
+                 }
+             });
+             return new_comp_dt;
+         });
+
+         estdt_vert_lowM_inv = ReduceMax(S_new, ccvel, 0,
+         [=] AMREX_GPU_HOST_DEVICE (Box const& b,
+                                    Array4<Real const> const& s,
+                                    Array4<Real const> const& u) -> Real
+         {
+             Real new_lowM_dt = -1.e100;
+             amrex::Loop(b, [=,&new_lowM_dt] (int i, int j, int k) noexcept
+             {
+                 new_lowM_dt = amrex::max((amrex::Math::abs(u(i,j,k,2))) * dzinv, new_lowM_dt);
+             });
+             return new_lowM_dt;
+         });
+
+         ParallelDescriptor::ReduceRealMax(estdt_vert_comp_inv);
+         ParallelDescriptor::ReduceRealMax(estdt_vert_lowM_inv);
+     }
 
      if (verbose) {
          if (fixed_dt[level] <= 0.0) {
@@ -313,12 +331,19 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
 
      // Print out some extra diagnostics -- dt calcs are repeated so as to not
      // disrupt the overall code flow...
-     if (l_substepping_diag) {
+     if (l_comp_substepping_diag) {
          Real dt = (fixed_dt[level] > 0.0) ? fixed_dt[level] : estdt_comp;
          int  ns = (fixed_mri_dt_ratio > 0.0) ? fixed_mri_dt_ratio : dt_fast_ratio;
+
+         // horizontal acoustic CFL must be < 1 (fully explicit)
+         // vertical   acoustic CFL may  be > 1
          Print() << "effective horiz,vert acoustic CFL with " << ns << " substeps : "
             << (dt / ns) * estdt_comp_inv << " "
             << (dt / ns) * estdt_vert_comp_inv << std::endl;
+
+         // vertical advective CFL should be < 1, otherwise w-damping may be needed
+         Print() << "effective vert advective CFL : "
+            << dt * estdt_vert_lowM_inv << std::endl;
      }
 
      if (fixed_dt[level] > 0.0) {

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -75,9 +75,12 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                                                         &vars_new[level][Vars::zvel]});
 
     bool l_substepping = (solverChoice.substepping_type[level] == SubsteppingType::Implicit);
-    int l_anelastic      = solverChoice.anelastic[level];
+    int  l_anelastic   = solverChoice.anelastic[level];
+
+    bool l_substepping_diag = (verbose && l_substepping && !l_anelastic && solverChoice.substepping_diag);
 
     Real estdt_comp_inv;
+    Real estdt_vert_comp_inv;
 
     if (l_substepping && (nxc==1) && (nyc==1)) {
         // SCM -- should not depend on dx or dy; force minimum number of substeps
@@ -202,6 +205,33 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
            });
            return new_comp_dt;
        });
+
+       if (l_substepping_diag) {
+           estdt_vert_comp_inv = ReduceMax(S_new, ccvel, 0,
+           [=] AMREX_GPU_HOST_DEVICE (Box const& b,
+                                      Array4<Real const> const& s,
+                                      Array4<Real const> const& u) -> Real
+           {
+               Real new_comp_dt = -1.e100;
+               amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
+               {
+                   {
+                       const Real rho      = s(i, j, k, Rho_comp);
+                       const Real rhotheta = s(i, j, k, RhoTheta_comp);
+
+                       // NOTE: even when moisture is present,
+                       //       we only use the partial pressure of the dry air
+                       //       to compute the soundspeed
+                       Real pressure = getPgivenRTh(rhotheta);
+                       Real c = std::sqrt(Gamma * pressure / rho);
+
+                       // Look at z-direction only
+                       new_comp_dt = amrex::max(((amrex::Math::abs(u(i,j,k,2))+c)*dzinv   ), new_comp_dt);
+                   }
+               });
+               return new_comp_dt;
+           });
+       }
     } // not EB
 
     ParallelDescriptor::ReduceRealMax(estdt_comp_inv);
@@ -281,6 +311,16 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
          }
      } // if substepping
 
+     // Print out some extra diagnostics -- dt calcs are repeated so as to not
+     // disrupt the overall code flow...
+     if (l_substepping_diag) {
+         Real dt = (fixed_dt[level] > 0.0) ? fixed_dt[level] : estdt_comp;
+         int  ns = (fixed_mri_dt_ratio > 0.0) ? fixed_mri_dt_ratio : dt_fast_ratio;
+         Print() << "effective horiz,vert acoustic CFL with " << ns << " substeps : "
+            << (dt / ns) * estdt_comp_inv << " "
+            << (dt / ns) * estdt_vert_comp_inv << std::endl;
+     }
+
      if (fixed_dt[level] > 0.0) {
          return fixed_dt[level];
      } else {
@@ -291,11 +331,10 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
             estdt_lowM = amrex::min(estdt_lowM, dt_max);
 
             // On the first timestep enforce dt_max_initial
-            if(istep[level] == 0){
+            if (istep[level] == 0) {
                 return amrex::min(dt_max_initial, estdt_lowM);
-             }
-            else{
-             return estdt_lowM;
+            } else {
+                return estdt_lowM;
             }
 
 

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -178,6 +178,75 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
 #include "ERF_Implicit.H"
         }
 
+        // Apply vertical velocity damping at the end of the timestep
+        if ( (solverChoice.dampingChoice.w_damping) &&
+             (nrk == 2) &&
+             (fast_step == n_sub-1))
+        {
+
+            amrex::Real w_damping_coeff = solverChoice.dampingChoice.w_damping_coeff;
+            amrex::Real cflw_lim        = solverChoice.dampingChoice.w_damping_cfl;
+
+            for ( MFIter mfi(S_data[IntVars::cons]); mfi.isValid(); ++mfi)
+            {
+                Box tbz = mfi.nodaltilebox(2);
+
+                const Array4<const Real>& z_nd_arr  = z_phys_nd[level]->const_array(mfi);
+
+                const Array4<const Real>& cell_data = S_data[IntVars::cons].const_array(mfi);
+                const Array4<      Real>& rho_w     = S_data[IntVars::zmom].array(mfi);
+
+                ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                {
+                    Real dzInv;
+                    if (z_nd_arr) {
+                        // average z_nd to face then diff
+                        if (k == domain.smallEnd(2)) {
+                            dzInv = 4.0 / (
+                                z_nd_arr(i  ,j  ,k+1) - z_nd_arr(i  ,j  ,k)
+                              + z_nd_arr(i+1,j  ,k+1) - z_nd_arr(i+1,j  ,k)
+                              + z_nd_arr(i  ,j+1,k+1) - z_nd_arr(i  ,j+1,k)
+                              + z_nd_arr(i+1,j+1,k+1) - z_nd_arr(i+1,j+1,k) );
+                        } else if (k == domain.bigEnd(2)+1) {
+                            dzInv = 4.0 / (
+                                z_nd_arr(i  ,j  ,k) - z_nd_arr(i  ,j  ,k-1)
+                              + z_nd_arr(i+1,j  ,k) - z_nd_arr(i+1,j  ,k-1)
+                              + z_nd_arr(i  ,j+1,k) - z_nd_arr(i  ,j+1,k-1)
+                              + z_nd_arr(i+1,j+1,k) - z_nd_arr(i+1,j+1,k-1) );
+                        } else {
+                            // dz = 0.5 * (dz[i,j,k] + dz[i,j,k+1])
+                            //    = 0.5 * (z_nd_face[i,j,k+1] - z_nd_face[i,j,k-1])
+                            dzInv = 8.0 / (
+                                z_nd_arr(i  ,j  ,k+1) - z_nd_arr(i  ,j  ,k-1)
+                              + z_nd_arr(i+1,j  ,k+1) - z_nd_arr(i+1,j  ,k-1)
+                              + z_nd_arr(i  ,j+1,k+1) - z_nd_arr(i  ,j+1,k-1)
+                              + z_nd_arr(i+1,j+1,k+1) - z_nd_arr(i+1,j+1,k-1) );
+                        }
+                    } else {
+                        dzInv = dxInv[2];
+                    }
+
+                    Real rho_on_w_face = 0.5 * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    Real wmag = std::abs(rho_w(i,j,k) / rho_on_w_face);
+
+                    // This is the dynamics timestep, not the slow or fast dt
+                    Real cflw = wmag * dt_advance * dzInv;
+
+                    if (cflw > cflw_lim) {
+                        Real sgn_w = (rho_w(i,j,k) > 0) ? 1.0 : -1.0;
+                        rho_w(i, j, k) -= rho_on_w_face * sgn_w * w_damping_coeff * (cflw - cflw_lim) * dt_advance;
+#ifdef AMREX_USE_GPU
+                        AMREX_DEVICE_PRINTF("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
+                               i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
+#else
+                        printf("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
+                               i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
+#endif
+                    }
+                });
+            }
+        }
+
         // NOTE: Numerical diffusion is tested on in FillPatchIntermediate and dictates the size of the
         //       box over which VelocityToMomentum is computed. V2M requires one more ghost cell be
         //       filled for rho than velocity. This logical condition ensures we fill enough ghost cells

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -183,7 +183,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
              (nrk == 2) &&
              (fast_step == n_sub-1))
         {
-
+            amrex::Real w_damping_const = solverChoice.dampingChoice.w_damping_const;
             amrex::Real w_damping_coeff = solverChoice.dampingChoice.w_damping_coeff;
             amrex::Real cflw_lim        = solverChoice.dampingChoice.w_damping_cfl;
 
@@ -226,6 +226,10 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
                         dzInv = dxInv[2];
                     }
 
+                    Real dampcoef = (w_damping_const > 0)
+                                  ? w_damping_const
+                                  : w_damping_coeff / (dzInv * dt_advance * dt_advance);
+
                     Real rho_on_w_face = 0.5 * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                     Real wmag = std::abs(rho_w(i,j,k) / rho_on_w_face);
 
@@ -234,7 +238,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
 
                     if (cflw > cflw_lim) {
                         Real sgn_w = (rho_w(i,j,k) > 0) ? 1.0 : -1.0;
-                        rho_w(i, j, k) -= rho_on_w_face * sgn_w * w_damping_coeff * (cflw - cflw_lim) * dt_advance;
+                        rho_w(i, j, k) -= rho_on_w_face * sgn_w * dampcoef * (cflw - cflw_lim) * dt_advance;
 #ifdef AMREX_USE_GPU
                         AMREX_DEVICE_PRINTF("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
                                i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -239,12 +239,13 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
                     if (cflw > cflw_lim) {
                         Real sgn_w = (rho_w(i,j,k) > 0) ? 1.0 : -1.0;
                         rho_w(i, j, k) -= rho_on_w_face * sgn_w * dampcoef * (cflw - cflw_lim) * dt_advance;
+                        // Note: These prints are not immediately flushed to screen
 #ifdef AMREX_USE_GPU
-                        AMREX_DEVICE_PRINTF("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
-                               i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
+                        AMREX_DEVICE_PRINTF("t=%f w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
+                               old_time+dt_advance, i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
 #else
-                        printf("w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
-                               i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
+                        printf("t=%f w-damping applied at (%d,%d,%d) for w-CFL = %f > %f : %f --> %f\n",
+                               old_time+dt_advance, i,j,k, cflw, cflw_lim, sgn_w*wmag, rho_w(i,j,k)/rho_on_w_face);
 #endif
                     }
                 });


### PR DESCRIPTION
* If `erf.substepping_diag` in the compressible path, print out the effective horizontal and vertical acoustic CFLs (based on the dynamics time step and the slow/fast timestep ratio); also, print out the vertical advective CFL
* Modified w-damping for operational robustness; original WRF-style w-damping is selected with `erf.w_damping=1` and `erf.w_damping_const=0.3`; alternative formulation uses a vertical grid spacing-dependent damping coefficient, `erf.w_damping_coeff` * (dz/dt**2) -- see updated docs