### PR TITLE
Squall Line Inputs

### DIFF
--- a/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_Gabersek
+++ b/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_Gabersek
@@ -45,8 +45,6 @@ erf.use_gravity = true
 erf.buoyancy_type = 1
 erf.use_coriolis = false
 
-#erf.les_type = "Smagorinsky"
-#erf.Cs              = 0.25
 erf.les_type = "None"
 
 # Constant diffusion coefficient

--- a/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_Morrison
+++ b/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_Morrison
@@ -19,8 +19,8 @@ zlo.type = "SlipWall"
 zhi.type = "Outflow"
 
 # TIME STEP CONTROL
-erf.fixed_dt       = 1.0     # fixed time step [s]
-erf.fixed_fast_dt  = 0.5     # fixed time step [s]
+erf.fixed_dt           = 0.25     # fixed time step [s]
+erf.fixed_mri_dt_ratio = 6
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass
@@ -53,13 +53,6 @@ erf.alpha_C           = 100.0
 
 erf.moisture_model = "Morrison"
 erf.use_moist_background = true
-
-erf.dycore_horiz_adv_type    = "Centered_2nd"
-erf.dycore_vert_adv_type     = "Centered_2nd"
-erf.dryscal_horiz_adv_type   = "Centered_2nd"
-erf.dryscal_vert_adv_type    = "Centered_2nd"
-erf.moistscal_horiz_adv_type = "Centered_2nd"
-erf.moistscal_vert_adv_type  = "Centered_2nd"
 
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0

--- a/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_SAM
+++ b/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_SAM
@@ -19,8 +19,8 @@ zlo.type = "SlipWall"
 zhi.type = "Outflow"
 
 # TIME STEP CONTROL
-erf.fixed_dt       = 1.0     # fixed time step [s]
-erf.fixed_fast_dt  = 0.5     # fixed time step [s]
+erf.fixed_dt           = 0.25     # fixed time step [s]
+erf.fixed_mri_dt_ratio = 6
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass
@@ -33,7 +33,6 @@ amr.max_level       = 0       # maximum level number allowed
 # CHECKPOINT FILES
 erf.check_file      = chk        # root name of checkpoint file
 erf.check_int       = 1000       # number of timesteps between checkpoints
-#amr.restart			= chk01000
 
 # PLOTFILES
 erf.plot_file_1         = plt        # root name of plotfile
@@ -53,13 +52,6 @@ erf.alpha_C           = 100.0
 
 erf.moisture_model = "SAM"
 erf.use_moist_background = true
-
-erf.dycore_horiz_adv_type    = "Centered_2nd"
-erf.dycore_vert_adv_type     = "Centered_2nd"
-erf.dryscal_horiz_adv_type   = "Centered_2nd"
-erf.dryscal_vert_adv_type    = "Centered_2nd"
-erf.moistscal_horiz_adv_type = "Centered_2nd"
-erf.moistscal_vert_adv_type  = "Centered_2nd"
 
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0

--- a/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_WRF
+++ b/Exec/MoistRegTests/SquallLine_2D/inputs_moisture_WRF
@@ -19,9 +19,9 @@ zlo.type = "SlipWall"
 zhi.type = "HO_Outflow"
 
 # TIME STEP CONTROL
-erf.fixed_dt       = 1.0     # fixed time step [s]
-erf.fixed_fast_dt  = 0.5     # fixed time step [s]
-
+erf.fixed_dt           = 0.25     # fixed time step [s]
+erf.fixed_mri_dt_ratio = 6
+    
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
@@ -54,12 +54,12 @@ erf.moisture_model = "Kessler"
 erf.use_moist_background = true
 
 erf.dycore_horiz_adv_type    = Upwind_3rd
-erf.dycore_vert_adv_type     = Upwind_3rd 
-erf.dryscal_horiz_adv_type   = Upwind_3rd 
-erf.dryscal_vert_adv_type    = Upwind_3rd 
-erf.moistscal_horiz_adv_type = Upwind_3rd 
-erf.moistscal_vert_adv_type  = Upwind_3rd 
-
+erf.dycore_vert_adv_type     = Upwind_3rd
+erf.dryscal_horiz_adv_type   = Upwind_3rd_SL
+erf.dryscal_vert_adv_type    = Upwind_3rd_SL
+erf.moistscal_horiz_adv_type = Upwind_3rd_SL
+erf.moistscal_vert_adv_type  = Upwind_3rd_SL
+    
 # PROBLEM PARAMETERS (optional)
 prob.z_tr = 12000.0
 prob.height = 1200.0


### PR DESCRIPTION
# Notes
This PR modifies the squall line inputs to respect CFL and NOT use 2nd order for everything. This dramatically improves stability.