### PR TITLE
[Data Assimilation] Spatially correlated perturbations

### DIFF
--- a/Exec/DevTests/DataAssimilation/ERF_Prob.cpp
+++ b/Exec/DevTests/DataAssimilation/ERF_Prob.cpp
@@ -142,13 +142,13 @@ Problem::init_custom_pert(
     // --------------------------------------------------------
     // Per-ensemble perturbation controls
     // --------------------------------------------------------
-    Real ens_pert_ampitude = 0.0;
-    ParmParse pp_pert("ensemble_pert");
-    pp_pert.query("amplitude", ens_pert_ampitude);
+    Real ens_pert_amplitude = 0.0;
+    ParmParse pp_ens("ensemble_pert");
+    pp_ens.query("amplitude", ens_pert_amplitude);
 
 
   // Set the x-velocity
-  ParallelForRNG(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+  ParallelFor(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
 
       const Real* prob_lo = geomdata.ProbLo();
@@ -161,10 +161,7 @@ Problem::init_custom_pert(
       const Real u = (parms_d.M_inf * std::cos(parms_d.alpha)
                           - (y - parms_d.yc)/parms_d.R * Omg) * parms_d.a_inf;
 
-       Real rand_double = amrex::Random(engine);
-
-      // Gaussian random number (mean 0, variance 1)
-       x_vel_pert(i, j, k) = u + ens_pert_ampitude*rand_double;
+       x_vel_pert(i, j, k) = u + ens_pert_amplitude*x_vel_pert(i, j, k);
 
   });
 

--- a/Exec/DevTests/DataAssimilation/inputs_advecting_coarse
+++ b/Exec/DevTests/DataAssimilation/inputs_advecting_coarse
@@ -1,5 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-max_step = 1000
+max_step = 1
 
 amrex.fpe_trap_invalid = 1
 
@@ -15,8 +15,10 @@ geometry.is_periodic = 1 1 0
 zlo.type = "SlipWall"
 zhi.type = "SlipWall"
 
-ensemble.n_members = 3
+ensemble.n_members = 1
 ensemble_pert.amplitude = 100
+ensemble.is_init_with_correlated_pert = true
+ensemble.pert_correlated_radius = 1.0
 
 
 # TIME STEP CONTROL

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -730,6 +730,8 @@ struct SolverChoice {
                               " location of the eye in the initial condition");
             }
         }
+
+        pp.query("init_with_correlated_pert", init_with_correlated_pert);
     }
 
     void check_params (int max_level, const amrex::Vector<amrex::Geometry>& geom_vect, amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2> phys_bc_type)
@@ -1208,5 +1210,7 @@ struct SolverChoice {
 
     bool io_hurricane_eye_tracker = false;
     amrex::Real hurricane_eye_latitude = -1e10, hurricane_eye_longitude = -1e10;
+
+    bool init_with_correlated_pert = false;
 };
 #endif

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -731,7 +731,7 @@ struct SolverChoice {
             }
         }
 
-        ParmParse pp_ens("ensemble");
+        amrex::ParmParse pp_ens("ensemble");
         pp_ens.query("is_init_with_correlated_pert", is_init_with_correlated_pert);
         if(is_init_with_correlated_pert) {
             pp_ens.query("pert_correlated_radius", pert_correlated_radius);

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -731,7 +731,7 @@ struct SolverChoice {
             }
         }
 
-        amrex::ParmParse pp_ens("ensemble");
+        ParmParse pp_ens("ensemble");
         pp_ens.query("is_init_with_correlated_pert", is_init_with_correlated_pert);
         if(is_init_with_correlated_pert) {
             pp_ens.query("pert_correlated_radius", pert_correlated_radius);

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -731,7 +731,17 @@ struct SolverChoice {
             }
         }
 
