### PR TITLE
Fix potential input_sounding gotcha

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -557,8 +557,10 @@ public:
   }
 
   amrex::MultiFab* get_t_surf (const int& lev) { return t_surf[lev].get(); }
+  void set_t_surf(const int& lev, const amrex::Real tsurf) { t_surf[lev]->setVal(tsurf); }
 
   amrex::MultiFab* get_q_surf (const int& lev) { return q_surf[lev].get(); }
+  void set_q_surf(const int& lev, const amrex::Real qsurf) { q_surf[lev]->setVal(qsurf); }
 
   amrex::Real get_zref () { return m_ma.get_zref(); }
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1581,6 +1581,18 @@ ERF::InitData_post ()
                                                        sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
         }
 
+        // If initializing from an input_sounding, make sure the surface layer
+        // is using the same surface conditions
+        if (solverChoice.init_type == InitType::Input_Sounding) {
+            const Real theta0 = input_sounding_data.theta_ref_inp_sound;
+            const Real qv0    = input_sounding_data.qv_ref_inp_sound;
+            for (int lev = 0; lev <= finest_level; lev++) {
+                MultiFab* t_surf_lev = m_SurfaceLayer->get_t_surf(lev);
+                MultiFab* q_surf_lev = m_SurfaceLayer->get_q_surf(lev);
+                t_surf_lev->setVal(theta0);
+                q_surf_lev->setVal(qv0);
+            }
+        }
 
         if (restart_chkfile != "") {
             // Update surface fields if needed (and available)

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1587,10 +1587,8 @@ ERF::InitData_post ()
             const Real theta0 = input_sounding_data.theta_ref_inp_sound;
             const Real qv0    = input_sounding_data.qv_ref_inp_sound;
             for (int lev = 0; lev <= finest_level; lev++) {
-                MultiFab* t_surf_lev = m_SurfaceLayer->get_t_surf(lev);
-                MultiFab* q_surf_lev = m_SurfaceLayer->get_q_surf(lev);
-                t_surf_lev->setVal(theta0);
-                q_surf_lev->setVal(qv0);
+                m_SurfaceLayer->set_t_surf(lev, theta0);
+                m_SurfaceLayer->set_q_surf(lev, qv0);
             }
         }
 

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -2170,9 +2170,9 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_t_surf(lev)->const_array(mfi);
+                    const auto& tsurf  = m_SurfaceLayer->get_t_surf(lev)->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
+                       derdat(i, j, k, mf_comp) = tsurf(i, j, 0);
                     });
                 }
             } else {


### PR DESCRIPTION
Currently `SurfaceLayer.t_surf` and `SurfaceLayer.q_surf` are initialized to default values if `erf.most.surf_temp` is not specified. This is inconsistent with initial conditions from a provided "input_sounding". This _shouldn't_ be an issue because by default, the code follows the specified heat flux path and the surface temperature is not updated or used by the surface layer under idealized conditions. However, other physics models (e.g., the PBL scheme) may request `m_SurfaceLayer->get_t_surf(lev)`, which would return an incorrect default value.

To be safe, if `erf.init_type = input_sounding`, then the initial surface layer t_surf and q_surf will now be updated from the sounding. A separate PR will address the PBL scheme dependencies on t_surf.