### PR TITLE
Radiation Orbital Calcs

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_OrbCosZenith.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_OrbCosZenith.H
@@ -373,12 +373,12 @@ orbital_params (int& iyear_AD,
         if (std::fabs(cossum) <= 1.0e-8) {
             if (sinsum == 0.0) {
                 fvelp = 0.0;
-            } else if (sinsum <= 0.0) {
+            } else if (sinsum < 0.0) {
                 fvelp = 1.5*PI;
             } else if (sinsum > 0.0) {
                 fvelp = 0.5*PI;
             }
-        } else if (cossum <= 0.0) {
+        } else if (cossum < 0.0) {
             fvelp = std::atan(sinsum/cossum) + PI;
         } else {
             if (sinsum < 0.0) {
@@ -405,13 +405,16 @@ orbital_params (int& iyear_AD,
         mvelp = fvelp/degrad + real(50.439273)*psecdeg*years + real(3.392506) + mvsum;
 
         // Cases to make sure mvelp is between 0 and 360.
-        do {
-            mvelp += 360.0;
-        } while (mvelp < 0.0);
-
-        do {
-            mvelp -= 360.0;
-        } while (mvelp >= 360.0);
+        if (mvelp < 0.0) {
+            do {
+                mvelp += 360.0;
+            } while (mvelp < 0.0);
+        }
+        if (mvelp >= 360.0) {
+            do {
+                mvelp -= 360.0;
+            } while (mvelp >= 360.0);
+        }
 
     }  // end of test on whether to calculate or use input orbital params
 
@@ -461,9 +464,9 @@ orbital_avg_cos_zenith (real& jday,
 {
     // adjust latitude so that its tangent will be defined
     real del;
-    if (lat ==  PIoTwo) {
+    if (lat == PIoTwo) {
         del = lat - real(1.0e-05);
-    } else if (lat ==  -PIoTwo) {
+    } else if (lat == -PIoTwo) {
         del = lat + real(1.0e-05);
     } else {
         del = lat;
@@ -494,7 +497,7 @@ orbital_avg_cos_zenith (real& jday,
     // Define Local Time t and t + dt
     // adjust t to be between -pi and pi
     real t1 = (jday - int(jday)) * 2.0*PI + lon - PI;
-    if (t1 >=  PI) {
+    if (t1 >= PI) {
         t1 = t1 - 2.0*PI;
     } else if (t1 < -PI) {
         t1 = t1 + 2.0*PI;
@@ -512,12 +515,12 @@ orbital_avg_cos_zenith (real& jday,
     // force it to be between -h and h
     // consider the situation when the night period is too short
     real tt1,tt2,tt3,tt4;
-    if ( (t2 >= PI) && (t1 <= PI) && (PI - h <= dt) ) {
+    if ( (t2 >= PI) && (t1 <= PI) && ((PI - h) <= dt) ) {
         tt2 = h;
         tt1 = std::min(std::max(t1,         -h),          h);
         tt4 = std::min(std::max(t2, 2.0*PI - h), 2.0*PI + h);
         tt3 = 2.0*PI - h;
-    } else if ( (t2 >= -PI) && (t1 <= -PI) && (PI - h <= dt) ) {
+    } else if ( (t2 >= -PI) && (t1 <= -PI) && ((PI - h) <= dt) ) {
         tt2 = - 2.0*PI + h;
         tt1 = std::min(std::max(t1, -2.0*PI - h), -2.0*PI + h);
         tt4 = std::min(std::max(t2,          -h),           h);
@@ -525,7 +528,7 @@ orbital_avg_cos_zenith (real& jday,
     } else {
         if (t2 > PI) {
             tt2 = std::min(std::max(t2 - 2.0*PI, -h), h);
-        } else if (t2 < - PI) {
+        } else if (t2 < -PI) {
             tt2 = std::min(std::max(t2 + 2.0*PI, -h), h);
         } else {
             tt2 = std::min(std::max(t2         , -h), h);

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -1068,8 +1068,8 @@ Radiation::run_impl ()
                                      181.0, 212.0, 243.0, 273.0, 304.0, 334.0};
     bool leap = (m_orbital_year % 4 == 0 && (!(m_orbital_year % 100 == 0) || (m_orbital_year % 400 == 0))) ? true : false;
     double calday = dpy[m_orbital_mon-1] + (m_orbital_day-1.0) + m_orbital_sec/86400.0;
-    // add extra day if leap year
-    if (leap) { calday += 1.0; }
+    // add extra day if leap year and past February
+    if (leap && m_orbital_mon>2) { calday += 1.0; }
     orbital_decl(calday, eccen, mvelpp, lambm0, obliqr, delta, eccf);
 
     // Overwrite eccf if using a fixed solar constant.
@@ -1144,7 +1144,7 @@ Radiation::run_impl ()
             double lon_col = h_lon(icol)*PI/180.0;
             double lcalday = calday;
             double ldelta  = delta;
-            h_mu0(icol)    = Real(orbital_cos_zenith(lcalday, lat_col, lon_col, ldelta, rad_freq_in_steps * dt));
+            h_mu0(icol)    = Real(orbital_cos_zenith(lcalday, lat_col, lon_col, ldelta));
         });
     }
     Kokkos::deep_copy(mu0, h_mu0);


### PR DESCRIPTION
# Notes
This PR modifies the following items related to the orbital calculations for RRTMGP:

1.  If statements were added to the do-while loops. The do-while loops in the E3SM FORTRAN code check before the first execution but the C++ loops in ERF execute once then check.
2. Fixes to some equality checks.
3. The calendar day should only have 1 added to it when it is a leap year AND we are past the month of February.
4. Change the cosine zenith call to NOT use time averaging. If the start and end times do not satisfy certain criteria, the return value is 0 and the radiation operations treat it as night time.