-        pp.query("init_with_correlated_pert", init_with_correlated_pert);
+        amrex::ParmParse pp_ens("ensemble");
+        pp_ens.query("is_init_with_correlated_pert", is_init_with_correlated_pert);
+        if(is_init_with_correlated_pert) {
+            pp_ens.query("pert_correlated_radius", pert_correlated_radius);
+            if(pert_correlated_radius <= 0.0) {
+                amrex::Abort("You are using initialization with spatially correlated perturbations using the inputs option "
+                             "ensemble.is_init_with_correlated_pert=true. In this case, there has to be an option "
+                             "ensemble.pert_correlated_radius which is the value of the the spatial correlation radius, "
+                             "and has to be greater than 0.0");
+            }
+        }
     }
 
     void check_params (int max_level, const amrex::Vector<amrex::Geometry>& geom_vect, amrex::GpuArray<ERF_BC, AMREX_SPACEDIM*2> phys_bc_type)
@@ -1211,6 +1221,7 @@ struct SolverChoice {
     bool io_hurricane_eye_tracker = false;
     amrex::Real hurricane_eye_latitude = -1e10, hurricane_eye_longitude = -1e10;
 
-    bool init_with_correlated_pert = false;
+    bool is_init_with_correlated_pert = false;
+    amrex::Real pert_correlated_radius = -1.0;
 };
 #endif

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -626,6 +626,8 @@ private:
     void init_phys_bcs (bool& rho_read, bool& read_prim_theta);
 
     void init_custom (int lev);
+    void apply_gaussian_smoothing_to_perturbations (int lev);
+    void create_random_perturbations (int lev);
 
     void init_uniform (int lev);
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -496,6 +496,17 @@ public:
                                   amrex::Vector<std::unique_ptr<amrex::MultiFab>>& z_phys_nd,
                                   bool regrid_forces_file_read);
 
+    void create_random_perturbations (const int lev,
+                                      amrex::MultiFab& cons_pert,
+                                      amrex::MultiFab& xvel_pert,
+                                      amrex::MultiFab& yvel_pert,
+                                      amrex::MultiFab& zvel_pert);
+
+    void apply_gaussian_smoothing_to_perturbations (const int lev,
+                                                    amrex::MultiFab& cons_pert,
+                                                    amrex::MultiFab& xvel_pert,
+                                                    amrex::MultiFab& yvel_pert,
+                                                    amrex::MultiFab& zvel_pert);
 
 #ifdef ERF_USE_MULTIBLOCK
     // constructor used when ERF is created by a multiblock driver
@@ -626,9 +637,7 @@ private:
     void init_phys_bcs (bool& rho_read, bool& read_prim_theta);
 
     void init_custom (int lev);
-    void apply_gaussian_smoothing_to_perturbations (int lev);
-    void create_random_perturbations (int lev);
-
+    
     void init_uniform (int lev);
 
     void init_stuff (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -637,7 +637,7 @@ private:
     void init_phys_bcs (bool& rho_read, bool& read_prim_theta);
 
     void init_custom (int lev);
-    
+
     void init_uniform (int lev);
 
     void init_stuff (int lev, const amrex::BoxArray& ba, const amrex::DistributionMapping& dm,

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2162,6 +2162,14 @@ ERF::init_only (int lev, Real time)
         init_from_hse(lev);
     }
 
+    // If the initial condition needs to have correlated perturbations above the 
+    // base state, then first create a multifab with random perturbations, 
+    // and then apply a Gaussian smoothing to make the perturbation correlated
+    if(solverChoice.init_with_correlated_pert) {
+        create_random_perturbations(lev);
+        apply_gaussian_smoothing_to_perturbations(lev);
+    }
+
     // Add problem-specific flow features
     //
     // Notes:

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2162,14 +2162,6 @@ ERF::init_only (int lev, Real time)
         init_from_hse(lev);
     }
 
-    // If the initial condition needs to have correlated perturbations above the 
-    // base state, then first create a multifab with random perturbations, 
-    // and then apply a Gaussian smoothing to make the perturbation correlated
-    if(solverChoice.init_with_correlated_pert) {
-        create_random_perturbations(lev);
-        apply_gaussian_smoothing_to_perturbations(lev);
-    }
-
     // Add problem-specific flow features
     //
     // Notes:

--- a/Source/Initialization/ERF_InitCustomPertState.cpp
+++ b/Source/Initialization/ERF_InitCustomPertState.cpp
@@ -42,10 +42,10 @@ ERF::init_custom (int lev)
     yvel_pert.setVal(0.);
     zvel_pert.setVal(0.);
 
