### PR TITLE
RANS improvements

### DIFF
--- a/Examples/Real_Terrain/Askervein/inputs_anel
+++ b/Examples/Real_Terrain/Askervein/inputs_anel
@@ -47,13 +47,13 @@ ylo.dirichlet_file = "inflow_powerlaw.txt"
 xhi.type = "Outflow"
 yhi.type = "Outflow"
 
-erf.sponge_type = "input_sponge"
-erf.input_sponge_file = "inflow_powerlaw.txt"
-erf.sponge_strength = 0.2  # match rayleigh
-erf.use_xlo_sponge_damping = true
-erf.use_ylo_sponge_damping = true
-erf.xlo_sponge_end = -2750.0  # L = 250, match rayleigh
-erf.ylo_sponge_end = -2750.0
+#erf.sponge_type = "input_sponge"
+#erf.input_sponge_file = "inflow_powerlaw.txt"
+#erf.sponge_strength = 0.2  # match rayleigh
+#erf.use_xlo_sponge_damping = true
+#erf.use_ylo_sponge_damping = true
+#erf.xlo_sponge_end = -2750.0  # L = 250, match rayleigh
+#erf.ylo_sponge_end = -2750.0
 
 # INITIALIZATION
 erf.init_type = "input_sounding"
@@ -63,7 +63,7 @@ erf.input_sounding_file = "sounding_powerlaw.txt"
 #erf.fixed_dt = 0.5
 #erf.substepping_cfl = 0.5 # compressible (18 substeps)
 
-erf.cfl = 0.5
+erf.cfl = 0.45
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval    = 1       # timesteps between computing mass
@@ -86,8 +86,8 @@ erf.plot_per_1      = 60.0       # time interval between plotfiles
 erf.plot_vars_1     = x_velocity y_velocity z_velocity z_phys walldist KE Kmh Kmv
 
 erf.plot2d_file_1   = "plt2d_"
-erf.plot2d_per_1    = 10.0
-erf.plot2d_vars_1   = z_surf u_star
+erf.plot2d_int_1    = 10
+erf.plot2d_vars_1   = u_star
 
 # SOLVER CHOICE
 erf.dycore_horiz_adv_type  = "Upwind_5th"

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -474,6 +474,7 @@ public:
                  const amrex::Real& time,
                  amrex::MultiFab& cons_in,
                  const std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                 const std::unique_ptr<amrex::MultiFab>& walldist,
                  int max_iters = 100);
 
   template <typename FluxIter>

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -256,7 +256,8 @@ public:
       // all levels are using the same RANS model.
       m_update_k_rans = (a_turb_choice.rans_type == RANSType::kEqn);
       if (m_update_k_rans) {
-          invCmu2 = 1.0 / (a_turb_choice.Cmu0 * a_turb_choice.Cmu0);
+          inv_Cmu2 = 1.0 / (a_turb_choice.Cmu0 * a_turb_choice.Cmu0);
+          theta_ref = a_turb_choice.theta_ref;
       }
 
   } // constructor
@@ -719,7 +720,8 @@ private:
   amrex::Vector<amrex::MultiFab*> m_eddyDiffs_lev;
 
   bool m_update_k_rans = false;
-  amrex::Real invCmu2 = 0.0;
+  amrex::Real inv_Cmu2 = 0.0;
+  amrex::Real theta_ref = 0.0;
 };
 
 #endif /* SURFACELAYER_H */

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -254,7 +254,8 @@ public:
       // BC based on the instantaneous u* and θ*; the turbulence modeling
       // choices can vary per level but for now, assume that if specified then
       // all levels are using the same RANS model.
-      m_update_k_rans = (a_turb_choice.rans_type == RANSType::kEqn);
+      m_update_k_rans = (a_turb_choice.rans_type == RANSType::kEqn &&
+                         a_turb_choice.dirichlet_k == true);
       if (m_update_k_rans) {
           inv_Cmu2 = 1.0 / (a_turb_choice.Cmu0 * a_turb_choice.Cmu0);
           theta_ref = a_turb_choice.theta_ref;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -472,7 +472,7 @@ public:
   void
   update_fluxes (const int& lev,
                  const amrex::Real& time,
-                 const amrex::MultiFab& cons_in,
+                 amrex::MultiFab& cons_in,
                  const std::unique_ptr<amrex::MultiFab>& z_phys_nd,
                  int max_iters = 100);
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -39,6 +39,7 @@ public:
                          amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd,
                          const MeshType& a_mesh_type,
                          const TerrainType& a_terrain_type,
+                         const TurbChoice& a_turb_choice,
                          amrex::Real start_time,
                          amrex::Real stop_time,
                          amrex::Real bdy_time_interval = 0.0)
