### PR TITLE
Multilevel Terrain + WRFInput

### DIFF
--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -650,7 +650,7 @@ ERF::init_zphys (int lev, Real time)
             //       the domain
             //
             InterpFromCoarseLevel(*z_phys_nd[lev], z_phys_nd[lev]->nGrowVect(),
-                                  IntVect(0,0,0), // do not fill ghost cells outside the domain
+                                  IntVect(0,0,0), // do NOT fill ghost cells outside the domain
                                   *z_phys_nd[lev-1], 0, 0, 1,
                                   geom[lev-1], geom[lev],
                                   refRatio(lev-1), &node_bilinear_interp,
@@ -700,9 +700,10 @@ ERF::init_zphys (int lev, Real time)
         } // lev == 0
 
     } else {
-        // NOTE: If a WRFInput file is not provided for a finer level,
+        // NOTE: If a WRFInput file is NOT provided for a finer level,
         //       we simply interpolate from the coarse. This is necessary
-        //       since average_down is called on the terrain (ERF_MakeNewLevel.cpp L351)
+        //       since we average_down the terrain (ERF_MakeNewLevel.cpp L351).
+        //       If a WRFInput file IS present, it overwrites the terrain data.
         if (lev > 0) {
             //
             // First interpolate from coarser level if there is one
@@ -711,7 +712,7 @@ ERF::init_zphys (int lev, Real time)
             //       the domain
             //
             InterpFromCoarseLevel(*z_phys_nd[lev], z_phys_nd[lev]->nGrowVect(),
-                                  IntVect(0,0,0), // do not fill ghost cells outside the domain
+                                  z_phys_nd[lev]->nGrowVect(), // DO fill ghost cells outside the domain
                                   *z_phys_nd[lev-1], 0, 0, 1,
                                   geom[lev-1], geom[lev],
                                   refRatio(lev-1), &node_bilinear_interp,

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -699,6 +699,24 @@ ERF::init_zphys (int lev, Real time)
             }
         } // lev == 0
 
+    } else {
+        // NOTE: If a WRFInput file is not provided for a finer level,
+        //       we simply interpolate from the coarse. This is necessary
+        //       since average_down is called on the terrain (ERF_MakeNewLevel.cpp L351)
+        if (lev > 0) {
+            //
+            // First interpolate from coarser level if there is one
+            // NOTE: this interpolater assumes that ALL ghost cells of the coarse MultiFab
+            //       have been pre-filled - this includes ghost cells both inside and outside
+            //       the domain
+            //
+            InterpFromCoarseLevel(*z_phys_nd[lev], z_phys_nd[lev]->nGrowVect(),
+                                  IntVect(0,0,0), // do not fill ghost cells outside the domain
+                                  *z_phys_nd[lev-1], 0, 0, 1,
+                                  geom[lev-1], geom[lev],
+                                  refRatio(lev-1), &node_bilinear_interp,
+                                  domain_bcs_type, BCVars::cons_bc);
+        }
     } // init_type
 
     if (solverChoice.terrain_type == TerrainType::ImmersedForcing ||


### PR DESCRIPTION
# Summary
The following PR addresses an issue with multi level simulations that have terrain and are initialized from a WRFInput file. Specifically, the `z_phys_nd` on the fine grid is NOT interpolated from the coarse if the simulation has an initialization type of `WRFInput/MetGrid`; see [here](https://github.com/erf-model/ERF/blob/49e746730ca61ae1cee011246e6f679ad4e134bb/Source/ERF_MakeNewArrays.cpp#L643-L658). We then average down the `detJ` variable; see [here](https://github.com/erf-model/ERF/blob/49e746730ca61ae1cee011246e6f679ad4e134bb/Source/ERF_MakeNewLevel.cpp#L342-L354). For a simulation that creates a fine patch from the coarse, without a WRFInput file, the `detJ` and `z_phys` values will be incorrect and the acoustic substepping algorithm will fail.

## Todo
1. Should the interpolation in this case cover the domain ghost cells?
2. Is there another check we can add to ensure we don't do the interpolation when a `WRFInput` file is present?