### PR TITLE
Init KE for WPS

### DIFF
--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.H
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.H
@@ -21,6 +21,7 @@ public:
     Problem();
 
 #include "Prob/ERF_InitDensityHSE.H"
+#include "Prob/ERF_InitCustomPert.H"
 #include "Prob/ERF_InitRayleighDamping.H"
 
 protected:

--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.cpp
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.cpp
@@ -19,3 +19,27 @@ Problem::Problem()
 
   init_base_parms(parms.rho_0, parms.T_0);
 }
+
+void
+Problem::init_custom_pert (
+    const Box& bx,
+    Array4<Real const> const& /*state*/,
+    Array4<Real      > const& state_pert,
+    Array4<Real      > const& r_hse,
+    Array4<Real      > const& p_hse,
+    Array4<Real const> const& /*z_nd*/,
+    Array4<Real const> const& z_cc,
+    GeometryData const& geomdata,
+    Array4<Real const> const&   mf_m,
+    const SolverChoice& sc,
+    const int lev)
+{
+    ParmParse pp_erf("erf");
+    std::string my_prob_name; pp_erf.get("prob_name",my_prob_name);
+
+    if (my_prob_name == "WPS") {
+#include "Prob/ERF_InitCustomPert_KE.H"
+    }
+
+    amrex::Gpu::streamSynchronize();
+}

--- a/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.cpp
+++ b/Exec/MoistRegTests/WPS_and_Metgrid_Tests/ERF_Prob.cpp
@@ -43,3 +43,24 @@ Problem::init_custom_pert (
 
     amrex::Gpu::streamSynchronize();
 }
+
+void
+Problem::init_custom_pert_vels (
+    const Box& xbx,
+    const Box& ybx,
+    const Box& zbx,
+    Array4<Real      > const& x_vel_pert,
+    Array4<Real      > const& y_vel_pert,
+    Array4<Real      > const& z_vel_pert,
+    Array4<Real const> const& z_nd,
+    GeometryData const& geomdata,
+    Array4<Real const> const& mf_u,
+    Array4<Real const> const& mf_v,
+    const SolverChoice& sc,
+    const int /*lev*/)
+{
+    ParmParse pp("erf");
+    std::string my_prob_name; pp.get("prob_name",my_prob_name);
+
+    amrex::Gpu::streamSynchronize();
+}

--- a/Source/Prob/ERF_InitCustomPert_KE.H
+++ b/Source/Prob/ERF_InitCustomPert_KE.H
@@ -11,7 +11,7 @@
                        << std::endl;
     }
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         // Set an initial value for SGS KE
         const Real z = z_cc(i,j,k);

--- a/Source/Prob/ERF_InitCustomPert_KE.H
+++ b/Source/Prob/ERF_InitCustomPert_KE.H
@@ -1,9 +1,7 @@
 
     ParmParse pp("prob");
 
-    Real A_0   = 1.0; pp.query("A_0", A_0);
     Real KE_0  = 0.1; pp.query("KE_0", KE_0);
-
     Real KE_decay_height = -1; pp.query("KE_decay_height", KE_decay_height);
     Real KE_decay_order  =  1; pp.query("KE_decay_order" , KE_decay_order );
 

--- a/Source/Prob/ERF_InitCustomPert_KE.H
+++ b/Source/Prob/ERF_InitCustomPert_KE.H
@@ -1,0 +1,29 @@
+
+    ParmParse pp("prob");
+
+    Real A_0   = 1.0; pp.query("A_0", A_0);
+    Real KE_0  = 0.1; pp.query("KE_0", KE_0);
+
+    Real KE_decay_height = -1; pp.query("KE_decay_height", KE_decay_height);
+    Real KE_decay_order  =  1; pp.query("KE_decay_order" , KE_decay_order );
+
+    if (KE_decay_height > 0) {
+        amrex::Print() << "Initial KE profile (order " << KE_decay_order
+                       << ") will extend up to " << KE_decay_height
+                       << std::endl;
+    }
+
+    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    {
+        // Set an initial value for SGS KE
+        const Real z = z_cc(i,j,k);
+        if (state_pert.nComp() > RhoKE_comp) {
+            state_pert(i, j, k, RhoKE_comp) = r_hse(i,j,k) * KE_0;
+            // scale initial SGS kinetic energy with height
+            if (KE_decay_height > 0) {
+                state_pert(i, j, k, RhoKE_comp) *= max(
+                    std::pow(1 - min(z/KE_decay_height,1.0), KE_decay_order),
+                    1e-12);
+            }
+        }
+    });

--- a/Source/Prob/Make.package
+++ b/Source/Prob/Make.package
@@ -2,6 +2,7 @@ CEXE_headers += ERF_InitDensityHSE.H
 CEXE_headers += ERF_InitCustomPert.H
 CEXE_headers += ERF_InitRayleighDamping.H
 
+CEXE_headers += ERF_InitCustomPert_KE.H
 CEXE_headers += ERF_InitCustomPert_DensityCurrent.H
 CEXE_headers += ERF_InitCustomPert_IsentropicVortex.H
 CEXE_headers += ERF_InitCustomPert_ParticleTests.H


### PR DESCRIPTION
To run with various turbulence models, we would need to initialize the KE since it's not read from wrfinput. This PR allows for that.