@@ -248,6 +249,16 @@ public:
       // use skin temperature instead of sea-surface temperature
       // (wrfinput data may have lower resolution SST data)
       pp.query("most.ignore_sst", m_ignore_sst);
+
+      // If we're using the RANS k model, then we need to update the dirichlet
+      // BC based on the instantaneous u* and θ*; the turbulence modeling
+      // choices can vary per level but for now, assume that if specified then
+      // all levels are using the same RANS model.
+      m_update_k_rans = (a_turb_choice.rans_type == RANSType::kEqn);
+      if (m_update_k_rans) {
+          invCmu2 = 1.0 / (a_turb_choice.Cmu0 * a_turb_choice.Cmu0);
+      }
+
   } // constructor
 
   void make_SurfaceLayer_at_level (const int& lev,
@@ -705,6 +716,9 @@ private:
   amrex::Vector<amrex::MultiFab*> m_Hwave_lev;
   amrex::Vector<amrex::MultiFab*> m_Lwave_lev;
   amrex::Vector<amrex::MultiFab*> m_eddyDiffs_lev;
+
+  bool m_update_k_rans = false;
+  amrex::Real invCmu2 = 0.0;
 };
 
 #endif /* SURFACELAYER_H */

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -11,7 +11,7 @@ using namespace amrex;
 void
 SurfaceLayer::update_fluxes (const int& lev,
                              const Real& time,
-                             const MultiFab& cons_in,
+                             MultiFab& cons_in,
                              const std::unique_ptr<MultiFab>& z_phys_nd,
                              int max_iters)
 {

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -169,6 +169,44 @@ SurfaceLayer::update_fluxes (const int& lev,
             q_star[lev]->setVal(custom_qstar);
         }
     }
