### PR TITLE
Rayleigh Damp WPS

### DIFF
--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.H
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.H
@@ -8,9 +8,11 @@
 #include "ERF_ProbCommon.H"
 
 struct ProbParm : ProbParmDefaults {
-  amrex::Real rho_0 = 1.0;
-  amrex::Real T_0   = 300.0;
-  amrex::Real V_0   = 1.0;
+    amrex::Real rho_0 = 1.0;
+    amrex::Real U_0   = 0.0;
+    amrex::Real V_0   = 0.0;
+    amrex::Real W_0   = 0.0;
+    amrex::Real T_0   = 300.0;
 }; // namespace ProbParm
 
 class Problem : public ProblemBase
@@ -19,6 +21,7 @@ public:
     Problem();
 
 #include "Prob/ERF_InitConstantDensityHSE.H"
+#include "Prob/ERF_InitRayleighDamping.H"
 
 protected:
 


### PR DESCRIPTION
Add header file to init rayleigh damping with wps. By default will be off, but now the user can just specify values in the inputs and not have the case die with an error.