### PR TITLE
Build multigrid EB geometry for anelastic

### DIFF
--- a/Exec/DevTests/EB_SquareCylinder/inputs_anelastic
+++ b/Exec/DevTests/EB_SquareCylinder/inputs_anelastic
@@ -25,8 +25,6 @@ zhi.type = "SlipWall"
 erf.substepping_type   = None
 erf.cfl                = 0.1     # cfl number for hyperbolic system
 #erf.dixed_dt = 1.e-7
-erf.anelastic = 1
-erf.mg_v = 1
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass
@@ -79,6 +77,9 @@ erf.plot_int_1      = 200        # number of timesteps between plotfiles
 erf.plot_vars_1     = density x_velocity y_velocity z_velocity volfrac theta
 
 # SOLVER CHOICE
+erf.anelastic = 1
+erf.mg_v = 4
+
 erf.use_gravity     = false
 
 erf.alpha_T = 0.0
@@ -93,7 +94,7 @@ erf.abl_driver_type = "None"
 erf.abl_pressure_grad = 0.0 0. 0.
 
 erf.init_type = "uniform"
-#erf.project_initial_velocity = true
+erf.project_initial_velocity = 1
 
 # PROBLEM PARAMETERS
 prob.T_0   = 300.0

--- a/Exec/DevTests/EB_SquareCylinder/inputs_anelastic
+++ b/Exec/DevTests/EB_SquareCylinder/inputs_anelastic
@@ -78,7 +78,7 @@ erf.plot_vars_1     = density x_velocity y_velocity z_velocity volfrac theta
 
 # SOLVER CHOICE
 erf.anelastic = 1
-erf.mg_v = 4
+erf.mg_v = 2
 
 erf.use_gravity     = false
 

--- a/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_anelastic
+++ b/Exec/DryRegTests/WitchOfAgnesi/inputs_EB_anelastic
@@ -1,0 +1,96 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 16000
+
+amrex.fpe_trap_invalid=1
+amrex.fpe_trap_zero=1
+amrex.fpe_trap_overflow=1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+eb2.geometry = terrain
+eb2.small_volfrac = 1.e-4
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     = 0.   0.   0. 
+geometry.prob_hi     = 600.0  24.0  600.
+amr.n_cell           = 200  8  200
+
+geometry.is_periodic = 1 1 0
+
+#xlo.type = "Inflow"
+#xhi.type = "Outflow"
+#xlo.velocity = 10. 0. 0.
+#xlo.density  = 1.0
+#xlo.theta    = 1.0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.substepping_type   = None
+#erf.fixed_dt           = 0.005   
+erf.cfl              = 0.5
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1        # timesteps between computing mass
+erf.v              = 1        # verbosity in ERF.cpp
+amr.v              = 1        # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level = 0
+amr.ref_ratio_vect = 2 2 2
+erf.refinement_indicators = box1
+erf.box1.max_level = 1
+erf.box1.in_box_lo = 4.  0.
+erf.box1.in_box_hi = 6.  0.4
+erf.coupling_type  = "OneWay"
+erf.cf_width = 0
+erf.cf_set_width = 0
+    
+# CHECKPOINT FILES
+erf.check_file      = chk     # root name of checkpoint file
+erf.check_int       = -57600  # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt     # prefix of plotfile name
+erf.plot_int_1      = 100       # number of timesteps between plotfiles
+erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta pert_pres pert_dens
+
+# SOLVER CHOICE
+erf.use_gravity = true
+erf.use_coriolis = false
+erf.les_type = "None"
+
+erf.anelastic = 1
+erf.mg_v = 2
+erf.project_initial_velocity = 1
+
+# TERRRAIN GRID TYPE
+erf.terrain_type = "EB"
+erf.write_eb_surface = TRUE
+erf.terrain_smoothing = 0
+erf.eb_boundary_type = "NoSlipWall"
+
+erf.molec_diff_type   = "Constant"
+erf.dynamic_viscosity = 60.0 # [kg/(m-s)]
+erf.alpha_T           = 0.0 # [m^2/s]
+erf.theta_ref = 300.0
+erf.eb_diff_constraint_y = true
+
+erf.abl_driver_type = "PressureGradient"
+erf.abl_pressure_grad = -0.02 0. 0.
+
+
+# Rayleigh Damping
+erf.rayleigh_damp_W = true
+erf.rayleigh_zdamp = 50.0
+erf.rayleigh_dampcoef = 0.25
+
+# PROBLEM PARAMETERS (optional)
+prob.dir   = 0
+prob.T_0   = 300.0
+prob.U_0   = 0.0
+prob.V_0   = 0.0
+prob.rho_0 = 1.16
+prob.hmax  = 100.0
+prob.L     = 100.0

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -489,8 +489,16 @@ ERF::ERF_shared ()
         ParmParse pp("eb2");
         pp.queryAdd("geometry", geometry);
 
