### PR TITLE
Surface Layer Zref MF

### DIFF
--- a/Source/BoundaryConditions/ERF_MOSTAverage.H
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.H
@@ -102,7 +102,7 @@ public:
     [[nodiscard]] const amrex::MultiFab* get_average (const int& lev, const int& comp) const { return m_averages[lev][comp].get(); }
 
     // Get z_ref (may be computed from specified k_indx)
-    [[nodiscard]] amrex::Real get_zref () const { return m_zref; }
+    [[nodiscard]] amrex::MultiFab* get_zref (const int& lev) const { return m_zref[lev].get(); }
 
     /**
      * Function to compute trilinear interpolation with terrain.
@@ -200,7 +200,7 @@ protected:
     int  m_maxlev{0};                                                // Total number of levels
     int  m_policy{0};                                                // Policy for type of averaging
     bool m_rotate{false};                                            // Do vector rotations for terrain?
-    amrex::Real m_zref{10.0};                                        // Height above surface for MOST BC
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_zref;          // Height above surface for MOST BC
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_x_pos;         // Ptr to 2D mf to hold x position (maxlev)
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_y_pos;         // Ptr to 2D mf to hold y position (maxlev)
     amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_z_pos;         // Ptr to 2D mf to hold z position (maxlev)

--- a/Source/BoundaryConditions/ERF_MOSTAverage.H
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.H
@@ -237,5 +237,9 @@ protected:
     //--------------------------------------------
     bool include_subgrid_vel = false;
     amrex::Vector<amrex::Real> m_Vsg;                                // Subgrid velocity scale (Mahrt & Sun 1995 MWR)
+
+    // Default values
+    //--------------------------------------------
+    const amrex::Real zref_default = 10.0;
 };
 #endif

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -432,7 +432,7 @@ MOSTAverage::set_k_indices_N (const int& lev)
 
         m_zref[lev]->setVal( (lk + 0.5) * m_dz + m_zlo );
 
-        AMREX_ALWAYS_ALWAYS_ASSERT(lk >= m_radius);
+        AMREX_ALWAYS_ASSERT(lk >= m_radius);
 
         m_k_indx[lev]->setVal(lk);
     // Specified k_indx & compute z_ref

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -68,6 +68,7 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
     m_rot_fields.resize(m_maxlev);
     m_averages.resize(m_maxlev);
     m_z_phys_nd.resize(m_maxlev);
+    m_zref.resize(m_maxlev);
 
     m_k_in.resize(m_maxlev);
 
@@ -174,6 +175,10 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
             m_rot_fields[lev][3] = nullptr;
         }
 
+        // Default zref to 10 and fill will true values later
+        m_zref[lev] = std::make_unique<MultiFab>(ba,dm,1,ng);
+        m_zref[lev]->setVal(10.0);
+
         if (use_terrain_fitted_coords && m_norm_vec && m_interp) {
             m_x_pos[lev] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
             m_y_pos[lev] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
@@ -203,7 +208,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         set_norm_indices_T(lev);
     } else if (use_terrain_fitted_coords) {                    // Terrain
         set_k_indices_T(lev);
-    } else {                                        // No Terrain
+    } else {                                                   // No Terrain
         set_k_indices_N(lev);
     }
 
@@ -396,15 +401,16 @@ void
 MOSTAverage::set_k_indices_N (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    auto read_z = pp.query("most.zref",m_zref);
+    Real zref_tmp = 10.0;;
+    auto read_z = pp.query("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
     // Default behavior is to use the first cell center
     if (!read_z && !read_k) {
         Real m_zlo = m_geom[0].ProbLo(2);
         Real m_dz  = m_geom[0].CellSize(2);
-        m_zref = m_zlo + 0.5 * m_dz;
-        Print() << "Reference height for MOST set to " << m_zref << std::endl;
+        m_zref[lev]->setVal( m_zlo + 0.5 * m_dz );
+        Print() << "Reference height for MOST set to " << m_zlo + 0.5 * m_dz << std::endl;
         read_z = true;
     }
 
@@ -416,15 +422,15 @@ MOSTAverage::set_k_indices_N (const int& lev)
 
         amrex::ignore_unused(m_zhi);
 
-        AMREX_ASSERT_WITH_MESSAGE(m_zref >= m_zlo + 0.5 * m_dz,
+        AMREX_ASSERT_WITH_MESSAGE(zref_tmp >= m_zlo + 0.5 * m_dz,
                                   "Query point must be past first z-cell!");
 
-        AMREX_ASSERT_WITH_MESSAGE(m_zref <= m_zhi - 0.5 * m_dz,
+        AMREX_ASSERT_WITH_MESSAGE(zref_tmp <= m_zhi - 0.5 * m_dz,
                                   "Query point must be below the last z-cell!");
 
-        int lk = static_cast<int>(floor((m_zref - m_zlo) / m_dz - 0.5));
+        int lk = static_cast<int>(floor((zref_tmp - m_zlo) / m_dz - 0.5));
 
-        m_zref = (lk + 0.5) * m_dz + m_zlo;
+        m_zref[lev]->setVal( (lk + 0.5) * m_dz + m_zlo );
 
         AMREX_ALWAYS_ASSERT(lk >= m_radius);
 
@@ -438,7 +444,7 @@ MOSTAverage::set_k_indices_N (const int& lev)
         // TODO: check that z_ref is constant across levels
         Real m_zlo = m_geom[0].ProbLo(2);
         Real m_dz  = m_geom[0].CellSize(2);
-        m_zref = ((Real)m_k_in[0] + 0.5) * m_dz + m_zlo;
+        m_zref[lev]->setVal( ((Real)m_k_in[0] + 0.5) * m_dz + m_zlo );
     }
 }
 
@@ -451,12 +457,13 @@ void
 MOSTAverage::set_k_indices_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    auto read_z = pp.query("most.zref",m_zref);
+    Real zref_tmp = 10.0;
+    auto read_z = pp.query("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
     // Allow default zref
     if (!read_z) {
-        Print() << "most.zref not specified, query distance default is " << m_zref << std::endl;
+        Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
         read_z = true;
     }
 
@@ -466,7 +473,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
                                      "Need to specify zref or k_arr_in for MOST");
 
     // Capture for device
-    Real d_zref   = m_zref;
+    Real d_zref   = zref_tmp;
     Real d_radius = m_radius;
     amrex::ignore_unused(d_radius);
 
@@ -477,6 +484,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
             Box npbx = mfi.tilebox(IntVect(1,1,0),IntVect(1,1,0));
             const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
             auto k_arr = m_k_indx[lev]->array(mfi);
+            auto zref_arr = m_zref[lev]->array(mfi);
             ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 k_arr(i,j,k) = 0;
@@ -492,6 +500,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
                         AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
                                                   "K index must be larger than averaging radius!");
                         k_arr(i,j,k) = lk;
+                        zref_arr(i,j,k) = 0.5 * (z_hi + z_lo) - z_bot_face;
                         break;
                     }
                 }
@@ -512,13 +521,14 @@ void
 MOSTAverage::set_norm_indices_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    auto read_zref = pp.query("most.zref",m_zref);
+    Real zref_tmp = 10.0;
+    auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
-        Print() << "most.zref not specified, query distance default is " << m_zref << std::endl;
+        Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }
 
     // Capture for device
-    Real d_zref   = m_zref;
+    Real d_zref   = zref_tmp;
     Real d_radius = m_radius;
 
     int kmax = m_geom[lev].Domain().bigEnd(2);
@@ -531,6 +541,7 @@ MOSTAverage::set_norm_indices_T (const int& lev)
         auto i_arr = m_i_indx[lev]->array(mfi);
         auto j_arr = m_j_indx[lev]->array(mfi);
         auto k_arr = m_k_indx[lev]->array(mfi);
+        auto zref_arr = m_zref[lev]->array(mfi);
         ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of normal vector
@@ -565,6 +576,7 @@ MOSTAverage::set_norm_indices_T (const int& lev)
                                               "K index must be larger than averaging radius!");
                     amrex::ignore_unused(d_radius);
                     k_arr(i,j,k) = lk;
+                    zref_arr(i,j,k) = 0.5 * (z_hi + z_lo) - z_bot_face;
                     break;
                 }
             }
@@ -586,13 +598,16 @@ void
 MOSTAverage::set_z_positions_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    auto read_zref = pp.query("most.zref",m_zref);
+    Real zref_tmp = 10.0;
+    auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
-        Print() << "most.zref not specified, query distance default is " << m_zref << std::endl;
+        Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
+    } else {
+        m_zref[lev]->setVal(zref_tmp);
     }
 
     // Capture for device
-    Real d_zref = m_zref;
+    Real d_zref = zref_tmp;
     const auto plo = m_geom[lev].ProbLoArray();
 
     RealVect base;
@@ -634,13 +649,14 @@ void
 MOSTAverage::set_norm_positions_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    auto read_zref = pp.query("most.zref",m_zref);
+    Real zref_tmp = 10.0;
+    auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
-        Print() << "most.zref not specified, query distance default is " << m_zref << std::endl;
+        Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }
 
     // Capture for device
-    Real d_zref = m_zref;
+    Real d_zref = zref_tmp;
     const auto plo = m_geom[lev].ProbLoArray();
 
     RealVect base;
@@ -656,6 +672,7 @@ MOSTAverage::set_norm_positions_T (const int& lev)
         auto x_pos_arr   = m_x_pos[lev]->array(mfi);
         auto y_pos_arr   = m_y_pos[lev]->array(mfi);
         auto z_pos_arr   = m_z_pos[lev]->array(mfi);
+        auto zref_arr    = m_zref[lev]->array(mfi);
         ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of normal vector
@@ -688,6 +705,8 @@ MOSTAverage::set_norm_positions_T (const int& lev)
             if (z_pos_arr(i,j,k) < z_new_bot_face) {
                 z_pos_arr(i,j,k) = z_new_bot_face + delta_z;
             }
+
+            zref_arr(i,j,k) = delta_z;
 
             // Destination position must be contained on the current process!
             Real pos[] = {x_pos_arr(i,j,k)-plo[0],y_pos_arr(i,j,k)-plo[1],0.5*dx[2]};

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -55,10 +55,10 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
     // For SYCL
     amrex::ignore_unused(has_zphys);
 
-    AMREX_ASSERT_WITH_MESSAGE(m_radius<=2, "Radius must be less than nGhost=3!");
-    if (m_interp) AMREX_ASSERT_WITH_MESSAGE(has_zphys, "Interpolation only implemented with terrain!");
-    if (m_rotate) AMREX_ASSERT_WITH_MESSAGE(has_zphys, "Stress rotations are only valid with terrain!");
-    if (m_norm_vec) AMREX_ASSERT_WITH_MESSAGE(has_zphys, "Normal vector is only valid with terrain!");
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_radius<=2, "Radius must be less than nGhost=3!");
+    if (m_interp) AMREX_ALWAYS_ASSERT_WITH_MESSAGE(has_zphys, "Interpolation only implemented with terrain!");
+    if (m_rotate) AMREX_ALWAYS_ASSERT_WITH_MESSAGE(has_zphys, "Stress rotations are only valid with terrain!");
+    if (m_norm_vec) AMREX_ALWAYS_ASSERT_WITH_MESSAGE(has_zphys, "Normal vector is only valid with terrain!");
 
     // Set up fields and 2D MF/iMFs for averages
     //--------------------------------------------------------
@@ -222,7 +222,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         set_region_normalization(lev);
         break;
     default:
-        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
     }
 
     // Set up the exponential time filtering
@@ -422,22 +422,22 @@ MOSTAverage::set_k_indices_N (const int& lev)
 
         amrex::ignore_unused(m_zhi);
 
-        AMREX_ASSERT_WITH_MESSAGE(zref_tmp >= m_zlo + 0.5 * m_dz,
-                                  "Query point must be past first z-cell!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(zref_tmp >= m_zlo + 0.5 * m_dz,
+                                         "Query point must be past first z-cell!");
 
-        AMREX_ASSERT_WITH_MESSAGE(zref_tmp <= m_zhi - 0.5 * m_dz,
-                                  "Query point must be below the last z-cell!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(zref_tmp <= m_zhi - 0.5 * m_dz,
+                                         "Query point must be below the last z-cell!");
 
         int lk = static_cast<int>(floor((zref_tmp - m_zlo) / m_dz - 0.5));
 
         m_zref[lev]->setVal( (lk + 0.5) * m_dz + m_zlo );
 
-        AMREX_ALWAYS_ASSERT(lk >= m_radius);
+        AMREX_ALWAYS_ALWAYS_ASSERT(lk >= m_radius);
 
         m_k_indx[lev]->setVal(lk);
     // Specified k_indx & compute z_ref
     } else if (read_k) {
-        AMREX_ASSERT_WITH_MESSAGE(m_k_in[lev] >= m_radius,
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_k_in[lev] >= m_radius,
                                   "K index must be larger than averaging radius!");
         m_k_indx[lev]->setVal(m_k_in[lev]);
 
@@ -488,6 +488,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
             ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 k_arr(i,j,k) = 0;
+                bool found = false;
                 Real z_bot_face  = 0.25 * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
                                           + z_phys_arr(i  ,j+1,k) + z_phys_arr(i+1,j+1,k) );
                 Real z_target    = z_bot_face + d_zref;
@@ -497,18 +498,21 @@ MOSTAverage::set_k_indices_T (const int& lev)
                     Real z_hi = 0.25 * ( z_phys_arr(i,j  ,lk+1) + z_phys_arr(i+1,j  ,lk+1)
                                        + z_phys_arr(i,j+1,lk+1) + z_phys_arr(i+1,j+1,lk+1) );
                     if (z_target > z_lo && z_target < z_hi){
-                        AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
-                                                  "K index must be larger than averaging radius!");
+                        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lk >= d_radius,
+                                                         "K index must be larger than averaging radius!");
                         k_arr(i,j,k) = lk;
                         zref_arr(i,j,k) = 0.5 * (z_hi + z_lo) - z_bot_face;
+                        found = true;
                         break;
                     }
                 }
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(found,
+                                                 "zref not found with terrain!");
             });
         }
     // Specified k_indx & compute z_ref
     } else if (read_k) {
-        AMREX_ASSERT_WITH_MESSAGE(false, "Specified k-indx with terrain not implemented!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "Specified k-indx with terrain not implemented!");
     }
 }
 
@@ -572,8 +576,8 @@ MOSTAverage::set_norm_indices_T (const int& lev)
                 Real z_hi = 0.25 * ( z_phys_arr(i_new,j_new  ,lk+1) + z_phys_arr(i_new+1,j_new  ,lk+1)
                                    + z_phys_arr(i_new,j_new+1,lk+1) + z_phys_arr(i_new+1,j_new+1,lk+1) );
                 if (z_target > z_lo && z_target < z_hi){
-                    AMREX_ASSERT_WITH_MESSAGE(lk >= d_radius,
-                                              "K index must be larger than averaging radius!");
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lk >= d_radius,
+                                                     "K index must be larger than averaging radius!");
                     amrex::ignore_unused(d_radius);
                     k_arr(i,j,k) = lk;
                     zref_arr(i,j,k) = 0.5 * (z_hi + z_lo) - z_bot_face;
@@ -583,8 +587,8 @@ MOSTAverage::set_norm_indices_T (const int& lev)
 
             // Destination cell must be contained on the current process!
             amrex::ignore_unused(gpbx);
-            AMREX_ASSERT_WITH_MESSAGE(gpbx.contains(i_arr(i,j,k),j_arr(i,j,k),k_arr(i,j,k)),
-                                      "Query index outside of proc domain!");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(gpbx.contains(i_arr(i,j,k),j_arr(i,j,k),k_arr(i,j,k)),
+                                             "Query index outside of proc domain!");
         });
     }
 }
@@ -634,8 +638,8 @@ MOSTAverage::set_z_positions_T (const int& lev)
             // Destination position must be contained on the current process!
             Real pos[] = {x_pos_arr(i,j,k)-plo[0],y_pos_arr(i,j,k)-plo[1],0.5*dx[2]};
             amrex::ignore_unused(pos);
-            AMREX_ASSERT_WITH_MESSAGE( grb.contains(&pos[0]),
-                                       "Query point outside of proc domain!");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grb.contains(&pos[0]),
+                                             "Query point outside of proc domain!");
         });
     }
 }
@@ -711,8 +715,8 @@ MOSTAverage::set_norm_positions_T (const int& lev)
             // Destination position must be contained on the current process!
             Real pos[] = {x_pos_arr(i,j,k)-plo[0],y_pos_arr(i,j,k)-plo[1],0.5*dx[2]};
             amrex::ignore_unused(pos);
-            AMREX_ASSERT_WITH_MESSAGE( grb.contains(&pos[0]),
-                                       "Query point outside of proc domain!");
+            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grb.contains(&pos[0]),
+                                              "Query point outside of proc domain!");
         });
     }
 }
@@ -736,7 +740,7 @@ MOSTAverage::compute_averages (const int& lev)
         compute_region_averages(lev);
         break;
     default:
-        AMREX_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(false, "Unknown policy for MOSTAverage!");
     }
 
     // We have initialized the averages

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -177,7 +177,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
 
         // Default zref to 10 and fill will true values later
         m_zref[lev] = std::make_unique<MultiFab>(ba,dm,1,ng);
-        m_zref[lev]->setVal(10.0);
+        m_zref[lev]->setVal(zref_default);
 
         if (use_terrain_fitted_coords && m_norm_vec && m_interp) {
             m_x_pos[lev] = std::make_unique<MultiFab>(ba2d,dm,ncomp,ng);
@@ -401,7 +401,7 @@ void
 MOSTAverage::set_k_indices_N (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    Real zref_tmp = 10.0;;
+    Real zref_tmp = zref_default;
     auto read_z = pp.query("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
@@ -409,8 +409,9 @@ MOSTAverage::set_k_indices_N (const int& lev)
     if (!read_z && !read_k) {
         Real m_zlo = m_geom[0].ProbLo(2);
         Real m_dz  = m_geom[0].CellSize(2);
-        m_zref[lev]->setVal( m_zlo + 0.5 * m_dz );
-        Print() << "Reference height for MOST set to " << m_zlo + 0.5 * m_dz << std::endl;
+        zref_tmp = m_zlo + 0.5 * m_dz;
+        m_zref[lev]->setVal( zref_tmp );
+        Print() << "Reference height for MOST set to " << zref_tmp << std::endl;
         read_z = true;
     }
 
@@ -457,7 +458,7 @@ void
 MOSTAverage::set_k_indices_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    Real zref_tmp = 10.0;
+    Real zref_tmp = zref_default;
     auto read_z = pp.query("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
@@ -525,7 +526,7 @@ void
 MOSTAverage::set_norm_indices_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    Real zref_tmp = 10.0;
+    Real zref_tmp = zref_default;
     auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
@@ -602,7 +603,7 @@ void
 MOSTAverage::set_z_positions_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    Real zref_tmp = 10.0;
+    Real zref_tmp = zref_default;
     auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
@@ -653,7 +654,7 @@ void
 MOSTAverage::set_norm_positions_T (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
-    Real zref_tmp = 10.0;
+    Real zref_tmp = zref_default;
     auto read_zref = pp.query("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;

--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -12,7 +12,6 @@
 struct most_data
 {
 public:
-    amrex::Real zref{10.0};           ///< Reference height (m)
     amrex::Real z0_const{0.1};        ///< Roughness height -- default constant value(m)
     amrex::Real kappa{KAPPA};         ///< von Karman constant
     amrex::Real gravity{CONST_GRAV};  ///< Acceleration due to gravity (m/s^2)
@@ -139,11 +138,9 @@ air_viscosity (amrex::Real T_degK)
  */
 struct adiabatic
 {
-    adiabatic (amrex::Real zref,
-               amrex::Real Tflux,
+    adiabatic (amrex::Real Tflux,
                amrex::Real Qvflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
     }
@@ -155,6 +152,7 @@ struct adiabatic
                   const int& j,
                   const int& k,
                   const int& /*max_iters*/,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<const amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& /*tm_arr*/,
@@ -173,7 +171,7 @@ struct adiabatic
                   const amrex::Array4<amrex::Real>& /*eta_arr*/) const
     {
         olen_arr(i,j,k)   = 1.0e16;
-        u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(mdata.zref / z0_arr(i,j,k));
+        u_star_arr(i,j,k) = mdata.kappa * umm_arr(i,j,k) / std::log(zref_arr(i,j,k) / z0_arr(i,j,k));
         t_star_arr(i,j,k) = 0.0;
         q_star_arr(i,j,k) = 0.0;
     }
@@ -189,13 +187,11 @@ private:
  */
 struct adiabatic_charnock
 {
-    adiabatic_charnock (amrex::Real zref,
-                        amrex::Real Tflux,
+    adiabatic_charnock (amrex::Real Tflux,
                         amrex::Real Qvflux,
                         amrex::Real cnk_a,
                         bool cnk_visc)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
@@ -209,6 +205,7 @@ struct adiabatic_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -227,11 +224,12 @@ struct adiabatic_charnock
                   const amrex::Array4<amrex::Real>& /*eta_arr*/) const
     {
         amrex::Real ustar  = 0.0;
+        amrex::Real zref   = zref_arr(i,j,k);
         amrex::Real z0     = z0_arr(i,j,k);
         amrex::Real z0_old = z0;
         amrex::Real psi_m  = 0.0;
         amrex::Real umm    = std::max(umm_arr(i,j,k), WSMIN);
-        amrex::Real C      = std::log(mdata.zref / z0);
+        amrex::Real C      = std::log(zref / z0);
 
         // Fixed point iteration on roughness
         int iter_z = 0;
@@ -240,7 +238,7 @@ struct adiabatic_charnock
             z0_old = z0;
 
             // Update
-            C = std::log(mdata.zref / z0_old);
+            C = std::log(zref / z0_old);
             ustar = mdata.kappa * umm / (C - psi_m);
             if (mdata.Cnk_a > 0) {
                 z0 = (mdata.Cnk_a / mdata.gravity) * ustar * ustar;
@@ -248,14 +246,14 @@ struct adiabatic_charnock
                     z0 += air_viscosity(tm_arr(i,j,k)) / std::max(ustar, 0.05);
                 }
             } else {
-                z0 = COARE3_roughness(mdata.zref, umm, ustar);
+                z0 = COARE3_roughness(zref, umm, ustar);
             }
 
             ++iter_z;
         } while ( (std::abs(z0 - z0_old) > tol_z) && (iter_z <= max_iters) );
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter_z < max_iters,
                                          "Maximum number of MOST roughness iterations reached.");
