### PR TITLE
Slip BC for viscous flow over EB surfaces.

### DIFF
--- a/Exec/DevTests/EB_SquareCylinder/inputs_multilevel
+++ b/Exec/DevTests/EB_SquareCylinder/inputs_multilevel
@@ -59,6 +59,7 @@ erf.cf_set_width = 0
 erf.terrain_type = "EB"
 erf.write_eb_surface = TRUE
 erf.terrain_smoothing = 0
+erf.eb_boundary_type = "NoSlipWall"
 
 # EB GEOMETRY
 eb2.geometry = "box"

--- a/Exec/DryRegTests/Terrain3d_Hemisphere/inputs_EB
+++ b/Exec/DryRegTests/Terrain3d_Hemisphere/inputs_EB
@@ -11,7 +11,7 @@ eb2.small_volfrac = 1.e-4
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_lo     = 0.   0.  0. 
 geometry.prob_hi     = 10  10  10
-amr.n_cell           = 256 256  256
+amr.n_cell           = 120 120 120
 
 geometry.is_periodic = 0 1 0
 
@@ -48,7 +48,7 @@ erf.sponge_z_velocity = 0.0
 # TIME STEP CONTROL
 erf.substepping_type    = None
 #erf.fixed_dt           = 1E-5
-erf.cfl = 0.3
+erf.cfl = 0.5
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1        # timesteps between computing mass
@@ -60,7 +60,7 @@ amr.max_level       = 0       # maximum level number allowed
 
 # CHECKPOINT FILES
 erf.check_file      = chk     # root name of checkpoint file
-erf.check_int       = 10000  # number of timesteps between checkpoints
+erf.check_int       = 1000  # number of timesteps between checkpoints
 
 # PLOTFILES
 erf.plot_file_1     = plt     # prefix of plotfile name
@@ -86,9 +86,12 @@ erf.terrain_type = "EB"
 erf.write_eb_surface = TRUE
 erf.terrain_smoothing = 0
 
+#EB
+erf.eb_boundary_type = "SlipWall"
+
 # Constant diffusion coefficient
-erf.molec_diff_type   = "None"
-erf.dynamic_viscosity = 0.0 # [kg/(m-s)]
+erf.molec_diff_type   = "Constant"
+erf.dynamic_viscosity = 0.1 # [kg/(m-s)]
 erf.alpha_T           = 0.0 # [m^2/s]
 erf.theta_ref = 300.0
 

--- a/Exec/DryRegTests/Terrain3d_Hemisphere/inputs_EB
+++ b/Exec/DryRegTests/Terrain3d_Hemisphere/inputs_EB
@@ -48,7 +48,7 @@ erf.sponge_z_velocity = 0.0
 # TIME STEP CONTROL
 erf.substepping_type    = None
 #erf.fixed_dt           = 1E-5
-erf.cfl = 0.5
+erf.cfl = 0.1
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1        # timesteps between computing mass

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_x
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_x
@@ -65,6 +65,7 @@ erf.les_type = "None"
 erf.terrain_type = "EB"
 erf.write_eb_surface = TRUE
 erf.terrain_smoothing = 0
+erf.eb_boundary_type = "NoSlipWall"
 
 erf.molec_diff_type   = "Constant"
 erf.dynamic_viscosity = 60.0 # [kg/(m-s)]

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_y
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_y
@@ -66,6 +66,7 @@ erf.les_type = "None"
 erf.terrain_type = "EB"
 erf.write_eb_surface = TRUE
 erf.terrain_smoothing = 0
+erf.eb_boundary_type = "NoSlipWall"
 
 erf.molec_diff_type   = "Constant"
 erf.dynamic_viscosity = 60.0 # [kg/(m-s)]

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -14,6 +14,7 @@
 #include <ERF_AdvStruct.H>
 #include <ERF_DampingStruct.H>
 #include <ERF_DiffStruct.H>
+#include <ERF_EBStruct.H>
 #include <ERF_SpongeStruct.H>
 #include <ERF_TurbStruct.H>
 #include <ERF_TurbPertStruct.H>