-    // If the initial condition needs to have spatially correlated perturbations superimposed onto 
+    // If the initial condition needs to have spatially correlated perturbations superimposed onto
     // the base state, then populate the "pert" multifabs with random perturbations,
     // and then apply a Gaussian smoothing to make the perturbations spatially correlated
-    if(solverChoice.init_with_correlated_pert) {
+    if(solverChoice.is_init_with_correlated_pert) {
         create_random_perturbations(lev, cons_pert, xvel_pert, yvel_pert, zvel_pert);
         apply_gaussian_smoothing_to_perturbations(lev, cons_pert, xvel_pert, yvel_pert, zvel_pert);
     }
@@ -110,23 +110,25 @@ ERF::init_custom (int lev)
 }
 
 void
-ERF::create_random_perturbations(const int lev, 
+ERF::create_random_perturbations(const int lev,
                                  MultiFab& cons_pert,
                                  MultiFab& xvel_pert,
                                  MultiFab& yvel_pert,
                                  MultiFab& zvel_pert)
 {
+    ignore_unused(cons_pert);
+    ignore_unused(yvel_pert);
+    ignore_unused(zvel_pert);
 
-  auto& lev_new = vars_new[lev];
-
-  for (MFIter mfi(lev_new[Vars::cons], TileNoZ()); mfi.isValid(); ++mfi) {
+    auto& lev_new = vars_new[lev];
+    for (MFIter mfi(lev_new[Vars::cons], TileNoZ()); mfi.isValid(); ++mfi) {
         const auto &xvel_pert_arr = xvel_pert.array(mfi);
         const Box &xbx = mfi.tilebox(IntVect(1,0,0));
         ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
         {
             xvel_pert_arr(i, j, k) = amrex::Random(engine);
         });
-   }
+    }
 }
 
 void
@@ -136,5 +138,73 @@ ERF::apply_gaussian_smoothing_to_perturbations(const int lev,
                                                MultiFab& yvel_pert,
                                                MultiFab& zvel_pert)
 {
+    ignore_unused(cons_pert);
+    ignore_unused(yvel_pert);
+    ignore_unused(zvel_pert);
 
+    const Geometry& gm = geom[lev];
+    const Real dx = gm.CellSize(0);
+    const Real dy = gm.CellSize(1);
+
+    const Real dmesh = std::min(dx, dy);
+    // ---- User choices ----
+    const Real sigma = solverChoice.pert_correlated_radius; // e.g. 2 km correlation length
+    const int  r     = static_cast<int>(3.0 * sigma / dmesh);  // stencil radius
+
+    // ---- Precompute Gaussian weights on host ----
+    const int wsize = 2*r + 1;
+    Vector<Real> w_host(wsize * wsize);
+
+    Real Z = 0.0;
+    for (int m = -r; m <= r; ++m) {
+        for (int n = -r; n <= r; ++n) {
+            Real val = std::exp(-(m*m*dx*dx + n*n*dy*dy)/(2.0*sigma*sigma));
+            w_host[(m+r)*wsize + (n+r)] = val;
+            Z += val;
+        }
+    }
+    for (auto& v : w_host) {
+        v = v/Z;
+    }
+
+    Gpu::DeviceVector<Real> w_dev;
+    w_dev.resize(w_host.size());
+    Gpu::copy(Gpu::hostToDevice, w_host.begin(), w_host.end(), w_dev.begin());
+
+    Real const* w = w_dev.data();
+
+    // 1. Define ngrow_big using the actual dimension macro
+    IntVect ngrow_big(AMREX_D_DECL(r, r, 0));
+
+    // 2. Create the copy
+    MultiFab xvel_pert_copy(xvel_pert.boxArray(),
+                        xvel_pert.DistributionMap(),
+                        1, ngrow_big);
+    //MultiFab::Copy(xvel_pert_copy, xvel_pert, 0, 0, 1, 0);
+
+    // 3. Use the built-in copy that includes ghost cell logic
+    // Copy(dst, src, src_comp, dst_comp, num_comp, ngrow)
+    // Setting ngrow to 0 ensures we only take valid data from the original
+    xvel_pert_copy.ParallelCopy(xvel_pert, 0, 0, 1, IntVect(0), ngrow_big, gm.periodicity());
+
+    for (MFIter mfi(xvel_pert, TileNoZ()); mfi.isValid(); ++mfi)
+    {
+        const Box& tbx = mfi.tilebox();
+
+        auto const& in  = xvel_pert_copy.array(mfi);
+        auto const& out = xvel_pert.array(mfi);
+
+        ParallelFor(tbx,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            Real sum = 0.0;
+            for (int m = -r; m <= r; ++m) {
+                for (int n = -r; n <= r; ++n) {
+                    Real wij = w[(m+r)*wsize + (n+r)];
+                    sum += wij * in(i+m, j+n, k);
+                }
+            }
+            out(i,j,k) = sum;
+        });
+    }
 }