-        C = std::log(mdata.zref / z0);
+        C = std::log(zref / z0);
 
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
@@ -278,12 +276,10 @@ private:
  */
 struct adiabatic_mod_charnock
 {
-    adiabatic_mod_charnock (amrex::Real zref,
-                            amrex::Real Tflux,
+    adiabatic_mod_charnock (amrex::Real Tflux,
                             amrex::Real Qvflux,
                             amrex::Real depth)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
@@ -297,6 +293,7 @@ struct adiabatic_mod_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& /*tm_arr*/,
@@ -315,11 +312,12 @@ struct adiabatic_mod_charnock
                   const amrex::Array4<amrex::Real>& /*eta_arr*/) const
     {
         amrex::Real ustar  = 0.0;
+        amrex::Real zref   = zref_arr(i,j,k);
         amrex::Real z0     = z0_arr(i,j,k);
         amrex::Real z0_old = z0;
         amrex::Real psi_m  = 0.0;
         amrex::Real umm    = std::max(umm_arr(i,j,k), WSMIN);
-        amrex::Real C      = std::log(mdata.zref / z0);
+        amrex::Real C      = std::log(zref / z0);
 
         // Fixed point iteration on roughness
         int iter_z = 0;
@@ -328,7 +326,7 @@ struct adiabatic_mod_charnock
             z0_old = z0;
 
             // Update
-            C = std::log(mdata.zref / z0_old);
+            C = std::log(zref / z0_old);
             ustar = mdata.kappa * umm / (C - psi_m);
             z0    = std::exp( (2.7*ustar - 1.8/mdata.Cnk_b) / (ustar + 0.17/mdata.Cnk_b) );
 
@@ -336,7 +334,7 @@ struct adiabatic_mod_charnock
         } while ( (std::abs(z0 - z0_old) > tol_z) && (iter_z <= max_iters) );
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter_z < max_iters,
                                          "Maximum number of MOST roughness iterations reached.");