-        int ngrow_for_eb = 4;  // This is the default in amrex but we need to explicitly pass it here since
+        constexpr int ngrow_for_eb = 4;  // This is the default in amrex but we need to explicitly pass it here since
                                // we want to also pass the build_coarse_level_by_coarsening argument
+        const bool build_eb_for_multigrid = (solverChoice.terrain_type == TerrainType::EB &&
+                                            ((solverChoice.project_initial_velocity[0] == 1) ||
+                                            solverChoice.anelastic[0] == 1));
+        // Note this just needs to be an integer > number of V-cycles one might use
+        const int max_coarsening_level = (build_eb_for_multigrid) ? 100 : 0;
+        const bool build_coarse_level_by_coarsening(false);
+
+        // Define GeometryShop using the implicit function
         if (geometry == "terrain") {
             Box terrain_bx(surroundingNodes(geom[max_level].Domain())); terrain_bx.grow(3);
             FArrayBox terrain_fab(makeSlab(terrain_bx,2,0),1);
@@ -498,7 +506,12 @@ ERF::ERF_shared ()
             prob->init_terrain_surface(geom[max_level], terrain_fab, dummy_time);
             TerrainIF implicit_fun(terrain_fab, geom[max_level], stretched_dz_d[max_level]);
             auto gshop = EB2::makeShop(implicit_fun);
-            amrex::EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            if (build_eb_for_multigrid) {
+                EB2::Build(gshop, geom[max_level], max_level, max_coarsening_level,
+                            ngrow_for_eb, build_coarse_level_by_coarsening);
+            } else {
+                EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            }
         } else if (geometry == "box") {
             RealArray box_lo{0.0, 0.0, 0.0};
             RealArray box_hi{0.0, 0.0, 0.0};
@@ -506,7 +519,12 @@ ERF::ERF_shared ()
             pp.query("box_hi", box_hi);
             EB2::BoxIF implicit_fun(box_lo, box_hi, false);
             auto gshop = EB2::makeShop(implicit_fun);
-            amrex::EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            if (build_eb_for_multigrid) {
+                EB2::Build(gshop, geom[max_level], max_level, max_coarsening_level,
+                            ngrow_for_eb, build_coarse_level_by_coarsening);
+            } else {
+                EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            }
         } else if (geometry == "sphere") {
             auto ProbLoArr = geom[max_level].ProbLoArray();
             auto ProbHiArr = geom[max_level].ProbHiArray();
@@ -515,19 +533,24 @@ ERF::ERF_shared ()
             RealArray sphere_center = {xcen, ycen, 0.0};
             EB2::SphereIF implicit_fun(0.5, sphere_center, false);
             auto gshop = EB2::makeShop(implicit_fun);
-            amrex::EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            if (build_eb_for_multigrid) {
+                EB2::Build(gshop, geom[max_level], max_level, max_coarsening_level,
+                            ngrow_for_eb, build_coarse_level_by_coarsening);
+            } else {
+                EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+            }
         }
     }
 
     if ( solverChoice.buildings_type == BuildingsType::ImmersedForcing) {
-        int ngrow_for_eb = 4;
+        constexpr int ngrow_for_eb = 4;
         Box buildings_bx(surroundingNodes(geom[max_level].Domain())); buildings_bx.grow(3);
         FArrayBox buildings_fab(makeSlab(buildings_bx,2,0),1);
         Real dummy_time = 0.0;
         prob->init_buildings_surface(geom[max_level], buildings_fab, dummy_time);
         TerrainIF implicit_fun(buildings_fab, geom[max_level], stretched_dz_d[max_level]);
         auto gshop = EB2::makeShop(implicit_fun);
-        amrex::EB2::Build(gshop, this->Geom(), ngrow_for_eb);
+        EB2::Build(gshop, this->Geom(), ngrow_for_eb);
     }
     forecast_state_1.resize(nlevs_max);
     forecast_state_2.resize(nlevs_max);


### PR DESCRIPTION
This PR enables building the multigrid geometry up to the maximum coarsenable level for the EB anelastic solver. Otherwise, the EB geometry is built only at the AMR levels.