### PR TITLE
Fix Zcc Stencil

### DIFF
--- a/Source/Utils/ERF_TerrainMetrics.H
+++ b/Source/Utils/ERF_TerrainMetrics.H
@@ -359,10 +359,10 @@ amrex::Real
 Compute_Z_AtCellCenter (const int &i, const int &j, const int &k,
                         const amrex::Array4<const amrex::Real>& z_nd)
 {
-    const amrex::Real z_cc = 0.125*(  z_nd(i  ,j  ,k  ) + z_nd(i  ,j  ,k+1) +
-                                    + z_nd(i+1,j  ,k  ) + z_nd(i  ,j  ,k+1)
+    const amrex::Real z_cc = 0.125*(  z_nd(i  ,j  ,k  ) + z_nd(i  ,j  ,k+1)
+                                    + z_nd(i+1,j  ,k  ) + z_nd(i+1,j  ,k+1)
                                     + z_nd(i  ,j+1,k  ) + z_nd(i  ,j+1,k+1)
-                                    + z_nd(i+1,j+1,k  ) + z_nd(i  ,j+1,k+1));
+                                    + z_nd(i+1,j+1,k  ) + z_nd(i+1,j+1,k+1));
 
     return z_cc;
 }


### PR DESCRIPTION
# Utils: Indexing Error in `Compute_Z_AtCellCenter`

## Summary
`Compute_Z_AtCellCenter` in `Source/Utils/ERF_TerrainMetrics.H` has a copy‑paste indexing bug: two nodal values are duplicated and two are omitted. This produces an incorrect cell‑center height (z) by averaging only 6 unique nodes (with two double-counted) instead of the correct 8.

## Location
`Source/Utils/ERF_TerrainMetrics.H:362-365`

## Problematic Code
Current code:

```
const amrex::Real z_cc = 0.125*(  z_nd(i  ,j  ,k  ) + z_nd(i  ,j  ,k+1) +
                                + z_nd(i+1,j  ,k  ) + z_nd(i  ,j  ,k+1)
                                + z_nd(i  ,j+1,k  ) + z_nd(i  ,j+1,k+1)
                                + z_nd(i+1,j+1,k  ) + z_nd(i  ,j+1,k+1));
```

Issues:
- `z_nd(i  ,j  ,k+1)` is duplicated.
- `z_nd(i  ,j+1,k+1)` is duplicated.
- Missing `z_nd(i+1,j  ,k+1)` and `z_nd(i+1,j+1,k+1)`.