+
+    if (m_update_k_rans) {
+        const bool use_ref_theta = (theta_ref > 0);
+        const Real l_inv_theta0  = (use_ref_theta) ? 1.0 / theta_ref : 1.0;
+
+        for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
+        {
+            Box gtbx = mfi.growntilebox();
+
+            auto cons_arr = cons_in.array(mfi);
+            const auto& u_star_arr = u_star[lev]->const_array(mfi);
+            const auto& t_star_arr = t_star[lev]->const_array(mfi);
+            const auto& dist_arr = walldist->const_array(mfi);
+
+            ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            {
+                Real rho = cons_arr(i,j,k,Rho_comp);
+                if (t_star_arr(i,j,k) < 0) {
+                    // Only destabilizing buoyancy flux affects the boundary k
+                    // tstar < 0 ==> B > 0
+                    Real B = -CONST_GRAV * l_inv_theta0 * u_star_arr(i,j,k) * t_star_arr(i,j,k);
+                    if (!use_ref_theta) {
+                        B *= cons_arr(i,j,k,Rho_comp) /
+                             cons_arr(i,j,k,RhoTheta_comp);
+                    }
+
+                    // Axell & Liungman 2001, Eqn. 16
+                    cons_arr(i,j,k,RhoKE_comp) = rho * inv_Cmu2 *
+                        std::pow(
+                            u_star_arr(i,j,k) * u_star_arr(i,j,k) * u_star_arr(i,j,k)
+                            + KAPPA * B * dist_arr(i,j,k),
+                        2.0/3.0);
+                } else {
+                    cons_arr(i,j,k,RhoKE_comp) = rho * inv_Cmu2 * u_star_arr(i,j,k) * u_star_arr(i,j,k);
+                }
+            });
+        }
+    }
 }
 
 /**

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -13,6 +13,7 @@ SurfaceLayer::update_fluxes (const int& lev,
                              const Real& time,
                              MultiFab& cons_in,
                              const std::unique_ptr<MultiFab>& z_phys_nd,
+                             const std::unique_ptr<MultiFab>& walldist,
                              int max_iters)
 {
     // Update with SST/TSK data if we have a valid pointer

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -186,7 +186,7 @@ SurfaceLayer::update_fluxes (const int& lev,
             ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real rho = cons_arr(i,j,k,Rho_comp);
-                if (t_star_arr(i,j,k) < 0) {
+                if (t_star_arr(i,j,k) < -1e-8) {
                     // Only destabilizing buoyancy flux affects the boundary k
                     // tstar < 0 ==> B > 0
                     Real B = -CONST_GRAV * l_inv_theta0 * u_star_arr(i,j,k) * t_star_arr(i,j,k);

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -173,6 +173,7 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (m_update_k_rans) {
         const bool use_ref_theta = (theta_ref > 0);
         const Real l_inv_theta0  = (use_ref_theta) ? 1.0 / theta_ref : 1.0;
+        const Real l_inv_Cmu2 = inv_Cmu2;
 
         for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
         {
@@ -196,13 +197,13 @@ SurfaceLayer::update_fluxes (const int& lev,
                     }
 
                     // Axell & Liungman 2001, Eqn. 16
-                    cons_arr(i,j,k,RhoKE_comp) = rho * inv_Cmu2 *
+                    cons_arr(i,j,k,RhoKE_comp) = rho * l_inv_Cmu2 *
                         std::pow(
                             u_star_arr(i,j,k) * u_star_arr(i,j,k) * u_star_arr(i,j,k)
                             + KAPPA * B * dist_arr(i,j,k),
                         2.0/3.0);
                 } else {
-                    cons_arr(i,j,k,RhoKE_comp) = rho * inv_Cmu2 * u_star_arr(i,j,k) * u_star_arr(i,j,k);
+                    cons_arr(i,j,k,RhoKE_comp) = rho * l_inv_Cmu2 * u_star_arr(i,j,k) * u_star_arr(i,j,k);
                 }
             });
         }

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -190,6 +190,7 @@ public:
     query_one_or_per_level(pp, "Rt_crit", Rt_crit, lev, max_level);
     query_one_or_per_level(pp, "Rt_min", Rt_min, lev, max_level);
     query_one_or_per_level(pp, "max_geom_lscale", l_g_max, lev, max_level);
+    query_one_or_per_level(pp, "dirichlet_k", dirichlet_k, lev, max_level);
 
     // Common inputs (LES or RANS)
     if (!query_one_or_per_level(pp, "sigma_k", sigma_k, lev, max_level) && rans_type == RANSType::kEqn) {
@@ -271,7 +272,8 @@ public:
       amrex::Print() << "    Using Deardorff LES model at level " << lev << std::endl;
     } else if (rans_type == RANSType::kEqn) {
       amrex::Print()
-        << "    Using Axell & Liungman one-equation RANS k model at level " << lev << std::endl;
+        << "    Using Axell & Liungman one-equation RANS k model at level " << lev
+        << std::endl;
     } else if (pbl_type == PBLType::MYJ) {
       amrex::Print() << "    Using MYJ PBL model at level " << lev << std::endl;
     } else if (pbl_type == PBLType::MYNN25) {
@@ -409,6 +411,8 @@ public:
 
   // RANS type
   RANSType rans_type;
+
+  bool dirichlet_k = false;
 
   // PBL model
   PBLType pbl_type;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1520,6 +1520,7 @@ ERF::InitData_post ()
                                                         z_phys_nd,
                                                         solverChoice.mesh_type,
                                                         solverChoice.terrain_type,
+                                                        solverChoice.turbChoice[finest_level],
                                                         start_time, stop_time
 #ifdef ERF_USE_NETCDF
                                                         , bdy_time_interval

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1589,7 +1589,10 @@ ERF::InitData_post ()
                 // it will change u* and theta* from their previous values
                 m_SurfaceLayer->update_pblh(lev, vars_new, z_phys_cc[lev].get(),
                                             solverChoice.moisture_indices);
-                m_SurfaceLayer->update_fluxes(lev, time, vars_new[lev][Vars::cons], z_phys_nd[lev]);
+                m_SurfaceLayer->update_fluxes(lev, time,
+                                              vars_new[lev][Vars::cons],
+                                              z_phys_nd[lev],
+                                              walldist[lev]);
 
                 // Initialize tke(x,y,z) as a function of u*(x,y)
                 if (solverChoice.turbChoice[lev].init_tke_from_ustar) {

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -295,6 +295,16 @@ void ERF::init_bcs ()
     cons_dir_init[BCVars::Rho_bc_comp] = 1.0;
     cons_dir_init[BCVars::RhoTheta_bc_comp] = -1.0;
 
+    bool keqn_rans = (solverChoice.turbChoice[max_level].rans_type == RANSType::kEqn);
+    if (keqn_rans) {
+        // Need to change wall BC type, assume for now that all levels are RANS
+        for (int lev = 0; lev < max_level; ++lev) {
+            if (solverChoice.turbChoice[lev].rans_type != RANSType::kEqn) {
+                Error("If using one-eqn RANS, all levels must be RANS for now");
+            }
+        }
+    }
+
     // *****************************************************************************
     //
     // Here we translate the physical boundary conditions -- one type per face --
@@ -647,6 +657,10 @@ void ERF::init_bcs ()
                 AMREX_ALWAYS_ASSERT(dir == 2 && side == Orientation::low);
                 for (int i = 0; i < NBCVAR_max; i++) {
                     domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::hoextrap);
+                }
+                if (keqn_rans) {
+                    Print() << "Setting surface layer logical BC to dirichlet for RANS with k model" << std::endl;
+                    domain_bcs_type[BCVars::RhoKE_bc_comp].setLo(dir, ERFBCType::ext_dir_prim);
                 }
             }
         }

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -295,14 +295,16 @@ void ERF::init_bcs ()
     cons_dir_init[BCVars::Rho_bc_comp] = 1.0;
     cons_dir_init[BCVars::RhoTheta_bc_comp] = -1.0;
 
-    bool keqn_rans = (solverChoice.turbChoice[max_level].rans_type == RANSType::kEqn);
-    if (keqn_rans) {
+    bool keqn_dir = (solverChoice.turbChoice[max_level].rans_type == RANSType::kEqn &&
+                     solverChoice.turbChoice[max_level].dirichlet_k == true);
+    if (keqn_dir) {
         // Need to change wall BC type, assume for now that all levels are RANS
         for (int lev = 0; lev < max_level; ++lev) {
             if (solverChoice.turbChoice[lev].rans_type != RANSType::kEqn) {
                 Error("If using one-eqn RANS, all levels must be RANS for now");
             }
         }
+        Print() << "Using dirichlet BC for k equation" << std::endl;
     }
 
     // *****************************************************************************
@@ -658,7 +660,7 @@ void ERF::init_bcs ()
                 for (int i = 0; i < NBCVAR_max; i++) {
                     domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::hoextrap);
                 }
-                if (keqn_rans) {
+                if (keqn_dir) {
                     Print() << "Setting surface layer logical BC to dirichlet for RANS with k model" << std::endl;
                     domain_bcs_type[BCVars::RhoKE_bc_comp].setLo(dir, ERFBCType::ext_dir);
                 }

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -660,7 +660,7 @@ void ERF::init_bcs ()
                 }
                 if (keqn_rans) {
                     Print() << "Setting surface layer logical BC to dirichlet for RANS with k model" << std::endl;
-                    domain_bcs_type[BCVars::RhoKE_bc_comp].setLo(dir, ERFBCType::ext_dir_prim);
+                    domain_bcs_type[BCVars::RhoKE_bc_comp].setLo(dir, ERFBCType::ext_dir);
                 }
             }
         }

--- a/Source/LinearSolvers/ERF_PoissonWallDist.cpp
+++ b/Source/LinearSolvers/ERF_PoissonWallDist.cpp
@@ -426,27 +426,7 @@ void ERF::poisson_wall_dist (int lev)
             dpdx = terrpoisson_flux_x(i, j, k, phi_arr[b], zphys_arr[b], dxinv[0]);
             dpdy = terrpoisson_flux_y(i, j, k, phi_arr[b], zphys_arr[b], dxinv[1]);
             if (k == dom_lo.z) {
-                // Simplified gradient calc
-                // - assuming dirichlet (phi_klo==0)
-                Real phi_khi = 0.5 * (phi_arr[b](i,j,k) + phi_arr[b](i,j,k+1));
-                Real dz = 0.25 * ( zphys_arr[b](i  ,j  ,k+1) - zphys_arr[b](i  ,j  ,k)
-                                 + zphys_arr[b](i+1,j  ,k+1) - zphys_arr[b](i+1,j  ,k)
-                                 + zphys_arr[b](i  ,j+1,k+1) - zphys_arr[b](i  ,j+1,k)
-                                 + zphys_arr[b](i+1,j+1,k+1) - zphys_arr[b](i+1,j+1,k) );
-                Real pz = phi_khi / dz;
-                // - central diff in horizontal
-                Real px = 0.5 * (phi_arr[b](i+1,j,k) - phi_arr[b](i-1,j,k)); // * dxinv[0];
-                Real py = 0.5 * (phi_arr[b](i,j+1,k) - phi_arr[b](i,j-1,k)); // * dxinv[1];
-                // - account for skew
-                Real h_xi = 0.25 * ( zphys_arr[b](i+1,j  ,k  ) - zphys_arr[b](i,j  ,k  )
-                                   + zphys_arr[b](i+1,j+1,k  ) - zphys_arr[b](i,j+1,k  )
-                                   + zphys_arr[b](i+1,j  ,k+1) - zphys_arr[b](i,j  ,k+1)
-                                   + zphys_arr[b](i+1,j+1,k+1) - zphys_arr[b](i,j+1,k+1) ); // * dxinv[0];
-                Real h_eta = 0.25 * ( zphys_arr[b](i  ,j+1,k  ) - zphys_arr[b](i  ,j,k  )
-                                    + zphys_arr[b](i+1,j+1,k  ) - zphys_arr[b](i+1,j,k  )
-                                    + zphys_arr[b](i  ,j+1,k+1) - zphys_arr[b](i  ,j,k+1)
-                                    + zphys_arr[b](i+1,j+1,k+1) - zphys_arr[b](i+1,j,k+1) ); // * dxinv[1];
-                dpdz = pz - h_xi * px - h_eta * py;
+                dpdz = terrpoisson_flux_zlo_dir(i, j, k, phi_arr[b], zphys_arr[b], dxinv[0], dxinv[1]);
             } else {
                 // This returns 0 at the wall, hence the need for the separate calc above
                 dpdz = terrpoisson_flux_z(i, j, k, phi_arr[b], zphys_arr[b], dxinv[0], dxinv[1]);

--- a/Source/LinearSolvers/ERF_TerrainPoisson_3D_K.H
+++ b/Source/LinearSolvers/ERF_TerrainPoisson_3D_K.H
@@ -153,6 +153,75 @@ T terrpoisson_flux_z (int i, int j, int k,
     return -pz_lo;
 }
 
+/*
+ * Simplified gradient calc with dirichlet BC (phi_zlo==0)
+ * - compare with terrpoisson_flux_z
+ */
+template <typename T>
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+T terrpoisson_flux_zlo_dir (int i, int j, int k,
+                            amrex::Array4<T const> const& sol,
+                            amrex::Array4<T const> const& zp,
+                            T dxinv, T dyinv) noexcept
+{
+    using amrex::Real;
+
+    Real h_xi, h_eta, h_zeta;
+
+    // On z-face, one-sided
+    Real pz_lo = sol(i,j,k);
+    Real hzeta_inv_on_zlo = 8.0 / ( (zp(i,j,k+1) + zp(i+1,j,k+1) + zp(i,j+1,k+1) + zp(i+1,j+1,k+1))
+                                   -(zp(i,j,k  ) + zp(i+1,j,k  ) + zp(i,j+1,k  ) + zp(i+1,j+1,k  )) );
+    pz_lo *= hzeta_inv_on_zlo;
+
+    // On corners
+    constexpr Real px_hi_md_lo = 0.0;
+    constexpr Real px_lo_md_lo = 0.0;
+    constexpr Real py_md_hi_lo = 0.0;
+    constexpr Real py_md_lo_lo = 0.0;
+
+    // On y-edges, one-sided
+    Real pz_hi_md_lo  = Real(0.5) * ( sol(i+1,j,k  ) + sol(i,j,k  ));
+         h_xi         = Real(0.25) * ( zp(i+1,j  ,k  ) - zp(i-1,j  ,k  )
+                                      +zp(i+1,j+1,k  ) - zp(i-1,j+1,k  ) ) * dxinv;
+         h_zeta       = Real(0.25) * ( zp(i+1,j  ,k+1) - zp(i+1,j  ,k  )
+                                      +zp(i+1,j+1,k+1) - zp(i+1,j+1,k  ) );
+         pz_hi_md_lo *= h_xi / h_zeta;
+
+    // On y-edges, one-sided
+    Real pz_lo_md_lo  = Real(0.5) * ( sol(i,j,k  ) + sol(i-1,j,k  ));
+         h_xi         = Real(0.25) * ( zp(i,j  ,k  ) - zp(i-2,j  ,k  )
+                                      +zp(i,j+1,k  ) - zp(i-2,j+1,k  ) ) * dxinv;
+         h_zeta       = Real(0.25) * ( zp(i,j  ,k+1) - zp(i  ,j  ,k  )
+                                      +zp(i,j+1,k+1) - zp(i  ,j+1,k  ) );
+         pz_lo_md_lo *= h_xi / h_zeta;
+
+    // On x-edges, one-sided
+    Real pz_md_hi_lo  = Real(0.5) * ( sol(i,j+1,k  ) + sol(i,j,k  ));
+         h_eta        = Real(0.25) * ( zp(i  ,j+1,k  ) - zp(i  ,j-1,k)
+                                      +zp(i+1,j+1,k  ) - zp(i+1,j-1,k) ) * dyinv;
+         h_zeta       = Real(0.25) * ( zp(i  ,j+1,k+1) - zp(i  ,j+1,k  )
+                                      +zp(i+1,j+1,k+1) - zp(i+1,j+1,k  ) );
+         pz_md_hi_lo *= h_eta/ h_zeta;
+
+    // On x-edges, one-sided
+    Real pz_md_lo_lo  = Real(0.5) * ( sol(i,j,k  ) + sol(i,j-1,k  ));
+         h_eta        = Real(0.25) * ( zp(i  ,j,k  ) - zp(i  ,j-2,k  )
+                                      +zp(i+1,j,k  ) - zp(i+1,j-2,k  ) ) * dyinv;
+         h_zeta       = Real(0.25) * ( zp(i  ,j,k+1) - zp(i  ,j  ,k  )
+                                      +zp(i+1,j,k+1) - zp(i+1,j  ,k  ) );
+         pz_md_lo_lo *= h_eta/ h_zeta;
+
+    // On z-face
+    Real h_xi_on_zlo  = 0.5 * (zp(i+1,j+1,k) + zp(i+1,j,k) - zp(i,j+1,k) - zp(i,j,k)) * dxinv;
+    Real h_eta_on_zlo = 0.5 * (zp(i+1,j+1,k) + zp(i,j+1,k) - zp(i+1,j,k) - zp(i,j,k)) * dyinv;
+
+    pz_lo -= 0.5 * h_xi_on_zlo  * ( (px_hi_md_lo + px_lo_md_lo) - (pz_hi_md_lo + pz_lo_md_lo) );
+    pz_lo -= 0.5 * h_eta_on_zlo * ( (py_md_hi_lo + py_md_lo_lo) - (pz_md_hi_lo + pz_md_lo_lo) );
+
+    return -pz_lo;
+}
+
 template <typename T>
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 void terrpoisson_adotx (int i, int j, int k, amrex::Array4<T> const& y,

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -112,7 +112,7 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
             m_SurfaceLayer->update_mac_ptrs(lev, vars_old, Theta_prim, Qv_prim, Qr_prim);
             m_SurfaceLayer->update_pblh(lev, vars_old, z_phys_cc[lev].get(),
                                         solverChoice.moisture_indices);
-            m_SurfaceLayer->update_fluxes(lev, time, S_old, z_phys_nd[lev]);
+            m_SurfaceLayer->update_fluxes(lev, time, S_old, z_phys_nd[lev], walldist[lev]);
         }
     }
 


### PR DESCRIPTION
Improvements for the (unsteady) RANS path:

* Add new `terrpoisson_flux_zlo_dir()` to make the wall distance calculation at klo more rigorous and consistent with `terrpoisson_flux_z()` -- this new function should be called at k=klo and assumes that solution is 0 at the k face. The resulting calculation gives a dramatically smoother walldist field. 
* Implement an experimental option (default: off) that uses dirichlet BCs for RhoKE with `zlo.type = surface_layer`. The TKE is set by Eqn 16 in Axell & Liungman 2001 -- interaction with wall model unclear

Re-running the previous Askervein case with the updated walldist calc gives no change / marginal improvement in most regions.

<img width="1021" height="391" alt="askervein_comparison" src="https://github.com/user-attachments/assets/1fe480c4-0051-488e-97a0-e98ed8699f9c" />
