### PR TITLE
Fix SYCL Compilation: Kokkos::View -> amrex::Table

### DIFF
--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -69,7 +69,7 @@ jobs:
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_SYCL:BOOL=ON \
-          -DERF_ENABLE_TESTS:BOOL=ON \
+          -DERF_ENABLE_TESTS:BOOL=OFF \
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DCMAKE_C_COMPILER=$(which icx) \

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -74,8 +74,9 @@ jobs:
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DCMAKE_C_COMPILER=$(which icx) \
           -DCMAKE_CXX_COMPILER=$(which icpx) \
-          -DCMAKE_CXX_STANDARD=17
-        make -j 2 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
+          -DCMAKE_CXX_STANDARD=17 \
+          -DAMReX_PARALLEL_LINK_JOBS=4
+        make -j 4 2>&1 | tee -a ${{runner.workspace}}/build-output.txt;
 
         ccache -s
         du -hs ~/.cache/ccache

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   Build-And-Test-SYCL:
     name: oneAPI SYCL - Particles ${{matrix.particles}}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         particles: [OFF, ON]
@@ -71,7 +71,6 @@ jobs:
           -DERF_ENABLE_SYCL:BOOL=ON \
           -DERF_ENABLE_TESTS:BOOL=ON \
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
-          -DERF_ENABLE_FCOMPARE:BOOL=ON \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DCMAKE_C_COMPILER=$(which icx) \
           -DCMAKE_CXX_COMPILER=$(which icpx) \

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -69,7 +69,7 @@ jobs:
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
           -DERF_ENABLE_SYCL:BOOL=ON \
-          -DERF_ENABLE_TESTS:BOOL=OFF \
+          -DERF_ENABLE_TESTS:BOOL=ON \
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DCMAKE_C_COMPILER=$(which icx) \

--- a/Exec/DryRegTests/ParticleTests/ERF_Prob.H
+++ b/Exec/DryRegTests/ParticleTests/ERF_Prob.H
@@ -7,7 +7,7 @@
 
 #include "ERF_ProbCommon.H"
 
