### PR TITLE
BDY Corner Nudging Fix

### DIFF
--- a/Source/Utils/ERF_Utils.H
+++ b/Source/Utils/ERF_Utils.H
@@ -307,7 +307,7 @@ realbdy_compute_laplacian_relaxation (const int& icomp,
         amrex::Real xi     = (x_end - x) / (x_end - ProbLo[0]);
         amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : 0.0;
         amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : 0.0;
-        amrex::Real eta    = std::min(eta_lo,eta_hi);
+        amrex::Real eta    = std::max(eta_lo,eta_hi);
         amrex::Real Factor = std::max(xi*xi,eta*eta);
 
         amrex::Real d        = data_arr(i  ,j  ,k  ,n+icomp);
@@ -335,7 +335,7 @@ realbdy_compute_laplacian_relaxation (const int& icomp,
         amrex::Real xi     = (x - x_strt) / (ProbHi[0] - x_strt);
         amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : 0.0;
         amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : 0.0;
-        amrex::Real eta    = std::min(eta_lo,eta_hi);
+        amrex::Real eta    = std::max(eta_lo,eta_hi);
         amrex::Real Factor = std::max(xi*xi,eta*eta);
 
         amrex::Real d        = data_arr(i  ,j  ,k  ,n+icomp);


### PR DESCRIPTION
## Notes
The `x_lo` and `x_hi` boxes own the corner regions. When we do nudging, we compute the physical distance from the boundary. At corners we should use the `MAX` of the `eta/xi` factor. For example, a cell at `(3,1,99)` on the `x_lo` face is closer to the `y_lo` boundary and thus should use `eta^2` instead of `xi^2`.