### PR TITLE
[Data Assimilation] Adding inputs for ensemble simulations

### DIFF
--- a/Exec/DevTests/DataAssimilation/inputs_advecting_coarse
+++ b/Exec/DevTests/DataAssimilation/inputs_advecting_coarse
@@ -1,0 +1,89 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 1000
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     = 0   0   -1
+geometry.prob_hi     = 50  25   1
+amr.n_cell           = 64  32   4
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+ensemble.n_members = 3
+ensemble_pert.amplitude = 100
+
+
+# TIME STEP CONTROL
+erf.substepping_type = None
+erf.fixed_dt         = 0.00005
+
+# OPTIONAL INCOMPRESSIBLE/ANELASTIC ALTERNATIVE
+erf.anelastic = 0
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval    = 1       # timesteps between computing mass
+erf.v               = 1       # verbosity in ERF.cpp
+amr.v               = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 100         # number of timesteps between plotfiles
+erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta temp
+erf.file_name_digits = 6
+
+# SOLVER CHOICE
+erf.alpha_T = 0.0
+erf.alpha_C = 0.0
+erf.use_gravity = false
+
+erf.les_type         = "None"
+erf.molec_diff_type  = "None"
+
+# PROBLEM PARAMETERS
+prob.p_inf = 1e5  # reference pressure [Pa]
+prob.T_inf = 300. # reference temperature [K]
+prob.M_inf = 1.1952286093343936  # freestream Mach number [-]
+prob.alpha = 0.0  # inflow angle, 0 --> x-aligned [rad]
+prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
+prob.R     = 0.25  # characteristic length scale for grid [m]
+prob.sigma = 1.0  # Gaussian standard deviation [-]
+prob.xc = 0.1
+prob.yc = 0.5
+
+
+#
+# SET max_level to greater than 0 for refinement 
+#
+erf.coupling_type = TwoWay
+erf.regrid_int    = 2
+
+amr.ref_ratio_vect = 2 2 1 2 2 1
+amr.max_level       = 0       # maximum level number allowed
+
+# USE THESE FOR STATIC REFINEMENT
+#erf.refinement_indicators = box1
+#erf.box1.max_level = 1
+#erf.box1.in_box_lo =  5 5
+
+# USE THESE FOR DYNAMIC REFINEMENT
+erf.refinement_indicators = lo_scalar
+
+erf.lo_scalar.max_level     = 0
+erf.lo_scalar.field_name    = scalar
+erf.lo_scalar.value_greater = 0.1
+
+amr.n_error_buf  = 5 5
+amr.grid_eff     = 0.8

--- a/Exec/DevTests/DataAssimilation/inputs_advecting_fine
+++ b/Exec/DevTests/DataAssimilation/inputs_advecting_fine
@@ -1,0 +1,89 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+max_step = 100
+
+amrex.fpe_trap_invalid = 1
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     = 0   0   -1
+geometry.prob_hi     = 50  25   1
+amr.n_cell           = 384 192   4
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+ensemble.n_members = 3
+ensemble_pert.amplitude = 100
+
+
+# TIME STEP CONTROL
+erf.substepping_type = None
+erf.fixed_dt         = 0.00005
+
+# OPTIONAL INCOMPRESSIBLE/ANELASTIC ALTERNATIVE
+erf.anelastic = 0
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval    = 1       # timesteps between computing mass
+erf.v               = 1       # verbosity in ERF.cpp
+amr.v               = 1       # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk        # root name of checkpoint file
+erf.check_int       = 100        # number of timesteps between checkpoints
+
+# PLOTFILES
+erf.plot_file_1     = plt        # prefix of plotfile name
+erf.plot_int_1      = 10         # number of timesteps between plotfiles
+erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta temp
+erf.file_name_digits = 6
+
+# SOLVER CHOICE
+erf.alpha_T = 0.0
+erf.alpha_C = 0.0
+erf.use_gravity = false
+
+erf.les_type         = "None"
+erf.molec_diff_type  = "None"
+
+# PROBLEM PARAMETERS
+prob.p_inf = 1e5  # reference pressure [Pa]
+prob.T_inf = 300. # reference temperature [K]
+prob.M_inf = 1.1952286093343936  # freestream Mach number [-]
+prob.alpha = 0.0  # inflow angle, 0 --> x-aligned [rad]
+prob.beta  = 1.1088514254079065 # non-dimensional max perturbation strength [-]
+prob.R     = 0.25  # characteristic length scale for grid [m]
+prob.sigma = 1.0  # Gaussian standard deviation [-]
+prob.xc = 0.1
+prob.yc = 0.5
+
+
+#
+# SET max_level to greater than 0 for refinement 
+#
+erf.coupling_type = TwoWay
+erf.regrid_int    = 2
+
+amr.ref_ratio_vect = 2 2 1 2 2 1
+amr.max_level       = 0       # maximum level number allowed
+
+# USE THESE FOR STATIC REFINEMENT
+#erf.refinement_indicators = box1
+#erf.box1.max_level = 1
+#erf.box1.in_box_lo =  5 5
+
+# USE THESE FOR DYNAMIC REFINEMENT
+erf.refinement_indicators = lo_scalar
+
+erf.lo_scalar.max_level     = 0
+erf.lo_scalar.field_name    = scalar
+erf.lo_scalar.value_greater = 0.1
+
+amr.n_error_buf  = 5 5
+amr.grid_eff     = 0.8


### PR DESCRIPTION
This PR adds the inputs file (`inputs_advecting_coarse`) for performing ensemble simulations of the isentropic convecting vortex. Each ensemble has a perturbation (currently completely random and not spatially correlated) to the base state. Currently only one variable (`x_velocity`) is perturbed.

The `inputs_advecting_fine` is the inputs file for generating the fine mesh solution which is the ground truth and will be used during the data assimilation procedure.

The options are
```
ensemble.n_members = 3 # number of ensembles
ensemble_pert.amplitude = 100 # pertubration of x_velocity in m/s
```