-        C = std::log(mdata.zref / z0);
+        C = std::log(zref / z0);
 
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
@@ -359,11 +357,9 @@ private:
  */
 struct adiabatic_donelan
 {
-    adiabatic_donelan (amrex::Real zref,
-                       amrex::Real Tflux,
+    adiabatic_donelan (amrex::Real Tflux,
                        amrex::Real Qvflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
     }
@@ -375,6 +371,7 @@ struct adiabatic_donelan
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& /*tm_arr*/,
@@ -395,15 +392,16 @@ struct adiabatic_donelan
         int iter = 0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         amrex::Real ustar = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real z0    = 0.0;
-        u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+        u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         }
         do {
             ustar = u_star_arr(i,j,k);
             z0    = Donelan_roughness(ustar);
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0);
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -429,11 +427,9 @@ private:
  */
 struct adiabatic_wave_coupled
 {
-    adiabatic_wave_coupled (amrex::Real zref,
-                            amrex::Real Tflux,
+    adiabatic_wave_coupled (amrex::Real Tflux,
                             amrex::Real Qvflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
     }
@@ -445,6 +441,7 @@ struct adiabatic_wave_coupled
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& /*tm_arr*/,
@@ -465,18 +462,19 @@ struct adiabatic_wave_coupled
         int iter = 0;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         amrex::Real ustar = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real z0    = 0.0;
         int ie, je;
         ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
         je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
         ie = ie > ubound(eta_arr).x ? ubound(eta_arr).x : ie;
         je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
-        u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+        u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         do {
             ustar = u_star_arr(i,j,k);
             z0    = std::min( std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
                                       + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps), z0_max );
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0);
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -505,12 +503,10 @@ private:
  */
 struct surface_flux
 {
-    surface_flux (amrex::Real zref,
-                  amrex::Real Tflux,
+    surface_flux (amrex::Real Tflux,
                   amrex::Real Qvflux,
                   bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -523,6 +519,7 @@ struct surface_flux
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<const amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -549,12 +546,13 @@ struct surface_flux
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -562,7 +560,7 @@ struct surface_flux
             ustar = u_star_arr(i,j,k);
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -572,10 +570,10 @@ struct surface_flux
                 umm = std::max(umm, WSMIN);
             }
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0_arr(i,j,k)) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0_arr(i,j,k)) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -583,16 +581,16 @@ struct surface_flux
 
         // Populate the stored MOST arrays
         olen_arr(i,j,k)   = Olen;
-        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -610,14 +608,12 @@ private:
  */
 struct surface_flux_charnock
 {
-    surface_flux_charnock (amrex::Real zref,
-                           amrex::Real Tflux,
+    surface_flux_charnock (amrex::Real Tflux,
                            amrex::Real Qvflux,
                            amrex::Real cnk_a,
                            bool cnk_visc,
                            bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
@@ -632,6 +628,7 @@ struct surface_flux_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -659,12 +656,13 @@ struct surface_flux_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -676,11 +674,11 @@ struct surface_flux_charnock
                     z0 += air_viscosity(tm_arr(i,j,k)) / std::max(ustar, 0.05);
                 }
             } else {
-                z0 = COARE3_roughness(mdata.zref, umm, ustar);
+                z0 = COARE3_roughness(zref, umm, ustar);
             }
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -690,10 +688,10 @@ struct surface_flux_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -702,16 +700,16 @@ struct surface_flux_charnock
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
-        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
+        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -729,13 +727,11 @@ private:
  */
 struct surface_flux_mod_charnock
 {
-    surface_flux_mod_charnock (amrex::Real zref,
-                               amrex::Real Tflux,
+    surface_flux_mod_charnock (amrex::Real Tflux,
                                amrex::Real Qvflux,
                                amrex::Real depth,
                                bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
@@ -750,6 +746,7 @@ struct surface_flux_mod_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -777,12 +774,13 @@ struct surface_flux_mod_charnock
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -791,7 +789,7 @@ struct surface_flux_mod_charnock
             z0    = std::exp( (2.7*ustar - 1.8/mdata.Cnk_b) / (ustar + 0.17/mdata.Cnk_b) );
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -801,10 +799,10 @@ struct surface_flux_mod_charnock
                 umm = std::max(umm, WSMIN);
             }
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -813,16 +811,16 @@ struct surface_flux_mod_charnock
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
-        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
+        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -840,12 +838,10 @@ private:
  */
 struct surface_flux_donelan
 {
-    surface_flux_donelan (amrex::Real zref,
-                          amrex::Real Tflux,
+    surface_flux_donelan (amrex::Real Tflux,
                           amrex::Real Qvflux,
                           bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -858,6 +854,7 @@ struct surface_flux_donelan
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -885,12 +882,13 @@ struct surface_flux_donelan
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -899,7 +897,7 @@ struct surface_flux_donelan
             z0    = Donelan_roughness(ustar);
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -909,10 +907,10 @@ struct surface_flux_donelan
                 umm = std::max(umm, WSMIN);
             }
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -921,16 +919,16 @@ struct surface_flux_donelan
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
-        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
+        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -948,12 +946,10 @@ private:
  */
 struct surface_flux_wave_coupled
 {
-    surface_flux_wave_coupled (amrex::Real zref,
-                               amrex::Real Tflux,
+    surface_flux_wave_coupled (amrex::Real Tflux,
                                amrex::Real Qvflux,
                                bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -966,6 +962,7 @@ struct surface_flux_wave_coupled
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -993,6 +990,7 @@ struct surface_flux_wave_coupled
         amrex::Real psi_m = 0.0;
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         int ie, je;
         ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
         je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
@@ -1000,10 +998,10 @@ struct surface_flux_wave_coupled
         je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -1013,7 +1011,7 @@ struct surface_flux_wave_coupled
                                       + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps), z0_max );
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux = mdata.surf_temp_flux*(1 + 0.61*qvm_arr(i,j,k)) + qflux*0.61*tm_arr(i,j,k);
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1023,10 +1021,10 @@ struct surface_flux_wave_coupled
                 umm = std::max(umm, WSMIN);
             }
             Olen  = -ustar * ustar * ustar * tvm_arr(i,j,k) / (mdata.kappa * mdata.gravity * tflux);
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -1035,16 +1033,16 @@ struct surface_flux_wave_coupled
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
-        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(mdata.zref / z0) - psi_h) /
+        t_surf_arr(i,j,k) = mdata.surf_temp_flux * (std::log(zref / z0) - psi_h) /
                             (u_star_arr(i,j,k) * mdata.kappa) + tm_arr(i,j,k);
         t_star_arr(i,j,k) = -mdata.surf_temp_flux / u_star_arr(i,j,k);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -1065,12 +1063,10 @@ private:
  */
 struct surface_temp
 {
-    surface_temp (amrex::Real zref,
-                  amrex::Real Tflux,
+    surface_temp (amrex::Real Tflux,
                   amrex::Real Qvflux,
                   bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -1083,6 +1079,7 @@ struct surface_temp
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<const amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -1107,13 +1104,14 @@ struct surface_temp
         amrex::Real psi_h    = 0.0;
         amrex::Real num      = 0.0;
         amrex::Real den      = 0.0;
+        amrex::Real zref     = zref_arr(i,j,k);
         amrex::Real z0       = z0_arr(i,j,k);
         amrex::Real umm      = std::max(umm_arr(i,j,k), WSMIN);
-        amrex::Real C        = std::log(mdata.zref / z0);
+        amrex::Real C        = std::log(zref / z0);
 
         // First iteration we assume neutral (L -> inf)
         if (u_star_arr(i,j,k) == 1.E34) { olen_arr(i,j,k) = 1.0e3; }
-        zeta  = mdata.zref / olen_arr(i,j,k);
+        zeta  = zref / olen_arr(i,j,k);
 
         // Water vapor in atmos and surface
         amrex::Real qv_s, qv_a;
@@ -1145,7 +1143,7 @@ struct surface_temp
         // Bulk Richardson number w/ moisture
         amrex::Real thv_s = t_surf_arr(i,j,k) * (1.0 + 0.61*qv_s);
         amrex::Real thv_a =     tm_arr(i,j,k) * (1.0 + 0.61*qv_a);
-        Rib = ( (mdata.gravity * mdata.zref) / tm_arr(i,j,k) ) *
+        Rib = ( (mdata.gravity * zref) / tm_arr(i,j,k) ) *
               ( (thv_a - thv_s) / (umm * umm) );
         Rib = std::min(std::max(Rib,-4.0),4.0);
 
@@ -1172,7 +1170,7 @@ struct surface_temp
                                          "Maximum number of MOST iterations reached.");
 
         // Populate the stored MOST arrays
-        olen_arr(i,j,k)   = mdata.zref / zeta;
+        olen_arr(i,j,k)   = zref / zeta;
         u_star_arr(i,j,k) = mdata.kappa * umm / (C - psi_m);
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / (C - psi_h);
         if (spec_qflux) {
@@ -1199,14 +1197,12 @@ private:
  */
 struct surface_temp_charnock
 {
-    surface_temp_charnock (amrex::Real zref,
-                           amrex::Real Tflux,
+    surface_temp_charnock (amrex::Real Tflux,
                            amrex::Real Qvflux,
                            amrex::Real cnk_a,
                            bool cnk_visc,
                            bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_a = cnk_a;
@@ -1221,6 +1217,7 @@ struct surface_temp_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -1248,12 +1245,13 @@ struct surface_temp_charnock
         amrex::Real z0       = z0_arr(i,j,k);
         amrex::Real z0_old   = z0;
         amrex::Real ustar    = 0.0;
+        amrex::Real zref     = zref_arr(i,j,k);
         amrex::Real umm      = std::max(umm_arr(i,j,k), WSMIN);
-        amrex::Real C        = std::log(mdata.zref / z0);
+        amrex::Real C        = std::log(zref / z0);
 
         // First iteration we assume neutral (L -> inf)
         if (u_star_arr(i,j,k) == 1.E34) { olen_arr(i,j,k) = 1.0e3; }
-        zeta  = mdata.zref / olen_arr(i,j,k);
+        zeta  = zref / olen_arr(i,j,k);
 
         // Water vapor in atmos and surface
         amrex::Real qv_s, qv_a;
@@ -1285,7 +1283,7 @@ struct surface_temp_charnock
         // Bulk Richardson number w/ moisture
         amrex::Real thv_s = t_surf_arr(i,j,k) * (1.0 + 0.61*qv_s);
         amrex::Real thv_a =     tm_arr(i,j,k) * (1.0 + 0.61*qv_a);
-        Rib = ( (mdata.gravity * mdata.zref) / tm_arr(i,j,k) ) *
+        Rib = ( (mdata.gravity * zref) / tm_arr(i,j,k) ) *
               ( (thv_a - thv_s) / (umm * umm) );
         Rib = std::min(std::max(Rib,-4.0),4.0);
 
@@ -1306,7 +1304,7 @@ struct surface_temp_charnock
                 z0_old = z0;
 
                 // Update
-                C = std::log(mdata.zref / z0_old);
+                C = std::log(zref / z0_old);
                 ustar = mdata.kappa * umm / (C - psi_m);
                 if (mdata.Cnk_a > 0) {
                     z0 = (mdata.Cnk_a / mdata.gravity) * ustar * ustar;
@@ -1314,14 +1312,14 @@ struct surface_temp_charnock
                         z0 += air_viscosity(tm_arr(i,j,k)) / std::max(ustar, 0.05);
                     }
                 } else {
-                    z0 = COARE3_roughness(mdata.zref, umm, ustar);
+                    z0 = COARE3_roughness(zref, umm, ustar);
                 }
 
                 ++iter_z;
             } while ( (std::abs(z0 - z0_old) > tol_z) && (iter_z <= max_iters) );
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter_z < max_iters,
                                              "Maximum number of MOST roughness iterations reached.");
-            C = std::log(mdata.zref / z0);
+            C = std::log(zref / z0);
 
             // Limiting
             num = std::max(C - psi_m, 1.0);
@@ -1337,7 +1335,7 @@ struct surface_temp_charnock
 
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
-        olen_arr(i,j,k)   = mdata.zref / zeta;
+        olen_arr(i,j,k)   = zref / zeta;
         u_star_arr(i,j,k) = mdata.kappa * umm / (C - psi_m);
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / (C - psi_h);
         if (spec_qflux) {
@@ -1365,13 +1363,11 @@ private:
  */
 struct surface_temp_mod_charnock
 {
-    surface_temp_mod_charnock (amrex::Real zref,
-                               amrex::Real Tflux,
+    surface_temp_mod_charnock (amrex::Real Tflux,
                                amrex::Real Qvflux,
                                amrex::Real depth,
                                bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         mdata.Cnk_d = depth;
@@ -1386,6 +1382,7 @@ struct surface_temp_mod_charnock
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -1413,12 +1410,13 @@ struct surface_temp_mod_charnock
         amrex::Real z0       = z0_arr(i,j,k);
         amrex::Real z0_old   = z0;
         amrex::Real ustar    = 0.0;
+        amrex::Real zref     = zref_arr(i,j,k);
         amrex::Real umm      = std::max(umm_arr(i,j,k), WSMIN);
-        amrex::Real C        = std::log(mdata.zref / z0);
+        amrex::Real C        = std::log(zref / z0);
 
         // First iteration we assume neutral (L -> inf)
         if (u_star_arr(i,j,k) == 1.E34) { olen_arr(i,j,k) = 1.0e3; }
-        zeta  = mdata.zref / olen_arr(i,j,k);
+        zeta  = zref / olen_arr(i,j,k);
 
         // Water vapor in atmos and surface
         amrex::Real qv_s, qv_a;
@@ -1450,7 +1448,7 @@ struct surface_temp_mod_charnock
         // Bulk Richardson number w/ moisture
         amrex::Real thv_s = t_surf_arr(i,j,k) * (1.0 + 0.61*qv_s);
         amrex::Real thv_a =     tm_arr(i,j,k) * (1.0 + 0.61*qv_a);
-        Rib = ( (mdata.gravity * mdata.zref) / tm_arr(i,j,k) ) *
+        Rib = ( (mdata.gravity * zref) / tm_arr(i,j,k) ) *
               ( (thv_a - thv_s) / (umm * umm) );
         Rib = std::min(std::max(Rib,-4.0),4.0);
 
@@ -1471,7 +1469,7 @@ struct surface_temp_mod_charnock
                 z0_old = z0;
 
                 // Update
-                C = std::log(mdata.zref / z0_old);
+                C = std::log(zref / z0_old);
                 ustar = mdata.kappa * umm / (C - psi_m);
                 z0    = std::exp( (2.7*ustar - 1.8/mdata.Cnk_b) / (ustar + 0.17/mdata.Cnk_b) );
 
@@ -1479,7 +1477,7 @@ struct surface_temp_mod_charnock
             } while ( (std::abs(z0 - z0_old) > tol_z) && (iter_z <= max_iters) );
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter_z < max_iters,
                                              "Maximum number of MOST roughness iterations reached.");
-            C = std::log(mdata.zref / z0);
+            C = std::log(zref / z0);
 
             // Limiting
             num = std::max(C - psi_m, 1.0);
@@ -1495,7 +1493,7 @@ struct surface_temp_mod_charnock
 
         // Populate the stored MOST arrays
         z0_arr(i,j,k)     = z0;
-        olen_arr(i,j,k)   = mdata.zref / zeta;
+        olen_arr(i,j,k)   = zref / zeta;
         u_star_arr(i,j,k) = mdata.kappa * umm / (C - psi_m);
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) / (C - psi_h);
         if (spec_qflux) {
@@ -1523,12 +1521,10 @@ private:
  */
 struct surface_temp_donelan
 {
-    surface_temp_donelan (amrex::Real zref,
-                          amrex::Real Tflux,
+    surface_temp_donelan (amrex::Real Tflux,
                           amrex::Real Qvflux,
                           bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -1541,6 +1537,7 @@ struct surface_temp_donelan
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -1569,13 +1566,14 @@ struct surface_temp_donelan
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
         amrex::Real Oleno = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         amrex::Real umm = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
             Oleno = Olen;
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -1583,11 +1581,11 @@ struct surface_temp_donelan
             ustar = u_star_arr(i,j,k);
             z0    = Donelan_roughness(ustar);
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0) - psi_h); // <w'T'>
+                     (std::log(zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1603,10 +1601,10 @@ struct surface_temp_donelan
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -1616,14 +1614,14 @@ struct surface_temp_donelan
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
+                            (std::log(zref / z0) - psi_h);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 
@@ -1641,12 +1639,10 @@ private:
  */
 struct surface_temp_wave_coupled
 {
-    surface_temp_wave_coupled (amrex::Real zref,
-                               amrex::Real Tflux,
+    surface_temp_wave_coupled (amrex::Real Tflux,
                                amrex::Real Qvflux,
                                bool cons_qflux)
     {
-        mdata.zref = zref;
         mdata.surf_temp_flux  = Tflux;
         mdata.surf_moist_flux = Qvflux;
         spec_qflux = cons_qflux;
@@ -1659,6 +1655,7 @@ struct surface_temp_wave_coupled
                   const int& j,
                   const int& k,
                   const int& max_iters,
+                  const amrex::Array4<const amrex::Real>& zref_arr,
                   const amrex::Array4<amrex::Real>& z0_arr,
                   const amrex::Array4<const amrex::Real>& umm_arr,
                   const amrex::Array4<const amrex::Real>& tm_arr,
@@ -1687,6 +1684,7 @@ struct surface_temp_wave_coupled
         amrex::Real psi_h = 0.0;
         amrex::Real Olen  = 0.0;
         amrex::Real Oleno = 0.0;
+        amrex::Real zref  = zref_arr(i,j,k);
         int ie, je;
         ie = i  < lbound(eta_arr).x ? lbound(eta_arr).x : i;
         je = j  < lbound(eta_arr).y ? lbound(eta_arr).y : j;
@@ -1694,11 +1692,11 @@ struct surface_temp_wave_coupled
         je = je > ubound(eta_arr).y ? ubound(eta_arr).y : je;
         amrex::Real umm   = std::max(umm_arr(i,j,k), WSMIN);
         if (u_star_arr(i,j,k) == 1.E34) {
-            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(mdata.zref / z0_arr(i,j,k));
+            u_star_arr(i,j,k) = mdata.kappa * umm / std::log(zref / z0_arr(i,j,k));
         } else {
             Olen  = olen_arr(i,j,k);
             Oleno = Olen;
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
         }
@@ -1707,11 +1705,11 @@ struct surface_temp_wave_coupled
             z0    = std::min( std::max(1200.0 * Hwave_arr(i,j,k) * std::pow( Hwave_arr(i,j,k)/(Lwave_arr(i,j,k)+eps), 4.5 )
                                       + 0.11 * eta_arr(ie,je,k,EddyDiff::Mom_v) / ustar, z0_eps), z0_max );
             tflux = -(tm_arr(i,j,k) - t_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                     (std::log(mdata.zref / z0) - psi_h); // <w'T'>
+                     (std::log(zref / z0) - psi_h); // <w'T'>
             tflux *= (1 + 0.61*qvm_arr(i,j,k));
             qflux = (spec_qflux) ? mdata.surf_moist_flux :
                                  -(qvm_arr(i,j,k) - q_surf_arr(i,j,k)) * ustar * mdata.kappa /
-                                  (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
+                                  (std::log(zref / z0_arr(i,j,k)) - psi_h); // <w'Qv'>
             tflux += 0.61*tm_arr(i,j,k) * qflux; // ~= <w'Tv'>
             if (w_star_arr) {
                 // update w* and Umagmean
@@ -1727,10 +1725,10 @@ struct surface_temp_wave_coupled
                 Olen = 0.5 * (Olen + Oleno);
             }
             Oleno = Olen;
-            zeta  = mdata.zref / Olen;
+            zeta  = zref / Olen;
             psi_m = sfuns.calc_psi_m(zeta);
             psi_h = sfuns.calc_psi_h(zeta);
-            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(mdata.zref / z0) - psi_m);
+            u_star_arr(i,j,k) = mdata.kappa * umm / (std::log(zref / z0) - psi_m);
             ++iter;
         } while ((std::abs(u_star_arr(i,j,k) - ustar) > tol) && iter <= max_iters);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(iter < max_iters,
@@ -1740,14 +1738,14 @@ struct surface_temp_wave_coupled
         z0_arr(i,j,k)     = z0;
         olen_arr(i,j,k)   = Olen;
         t_star_arr(i,j,k) = mdata.kappa * (tm_arr(i,j,k) - t_surf_arr(i,j,k)) /
-                            (std::log(mdata.zref / z0) - psi_h);
+                            (std::log(zref / z0) - psi_h);
         if (spec_qflux) {
-            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h) /
+            q_surf_arr(i,j,k) = mdata.surf_moist_flux * (std::log(zref / z0_arr(i,j,k)) - psi_h) /
                                 (u_star_arr(i,j,k) * mdata.kappa) + qvm_arr(i,j,k);
             q_star_arr(i,j,k) = -mdata.surf_moist_flux / u_star_arr(i,j,k);
         } else {
             q_star_arr(i,j,k) = mdata.kappa * (qvm_arr(i,j,k) - q_surf_arr(i,j,k)) /
-                                (std::log(mdata.zref / z0_arr(i,j,k)) - psi_h);
+                                (std::log(zref / z0_arr(i,j,k)) - psi_h);
         }
     }
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -383,8 +383,7 @@ public:
       amrex::BoxArray ba2d(std::move(bl2d));
       const amrex::DistributionMapping& dm = mf.DistributionMap();
       const int ncomp = 1;
-      amrex::IntVect ng = mf.nGrowVect();
-      ng[2] = 0;
+      amrex::IntVect ng{1,1,0};
 
       // Z0 heights FAB
       //--------------------------------------------------------

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -562,7 +562,7 @@ public:
   amrex::MultiFab* get_q_surf (const int& lev) { return q_surf[lev].get(); }
   void set_q_surf(const int& lev, const amrex::Real qsurf) { q_surf[lev]->setVal(qsurf); }
 
-  amrex::Real get_zref () { return m_ma.get_zref(); }
+  amrex::Real get_zref (const int& lev) { return (m_ma.get_zref(lev))->min(0); }
 
   amrex::MultiFab* get_z0 (const int& lev) { return &z_0[lev]; }
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -53,14 +53,14 @@ SurfaceLayer::update_fluxes (const int& lev,
                             (moist_type == MoistCalcType::ADIABATIC) );
         if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_flux most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
+                surface_flux most_flux(surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
             }
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                surface_temp most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux, cons_qflux);
+                surface_temp most_flux(surf_temp_flux, surf_moist_flux, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
@@ -68,7 +68,7 @@ SurfaceLayer::update_fluxes (const int& lev,
         } else if ((theta_type == ThetaCalcType::ADIABATIC) &&
                    (moist_type == MoistCalcType::ADIABATIC)) {
             if (rough_type_land == RoughCalcType::CONSTANT) {
-                adiabatic most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+                adiabatic most_flux(surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_land");
@@ -91,23 +91,19 @@ SurfaceLayer::update_fluxes (const int& lev,
         bool cons_qflux = (moist_type == MoistCalcType::MOISTURE_FLUX);
         if (theta_type == ThetaCalcType::HEAT_FLUX) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                surface_flux_charnock most_flux(m_ma.get_zref(),
-                                                surf_temp_flux, surf_moist_flux,
+                surface_flux_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                                 cnk_a, cnk_visc, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                surface_flux_mod_charnock most_flux(m_ma.get_zref(),
-                                                    surf_temp_flux, surf_moist_flux,
+                surface_flux_mod_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                                     depth, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                surface_flux_donelan most_flux(m_ma.get_zref(),
-                                               surf_temp_flux, surf_moist_flux,
+                surface_flux_donelan most_flux(surf_temp_flux, surf_moist_flux,
                                                cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                surface_flux_wave_coupled most_flux(m_ma.get_zref(),
-                                                    surf_temp_flux, surf_moist_flux,
+                surface_flux_wave_coupled most_flux(surf_temp_flux, surf_moist_flux,
                                                     cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
@@ -116,23 +112,19 @@ SurfaceLayer::update_fluxes (const int& lev,
 
         } else if (theta_type == ThetaCalcType::SURFACE_TEMPERATURE) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                surface_temp_charnock most_flux(m_ma.get_zref(),
-                                                surf_temp_flux, surf_moist_flux,
+                surface_temp_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                                 cnk_a, cnk_visc, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                surface_temp_mod_charnock most_flux(m_ma.get_zref(),
-                                                    surf_temp_flux, surf_moist_flux,
+                surface_temp_mod_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                                     depth, cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                surface_temp_donelan most_flux(m_ma.get_zref(),
-                                               surf_temp_flux, surf_moist_flux,
+                surface_temp_donelan most_flux(surf_temp_flux, surf_moist_flux,
                                                cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                surface_temp_wave_coupled most_flux(m_ma.get_zref(),
-                                                    surf_temp_flux, surf_moist_flux,
+                surface_temp_wave_coupled most_flux(surf_temp_flux, surf_moist_flux,
                                                     cons_qflux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
@@ -142,20 +134,18 @@ SurfaceLayer::update_fluxes (const int& lev,
         } else if ((theta_type == ThetaCalcType::ADIABATIC) &&
                    (moist_type == MoistCalcType::ADIABATIC)) {
             if (rough_type_sea == RoughCalcType::CHARNOCK) {
-                adiabatic_charnock most_flux(m_ma.get_zref(),
-                                             surf_temp_flux, surf_moist_flux,
+                adiabatic_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                              cnk_a, cnk_visc);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::MODIFIED_CHARNOCK) {
-                adiabatic_mod_charnock most_flux(m_ma.get_zref(),
-                                                 surf_temp_flux, surf_moist_flux,
+                adiabatic_mod_charnock most_flux(surf_temp_flux, surf_moist_flux,
                                                  depth);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::DONELAN) {
-                adiabatic_donelan most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+                adiabatic_donelan most_flux(surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else if (rough_type_sea == RoughCalcType::WAVE_COUPLED) {
-                adiabatic_wave_coupled most_flux(m_ma.get_zref(), surf_temp_flux, surf_moist_flux);
+                adiabatic_wave_coupled most_flux(surf_temp_flux, surf_moist_flux);
                 compute_fluxes(lev, max_iters, most_flux, is_land);
             } else {
                 amrex::Abort("Unknown value for rough_type_sea");
@@ -195,10 +185,11 @@ SurfaceLayer::compute_fluxes (const int& lev,
                               bool is_land)
 {
     // Pointers to the computed averages
-    const auto *const tm_ptr  = m_ma.get_average(lev,2); // potential temperature
-    const auto *const qvm_ptr = m_ma.get_average(lev,3); // water vapor mixing ratio
-    const auto *const tvm_ptr = m_ma.get_average(lev,4); // virtual potential temperature
-    const auto *const umm_ptr = m_ma.get_average(lev,5); // horizontal velocity magnitude
+    const auto *const tm_ptr   = m_ma.get_average(lev,2); // potential temperature
+    const auto *const qvm_ptr  = m_ma.get_average(lev,3); // water vapor mixing ratio
+    const auto *const tvm_ptr  = m_ma.get_average(lev,4); // virtual potential temperature
+    const auto *const umm_ptr  = m_ma.get_average(lev,5); // horizontal velocity magnitude
+    const auto *const zref_ptr = m_ma.get_zref(lev);     // reference height
 
     for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
     {
@@ -211,11 +202,12 @@ SurfaceLayer::compute_fluxes (const int& lev,
         auto q_surf_arr = q_surf[lev]->array(mfi);
         auto olen_arr   = olen[lev]->array(mfi);
 
-        const auto tm_arr  = tm_ptr->array(mfi);
-        const auto tvm_arr = tvm_ptr->array(mfi);
-        const auto qvm_arr = qvm_ptr->array(mfi);
-        const auto umm_arr = umm_ptr->array(mfi);
-        const auto z0_arr  = z_0[lev].array(mfi);
+        const auto tm_arr   = tm_ptr->array(mfi);
+        const auto tvm_arr  = tvm_ptr->array(mfi);
+        const auto qvm_arr  = qvm_ptr->array(mfi);
+        const auto umm_arr  = umm_ptr->array(mfi);
+        const auto zref_arr = zref_ptr->array(mfi);
+        const auto z0_arr   = z_0[lev].array(mfi);
 
         // PBL height if we need to calculate wstar for the Beljaars correction
         // TODO: can/should we apply this in LES mode?
@@ -237,6 +229,7 @@ SurfaceLayer::compute_fluxes (const int& lev,
                 (!is_land && lmask_arr(i,j,k) == 0))
             {
                 most_flux.iterate_flux(i, j, k, max_iters,
+                                       zref_arr,                            // set in most average
                                        z0_arr,                              // updated if(!is_land)
                                        umm_arr, tm_arr, tvm_arr, qvm_arr,
                                        u_star_arr,                          // updated

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -256,7 +256,7 @@ ERF::WriteCheckpointFile () const
 
         if (m_SurfaceLayer)  {
             amrex::Print() << "Writing SurfaceLayer variables at level " << lev << std::endl;
-            ng = vars_new[lev][Vars::cons].nGrowVect(); ng[2]=0;
+            ng = IntVect(1,1,0);
             MultiFab   m_var(ba2d[lev],dmap[lev],1,ng);
             MultiFab* src = nullptr;
 
@@ -1043,7 +1043,7 @@ ERF::ReadCheckpointFileSurfaceLayer ()
     {
         amrex::Print() << "Reading MOST variables" << std::endl;
 
-        IntVect ng = vars_new[lev][Vars::cons].nGrowVect(); ng[2]=0;
+        IntVect ng(1,1,0);
         MultiFab  m_var(ba2d[lev],dmap[lev],1,ng);
         MultiFab* dst = nullptr;
 

--- a/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
@@ -56,7 +56,7 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
             const auto& over_land_arr = (SurfLayer->get_lmask(level)) ? SurfLayer->get_lmask(level)->const_array(mfi) :
                                                                       Array4<int> {};
             const Array4<Real const> z_nd_arr = z_phys_nd->array(mfi);
-            const Real most_zref = SurfLayer->get_zref();
+            const Real most_zref = SurfLayer->get_zref(level);
 
             // Require that MOST zref is 10 m so we get the wind speed at 10 m from most
             bool invalid_zref = false;


### PR DESCRIPTION
# Notes
This PR modifes the MOSTAverage class and SurfaceLayer to make `zref` a multifab that can vary spatially. The functionality should not change for non-terrain grids. However, with terrain grids, these changes protect a user from specifying a "bad" zref that is corrected by the most average class but not passed to the most iterations. Furthermore, the number of ghost cells has been reduced from 3 to 1 since only 1 is needed to go from CC -> FC. Finally, the zref MF is written and read from the chk file now.