-struct ProbParm : ProbParmDefaults {
+struct ProbParmCore : ProbParmDefaults {
   amrex::Real T_0 = 300.0; // surface temperature == mean potential temperature
   amrex::Real U_0 = 0.0;
   amrex::Real V_0 = 0.0;
@@ -23,6 +23,9 @@ struct ProbParm : ProbParmDefaults {
   // overridden physical constants
   amrex::Real C_p = 1004.0;
 
+};
+
+struct ProbParm : ProbParmCore {
   std::string custom_terrain_type;
 }; // namespace ProbParm
 

--- a/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
+++ b/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
@@ -60,7 +60,8 @@ Problem::init_custom_pert(
 
   AMREX_ALWAYS_ASSERT(bx.length()[2] == khi+1);
 
-  ParallelFor(bx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+  const ProbParmCore& parms_d = parms;
+  ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
     // Geometry (note we must include these here to get the data on device)
     const auto prob_lo  = geomdata.ProbLo();

--- a/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
+++ b/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
@@ -96,11 +96,12 @@ Problem::init_custom_pert(
   });
 
   // Set the x-velocity
+  auto U_0 = parms.U_0;
   ParallelFor(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
       Real ztop = z_nd(i,j,khi+1);
       Real zht  = z_nd(i,j,klo);
-      x_vel_pert(i, j, k) = parms_d.U_0 * ztop / (ztop - zht);
+      x_vel_pert(i, j, k) = U_0 * ztop / (ztop - zht);
   });
 
   // Set the y-velocity

--- a/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
+++ b/Exec/DryRegTests/ParticleTests/ERF_Prob.cpp
@@ -97,7 +97,7 @@ Problem::init_custom_pert(
 
   // Set the x-velocity
   auto U_0 = parms.U_0;
-  ParallelFor(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+  ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
       Real ztop = z_nd(i,j,khi+1);
       Real zht  = z_nd(i,j,klo);

--- a/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.H
+++ b/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.H
@@ -6,7 +6,7 @@
 #include "AMReX_REAL.H"
 #include "ERF_ProbCommon.H"
 
-struct ProbParm : ProbParmDefaults {
+struct ProbParmCore : ProbParmDefaults {
   // perturbations to initial conditions
   amrex::Real rho_0 = 0.0;
   amrex::Real T_0 = 0.0;
@@ -21,7 +21,9 @@ struct ProbParm : ProbParmDefaults {
 
   // Default to the x-direction
   int dir = 0;
+}; // namespace ProbParm
 
+struct ProbParm : ProbParmCore {
   std::string custom_terrain_type;
 }; // namespace ProbParm
 

--- a/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
+++ b/Exec/DryRegTests/WitchOfAgnesi/ERF_Prob.cpp
@@ -67,15 +67,17 @@ Problem::init_custom_pert (
     });
 
     // Set the x-velocity
-    ParallelFor(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    auto U_0 = parms.U_0;
+    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
-        x_vel_pert(i, j, k) = parms_d.U_0;
+        x_vel_pert(i, j, k) = U_0;
     });
 
     // Set the y-velocity
-    ParallelFor(ybx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    auto V_0 = parms.V_0;
+    ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
-        y_vel_pert(i, j, k) = parms_d.V_0;
+        y_vel_pert(i, j, k) = V_0;
     });
 
     const auto dx = geomdata.CellSize();

--- a/Source/MaterialProperties/ERF_MaterialProperties.H
+++ b/Source/MaterialProperties/ERF_MaterialProperties.H
@@ -44,8 +44,7 @@ namespace saturation_funcs
                                            const amrex::MultiFab& );
 }
 
-/*! Class for material properties */
-struct MaterialProperties {
+struct MaterialPropertiesCore { // For GPU
 
     static constexpr amrex::Real s_N_av = 6.02214076e23; /*!< Avogadro's number */
     static constexpr amrex::Real s_kb   = 1.380649e-23; /*!< Boltzmann constant [J K^{-1}] */
@@ -57,7 +56,6 @@ struct MaterialProperties {
     /*! Temperature parameter for air [K] */
     static constexpr amrex::Real s_eps_air_k = 97;
 
-    Species::Name m_name = Species::Name::none; /*!< name */
     amrex::Real m_density = DBL_MAX; /*!< density */
     amrex::Real m_ionization = DBL_MAX; /*!< ionization */
     amrex::Real m_mol_weight = DBL_MAX; /*!< molecular weight (condensate) */
@@ -76,61 +74,6 @@ struct MaterialProperties {
                                         amrex::Real(DBL_MAX) };
     bool m_is_soluble = false; /*!< is soluble in water? */
     bool m_is_water = false; /*!< is this water? */
-    /*! pointer to function to compute saturation pressure */
-    decltype(saturation_funcs::compute_saturation_pressure_null)* m_saturation_pressure_func = nullptr;
-    /*! pointer to function to compute vapour fraction */
-    decltype(saturation_funcs::compute_saturation_vapfrac_null)* m_saturation_vapfrac_func = nullptr;
-
-    /*! \brief Constructor */
-    AMREX_GPU_HOST_DEVICE
-    MaterialProperties ( const Species::Name& a_name );
-
-    /*! \brief Copy constructor */
-    AMREX_GPU_HOST_DEVICE
-    MaterialProperties ( const MaterialProperties& a_matprop );
-
-    /*! \brief Default destructor */
-    AMREX_GPU_HOST_DEVICE
-    ~MaterialProperties () = default;
-
-    /*! \brief Print parameters */
-    AMREX_GPU_HOST
-    void print() const {
-        amrex::Print() << "Material properties of " << amrex::getEnumNameString(m_name) << ":\n";
-        amrex::Print() << "    density: " << m_density << "\n";
-        amrex::Print() << "    ionization: " << m_ionization << "\n";
-        amrex::Print() << "    mol. weight: " << m_mol_weight << "\n";
-        amrex::Print() << "    latent heat (vap.): " << m_lat_vap << "\n";
-        amrex::Print() << "    Rv: " << m_Rv << "\n";
-        amrex::Print() << "    Tc: " << m_Tc << "\n";
-        amrex::Print() << "    Tb: " << m_Tb << "\n";
-        amrex::Print() << "    N_av/mol.weight: " << m_Nav_by_molweight << "\n";
-        amrex::Print() << "    mol. Cp coeffs: ";
-        for (int i = 0; i < 7; i++) { amrex::Print() << m_mol_Cp_coeffs[i] << ", "; }
-        amrex::Print() << "\n";
-    }
-
-    /*! \brief Set this material to H20 */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_H2O();
-    /*! \brief Set this material to water */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_water();
-    /*! \brief Set this material to agua */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_agua();
-    /*! \brief Set this material to NaCl */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_NaCl();
-    /*! \brief Set this material to ammonium sulfate */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_NH42SO4();
-    /*! \brief Set this material to ammonium bisulfate */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_NH4HSO4();
-    /*! \brief Set this material to soil */
-    AMREX_GPU_HOST_DEVICE
-    void setProperties_soil();
 
     /*! \brief Return the molar heat capacity */
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -211,6 +154,69 @@ struct MaterialProperties {
         }
     }
 
+};
+
+/*! Class for material properties */
+struct MaterialProperties : public MaterialPropertiesCore {
+
+    Species::Name m_name = Species::Name::none; /*!< name */
+
+    /*! pointer to function to compute saturation pressure */
+    decltype(saturation_funcs::compute_saturation_pressure_null)* m_saturation_pressure_func = nullptr;
+    /*! pointer to function to compute vapour fraction */
+    decltype(saturation_funcs::compute_saturation_vapfrac_null)* m_saturation_vapfrac_func = nullptr;
+
+    /*! \brief Constructor */
+    AMREX_GPU_HOST_DEVICE
+    MaterialProperties ( const Species::Name& a_name );
+
+    /*! \brief Copy constructor */
+    AMREX_GPU_HOST_DEVICE
+    MaterialProperties ( const MaterialProperties& a_matprop );
+
+    /*! \brief Default destructor */
+    AMREX_GPU_HOST_DEVICE
+    ~MaterialProperties () = default;
+
+    /*! \brief Print parameters */
+    AMREX_GPU_HOST
+    void print() const {
+        amrex::Print() << "Material properties of " << amrex::getEnumNameString(m_name) << ":\n";
+        amrex::Print() << "    density: " << m_density << "\n";
+        amrex::Print() << "    ionization: " << m_ionization << "\n";
+        amrex::Print() << "    mol. weight: " << m_mol_weight << "\n";
+        amrex::Print() << "    latent heat (vap.): " << m_lat_vap << "\n";
+        amrex::Print() << "    Rv: " << m_Rv << "\n";
+        amrex::Print() << "    Tc: " << m_Tc << "\n";
+        amrex::Print() << "    Tb: " << m_Tb << "\n";
+        amrex::Print() << "    N_av/mol.weight: " << m_Nav_by_molweight << "\n";
+        amrex::Print() << "    mol. Cp coeffs: ";
+        for (int i = 0; i < 7; i++) { amrex::Print() << m_mol_Cp_coeffs[i] << ", "; }
+        amrex::Print() << "\n";
+    }
+
+    /*! \brief Set this material to H20 */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_H2O();
+    /*! \brief Set this material to water */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_water();
+    /*! \brief Set this material to agua */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_agua();
+    /*! \brief Set this material to NaCl */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_NaCl();
+    /*! \brief Set this material to ammonium sulfate */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_NH42SO4();
+    /*! \brief Set this material to ammonium bisulfate */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_NH4HSO4();
+    /*! \brief Set this material to soil */
+    AMREX_GPU_HOST_DEVICE
+    void setProperties_soil();
+
     /*! \brief Compute saturation pressure */
     AMREX_GPU_HOST AMREX_FORCE_INLINE
     void computeSaturationPressure ( amrex::MultiFab& a_e, const amrex::MultiFab& a_T) const
@@ -226,7 +232,6 @@ struct MaterialProperties {
     {
         m_saturation_vapfrac_func(a_S, a_T, a_p);
     }
-
 };
 
 #endif

--- a/Source/Particles/ERF_SuperDropletPCMassChange.H
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.H
@@ -341,7 +341,7 @@ namespace SDMassChangeUtils
                     cur_time += dt;
 
                     if (m_verbose) {
-                        printf( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
+                        AMREX_DEVICE_PRINTF( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
                                 cur_time, dt, dt * std::sqrt(tau*tau), std::sqrt(a_u), snorm);
                     }
                     if (snorm < m_stol) {
@@ -437,7 +437,7 @@ namespace SDMassChangeUtils
                     cur_time += dt;
 
                     if (m_verbose) {
-                        printf( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
+                        AMREX_DEVICE_PRINTF( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
                                 cur_time, dt, dt * std::sqrt(tau*tau), std::sqrt(a_u), snorm);
                     }
                     if (snorm < m_stol) {
@@ -516,9 +516,9 @@ namespace SDMassChangeUtils
                     cur_time += dt;
 
                     if (m_verbose) {
-                        printf( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
+                        AMREX_DEVICE_PRINTF( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
                                 cur_time, dt, dt * std::sqrt(tau*tau), std::sqrt(a_u), snorm);
-                        printf( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
+                        AMREX_DEVICE_PRINTF( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
                                 res_norm_a, res_norm_r,
                                 (converged ? "yes" : "no") );
                     }
@@ -608,9 +608,9 @@ namespace SDMassChangeUtils
                     cur_time += dt;
 
                     if (m_verbose) {
-                        printf( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
+                        AMREX_DEVICE_PRINTF( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
                                 cur_time, dt, dt * std::sqrt(tau*tau), std::sqrt(a_u), snorm);
-                        printf( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
+                        AMREX_DEVICE_PRINTF( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
                                 res_norm_a, res_norm_r,
                                 (converged ? "yes" : "no") );
                     }
@@ -728,9 +728,9 @@ namespace SDMassChangeUtils
                     cur_time += dt;
 
                     if (m_verbose) {
-                        printf( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
+                        AMREX_DEVICE_PRINTF( "Time %1.2e, dt = %1.2e, cfl = %1.1e, radius = %1.4e, snorm = %1.1e\n",
                                 cur_time, dt, dt * std::sqrt(tau*tau), std::sqrt(a_u), snorm);
-                        printf( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
+                        AMREX_DEVICE_PRINTF( "    norms = %1.3e (abs), %1.3e (rel), converged = %s\n",
                                 res_norm_a, res_norm_r,
                                 (converged ? "yes" : "no") );
                     }

--- a/Source/Particles/ERF_SuperDropletPCMassChange.cpp
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.cpp
@@ -176,6 +176,12 @@ void SuperDropletPC::MassChange ( int                                         a_
 
         auto cfl = m_mass_change_cfl;
         auto ti_choice = m_mass_change_ti;
+        AMREX_ASSERT_WITH_MESSAGE( ti_choice == SDMassChangeTIMethod::RK4 ||
+                                   ti_choice == SDMassChangeTIMethod::RK3BS ||
+                                   ti_choice == SDMassChangeTIMethod::BE ||
+                                   ti_choice == SDMassChangeTIMethod::CN ||
+                                   ti_choice == SDMassChangeTIMethod::DIRK2,
+                                   "ERROR: invalid time integrator choice!" );
 
         auto sp_i_arr = sp_ionization.data();
         auto sp_mw_arr = sp_mol_weight.data();
@@ -261,9 +267,6 @@ void SuperDropletPC::MassChange ( int                                         a_
                 ti.cn(r_sq, success);
             } else if (ti_choice == SDMassChangeTIMethod::DIRK2) {
                 ti.dirk212(r_sq, success);
-            } else {
-                printf("ERROR: invalid time integrator choice!\n");
-                return;
             }
 
             if (!success) {

--- a/Source/Particles/ERF_SuperDropletPCMassChange.cpp
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.cpp
@@ -51,6 +51,7 @@ void SuperDropletPC::MassChange ( int                                         a_
     AMREX_ALWAYS_ASSERT(idx_vap >= 0);
     AMREX_ALWAYS_ASSERT(mat_density >= 0);
     const MaterialProperties vapour_mat(*(m_species_mat[idx_vap]));
+    const MaterialPropertiesCore& vapour_mat_core = vapour_mat;
 
     const bool log_unconverged = m_mass_change_logging;
     [[maybe_unused]] FILE* file_handle = m_mass_change_log;
@@ -223,9 +224,9 @@ void SuperDropletPC::MassChange ( int                                         a_
                 }
             }
 
-            auto coeff_curv = vapour_mat.coeffCurv(temperature);
-            auto coeff_sol = vapour_mat.coeffVPSolute();
-            auto coeff_moldiff = vapour_mat.coeffMolecularDiffusion(temperature, pressure);
+            auto coeff_curv = vapour_mat_core.coeffCurv(temperature);
+            auto coeff_sol = vapour_mat_core.coeffVPSolute();
+            auto coeff_moldiff = vapour_mat_core.coeffMolecularDiffusion(temperature, pressure);
 
 #ifdef ERF_USE_ML_UPHYS_DIAGNOSTICS
             if (a_is_water) {

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -582,7 +582,9 @@ Radiation::mf_to_kokkos_buffers (iMultiFab* lmask,
                                             0.06, 0.06};
         for (int ivar(0); ivar<lsm_input_ptrs.size(); ivar++) {
             auto rrtmgp_default_val = rrtmgp_default_vals[ivar];
-            auto rrtmgp_to_fill = rrtmgp_in_vars[ivar];
+            auto rrtmgp_to_fill_k = rrtmgp_in_vars[ivar];
+            amrex::Table1D<amrex::Real> rrtmgp_to_fill(rrtmgp_to_fill_k.data(),
+                                                       0, rrtmgp_to_fill_k.extent(0));
             for (MFIter mfi(*m_cons_in); mfi.isValid(); ++mfi) {
                 const auto& vbx  = mfi.validbox();
                 const auto& sbx  = makeSlab(vbx,2,vbx.smallEnd(2));
@@ -732,7 +734,11 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
                         lsm_out_arr(i,j,k) = mu0_tab(icol);
                     });
                 } else {
-                    auto rrtmgp_for_fill = rrtmgp_out_vars[ivar-1];
+                    auto rrtmgp_for_fill_k = rrtmgp_out_vars[ivar-1];
+                    amrex::Table2D<amrex::Real const, amrex::Order::C>
+                        rrtmgp_for_fill(rrtmgp_for_fill_k.data(),
+                                        {0,0}, {int(rrtmgp_for_fill_k.extent(0)),
+                                                int(rrtmgp_for_fill_k.extent(1))});
                     ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         // map [i,j,k] 0-based to [icol, ilay] 0-based


### PR DESCRIPTION
`sycl::is_device_copyable<Kokkos::View>` is false. Thus `Kokkos::View` cannot be used directly in SYCL kernels.