--- a/Source/Initialization/ERF_InitCustomPertState.cpp
+++ b/Source/Initialization/ERF_InitCustomPertState.cpp
@@ -42,6 +42,9 @@ ERF::init_custom (int lev)
     yvel_pert.setVal(0.);
     zvel_pert.setVal(0.);
 
+    create_random_perturbations(lev);
+    apply_gaussian_smoothing_to_perturbations(lev);
+
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -99,4 +102,47 @@ ERF::init_custom (int lev)
     MultiFab::Add(lev_new[Vars::xvel], xvel_pert, 0,             0,             1, xvel_pert.nGrowVect());
     MultiFab::Add(lev_new[Vars::yvel], yvel_pert, 0,             0,             1, yvel_pert.nGrowVect());
     MultiFab::Add(lev_new[Vars::zvel], zvel_pert, 0,             0,             1, zvel_pert.nGrowVect());
+}
+
+void
+ERF::create_random_perturbations(lev)
+{
+  // Set the x-velocity
+  ParallelForRNG(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+  {
+
+      const Real* prob_lo = geomdata.ProbLo();
+      const Real* dx = geomdata.CellSize();
+
+      const Real x = prob_lo[0] + i * dx[0]; // face center
+      const Real y = prob_lo[1] + (j + 0.5) * dx[1]; // cell center
+      const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
+
+      const Real u = (parms_d.M_inf * std::cos(parms_d.alpha)
+                          - (y - parms_d.yc)/parms_d.R * Omg) * parms_d.a_inf;
+
+       Real rand_double = amrex::Random(engine);
+
+      // Gaussian random number (mean 0, variance 1)
+       x_vel_pert(i, j, k) = u + ens_pert_ampitude*rand_double;
+
+  });
+}
+
+void
+ERF::apply_gaussian_smoothing_to_perturbations(lev)
+{
+
+    auto& lev_new = vars_new[lev];
+
+    MultiFab r_hse(base_state[lev], make_alias, BaseState::r0_comp, 1);
+    MultiFab p_hse(base_state[lev], make_alias, BaseState::p0_comp, 1);
+
+    MultiFab cons_pert(lev_new[Vars::cons].boxArray(), lev_new[Vars::cons].DistributionMap(),
+                       lev_new[Vars::cons].nComp()   , lev_new[Vars::cons].nGrow());
+    MultiFab xvel_pert(lev_new[Vars::xvel].boxArray(), lev_new[Vars::xvel].DistributionMap(), 1, lev_new[Vars::xvel].nGrowVect());
+    MultiFab yvel_pert(lev_new[Vars::yvel].boxArray(), lev_new[Vars::yvel].DistributionMap(), 1, lev_new[Vars::yvel].nGrowVect());
+    MultiFab zvel_pert(lev_new[Vars::zvel].boxArray(), lev_new[Vars::zvel].DistributionMap(), 1, lev_new[Vars::zvel].nGrowVect());
+
+
 }

--- a/Source/Initialization/ERF_InitCustomPertState.cpp
+++ b/Source/Initialization/ERF_InitCustomPertState.cpp
@@ -42,8 +42,13 @@ ERF::init_custom (int lev)
     yvel_pert.setVal(0.);
     zvel_pert.setVal(0.);
 