@@ -537,8 +538,7 @@ struct SolverChoice {
            diffChoice.init_params(pp_prefix);
         dampingChoice.init_params(pp_prefix);
          spongeChoice.init_params(pp_prefix);
-
-
+             ebChoice.init_params(pp_prefix);
 
         turbChoice.resize(max_level+1);
         for (int lev = 0; lev <= max_level; lev++) {
@@ -831,6 +831,7 @@ struct SolverChoice {
             amrex::Print() << "Terrain Type: MovingFittedMesh" << std::endl;
         } else if (terrain_type == TerrainType::EB) {
             amrex::Print() << "Terrain Type: EB" << std::endl;
+            ebChoice.display();
         } else if (terrain_type == TerrainType::ImmersedForcing) {
             amrex::Print() << "Terrain Type: ImmersedForcing" << std::endl;
         } else {
@@ -888,7 +889,7 @@ struct SolverChoice {
         }
 
             advChoice.display(pp_prefix);
-           diffChoice.display();
+           diffChoice.display();     
          spongeChoice.display();
         dampingChoice.display();
 
@@ -993,6 +994,7 @@ struct SolverChoice {
     DampingChoice dampingChoice;
     SpongeChoice  spongeChoice;
     amrex::Vector<TurbChoice>  turbChoice;
+    EBChoice      ebChoice;
 
     int         force_stage1_single_substep = 1;
 

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -889,7 +889,7 @@ struct SolverChoice {
         }
 
             advChoice.display(pp_prefix);
-           diffChoice.display();     
+           diffChoice.display();
          spongeChoice.display();
         dampingChoice.display();
 

--- a/Source/DataStructs/ERF_EBStruct.H
+++ b/Source/DataStructs/ERF_EBStruct.H
@@ -1,0 +1,49 @@
+#ifndef ERF_EB_STRUCT_H_
+#define ERF_EB_STRUCT_H_
+
+#include <string>
+#include <iostream>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_Print.H>
+#include <AMReX_Gpu.H>
+
+enum struct EBBoundaryType {
+    SlipWall, NoSlipWall
+};
+
+/**
+ * Container holding EB-related choices
+ */
+
+struct EBChoice {
+  public:
+    void init_params(std::string pp_prefix)
+    {
+        amrex::ParmParse pp(pp_prefix);
+
+        static std::string eb_boundary_type_string = "SlipWall";
+        pp.query("eb_boundary_type",eb_boundary_type_string);
+
+        if (!eb_boundary_type_string.compare("SlipWall")) {
+            eb_boundary_type = EBBoundaryType::SlipWall;
+        } else if (!eb_boundary_type_string.compare("NoSlipWall")) {
+            eb_boundary_type = EBBoundaryType::NoSlipWall;
+        } else {
+            amrex::Error("Don't know this eb_boundary_type");
+        }
+    }
+
+    void display()
+    {
+        amrex::Print() << "EB choices: " << std::endl;
+        if (eb_boundary_type == EBBoundaryType::SlipWall) {
+            amrex::Print() << "    eb_boundary_type        : SlipWall" << std::endl;
+        } else if (eb_boundary_type == EBBoundaryType::NoSlipWall) {
+            amrex::Print() << "    eb_boundary_type        : NoSlipWall" << std::endl;
+        }
+    }
+
+    EBBoundaryType eb_boundary_type = EBBoundaryType::SlipWall;
+};
+#endif

--- a/Source/DataStructs/ERF_EBStruct.H
+++ b/Source/DataStructs/ERF_EBStruct.H
@@ -22,7 +22,7 @@ struct EBChoice {
     {
         amrex::ParmParse pp(pp_prefix);
 
-        static std::string eb_boundary_type_string = "SlipWall";
+        static std::string eb_boundary_type_string = "NoSlipWall";
         pp.query("eb_boundary_type",eb_boundary_type_string);
 
         if (!eb_boundary_type_string.compare("SlipWall")) {

--- a/Source/DataStructs/Make.package
+++ b/Source/DataStructs/Make.package
@@ -1,6 +1,7 @@
 CEXE_headers += ERF_DampingStruct.H
 CEXE_headers += ERF_DataStruct.H
 CEXE_headers += ERF_DiffStruct.H
+CEXE_headers += ERF_EBStruct.H
 CEXE_headers += ERF_AdvStruct.H
 CEXE_headers += ERF_InputSoundingData.H
 CEXE_headers += ERF_InputSpongeData.H

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -5,6 +5,7 @@
 #include <ERF_IndexDefines.H>
 #include <ERF_EBSlopes.H>
 #include <ERF_DiffStruct.H>
+#include <ERF_EBStruct.H>
 
 using namespace amrex;
 
@@ -68,7 +69,8 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
     Real dx = dx_arr[0], dy = dx_arr[1], dz = dx_arr[2];
     Real vol = dx * dy * dz;
 
-    const bool l_simple = false;
+    EBChoice ebChoice = solverChoice.ebChoice;
+
     const bool l_constraint_x = solverChoice.diffChoice.eb_diff_constraint_x;
     const bool l_constraint_y = solverChoice.diffChoice.eb_diff_constraint_y;
     const bool l_constraint_z = solverChoice.diffChoice.eb_diff_constraint_z;
@@ -142,50 +144,32 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
                 Real barea = std::sqrt(adx*adx + ady*ady + adz*adz);
 
-                Real dudn;
+                const RealVect bcent_eb {u_bcent(i,j,k,0), u_bcent(i,j,k,1), u_bcent(i,j,k,2)};
+                const Real Dirichlet_u {0.};
+                const Real Dirichlet_v {0.};
+                const Real Dirichlet_w {0.};
 
-                if (l_simple) {
+                GpuArray<Real,AMREX_SPACEDIM> slopes_u;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_v;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_w;
 
-                    Real dist_x = u_bcent(i,j,k,0)*dx;
-                    Real dist_y = u_bcent(i,j,k,1)*dy;
-                    Real dist_z = u_bcent(i,j,k,2)*dz;
+                slopes_u = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
+                slopes_v = erf_calc_slopes_eb_Dirichlet_staggered( Vars::xvel, Vars::yvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
+                slopes_w = erf_calc_slopes_eb_Dirichlet_staggered( Vars::xvel, Vars::zvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
 
-                    //
-                    // Should this be the distance from the centroid to the face?
-                    //
-                    Real dn = std::sqrt( dist_x * dist_x + dist_y * dist_y + dist_z * dist_z );
+                Real dudx = slopes_u[0];
+                Real dudy = slopes_u[1];
+                Real dudz = slopes_u[2];
+                Real dvdx = slopes_v[0];
+                Real dvdy = slopes_v[1];
+                Real dwdx = slopes_w[0];
+                Real dwdz = slopes_w[2];
 
-                    dudn = -u_arr(i,j,k) / dn;
+                Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / 3. );
+                Real tau12_eb = 0.5 * (dudy + dvdx);
+                Real tau13_eb = 0.5 * (dudz + dwdx);
 
-                } else {
-
-                    const RealVect bcent_eb {u_bcent(i,j,k,0), u_bcent(i,j,k,1), u_bcent(i,j,k,2)};
-                    const Real Dirichlet_u {0.};
-                    const Real Dirichlet_v {0.};
-                    const Real Dirichlet_w {0.};
-
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_u;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_v;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_w;
-
-                    slopes_u = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
-                    slopes_v = erf_calc_slopes_eb_Dirichlet_staggered( Vars::xvel, Vars::yvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
-                    slopes_w = erf_calc_slopes_eb_Dirichlet_staggered( Vars::xvel, Vars::zvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
-
-                    Real dudx = slopes_u[0];
-                    Real dudy = slopes_u[1];
-                    Real dudz = slopes_u[2];
-                    Real dvdx = slopes_v[0];
-                    Real dvdy = slopes_v[1];
-                    Real dwdx = slopes_w[0];
-                    Real dwdz = slopes_w[2];
-
-                    Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / 3. );
-                    Real tau12_eb = 0.5 * (dudy + dvdx);
-                    Real tau13_eb = 0.5 * (dudz + dwdx);
-
-                    dudn = -(u_bnorm(i,j,k,0) * tau11_eb + u_bnorm(i,j,k,1) * tau12_eb + u_bnorm(i,j,k,2) * tau13_eb);
-                }
+                Real dudn = -(u_bnorm(i,j,k,0) * tau11_eb + u_bnorm(i,j,k,1) * tau12_eb + u_bnorm(i,j,k,2) * tau13_eb);
 
                 rho_u_rhs(i,j,k) -= mu_eff * barea * dudn / (vol * u_volfrac(i,j,k));
             }
@@ -209,7 +193,6 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
             rho_v_rhs(i,j,k) -= diffContrib;
 
-            // Boundary flux (simple version)
             if (!l_constraint_y && v_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = v_afrac_x(i  ,j  ,k  );
@@ -224,50 +207,33 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                 Real adz = (azm-azp) * dx * dy;
 
                 Real barea = std::sqrt(adx*adx + ady*ady + adz*adz);
-                Real dvdn;
 
-                if (l_simple) {
+                const RealVect bcent_eb {v_bcent(i,j,k,0), v_bcent(i,j,k,1), v_bcent(i,j,k,2)};
+                const Real Dirichlet_u {0.};
+                const Real Dirichlet_v {0.};
+                const Real Dirichlet_w {0.};
 
-                    Real dist_x = v_bcent(i,j,k,0)*dx;
-                    Real dist_y = v_bcent(i,j,k,1)*dy;
-                    Real dist_z = v_bcent(i,j,k,2)*dz;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_u;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_v;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_w;
 
-                    //
-                    // Should this be the distance from the centroid to the face?
-                    //
-                    Real dn = std::sqrt( dist_x * dist_x + dist_y * dist_y + dist_z * dist_z );
+                slopes_u = erf_calc_slopes_eb_Dirichlet_staggered( Vars::yvel, Vars::xvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
+                slopes_v = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
+                slopes_w = erf_calc_slopes_eb_Dirichlet_staggered( Vars::yvel, Vars::zvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
 
-                    dvdn = -v_arr(i,j,k) / dn;
+                Real dudx = slopes_u[0];
+                Real dudy = slopes_u[1];
+                Real dvdx = slopes_v[0];
+                Real dvdy = slopes_v[1];
+                Real dvdz = slopes_v[2];
+                Real dwdy = slopes_w[1];
+                Real dwdz = slopes_w[2];
 
-                } else {
+                Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / 3. );
+                Real tau12_eb = 0.5 * (dudy + dvdx);
+                Real tau23_eb = 0.5 * (dvdz + dwdy);
 
-                    const RealVect bcent_eb {v_bcent(i,j,k,0), v_bcent(i,j,k,1), v_bcent(i,j,k,2)};
-                    const Real Dirichlet_u {0.};
-                    const Real Dirichlet_v {0.};
-                    const Real Dirichlet_w {0.};
-
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_u;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_v;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_w;
-
-                    slopes_u = erf_calc_slopes_eb_Dirichlet_staggered( Vars::yvel, Vars::xvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
-                    slopes_v = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
-                    slopes_w = erf_calc_slopes_eb_Dirichlet_staggered( Vars::yvel, Vars::zvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
-
-                    Real dudx = slopes_u[0];
-                    Real dudy = slopes_u[1];
-                    Real dvdx = slopes_v[0];
-                    Real dvdy = slopes_v[1];
-                    Real dvdz = slopes_v[2];
-                    Real dwdy = slopes_w[1];
-                    Real dwdz = slopes_w[2];
-
-                    Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / 3. );
-                    Real tau12_eb = 0.5 * (dudy + dvdx);
-                    Real tau23_eb = 0.5 * (dvdz + dwdy);
-
-                    dvdn = -(v_bnorm(i,j,k,0) * tau12_eb + v_bnorm(i,j,k,1) * tau22_eb + v_bnorm(i,j,k,2) * tau23_eb);
-                }
+                Real dvdn = -(v_bnorm(i,j,k,0) * tau12_eb + v_bnorm(i,j,k,1) * tau22_eb + v_bnorm(i,j,k,2) * tau23_eb);
 
                 rho_v_rhs(i,j,k) -= mu_eff * barea * dvdn / (vol * v_volfrac(i,j,k));
             }
@@ -289,7 +255,6 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
             diffContrib      /= w_volfrac(i,j,k);
             rho_w_rhs(i,j,k) -= diffContrib;
 
-            // Boundary flux (simple version)
             if (!l_constraint_z && w_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = w_afrac_x(i  ,j  ,k  );
@@ -304,52 +269,33 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                 Real adz = (azm-azp) * dx * dy;
 
                 Real barea = std::sqrt(adx*adx + ady*ady + adz*adz);
-                Real dwdn;
 
-                if (l_simple) {
+                const RealVect bcent_eb {w_bcent(i,j,k,0), w_bcent(i,j,k,1), w_bcent(i,j,k,2)};
+                const Real Dirichlet_u {0.};
+                const Real Dirichlet_v {0.};
+                const Real Dirichlet_w {0.};
 
-                    Real dist_x = w_bcent(i,j,k,0)*dx;
-                    Real dist_y = w_bcent(i,j,k,1)*dy;
-                    Real dist_z = w_bcent(i,j,k,2)*dz;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_u;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_v;
+                GpuArray<Real,AMREX_SPACEDIM> slopes_w;
 
-                    //
-                    // Should this be the distance from the centroid to the face?
-                    //
-                    Real dn = std::sqrt( dist_x * dist_x + dist_y * dist_y + dist_z * dist_z );
+                slopes_u = erf_calc_slopes_eb_Dirichlet_staggered( Vars::zvel, Vars::xvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
+                slopes_v = erf_calc_slopes_eb_Dirichlet_staggered( Vars::zvel, Vars::yvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
+                slopes_w = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
 
-                    dwdn = -w_arr(i,j,k) / dn;
+                Real dudx = slopes_u[0];
+                Real dudz = slopes_u[2];
+                Real dvdy = slopes_v[1];
+                Real dvdz = slopes_v[2];
+                Real dwdx = slopes_w[0];
+                Real dwdy = slopes_w[1];
+                Real dwdz = slopes_w[2];
 
-                } else {
+                Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / 3. );
+                Real tau13_eb = 0.5 * (dudz + dwdx);
+                Real tau23_eb = 0.5 * (dvdz + dwdy);
 
-                    const RealVect bcent_eb {w_bcent(i,j,k,0), w_bcent(i,j,k,1), w_bcent(i,j,k,2)};
-                    const Real Dirichlet_u {0.};
-                    const Real Dirichlet_v {0.};
-                    const Real Dirichlet_w {0.};
-
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_u;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_v;
-                    GpuArray<Real,AMREX_SPACEDIM> slopes_w;
-
-                    slopes_u = erf_calc_slopes_eb_Dirichlet_staggered( Vars::zvel, Vars::xvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_u, u_arr, u_volcent, u_cellflg);
-                    slopes_v = erf_calc_slopes_eb_Dirichlet_staggered( Vars::zvel, Vars::yvel, dx, dy, dz, i, j, k, bcent_eb, Dirichlet_v, v_arr, v_volcent, v_cellflg);
-                    slopes_w = erf_calc_slopes_eb_Dirichlet          (                         dx, dy, dz, i, j, k, bcent_eb, Dirichlet_w, w_arr, w_volcent, w_cellflg);
-
-                    Real dudx = slopes_u[0];
-                    // Real dudy = slopes_u[1];
-                    Real dudz = slopes_u[2];
-                    // Real dvdx = slopes_v[0];
-                    Real dvdy = slopes_v[1];
-                    Real dvdz = slopes_v[2];
-                    Real dwdx = slopes_w[0];
-                    Real dwdy = slopes_w[1];
-                    Real dwdz = slopes_w[2];
-
-                    Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / 3. );
-                    Real tau13_eb = 0.5 * (dudz + dwdx);
-                    Real tau23_eb = 0.5 * (dvdz + dwdy);
-
-                    dwdn = -(w_bnorm(i,j,k,0) * tau13_eb + w_bnorm(i,j,k,1) * tau23_eb + w_bnorm(i,j,k,2) * tau33_eb);
-                }
+                Real dwdn = -(w_bnorm(i,j,k,0) * tau13_eb + w_bnorm(i,j,k,1) * tau23_eb + w_bnorm(i,j,k,2) * tau33_eb);
 
                 rho_w_rhs(i,j,k) -= mu_eff * barea * dwdn / (vol * w_volfrac(i,j,k));
             }

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -70,6 +70,7 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
     Real vol = dx * dy * dz;
 
     EBChoice ebChoice = solverChoice.ebChoice;
+    const bool l_no_slip = (ebChoice.eb_boundary_type == EBBoundaryType::NoSlipWall);
 
     const bool l_constraint_x = solverChoice.diffChoice.eb_diff_constraint_x;
     const bool l_constraint_y = solverChoice.diffChoice.eb_diff_constraint_y;
@@ -129,7 +130,7 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
             rho_u_rhs(i,j,k) -= diffContrib;
 
-            if (!l_constraint_x && u_cellflg(i,j,k).isSingleValued()) {
+            if (!l_constraint_x && l_no_slip && (i,j,k).isSingleValued()) {
 
                 Real axm = u_afrac_x(i  ,j  ,k  );
                 Real axp = u_afrac_x(i+1,j  ,k  );
@@ -193,7 +194,7 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
             rho_v_rhs(i,j,k) -= diffContrib;
 
-            if (!l_constraint_y && v_cellflg(i,j,k).isSingleValued()) {
+            if (!l_constraint_y && l_no_slip && v_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = v_afrac_x(i  ,j  ,k  );
                 Real axp = v_afrac_x(i+1,j  ,k  );
@@ -255,7 +256,7 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
             diffContrib      /= w_volfrac(i,j,k);
             rho_w_rhs(i,j,k) -= diffContrib;
 
-            if (!l_constraint_z && w_cellflg(i,j,k).isSingleValued()) {
+            if (!l_constraint_z && l_no_slip && w_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = w_afrac_x(i  ,j  ,k  );
                 Real axp = w_afrac_x(i+1,j  ,k  );

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -130,7 +130,7 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
             rho_u_rhs(i,j,k) -= diffContrib;
 
-            if (!l_constraint_x && l_no_slip && (i,j,k).isSingleValued()) {
+            if (!l_constraint_x && l_no_slip && u_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = u_afrac_x(i  ,j  ,k  );
                 Real axp = u_afrac_x(i+1,j  ,k  );

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -108,10 +108,6 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
     Array4<const Real      > w_bcent = (ebfact.get_w_const_factory())->getBndryCent().const_array(mfi);
     Array4<const Real      > w_bnorm = (ebfact.get_w_const_factory())->getBndryNorm().const_array(mfi);
 
-    // Two methods are implemented:
-    // (1) Simple method: approximate the gradient at EB
-    // (2) Compute the gradient at EB using Least-Squares fitting
-
     ParallelFor(bxx, bxy, bxz,
     [=] AMREX_GPU_DEVICE (int i, int j, int k)
     {

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -610,6 +610,12 @@ define( [[maybe_unused]] int const& a_level,
             aux_afrac_y(i,j,k) = (a_idim == 1) ? lo_areaLo_y : lo_areaLo_y + hi_areaLo_y;
             aux_afrac_z(i,j,k) = (a_idim == 2) ? lo_areaLo_z : lo_areaLo_z + hi_areaLo_z;
 
+            // // ===================== DEBUG =====================
+            // if (i==53 && j==59 && k==0) {
+            //   Print() << "aux_afrac_z(" << i << "," << j << "," << k << ") = " << aux_afrac_z(i,j,k) << std::endl;
+            // }
+            // // =================================================
+
             if (i==bx.bigEnd(0)) {
               Real lo_areaHi_x {lo_eb_cc.areaHi(0)};
               Real hi_areaHi_x {hi_eb_cc.areaHi(0)};
@@ -847,6 +853,13 @@ define( [[maybe_unused]] int const& a_level,
 
     const Box& bx = mfi.validbox();
     const Box& bx_grown = mfi.growntilebox();
+    const Box domain = surroundingNodes(a_geom.Domain(), a_idim);
+    const int dom_lo_i = domain.smallEnd(0);
+    const int dom_hi_i = domain.bigEnd(0);
+    const int dom_lo_j = domain.smallEnd(1);
+    const int dom_hi_j = domain.bigEnd(1);
+    const int dom_lo_k = domain.smallEnd(2);
+    const int dom_hi_k = domain.bigEnd(2);
 
     Array4<EBCellFlag> const& aux_flag  = m_cellflags->array(mfi);
     Array4<Real>       const& aux_vfrac = m_volfrac->array(mfi);
@@ -869,7 +882,12 @@ define( [[maybe_unused]] int const& a_level,
       ParallelFor(my_xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i-1,j,k) < small_volfrac) {
-          aux_afrac_x(i,j,k) = 0.0;
+          // At domain boundary, keep area fraction as is unless inside cell is small
+          if ((i == dom_lo_i && aux_vfrac(i,j,k) < small_volfrac) ||
+              (i == dom_hi_i+1 && aux_vfrac(i-1,j,k) < small_volfrac) ||
+              (i != dom_lo_i && i != dom_hi_i+1)) {
+              aux_afrac_x(i,j,k) = 0.0;
+          }
         }
       });
 
@@ -877,7 +895,12 @@ define( [[maybe_unused]] int const& a_level,
       ParallelFor(my_ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i,j-1,k) < small_volfrac) {
-          aux_afrac_y(i,j,k) = 0.0;
+          // At domain boundary, keep area fraction as is unless inside cell is small
+          if ((j == dom_lo_j && aux_vfrac(i,j,k) < small_volfrac) ||
+              (j == dom_hi_j+1 && aux_vfrac(i,j-1,k) < small_volfrac) ||
+              (j != dom_lo_j && j != dom_hi_j+1)) {
+              aux_afrac_y(i,j,k) = 0.0;
+          }
         }
       });
 
@@ -885,7 +908,12 @@ define( [[maybe_unused]] int const& a_level,
       ParallelFor(my_zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i,j,k-1) < small_volfrac) {
-          aux_afrac_z(i,j,k) = 0.0;
+          // At domain boundary, keep area fraction as is unless inside cell is small
+          if ((k == dom_lo_k && aux_vfrac(i,j,k) < small_volfrac) ||
+              (k == dom_hi_k+1 && aux_vfrac(i,j,k-1) < small_volfrac) ||
+              (k != dom_lo_k && k != dom_hi_k+1)) {
+              aux_afrac_z(i,j,k) = 0.0;
+          }
         }
       });
 

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -610,12 +610,6 @@ define( [[maybe_unused]] int const& a_level,
             aux_afrac_y(i,j,k) = (a_idim == 1) ? lo_areaLo_y : lo_areaLo_y + hi_areaLo_y;
             aux_afrac_z(i,j,k) = (a_idim == 2) ? lo_areaLo_z : lo_areaLo_z + hi_areaLo_z;
 
-            // // ===================== DEBUG =====================
-            // if (i==53 && j==59 && k==0) {
-            //   Print() << "aux_afrac_z(" << i << "," << j << "," << k << ") = " << aux_afrac_z(i,j,k) << std::endl;
-            // }
-            // // =================================================
-
             if (i==bx.bigEnd(0)) {
               Real lo_areaHi_x {lo_eb_cc.areaHi(0)};
               Real hi_areaHi_x {hi_eb_cc.areaHi(0)};


### PR DESCRIPTION
This PR adds an option of Slip BC for viscous flow over EB surfaces. 
- Adds a new data structure `EBChoice` (defined in `ERF_EBStruct.H`) to store EB-related input parameters, e.g., `erf.eb_boundary_type="SlipWall"`.
- Implements the slip boundary condition by zeroing the diffusive flux at the EB surface.