### PR TITLE
Coriolis Fix

### DIFF
--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -353,7 +353,7 @@ void make_mom_sources (Real time,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     Real rho_v_loc = 0.25 * (rho_v(i,j+1,k) + rho_v(i,j,k) + rho_v(i-1,j+1,k) + rho_v(i-1,j,k));
-                    Real rho_w_loc = 0.25 * (rho_w(i,j,k+1) + rho_w(i,j,k) + rho_w(i,j-1,k+1) + rho_w(i,j-1,k));
+                    Real rho_w_loc = 0.25 * (rho_w(i,j,k+1) + rho_w(i,j,k) + rho_w(i-1,j,k+1) + rho_w(i-1,j,k));
                     Real sphi_loc  = 0.5  * (sphi_arr(i,j,0) + sphi_arr(i-1,j,0));
                     Real cphi_loc  = 0.5  * (cphi_arr(i,j,0) + cphi_arr(i-1,j,0));
                     xmom_src_arr(i, j, k) += coriolis_factor * (rho_v_loc * sphi_loc - rho_w_loc * cphi_loc);
@@ -372,7 +372,7 @@ void make_mom_sources (Real time,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     Real rho_v_loc = 0.25 * (rho_v(i,j+1,k) + rho_v(i,j,k) + rho_v(i-1,j+1,k) + rho_v(i-1,j,k));
-                    Real rho_w_loc = 0.25 * (rho_w(i,j,k+1) + rho_w(i,j,k) + rho_w(i,j-1,k+1) + rho_w(i,j-1,k));
+                    Real rho_w_loc = 0.25 * (rho_w(i,j,k+1) + rho_w(i,j,k) + rho_w(i-1,j,k+1) + rho_w(i-1,j,k));
                     xmom_src_arr(i, j, k) += coriolis_factor * (rho_v_loc * sinphi - rho_w_loc * cosphi);
                 },
                 [=] AMREX_GPU_DEVICE (int i, int j, int k) {

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -557,8 +557,10 @@ make_J (const Geometry& geom,
  */
 void
 make_areas (const Geometry& geom,
-            MultiFab& z_phys_nd, MultiFab& ax,
-            MultiFab& ay, MultiFab& az)
+            MultiFab& z_phys_nd,
+            MultiFab& ax,
+            MultiFab& ay,
+            MultiFab& az)
 {
     const auto* dx = geom.CellSize();
     Real dzInv = 1.0/dx[2];


### PR DESCRIPTION
# Notes
Source terms must be averaged to the location of the dycore variable. The `rhoW` variable was incorrectly averaged and did not reside at the x face.

<img width="735" height="408" alt="image" src="https://github.com/user-attachments/assets/61ef94a1-7c52-45ce-9fe9-4990b514a651" />