-    create_random_perturbations(lev);
-    apply_gaussian_smoothing_to_perturbations(lev);
+    // If the initial condition needs to have spatially correlated perturbations superimposed onto 
+    // the base state, then populate the "pert" multifabs with random perturbations,
+    // and then apply a Gaussian smoothing to make the perturbations spatially correlated
+    if(solverChoice.init_with_correlated_pert) {
+        create_random_perturbations(lev, cons_pert, xvel_pert, yvel_pert, zvel_pert);
+        apply_gaussian_smoothing_to_perturbations(lev, cons_pert, xvel_pert, yvel_pert, zvel_pert);
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -105,44 +110,31 @@ ERF::init_custom (int lev)
 }
 
 void
-ERF::create_random_perturbations(lev)
+ERF::create_random_perturbations(const int lev, 
+                                 MultiFab& cons_pert,
+                                 MultiFab& xvel_pert,
+                                 MultiFab& yvel_pert,
+                                 MultiFab& zvel_pert)
 {
-  // Set the x-velocity
-  ParallelForRNG(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
-  {
 
-      const Real* prob_lo = geomdata.ProbLo();
-      const Real* dx = geomdata.CellSize();
+  auto& lev_new = vars_new[lev];
 
-      const Real x = prob_lo[0] + i * dx[0]; // face center
-      const Real y = prob_lo[1] + (j + 0.5) * dx[1]; // cell center
-      const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
-
-      const Real u = (parms_d.M_inf * std::cos(parms_d.alpha)
-                          - (y - parms_d.yc)/parms_d.R * Omg) * parms_d.a_inf;
-
-       Real rand_double = amrex::Random(engine);
-
-      // Gaussian random number (mean 0, variance 1)
-       x_vel_pert(i, j, k) = u + ens_pert_ampitude*rand_double;
-
-  });
+  for (MFIter mfi(lev_new[Vars::cons], TileNoZ()); mfi.isValid(); ++mfi) {
+        const auto &xvel_pert_arr = xvel_pert.array(mfi);
+        const Box &xbx = mfi.tilebox(IntVect(1,0,0));
+        ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+        {
+            xvel_pert_arr(i, j, k) = amrex::Random(engine);
+        });
+   }
 }
 
 void
-ERF::apply_gaussian_smoothing_to_perturbations(lev)
+ERF::apply_gaussian_smoothing_to_perturbations(const int lev,
+                                               MultiFab& cons_pert,
+                                               MultiFab& xvel_pert,
+                                               MultiFab& yvel_pert,
+                                               MultiFab& zvel_pert)
 {
-
-    auto& lev_new = vars_new[lev];
-
-    MultiFab r_hse(base_state[lev], make_alias, BaseState::r0_comp, 1);
-    MultiFab p_hse(base_state[lev], make_alias, BaseState::p0_comp, 1);
-
-    MultiFab cons_pert(lev_new[Vars::cons].boxArray(), lev_new[Vars::cons].DistributionMap(),
-                       lev_new[Vars::cons].nComp()   , lev_new[Vars::cons].nGrow());
-    MultiFab xvel_pert(lev_new[Vars::xvel].boxArray(), lev_new[Vars::xvel].DistributionMap(), 1, lev_new[Vars::xvel].nGrowVect());
-    MultiFab yvel_pert(lev_new[Vars::yvel].boxArray(), lev_new[Vars::yvel].DistributionMap(), 1, lev_new[Vars::yvel].nGrowVect());
-    MultiFab zvel_pert(lev_new[Vars::zvel].boxArray(), lev_new[Vars::zvel].DistributionMap(), 1, lev_new[Vars::zvel].nGrowVect());
-
 
 }


### PR DESCRIPTION
This PR adds the functions for spatially correlated perturbations for ensemble simulation for data assimilation. A Gaussian filter is applied to the random perturbation field to get spatially correlated perturbations. A Gaussian spatial localization is used. The options are as below.

```
ensemble.is_init_with_correlated_pert = true
ensemble.pert_correlated_radius = 1.0
``` 
<img width="1056" height="354" alt="Screen Shot 2026-02-03 at 5 30 24 PM" src="https://github.com/user-attachments/assets/f39feda5-4627-4404-aac6-162a1dbec107" />
