### PR TITLE
k-equation fixes

### DIFF
--- a/Source/Diffusion/ERF_AddTKESources.H
+++ b/Source/Diffusion/ERF_AddTKESources.H
@@ -26,6 +26,10 @@
             // mixing ratios, depending on whether conditions are saturated or
             // not (see the WRF model description, Skamarock et al 2019).
             cell_rhs(i,j,k,qty_index) += l_abs_g * l_inv_theta0 * hfx_z(i,j,k);
+            if (!use_ref_theta) {
+                // l_inv_theta0 == 1, divide by actual theta
+                cell_rhs(i,j,k,qty_index) /= cell_prim(i,j,k,PrimTheta_comp);
+            }
 
             // TKE shear production
             //   P = -tau_ij * S_ij = 2 * mu_turb * S_ij * S_ij

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -432,14 +432,8 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                 // Enforce a maximum value
                 l_g = l_g_max * l_g / (l_g_max + l_g);
 
-                // Turbulent Richardson number (AL01, Eqn. 29)
-                // using the old dissipation value
-                Real diss0 = max(diss(i, j, k) / cell_data(i, j, k, Rho_comp),
-                                 eps);
-                Real Rt = tke*tke * N2 / (diss0*diss0);
-
                 // Turbulent length scale
-                Real length;
+                Real length, Rt;
                 if (std::abs(N2) <= eps) {
                     length = l_g;
                 } else if (N2 > eps) {
@@ -447,10 +441,25 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                     length = std::sqrt(1.0 /
                             (1.0 / (l_g * l_g) + inv_Cb_sq * N2 / tke));
                 } else {
+                    Real diss0 = Cmu0_pow3 * std::pow(tke,1.5) / l_g; // approx
+                    Rt = tke*tke * N2 / (diss0*diss0);
+
                     // Unstable (AL01, Eqn. 28)
+                    // - predict
                     length = l_g * std::sqrt(1.0 - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
+                    // - correct
+                    diss0 = Cmu0_pow3 * std::pow(tke,1.5) / length;
+                    Rt = tke*tke * N2 / (diss0*diss0);
+                    length  = l_g * std::sqrt(1.0 - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
                 }
                 mu_turb(i, j, k, EddyDiff::Turb_lengthscale) = length;
+
+                // Dissipation rate (AL01, Eqn. 19)
+                diss(i, j, k) = cell_data(i, j, k, Rho_comp) * Cmu0_pow3 * std::pow(tke,1.5) / length;
+
+                // Turbulent Richardson number (AL01, Eqn. 29)
+                //Real Rt = tke*tke * N2 / (diss(i,j,k)*diss(i,j,k));
+                Rt = length*length * N2 / (tke * Cmu0_pow3 * Cmu0_pow3); // combined with Eqn. 19
 
                 // Burchard & Petersen smoothing function
                 Rt = (Rt >= Rt_crit) ? Rt
@@ -472,13 +481,8 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                 mu_turb(i, j, k, EddyDiff::Mom_v) = mu_turb(i, j, k, EddyDiff::Mom_h);
                 mu_turb(i, j, k, EddyDiff::Theta_v) = cell_data(i, j, k, Rho_comp) * nut_prime;
 
-                // Calculate SFS quantities
-                // - dissipation (AL01 Eqn. 19)
-                diss(i, j, k) = cell_data(i, j, k, Rho_comp) * Cmu0_pow3 * std::pow(tke,1.5) / length;
-
-                // - heat flux
-                //   (Note: If using SurfaceLayer, the value at k=0 will
-                //    be overwritten)
+                // Calculate heat flux
+                // - If using SurfaceLayer, the value at k=0 will be overwritten
                 hfx_x(i, j, k) = 0.0;
                 hfx_y(i, j, k) = 0.0;
                 // Note: buoyant production = g/theta0 * hfx == -nut_prime * N^2 (c.f. AL01 Eqn. 15)

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -436,7 +436,7 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                 // using the old dissipation value
                 Real diss0 = max(diss(i, j, k) / cell_data(i, j, k, Rho_comp),
                                  eps);
-                Real Rt = tke*tke * N2 / diss0;
+                Real Rt = tke*tke * N2 / (diss0*diss0);
 
                 // Turbulent length scale
                 Real length;

--- a/Source/Diffusion/ERF_SetupDiff.H
+++ b/Source/Diffusion/ERF_SetupDiff.H
@@ -14,7 +14,8 @@
     bool l_use_mynn = turbChoice.use_pbl_tke;
 
     // used by ERF_AddTKESources.H
-    Real l_inv_theta0 = (turbChoice.theta_ref > 0) ? 1.0 / turbChoice.theta_ref : 1.0;
+    const bool use_ref_theta = (turbChoice.theta_ref > 0);
+    const Real l_inv_theta0 = (use_ref_theta) ? 1.0 / turbChoice.theta_ref : 1.0;
 
     // vertical diffusivities are defined in ERF_SetupVertDiff.H
     Vector<int> eddy_diff_idx{EddyDiff::Theta_h, EddyDiff::KE_h, EddyDiff::Scalar_h,

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -991,6 +991,7 @@ ERF::InitData_post ()
     if (!restart_chkfile.empty()) {
         restart();
     }
+
     //
     // Make sure that detJ and z_phys_cc are the average of the data on a finer level if there is one and if two way coupling
     //
@@ -1609,6 +1610,24 @@ ERF::InitData_post ()
             }
         }
     } // end if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::surface_layer)
