### PR TITLE
RRTMGP Effective Radius

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -529,8 +529,9 @@ Radiation::mf_to_kokkos_buffers (iMultiFab* lmask,
             iwp_tab(icol,ilay) = 0.0;
 
             // NOTE: These would be populated from P3 (we use the constants in p3_main_impl.hpp)
-            eff_radius_qc_tab(icol,ilay) = (qc>0.0) ? 10.0e-6 : 0.0;
-            eff_radius_qi_tab(icol,ilay) = (qi>0.0) ? 25.0e-6 : 0.0;
+            // NOTE: These are in units of micron!
+            eff_radius_qc_tab(icol,ilay) = (qc>0.0) ? 10.0 : 0.0;
+            eff_radius_qi_tab(icol,ilay) = (qi>0.0) ? 25.0 : 0.0;
 
             // Buffers on z-faces (nlay+1)
             p_lev_tab(icol,ilay) = getPgivenRTh(rt_avg, qv_avg);


### PR DESCRIPTION
# Notes
The effective radius is populated by `P3` in E3SM and has units of `micron`. This PR corrects the units employed in the ERF RRTMGP interface (which are in units of meter).