### PR TITLE
Shoc Interface Index Fix

### DIFF
--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -427,6 +427,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             // map [i,j,k] 0-based to [icol, ilay] 0-based
             const int icol   = (j-jmin)*nx + (i-imin) + offset;
             const int ilay   = kmax - k;
+            const int ilayi  = kmax + 1 - k;
 
             // EOS input (at CC)
             Real r  = cons_arr(i,j,k,Rho_comp);
@@ -485,7 +486,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             // Input data structures
             //=======================================================
             p_mid_d(icol,ilay)       = getPgivenRTh(rt, qv);
-            p_int_d(icol,ilay)       = getPgivenRTh(rt_avg, qv_avg);
+            p_int_d(icol,ilayi)      = getPgivenRTh(rt_avg, qv_avg);
             // eamxx_common_physics_functions_impl.hpp: calculate_density
             pseudo_dens_d(icol,ilay) = r * CONST_GRAV * delz;
             // Enforce the grid spacing
@@ -500,13 +501,13 @@ SHOCInterface::mf_to_kokkos_buffers ()
                 phis_d(icol) = CONST_GRAV * z;
             }
 
-            if (ilay==(nlay-1)) {
+            if (ilay==0) {
                 Real r_hi  = cons_arr(i,j,k+1,Rho_comp);
                 Real rt_hi = cons_arr(i,j,k+1,RhoTheta_comp);
                 Real qv_hi = (moist) ? std::max(cons_arr(i,j,k+1,RhoQ1_comp)/r_hi,0.0) : 0.0;
                 rt_avg = 0.5 * (rt + rt_hi);
                 qv_avg = 0.5 * (qv + qv_hi);
-                p_int_d(icol,ilay+1) = getPgivenRTh(rt_avg, qv_avg);
+                p_int_d(icol,0) = getPgivenRTh(rt_avg, qv_avg);
             }
         });
     }


### PR DESCRIPTION
## Notes
We have to permute the vertical indices to be consistent with Shoc. This PR fixes that permutation operation for vars defined at the interface.