### PR TITLE
Fix MetGrid

### DIFF
--- a/Source/Initialization/ERF_InitFromMetgrid.cpp
+++ b/Source/Initialization/ERF_InitFromMetgrid.cpp
@@ -610,7 +610,7 @@ init_state_from_metgrid (const bool use_moisture,
                          FArrayBox& x_vel_fab,
                          FArrayBox& y_vel_fab,
                          FArrayBox& z_vel_fab,
-                         FArrayBox& z_phys_nd_fab,
+                         FArrayBox& z_phys_cc_fab,
                          const Vector<FArrayBox>& NC_hgt_fab,
                          const Vector<FArrayBox>& NC_ght_fab,
                          const Vector<FArrayBox>& NC_xvel_fab,
@@ -649,7 +649,7 @@ init_state_from_metgrid (const bool use_moisture,
         auto const orig_data = NC_xvel_fab[itime].const_array();
         auto const orig_z    = NC_ght_fab[itime].const_array();
         auto       new_data  = x_vel_fab.array();
-        auto const new_z     = z_phys_nd_fab.const_array();
+        auto const new_z     = z_phys_cc_fab.const_array();
 
         Box bx_xlo = fabs_for_bcs_xlo[itime][MetGridBdyVars::U].box();
         Box bx_xhi = fabs_for_bcs_xhi[itime][MetGridBdyVars::U].box();
@@ -684,7 +684,7 @@ init_state_from_metgrid (const bool use_moisture,
             } else { // Vertical interpolation and quality control similar to that from WRF.
                 interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, metgrid_exp_interp,
                                            metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                           metgrid_force_sfc_k, i, j, 0, itime, 'U', 'X',
+                                           metgrid_force_sfc_k, i, j, kmax, 0, itime, 'U', 'X',
                                            orig_z, orig_data, new_z, new_data, true,
                                            bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                            bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_u_arr);
@@ -705,7 +705,7 @@ init_state_from_metgrid (const bool use_moisture,
         auto const orig_data = NC_yvel_fab[itime].const_array();
         auto const orig_z    = NC_ght_fab[itime].const_array();
         auto       new_data  = y_vel_fab.array();
-        auto const new_z     = z_phys_nd_fab.const_array();
+        auto const new_z     = z_phys_cc_fab.const_array();
 
         Box bx_xlo = fabs_for_bcs_xlo[itime][MetGridBdyVars::V].box();
         Box bx_xhi = fabs_for_bcs_xhi[itime][MetGridBdyVars::V].box();
@@ -740,7 +740,7 @@ init_state_from_metgrid (const bool use_moisture,
             } else {
                 interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, metgrid_exp_interp,
                                            metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                           metgrid_force_sfc_k, i, j, 0, itime, 'V', 'Y',
+                                           metgrid_force_sfc_k, i, j, kmax, 0, itime, 'V', 'Y',
                                            orig_z, orig_data, new_z, new_data, true,
                                            bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                            bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_v_arr);
@@ -793,7 +793,7 @@ init_state_from_metgrid (const bool use_moisture,
             auto const orig_data = theta_fab.const_array();
             auto const orig_z    = NC_ght_fab[itime].const_array();
             auto       new_data  = state_fab.array();
-            auto const new_z     = z_phys_nd_fab.const_array();
+            auto const new_z     = z_phys_cc_fab.const_array();
 
             Box bx_xlo = fabs_for_bcs_xlo[itime][MetGridBdyVars::T].box();
             Box bx_xhi = fabs_for_bcs_xhi[itime][MetGridBdyVars::T].box();
@@ -828,7 +828,7 @@ init_state_from_metgrid (const bool use_moisture,
                 } else { // Vertical interpolation and quality control similar to that from WRF.
                     interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, metgrid_exp_interp,
                                                metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                               metgrid_force_sfc_k, i, j, RhoTheta_comp, itime, 'T', 'M',
+                                               metgrid_force_sfc_k, i, j, kmax, RhoTheta_comp, itime, 'T', 'M',
                                                orig_z, orig_data, new_z, new_data, true,
                                                bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                                bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_c_arr);
@@ -847,7 +847,7 @@ init_state_from_metgrid (const bool use_moisture,
             auto const orig_data = NC_pres_fab[itime].const_array();
             auto const orig_z    = NC_ght_fab[itime].const_array();
             auto       new_data  = p_interp_fab.array();
-            auto const new_z     = z_phys_nd_fab.const_array();
+            auto const new_z     = z_phys_cc_fab.const_array();
 
             Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
             const amrex::Array4<amrex::Real> bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi;
@@ -866,7 +866,7 @@ init_state_from_metgrid (const bool use_moisture,
                     // This is akin to interpolating in pressure-space assuming a baroclinic atmosphere.
                     interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, true,
                                                metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                               metgrid_force_sfc_k, i, j, 0, 0, 'T', 'M',
+                                               metgrid_force_sfc_k, i, j, kmax, 0, 0, 'T', 'M',
                                                orig_z, orig_data, new_z, new_data, false,
                                                bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                                bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_c_arr);
@@ -883,7 +883,7 @@ init_state_from_metgrid (const bool use_moisture,
             auto const orig_data = NC_temp_fab[itime].const_array();
             auto const orig_z    = NC_ght_fab[itime].const_array();
             auto       new_data  = t_interp_fab.array();
-            auto const new_z     = z_phys_nd_fab.const_array();
+            auto const new_z     = z_phys_cc_fab.const_array();
 
             Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
             const amrex::Array4<amrex::Real> bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi;
@@ -903,7 +903,7 @@ init_state_from_metgrid (const bool use_moisture,
                     // in LOG(p), regardless of requested default."
                     interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, false,
                                                metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                               metgrid_force_sfc_k, i, j, 0, 0, 'T', 'M',
+                                               metgrid_force_sfc_k, i, j, kmax, 0, 0, 'T', 'M',
                                                orig_z, orig_data, new_z, new_data, false,
                                                bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                                bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_c_arr);
@@ -970,7 +970,7 @@ init_state_from_metgrid (const bool use_moisture,
                 auto const orig_data = mxrat_fab.const_array();
                 auto const orig_z    = NC_ght_fab[itime].const_array();
                 auto       new_data  = state_fab.array();
-                auto const new_z     = z_phys_nd_fab.const_array();
+                auto const new_z     = z_phys_cc_fab.const_array();
 
                 Box bx_xlo = fabs_for_bcs_xlo[itime][MetGridBdyVars::QV].box();
                 Box bx_xhi = fabs_for_bcs_xhi[itime][MetGridBdyVars::QV].box();
@@ -1006,7 +1006,7 @@ init_state_from_metgrid (const bool use_moisture,
                     } else { // Vertical interpolation and quality control similar to that from WRF.
                         interpolate_column_metgrid(metgrid_use_below_sfc, metgrid_use_sfc, metgrid_exp_interp,
                                                    metgrid_retain_sfc, metgrid_proximity, metgrid_order,
-                                                   metgrid_force_sfc_k, i, j, state_indx, itime, 'Q', 'M',
+                                                   metgrid_force_sfc_k, i, j, kmax, state_indx, itime, 'Q', 'M',
                                                    orig_z, orig_data, new_z, new_data, true,
                                                    bc_data_xlo, bc_data_xhi, bc_data_ylo, bc_data_yhi,
                                                    bx_xlo, bx_xhi, bx_ylo, bx_yhi, mask_c_arr);

--- a/Source/Initialization/ERF_MetgridUtils.H
+++ b/Source/Initialization/ERF_MetgridUtils.H
@@ -65,7 +65,7 @@ init_state_from_metgrid (const bool use_moisture,
                          amrex::FArrayBox& x_vel_fab,
                          amrex::FArrayBox& y_vel_fab,
                          amrex::FArrayBox& z_vel_fab,
-                         amrex::FArrayBox& z_phys_nd_fab,
+                         amrex::FArrayBox& z_phys_cc_fab,
                          const amrex::Vector<amrex::FArrayBox>& NC_hgt_fab,
                          const amrex::Vector<amrex::FArrayBox>& NC_ght_fab,
                          const amrex::Vector<amrex::FArrayBox>& NC_xvel_fab,
@@ -465,6 +465,7 @@ interpolate_column_metgrid (const bool& metgrid_use_below_sfc,
                             const int& metgrid_force_sfc_k,
                             const int& i,
                             const int& j,
+                            const int& kmax,
                             const int& src_comp,
                             const int& itime,
                             char var_type,
@@ -491,7 +492,7 @@ interpolate_column_metgrid (const bool& metgrid_use_below_sfc,
     int imax_orig = amrex::ubound(amrex::Box(orig_data)).x;
     int jmax_orig = amrex::ubound(amrex::Box(orig_data)).y;
     int kmax_orig = amrex::ubound(amrex::Box(orig_data)).z;
-    int kmax_new  = amrex::ubound(amrex::Box(new_z_full)).z;
+    int kmax_new  = kmax + 1;
 
     AMREX_ASSERT(kmax_orig < 256);
     AMREX_ASSERT(kmax_new  < 256);


### PR DESCRIPTION
Metgrid tries to loop over ghost cells when it shouldn't. The addition of more ghost cells to z_cc causes an out of bounds error. This PR explicitly passes kmax now.