+
+    // Create wall distance field for RANS model
+    for (int lev = 0; lev <= finest_level; lev++) {
+        if (solverChoice.turbChoice[lev].rans_type != RANSType::None) {
+            // Handle bottom boundary
+            poisson_wall_dist(lev);
+
+            // Correct the wall distance for immersed bodies
+            if (solverChoice.advChoice.have_zero_flux_faces) {
+                thinbody_wall_dist(walldist[lev],
+                                   solverChoice.advChoice.zero_xflux,
+                                   solverChoice.advChoice.zero_yflux,
+                                   solverChoice.advChoice.zero_zflux,
+                                   geom[lev],
+                                   z_phys_cc[lev]);
+            }
+        }
+    }
 
     // Update micro vars and finish moisture model initializations before first plot file
     if (solverChoice.moisture_type != MoistureType::None) {

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1498,6 +1498,24 @@ ERF::InitData_post ()
    // send_to_ww3(my_lev);
 #endif
 
+    // Create wall distance field for RANS model
+    for (int lev = 0; lev <= finest_level; lev++) {
+        if (solverChoice.turbChoice[lev].rans_type != RANSType::None) {
+            // Handle bottom boundary
+            poisson_wall_dist(lev);
+
+            // Correct the wall distance for immersed bodies
+            if (solverChoice.advChoice.have_zero_flux_faces) {
+                thinbody_wall_dist(walldist[lev],
+                                   solverChoice.advChoice.zero_xflux,
+                                   solverChoice.advChoice.zero_yflux,
+                                   solverChoice.advChoice.zero_zflux,
+                                   geom[lev],
+                                   z_phys_cc[lev]);
+            }
+        }
+    }
+
     // Configure SurfaceLayer params if used
     // NOTE: we must set up the MOST routine after calling FillPatch
     //       in order to have lateral ghost cells filled (MOST + terrain interp).
@@ -1610,24 +1628,6 @@ ERF::InitData_post ()
             }
         }
     } // end if (phys_bc_type[Orientation(Direction::z,Orientation::low)] == ERF_BC::surface_layer)
-
-    // Create wall distance field for RANS model
-    for (int lev = 0; lev <= finest_level; lev++) {
-        if (solverChoice.turbChoice[lev].rans_type != RANSType::None) {
-            // Handle bottom boundary
-            poisson_wall_dist(lev);
-
-            // Correct the wall distance for immersed bodies
-            if (solverChoice.advChoice.have_zero_flux_faces) {
-                thinbody_wall_dist(walldist[lev],
-                                   solverChoice.advChoice.zero_xflux,
-                                   solverChoice.advChoice.zero_yflux,
-                                   solverChoice.advChoice.zero_zflux,
-                                   geom[lev],
-                                   z_phys_cc[lev]);
-            }
-        }
-    }
 
     // Update micro vars and finish moisture model initializations before first plot file
     if (solverChoice.moisture_type != MoistureType::None) {

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -222,24 +222,6 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
     }
 
     //********************************************************************************************
-    // Create wall distance field for RANS model (depends upon z_phys)
-    // *******************************************************************************************
-    if (solverChoice.turbChoice[lev].rans_type != RANSType::None) {
-        // Handle bottom boundary
-        poisson_wall_dist(lev);
-
-        // Correct the wall distance for immersed bodies
-        if (solverChoice.advChoice.have_zero_flux_faces) {
-            thinbody_wall_dist(walldist[lev],
-                               solverChoice.advChoice.zero_xflux,
-                               solverChoice.advChoice.zero_yflux,
-                               solverChoice.advChoice.zero_zflux,
-                               geom[lev],
-                               z_phys_cc[lev]);
-        }
-    }
-
-    //********************************************************************************************
     // Microphysics
     // *******************************************************************************************
     int q_size  = micro->Get_Qmoist_Size(lev);


### PR DESCRIPTION
* Fix buoyancy source term when `erf.theta_ref` is _not_ specified, i.e., when the local θ is supposed to be used in the Brunt-Vaisala frequency — affects both Deardorff LES and Axell-Liungman RANS
* For k-eqn RANS, make the turbulent Richardson number consistent with the instantaneous dissipation rate; under unstable conditions, use a predict–correct approach
* Fix restart for k-eqn RANS (verified bit-wise identical) — wall dist is calculated in the appropriate stage of initialization and the eddy viscosity no longer depends on the dissipation rate from the previous time step (due to the turbulent Ri fix)