### PR TITLE
Bndry Planes

### DIFF
--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -476,8 +476,8 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = 0.5 * (R1*Th1 + R2*Th2);
                         });
-                  } else if (var_name == "scalar" || var_name == "qv" || var_name == "qc" ||
-                             var_name == "ke") {
+                  } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
+                             var_name == "qv"    || var_name == "qc") {
                     ParallelFor(
                         bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1 =  bndry_read_r_arr(i, j, k, 0);
@@ -506,8 +506,8 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = 0.5 * (R1*Th1 + R2*Th2);
                         });
-                  } else if (var_name == "scalar" || var_name == "qv" || var_name == "qc" ||
-                             var_name == "ke") {
+                  } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
+                             var_name == "qv"    || var_name == "qc") {
                       ParallelFor(
                         bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];

--- a/Source/IO/ERF_WriteBndryPlanes.cpp
+++ b/Source/IO/ERF_WriteBndryPlanes.cpp
@@ -165,7 +165,6 @@ void WriteBndryPlanes::write_planes (const int t_step, const Real time,
             bndry.copyFrom(S, nghost, Rho_comp, 0, ncomp, m_geom[bndry_lev].periodicity());
 
         } else if (var_name == "temperature") {
-
             MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
             for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
@@ -177,18 +176,23 @@ void WriteBndryPlanes::write_planes (const int t_step, const Real time,
                 }
             }
             bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
-        } else if (var_name == "scalar") {
-
+        } else if (var_name == "theta") {
             MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
             for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 const Box& bx = mfi.tilebox();
-                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoKE_comp);
+                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoTheta_comp);
             }
             bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
-
+        } else if (var_name == "scalar") {
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
+            for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+            {
+                const Box& bx = mfi.tilebox();
+                derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoScalar_comp);
+            }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
         } else if (var_name == "ke") {
-
             MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
             for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
@@ -197,25 +201,29 @@ void WriteBndryPlanes::write_planes (const int t_step, const Real time,
             }
             bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
         } else if (var_name == "qv") {
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
             if (S.nComp() > RhoQ2_comp) {
-                MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
                 for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoQ1_comp);
                 }
-                bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+            } else {
+                Temp.setVal(0.);
             }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
         } else if (var_name == "qc") {
+            MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
             if (S.nComp() > RhoQ2_comp) {
-                MultiFab Temp(S.boxArray(),S.DistributionMap(),ncomp,0);
                 for (MFIter mfi(Temp, TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     derived::erf_derrhodivide(bx, Temp[mfi], S[mfi], RhoQ2_comp);
                 }
-                bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
+            } else {
+                Temp.setVal(0.);
             }
+            bndry.copyFrom(Temp, nghost, 0, 0, ncomp, m_geom[bndry_lev].periodicity());
         } else if (var_name == "velocity") {
             MultiFab Vel(S.boxArray(), S.DistributionMap(), 3, m_out_rad);
             average_face_to_cellcenter(Vel,0,Array<const MultiFab*,3>{&xvel,&yvel,&zvel});


### PR DESCRIPTION
# Notes
The boundary plane code does not account for complex box arrays or distribution maps but instead writes the whole subdomain data. Planes of the subdomain may be utilized for boundary conditions, but the whole subdomain must be read. For this reason, the multiple bndry file pathway is not needed. Future work could optimize this since it will get memory and IO intensive for large runs.

## Changes
1. Add theta read and write
2. Fix scalar component index
3. Protect against writing moisture in a "dry" simulation