### PR TITLE
Surface Layer W/ Vert Refinement

### DIFF
--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -97,9 +97,6 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
     bool use_terrain_fitted_coords = ( (m_terrain_type == TerrainType::StaticFittedMesh) ||
                                        (m_terrain_type == TerrainType::MovingFittedMesh) );
 
-    int klo = m_geom[lev].Domain().smallEnd(2);
-    int khi = m_geom[lev].Domain().bigEnd(2);
-
     { // Nodal in x
         auto& mf = *vars_old[Vars::xvel];
         // Create a 2D ba, dm, & ghost cells

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -97,12 +97,18 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
     bool use_terrain_fitted_coords = ( (m_terrain_type == TerrainType::StaticFittedMesh) ||
                                        (m_terrain_type == TerrainType::MovingFittedMesh) );
 
+    int klo = m_geom[lev].Domain().smallEnd(2);
+    int khi = m_geom[lev].Domain().bigEnd(2);
+
     { // Nodal in x
         auto& mf = *vars_old[Vars::xvel];
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) b.setRange(2,0);
+        for (auto& b : bl2d) {
+            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
+            b.setRange(2,kval);
+        }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp = 1;
@@ -123,7 +129,10 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) b.setRange(2,0);
+        for (auto& b : bl2d) {
+            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
+            b.setRange(2,kval);
+        }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp = 1;
@@ -144,7 +153,10 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) b.setRange(2,0);
+        for (auto& b : bl2d) {
+            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
+            b.setRange(2,kval);
+        }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp  = 1;
@@ -461,6 +473,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
     Real zref_tmp = zref_default;
     auto read_z = pp.query("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
+    int klo     = m_geom[lev].Domain().smallEnd(2);
 
     // Allow default zref
     if (!read_z) {
@@ -483,6 +496,9 @@ MOSTAverage::set_k_indices_T (const int& lev)
         int kmax = m_geom[lev].Domain().bigEnd(2);
         for (MFIter mfi(*m_k_indx[lev], TileNoZ()); mfi.isValid(); ++mfi) {
             Box npbx = mfi.tilebox(IntVect(1,1,0),IntVect(1,1,0));
+
+            if (npbx.smallEnd(2) != klo) { continue; }
+
             const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
             auto k_arr = m_k_indx[lev]->array(mfi);
             auto zref_arr = m_zref[lev]->array(mfi);
@@ -531,6 +547,7 @@ MOSTAverage::set_norm_indices_T (const int& lev)
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     // Capture for device
     Real d_zref   = zref_tmp;
@@ -542,6 +559,9 @@ MOSTAverage::set_norm_indices_T (const int& lev)
     for (MFIter mfi(*m_k_indx[lev], TileNoZ()); mfi.isValid(); ++mfi) {
         Box npbx  = mfi.tilebox(IntVect(1,1,0),IntVect(1,1,0));
         Box gpbx  = mfi.growntilebox(ng);
+
+        if (npbx.smallEnd(2) != klo) { continue; }
+
         const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
         auto i_arr = m_i_indx[lev]->array(mfi);
         auto j_arr = m_j_indx[lev]->array(mfi);
@@ -610,6 +630,7 @@ MOSTAverage::set_z_positions_T (const int& lev)
     } else {
         m_zref[lev]->setVal(zref_tmp);
     }
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     // Capture for device
     Real d_zref = zref_tmp;
@@ -621,6 +642,9 @@ MOSTAverage::set_z_positions_T (const int& lev)
     for (MFIter mfi(*m_x_pos[lev], TileNoZ()); mfi.isValid(); ++mfi) {
         Box npbx  = mfi.tilebox(IntVect(1,1,0),IntVect(1,1,0));
         Box gpbx  = mfi.growntilebox(ng);
+
+        if (npbx.smallEnd(2) != klo) { continue; }
+
         RealBox grb{gpbx,dx.data(),base.dataPtr()};
 
         const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
@@ -659,6 +683,7 @@ MOSTAverage::set_norm_positions_T (const int& lev)
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     // Capture for device
     Real d_zref = zref_tmp;
@@ -672,6 +697,8 @@ MOSTAverage::set_norm_positions_T (const int& lev)
         Box npbx  = mfi.tilebox(IntVect(1,1,0),IntVect(1,1,0));
         Box gpbx  = mfi.growntilebox(ng);
         RealBox grb{gpbx,dx.data(),base.dataPtr()};
+
+        if (npbx.smallEnd(2) != klo) { continue; }
 
         const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
         auto x_pos_arr   = m_x_pos[lev]->array(mfi);
@@ -785,6 +812,8 @@ MOSTAverage::compute_plane_averages (const int& lev)
         d_fact_old = 0.0;
     }
 
+    int klo = m_geom[lev].Domain().smallEnd(2);
+
     // GPU array to accumulate averages into
     Gpu::DeviceVector<Real> pavg(plane_average.size(), 0.0);
     Real* plane_avg = pavg.data();
@@ -820,7 +849,11 @@ MOSTAverage::compute_plane_averages (const int& lev)
         for (MFIter mfi(*fields[imf], TileNoZ()); mfi.isValid(); ++mfi) {
             Box vbx = mfi.validbox(); // This is the grid (not tile)
             Box pbx = mfi.tilebox();  // This is the tile (not grid)
-            pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            if (pbx.smallEnd(2) != klo) { continue; }
+
+            // Make planar since mfiter is over fields
+            pbx.setSmall(2,klo); pbx.setBig(2,klo);
 
             // Avoid double counting nodal data by changing the high end when we are
             //     at the high side of the grid (not just of the tile)
@@ -888,7 +921,8 @@ MOSTAverage::compute_plane_averages (const int& lev)
         for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi)
         {
             Box pbx = mfi.tilebox();
-            pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            if (pbx.smallEnd(2) != klo) { continue; }
 
             const Array4<Real const>& T_mf_arr = fields[2]->const_array(mfi);
             const Array4<Real const>& qv_mf_arr = (fields[3])? fields[3]->const_array(mfi) : Array4<const Real>{};
@@ -975,7 +1009,8 @@ MOSTAverage::compute_plane_averages (const int& lev)
         for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi)
         {
             Box pbx = mfi.tilebox();
-            pbx.setSmall(2,0); pbx.setBig(2,0);
+
+            if (pbx.smallEnd(2) != klo) { continue; }
 
             // Last element is Umag and always cell centered
             auto u_mf_arr = (m_rotate) ? rot_fields[imf  ]->const_array(mfi) :
@@ -1057,6 +1092,8 @@ MOSTAverage::compute_region_averages (const int& lev)
     auto& j_indx   = m_j_indx[lev];
     auto& k_indx   = m_k_indx[lev];
 
+    int klo = m_geom[lev].Domain().smallEnd(2);
+
     // Set factors for time averaging
     Real d_fact_new, d_fact_old;
     if (m_t_avg && m_t_init[lev]) {
@@ -1087,7 +1124,12 @@ MOSTAverage::compute_region_averages (const int& lev)
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*fields[imf], TileNoZ()); mfi.isValid(); ++mfi) {
-            Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+            Box pbx = mfi.tilebox();
+
+            if (pbx.smallEnd(2) != klo) { continue; }
+
+            // Make planar since mfiter is over fields
+            pbx.setSmall(2,klo); pbx.setBig(2,klo);
 
             auto mf_arr = (m_rotate) ? rot_fields[imf]->const_array(mfi) :
                                            fields[imf]->const_array(mfi);
@@ -1162,7 +1204,9 @@ MOSTAverage::compute_region_averages (const int& lev)
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi) {
-            Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+            Box pbx = mfi.tilebox();
+
+            if (pbx.smallEnd(2) != klo) { continue; }
 
             const Array4<Real const>& T_mf_arr = fields[2]->const_array(mfi);
             const Array4<Real const>& qv_mf_arr = (fields[3])? fields[3]->const_array(mfi) : Array4<const Real>{};
@@ -1267,7 +1311,9 @@ MOSTAverage::compute_region_averages (const int& lev)
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
         for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi) {
-            Box pbx = mfi.tilebox(); pbx.setSmall(2,0); pbx.setBig(2,0);
+            Box pbx = mfi.tilebox();
+
+            if (pbx.smallEnd(2) != klo) { continue; }
 
             auto u_mf_arr = (m_rotate) ? rot_fields[imf  ]->const_array(mfi) :
                                              fields[imf  ]->const_array(mfi);
@@ -1367,7 +1413,9 @@ MOSTAverage::compute_region_averages (const int& lev)
 #pragma omp parallel if (Gpu::notInLaunchRegion())
 #endif
             for (MFIter mfi(*averages[iavg], TileNoZ()); mfi.isValid(); ++mfi) {
-                Box gpbx = mfi.growntilebox(ng); gpbx.setSmall(2,0); gpbx.setBig(2,0);
+                Box gpbx = mfi.growntilebox(ng);
+
+                if (gpbx.smallEnd(2) != klo) { continue; }
 
                 if (bnd_bx.contains(gpbx)) continue;
 
@@ -1402,6 +1450,7 @@ MOSTAverage::write_k_indices (const int& lev)
     // Peel back the level
     auto& averages = m_averages[lev];
     auto& k_indx   = m_k_indx[lev];
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     int navg = m_navg - 1;
 
@@ -1410,7 +1459,10 @@ MOSTAverage::write_k_indices (const int& lev)
     ofile << "K indices used to compute averages via MOSTAverages class:\n";
 
     for (MFIter mfi(*averages[navg], TileNoZ()); mfi.isValid(); ++mfi) {
-        Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        Box bx  = mfi.tilebox();
+
+        if(bx.smallEnd(2) != klo) { continue; }
+
         int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
         int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
 
@@ -1419,7 +1471,7 @@ MOSTAverage::write_k_indices (const int& lev)
         for (int j(jl); j <= ju; ++j) {
             for (int i(il); i <= iu; ++i) {
                 ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
-                int k = 0;
+                int k = klo;
                 ofile << "K_ind: "
                       << k_arr(i,j,k) << "\n";
                 ofile << "\n";
@@ -1443,6 +1495,7 @@ MOSTAverage::write_norm_indices (const int& lev)
     auto& k_indx   = m_k_indx[lev];
     auto& j_indx   = m_j_indx[lev];
     auto& i_indx   = m_i_indx[lev];
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     int navg = m_navg - 1;
 
@@ -1451,7 +1504,10 @@ MOSTAverage::write_norm_indices (const int& lev)
     ofile << "IJK indices used to compute averages via MOSTAverages class:\n";
 
     for (MFIter mfi(*averages[navg], TileNoZ()); mfi.isValid(); ++mfi) {
-        Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        Box bx  = mfi.tilebox();
+
+        if(bx.smallEnd(2) != klo) { continue; }
+
         int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
         int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
 
@@ -1463,7 +1519,7 @@ MOSTAverage::write_norm_indices (const int& lev)
             for (int i(il); i <= iu; ++i) {
                 ofile << "(I1,J1,K1): " << "(" << i << "," << j << "," << 0 << ")" << "\n";
 
-                int k = 0;
+                int k  = klo;
                 int km = k_arr(i,j,k);
                 int jm = j_arr ? j_arr(i,j,k) : j;
                 int im = i_arr ? i_arr(i,j,k) : i;
@@ -1491,18 +1547,22 @@ MOSTAverage::write_xz_positions (const int& lev,
     // Peel back the level
     auto& x_pos_mf  = m_x_pos[lev];
     auto& z_pos_mf  = m_z_pos[lev];
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     std::ofstream ofile;
     ofile.open ("MOST_xz_positions.txt");
 
     for (MFIter mfi(*x_pos_mf, TileNoZ()); mfi.isValid(); ++mfi) {
-        Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        Box bx  = mfi.tilebox();
+
+        if(bx.smallEnd(2) != klo) { continue; }
+
         int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
 
         auto x_pos_arr  = x_pos_mf->array(mfi);
         auto z_pos_arr  = z_pos_mf->array(mfi);
 
-        int k  = 0;
+        int k  = klo;
         for (int i(il); i <= iu; ++i)
             ofile << x_pos_arr(i,j,k) << ' ' << z_pos_arr(i,j,k) << "\n";
     }
@@ -1520,6 +1580,7 @@ MOSTAverage::write_averages (const int& lev)
 {
     // Peel back the level
     auto& averages = m_averages[lev];
+    int klo = m_geom[lev].Domain().smallEnd(2);
 
     int navg = m_navg - 1;
 
@@ -1528,14 +1589,17 @@ MOSTAverage::write_averages (const int& lev)
     ofile << "Averages computed via MOSTAverages class:\n";
 
     for (MFIter mfi(*averages[navg], TileNoZ()); mfi.isValid(); ++mfi) {
-        Box bx  = mfi.tilebox(); bx.setBig(2,0);
+        Box bx  = mfi.tilebox();
+
+        if(bx.smallEnd(2) != klo) { continue; }
+
         int il = bx.smallEnd(0); int iu = bx.bigEnd(0);
         int jl = bx.smallEnd(1); int ju = bx.bigEnd(1);
 
         for (int j(jl); j <= ju; ++j) {
             for (int i(il); i <= iu; ++i) {
                 ofile << "(I,J): " << "(" << i << "," << j << ")" << "\n";
-                int k = 0;
+                int k = klo;
                 for (int iavg(0); iavg <= navg; ++iavg) {
                     auto mf_arr = averages[iavg]->array(mfi);
                     ofile << "iavg val: "

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -105,10 +105,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
-            b.setRange(2,kval);
-        }
+        for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp = 1;
@@ -129,10 +126,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
-            b.setRange(2,kval);
-        }
+        for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp = 1;
@@ -153,10 +147,7 @@ MOSTAverage::make_MOSTAverage_at_level (const int& lev,
         // Create a 2D ba, dm, & ghost cells
         const BoxArray& ba = mf.boxArray();
         BoxList bl2d = ba.boxList();
-        for (auto& b : bl2d) {
-            int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
-            b.setRange(2,kval);
-        }
+        for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
         BoxArray ba2d(std::move(bl2d));
         const DistributionMapping& dm = mf.DistributionMap();
         const int ncomp  = 1;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -397,9 +397,7 @@ public:
       // Attributes for MFs and FABs
       //--------------------------------------------------------
       // Create a 2D ba, dm, & ghost cells
-      int klo = m_geom[lev].Domain().smallEnd(2);
-      int khi = m_geom[lev].Domain().bigEnd(2);
-      amrex::BoxArray ba = mf.boxArray();
+      amrex::BoxArray ba  = mf.boxArray();
       amrex::BoxList bl2d = ba.boxList();
       for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
       amrex::BoxArray ba2d(std::move(bl2d));

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -401,10 +401,7 @@ public:
       int khi = m_geom[lev].Domain().bigEnd(2);
       amrex::BoxArray ba = mf.boxArray();
       amrex::BoxList bl2d = ba.boxList();
-      for (auto& b : bl2d) {
-          int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
-          b.setRange(2, kval);
-      }
+      for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
       amrex::BoxArray ba2d(std::move(bl2d));
       const amrex::DistributionMapping& dm = mf.DistributionMap();
       const int ncomp = 1;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -397,10 +397,13 @@ public:
       // Attributes for MFs and FABs
       //--------------------------------------------------------
       // Create a 2D ba, dm, & ghost cells
+      int klo = m_geom[lev].Domain().smallEnd(2);
+      int khi = m_geom[lev].Domain().bigEnd(2);
       amrex::BoxArray ba = mf.boxArray();
       amrex::BoxList bl2d = ba.boxList();
       for (auto& b : bl2d) {
-          b.setRange(2, 0);
+          int kval = (b.smallEnd(2) == klo) ? klo : klo-khi;
+          b.setRange(2, kval);
       }
       amrex::BoxArray ba2d(std::move(bl2d));
       const amrex::DistributionMapping& dm = mf.DistributionMap();

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -173,11 +173,14 @@ SurfaceLayer::update_fluxes (const int& lev,
     if (m_update_k_rans) {
         const bool use_ref_theta = (theta_ref > 0);
         const Real l_inv_theta0  = (use_ref_theta) ? 1.0 / theta_ref : 1.0;
-        const Real l_inv_Cmu2 = inv_Cmu2;
+        const Real l_inv_Cmu2    = inv_Cmu2;
+        const int klo = m_geom[lev].Domain().smallEnd(2);
 
         for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
         {
             Box gtbx = mfi.growntilebox();
+
+            if (gtbx.smallEnd(2) != klo) { continue; }
 
             auto cons_arr = cons_in.array(mfi);
             const auto& u_star_arr = u_star[lev]->const_array(mfi);
@@ -624,10 +627,14 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
     bool use_tsk = (m_tsk_lev[lev][0]);
     bool ignore_sst = m_ignore_sst;
 
+    const int klo = m_geom[lev].Domain().smallEnd(2);
+
     // Populate t_surf
     for (MFIter mfi(*t_surf[lev]); mfi.isValid(); ++mfi)
     {
         Box gtbx = mfi.growntilebox();
+
+        if (gtbx.smallEnd(2) != klo) { continue; }
 
         auto t_surf_arr = t_surf[lev]->array(mfi);
 
@@ -674,9 +681,12 @@ SurfaceLayer::fill_qsurf_with_qsat (const int& lev,
 
     // Populate q_surf with qsat over water
     auto dz = m_geom[lev].CellSize(2);
+    const int klo = m_geom[lev].Domain().smallEnd(2);
     for (MFIter mfi(*q_surf[lev]); mfi.isValid(); ++mfi)
     {
         Box gtbx = mfi.growntilebox();
+
+        if (gtbx.smallEnd(2) != klo) { continue; }
 
         auto t_surf_arr = t_surf[lev]->array(mfi);
         auto q_surf_arr = q_surf[lev]->array(mfi);
@@ -708,9 +718,12 @@ SurfaceLayer::fill_qsurf_with_qsat (const int& lev,
 void
 SurfaceLayer::get_lsm_tsurf (const int& lev)
 {
+    const int klo = m_geom[lev].Domain().smallEnd(2);
     for (MFIter mfi(*t_surf[lev]); mfi.isValid(); ++mfi)
     {
         Box gtbx = mfi.growntilebox();
+
+        if (gtbx.smallEnd(2) != klo) { continue; }
 
         // NOTE: LSM does not carry lateral ghost cells.
         //       This copies the valid box into the ghost cells.
@@ -773,21 +786,46 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
 {
     Print() << "Initializing TKE from surface layer ustar on level " << lev << std::endl;
 
-    constexpr Real small = 0.01;
+    const int klo = m_geom[lev].Domain().smallEnd(2);
 
+    // Handle vertical decomposition by copying into boxes not at klo
+    for (MFIter mfi_dst(*u_star[lev]); mfi.isValid(); ++mfi)
+    {
+        Box vbx_dst = mfi_dst.validbox();
+
+        if (vbx_dst.smallEnd(2) == klo) { continue; }
+
+        Box vbx_tmp = vbx_dst; vbx_tmp.setRange(2,klo);
+
+        FArrayBox dst_fab = u_star[lev]->get(mfi_dst);
+
+        for (MFIter mfi_src(*u_star[lev]); mfi.isValid(); ++mfi)
+        {
+            Box vbx_src = mfi_src.validbox();
+            if (vbx_src == vbx_tmp) {
+                FArrayBox src_fab = u_star[lev]->get(mfi_src);
+                dst_fab.copy<RunOn::Device>(src_fab, vbx_src, 0, vbx_dst, 0, 1);
+            }
+        }
+
+    }
+
+    // Now work on all boxes (ustar has been filled)
+    constexpr Real small = 0.01;
     for (MFIter mfi(cons); mfi.isValid(); ++mfi)
     {
-        Box gtbx = mfi.tilebox();
+        Box vbx  = mfi.validbox();
+        int kmin = vbx.smallEnd(2);
 
         auto const& u_star_arr = u_star[lev]->const_array(mfi);
         auto const& z_phys_arr = z_phys_nd->const_array(mfi);
 
         auto const& cons_arr   = cons.array(mfi);
 
-        ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            Real rho = cons_arr(i, j, k, Rho_comp);
-            Real ust = u_star_arr(i, j, 0);
+            Real rho  = cons_arr(i, j, k, Rho_comp);
+            Real ust  = u_star_arr(i, j, kmin);
             Real tke0 = tkefac * ust * ust; // surface value
             Real zagl = Compute_Zrel_AtCellCenter(i, j, k, z_phys_arr);
 
@@ -848,9 +886,12 @@ SurfaceLayer::read_custom_roughness (const int& lev,
         Real* z0p = d_z0.data();
 
         // Each rank populates it's z_0[lev] MultiFab
+        const int klo = m_geom[lev].Domain().smallEnd(2);
         for (MFIter mfi(z_0[lev]); mfi.isValid(); ++mfi)
         {
             Box gtbx = mfi.growntilebox();
+
+            if (gtbx.smallEnd(2) != klo) { continue; }
 
             // Populate z_phys data
             Real tol = 1.0e-4;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -789,7 +789,7 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
     const int klo = m_geom[lev].Domain().smallEnd(2);
 
     // Handle vertical decomposition by copying into boxes not at klo
-    for (MFIter mfi_dst(*u_star[lev]); mfi.isValid(); ++mfi)
+    for (MFIter mfi_dst(*u_star[lev]); mfi_dst.isValid(); ++mfi_dst)
     {
         Box vbx_dst = mfi_dst.validbox();
 
@@ -797,20 +797,20 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
 
         Box vbx_tmp = vbx_dst; vbx_tmp.setRange(2,klo);
 
-        FArrayBox dst_fab = u_star[lev]->get(mfi_dst);
+        FArrayBox& dst_fab = u_star[lev]->get(mfi_dst);
 
-        for (MFIter mfi_src(*u_star[lev]); mfi.isValid(); ++mfi)
+        for (MFIter mfi_src(*u_star[lev]); mfi_src.isValid(); ++mfi_src)
         {
             Box vbx_src = mfi_src.validbox();
             if (vbx_src == vbx_tmp) {
-                FArrayBox src_fab = u_star[lev]->get(mfi_src);
+                FArrayBox& src_fab = u_star[lev]->get(mfi_src);
                 dst_fab.copy<RunOn::Device>(src_fab, vbx_src, 0, vbx_dst, 0, 1);
             }
         }
 
     }
 
-    // Now work on all boxes (ustar has been filled)
+    // Now work on all boxes (ustar has been filled above)
     constexpr Real small = 0.01;
     for (MFIter mfi(cons); mfi.isValid(); ++mfi)
     {
@@ -899,7 +899,6 @@ SurfaceLayer::read_custom_roughness (const int& lev,
             auto ProbLoArr = m_geom[lev].ProbLoArray();
             int ilo = m_geom[lev].Domain().smallEnd(0);
             int jlo = m_geom[lev].Domain().smallEnd(1);
-            int klo = 0;
             int ihi = m_geom[lev].Domain().bigEnd(0);
             int jhi = m_geom[lev].Domain().bigEnd(1);
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -231,9 +231,13 @@ SurfaceLayer::compute_fluxes (const int& lev,
     const auto *const umm_ptr  = m_ma.get_average(lev,5); // horizontal velocity magnitude
     const auto *const zref_ptr = m_ma.get_zref(lev);     // reference height
 
+    const int klo = m_geom[lev].Domain().smallEnd(2);
+
     for (MFIter mfi(*u_star[lev]); mfi.isValid(); ++mfi)
     {
         Box gtbx = mfi.growntilebox();
+
+        if (gtbx.smallEnd(2) != klo) { continue; }
 
         auto u_star_arr = u_star[lev]->array(mfi);
         auto t_star_arr = t_star[lev]->array(mfi);

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -274,9 +274,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     // Map factors
     // ********************************************************************************************
     BoxList bl2d_mf = ba.boxList();
-    for (auto& b : bl2d_mf) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl2d_mf) { b.setRange(2,b.smallEnd(2)); }
     BoxArray ba2d_mf(std::move(bl2d_mf));
 
     mapfac[lev].resize(MapFacType::num);
@@ -323,9 +321,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
 
     // Build 2D BA
     BoxList bl2d = ba.boxList();
-    for (auto& b : bl2d) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
     ba2d[lev]  = BoxArray(std::move(bl2d));
 
     IntVect ng  = vars_new[lev][Vars::cons].nGrowVect();
@@ -403,9 +399,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
         const MultiFab& src = vars_new[lev][0];
         BoxArray ba_hc = src.boxArray();
         BoxList bl2d_hc = ba_hc.boxList();
-        for (auto& b : bl2d_hc) {
-            b.setRange(2, 0);
-        }
+        for (auto& b : bl2d_hc) { b.setRange(2,b.smallEnd(2)); }
         BoxArray ba2d_hc(std::move(bl2d_hc));
         const amrex::DistributionMapping& dm_hc = src.DistributionMap();
 
@@ -421,9 +415,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     // create a new BoxArray and DistributionMapping for a MultiFab with 1 box
     BoxArray ba_onegrid(geom[lev].Domain());
     BoxList bl2d_onegrid = ba_onegrid.boxList();
-    for (auto& b : bl2d_onegrid) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl2d_onegrid) { b.setRange(2,b.smallEnd(2)); }
     BoxArray ba2d_onegrid(std::move(bl2d_onegrid));
     Vector<int> pmap;
     pmap.resize(1);
@@ -435,9 +427,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     Lwave_onegrid[lev] = std::make_unique<MultiFab>(ba2d_onegrid,dm_onegrid,1,IntVect(1,1,0));
 
     BoxList bl2d_wave = ba.boxList();
-    for (auto& b : bl2d_wave) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl2d_wave) { b.setRange(2,b.smallEnd(2)); }
     BoxArray ba2d_wave(std::move(bl2d_wave));
 
     Hwave[lev] = std::make_unique<MultiFab>(ba2d_wave,dm,1,IntVect(3,3,0));
@@ -507,9 +497,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     lmask_lev[lev].resize(1);
     auto ngv = lev_new[Vars::cons].nGrowVect(); ngv[2] = 0;
     BoxList bl2d_mask = ba.boxList();
-    for (auto& b : bl2d_mask) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl2d_mask) { b.setRange(2,b.smallEnd(2)); }
     BoxArray ba2d_mask(std::move(bl2d_mask));
     lmask_lev[lev][0] = std::make_unique<iMultiFab>(ba2d_mask,dm,1,ngv);
     lmask_lev[lev][0]->setVal(1);

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -274,7 +274,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     // Map factors
     // ********************************************************************************************
     BoxList bl2d_mf = ba.boxList();
-    for (auto& b : bl2d_mf) { b.setRange(2,b.smallEnd(2)); }
+    for (auto& b : bl2d_mf) { b.setRange(2,0); }
     BoxArray ba2d_mf(std::move(bl2d_mf));
 
     mapfac[lev].resize(MapFacType::num);

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -228,7 +228,10 @@ ERF::WriteCheckpointFile () const
         }
 
         IntVect ng = mapfac[lev][MapFacType::m_x]->nGrowVect();
-        MultiFab mf_m(ba2d[lev],dmap[lev],1,ng);
+        BoxList bl2d_mf = ba2d[lev].boxList();
+        for (auto& b : bl2d_mf) { b.setRange(2,0); }
+        BoxArray ba2d_mf(std::move(bl2d_mf));
+        MultiFab mf_m(ba2d_mf,dmap[lev],1,ng);
         MultiFab::Copy(mf_m,*mapfac[lev][MapFacType::m_x],0,0,1,ng);
         VisMF::Write(mf_m, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_mx"));
 
@@ -240,7 +243,7 @@ ERF::WriteCheckpointFile () const
 #endif
 
         ng = mapfac[lev][MapFacType::u_x]->nGrowVect();
-        MultiFab mf_u(convert(ba2d[lev],IntVect(1,0,0)),dmap[lev],1,ng);
+        MultiFab mf_u(convert(ba2d_mf,IntVect(1,0,0)),dmap[lev],1,ng);
         MultiFab::Copy(mf_u,*mapfac[lev][MapFacType::u_x],0,0,1,ng);
         VisMF::Write(mf_u, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_ux"));
 
@@ -252,7 +255,7 @@ ERF::WriteCheckpointFile () const
 #endif
 
         ng = mapfac[lev][MapFacType::v_x]->nGrowVect();
-        MultiFab mf_v(convert(ba2d[lev],IntVect(0,1,0)),dmap[lev],1,ng);
+        MultiFab mf_v(convert(ba2d_mf,IntVect(0,1,0)),dmap[lev],1,ng);
         MultiFab::Copy(mf_v,*mapfac[lev][MapFacType::v_x],0,0,1,ng);
         VisMF::Write(mf_v, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_vx"));
 
@@ -764,7 +767,10 @@ ERF::ReadCheckpointFile ()
 
 
         IntVect ng = mapfac[lev][MapFacType::m_x]->nGrowVect();
-        MultiFab mf_m(ba2d[lev],dmap[lev],1,ng);
+        BoxList bl2d_mf = ba2d[lev].boxList();
+        for (auto& b : bl2d_mf) { b.setRange(2,0); }
+        BoxArray ba2d_mf(std::move(bl2d_mf));
+        MultiFab mf_m(ba2d_mf,dmap[lev],1,ng);
 
         std::string MapFacMFileName(restart_chkfile + "/Level_0/MapFactor_mx_H");
         if (amrex::FileExists(MapFacMFileName)) {
@@ -782,7 +788,7 @@ ERF::ReadCheckpointFile ()
 #endif
 
         ng = mapfac[lev][MapFacType::u_x]->nGrowVect();
-        MultiFab mf_u(convert(ba2d[lev],IntVect(1,0,0)),dmap[lev],1,ng);
+        MultiFab mf_u(convert(ba2d_mf,IntVect(1,0,0)),dmap[lev],1,ng);
 
         std::string MapFacUFileName(restart_chkfile + "/Level_0/MapFactor_ux_H");
         if (amrex::FileExists(MapFacUFileName)) {
@@ -800,7 +806,7 @@ ERF::ReadCheckpointFile ()
 #endif
 
         ng = mapfac[lev][MapFacType::v_x]->nGrowVect();
-        MultiFab mf_v(convert(ba2d[lev],IntVect(0,1,0)),dmap[lev],1,ng);
+        MultiFab mf_v(convert(ba2d_mf,IntVect(0,1,0)),dmap[lev],1,ng);
 
         std::string MapFacVFileName(restart_chkfile + "/Level_0/MapFactor_vx_H");
         if (amrex::FileExists(MapFacVFileName)) {

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -59,9 +59,7 @@ NOAHMP::Init (const int& lev,
     BoxArray ba = cons_in.boxArray();
     DistributionMapping dm = cons_in.DistributionMap();
     BoxList bl_lsm = ba.boxList();
-    for (auto& b : bl_lsm) {
-        b.setRange(2,0);
-    }
+    for (auto& b : bl_lsm) { b.setRange(2,b.smallEnd(2)); }
     BoxArray ba_lsm(std::move(bl_lsm));
 
     // Set up lsm geometry

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -287,9 +287,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
         MultiFab mf2d;
         {
             BoxList bl2d = h_mf.boxArray().boxList();
-            for (auto& b : bl2d) {
-                b.setRange(2,0);
-            }
+            for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
             BoxArray ba2d(std::move(bl2d));
             mf2d = MultiFab(ba2d, h_mf.DistributionMap(), 1, ngrow, MFInfo().SetAlloc(false));
         }


### PR DESCRIPTION
# Summary
This PR modifies classes that operate on the surface only (e.g., Surface Layer and Land Surface Model) to use a modified 2D box array. Specifically, the box array is collapsed onto the valid box's `smallEnd(2)`. This change allows us to only operate **ONLY** on the surface by adding the following lines to an MFIter loop.
```
int klo = geom[lev].Domain().smallEnd(2);
if (my_bx.smallEnd(2) != klo) { continue; }
```

## Notes
The only 2D BA that does not follow this canonical form is that for the mapfactors, which are implicitly assumed to be defined at `k==0`. For this reason, the `ba2d_mf` is retained in MakeNewArrays and added to Checkpoint.
