### PR TITLE
Variable Coriolis Restart

### DIFF
--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -449,7 +449,6 @@ struct SolverChoice {
 
         // Include Coriolis forcing?
         pp.query("use_coriolis", use_coriolis);
-        pp.query("has_lat_lon", has_lat_lon);
         pp.query("variable_coriolis", variable_coriolis);
 
         // Include four stream radiation approximation
@@ -1203,7 +1202,6 @@ struct SolverChoice {
     std::string abl_geo_wind_table;
     bool have_geo_wind_profile {false};
 
-    bool has_lat_lon{false};
     bool variable_coriolis{false};
 
     int ave_plane {2};

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -271,28 +271,47 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     }
 
     // ********************************************************************************************
+    // Build 1D BA and 2D BA
+    // ********************************************************************************************
+
+    // Build 2D BA with k==klo
+    BoxList bl2d = ba.boxList();
+    for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
+    ba2d[lev]  = BoxArray(std::move(bl2d));
+
+    // Build SD BA with k==0
+    BoxList bl2d_0 = ba.boxList();
+    for (auto& b : bl2d_0) { b.setRange(2,0); }
+    BoxArray ba2d_0(std::move(bl2d_0));
+
+    // Build 1D BA with k==0
+    BoxList bl1d_0 = ba.boxList();
+    for (auto& b : bl1d_0) {
+        b.setRange(0,0);
+        b.setRange(1,0);
+    }
+    ba1d[lev]  = BoxArray(std::move(bl1d_0));
+
+    // ********************************************************************************************
     // Map factors
     // ********************************************************************************************
-    BoxList bl2d_mf = ba.boxList();
-    for (auto& b : bl2d_mf) { b.setRange(2,0); }
-    BoxArray ba2d_mf(std::move(bl2d_mf));
 
     mapfac[lev].resize(MapFacType::num);
-    mapfac[lev][MapFacType::m_x] = std::make_unique<MultiFab>(                        ba2d_mf,dm,1,IntVect(3,3,0));
-    mapfac[lev][MapFacType::u_x] = std::make_unique<MultiFab>(convert(ba2d_mf,IntVect(1,0,0)),dm,1,IntVect(3,3,0));
-    mapfac[lev][MapFacType::v_x] = std::make_unique<MultiFab>(convert(ba2d_mf,IntVect(0,1,0)),dm,1,IntVect(3,3,0));
+    mapfac[lev][MapFacType::m_x] = std::make_unique<MultiFab>(                        ba2d_0,dm,1,IntVect(3,3,0));
+    mapfac[lev][MapFacType::u_x] = std::make_unique<MultiFab>(convert(ba2d_0,IntVect(1,0,0)),dm,1,IntVect(3,3,0));
+    mapfac[lev][MapFacType::v_x] = std::make_unique<MultiFab>(convert(ba2d_0,IntVect(0,1,0)),dm,1,IntVect(3,3,0));
 
 #if 0
     // For now we comment this out to avoid CI failures but we will need to re-enable
     //     this if using non-conformal mappings
     if (MapFacType::m_y != MapFacType::m_x) {
-        mapfac[lev][MapFacType::m_y] = std::make_unique<MultiFab>(ba2d_mf,dm,1,IntVect(3,3,0));
+        mapfac[lev][MapFacType::m_y] = std::make_unique<MultiFab>(ba2d_0,dm,1,IntVect(3,3,0));
     }
     if (MapFacType::u_y != MapFacType::u_x) {
-        mapfac[lev][MapFacType::u_y] = std::make_unique<MultiFab>(convert(ba2d_mf,IntVect(1,0,0)),dm,1,IntVect(3,3,0));
+        mapfac[lev][MapFacType::u_y] = std::make_unique<MultiFab>(convert(ba2d_0,IntVect(1,0,0)),dm,1,IntVect(3,3,0));
     }
     if (MapFacType::v_y != MapFacType::v_x) {
-        mapfac[lev][MapFacType::v_y] = std::make_unique<MultiFab>(convert(ba2d_mf,IntVect(0,1,0)),dm,1,IntVect(3,3,0));
+        mapfac[lev][MapFacType::v_y] = std::make_unique<MultiFab>(convert(ba2d_0,IntVect(0,1,0)),dm,1,IntVect(3,3,0));
     }
 #endif
 
@@ -310,29 +329,18 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     }
 
     // ********************************************************************************************
-    // Build 1D BA and 2D BA
+    // Build 1D and 2D WRF Vars
     // ********************************************************************************************
-    BoxList bl1d = ba.boxList();
-    for (auto& b : bl1d) {
-        b.setRange(0,0);
-        b.setRange(1,0);
-    }
-    ba1d[lev]  = BoxArray(std::move(bl1d));
-
-    // Build 2D BA
-    BoxList bl2d = ba.boxList();
-    for (auto& b : bl2d) { b.setRange(2,b.smallEnd(2)); }
-    ba2d[lev]  = BoxArray(std::move(bl2d));
 
     IntVect ng  = vars_new[lev][Vars::cons].nGrowVect();
 
     if (lev == 0) {
         mf_C1H = std::make_unique<MultiFab>(ba1d[lev],dm,1,IntVect(ng[0],ng[1],ng[2]));
         mf_C2H = std::make_unique<MultiFab>(ba1d[lev],dm,1,IntVect(ng[0],ng[1],ng[2]));
-        mf_MUB = std::make_unique<MultiFab>(ba2d[lev],dm,1,IntVect(ng[0],ng[1],ng[2]));
+        mf_MUB = std::make_unique<MultiFab>(ba2d_0,dm,1,IntVect(ng[0],ng[1],ng[2]));
     }
 
-    mf_PSFC[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ng);
+    mf_PSFC[lev] = std::make_unique<MultiFab>(ba2d_0,dm,1,ng);
 
     //*********************************************************
     // Variables for Fitch model for windfarm parametrization
@@ -396,16 +404,9 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
         solverChoice.hindcast_surface_bcs)
 
     {
-        const MultiFab& src = vars_new[lev][0];
-        BoxArray ba_hc = src.boxArray();
-        BoxList bl2d_hc = ba_hc.boxList();
-        for (auto& b : bl2d_hc) { b.setRange(2,b.smallEnd(2)); }
-        BoxArray ba2d_hc(std::move(bl2d_hc));
-        const amrex::DistributionMapping& dm_hc = src.DistributionMap();
-
-        surface_state_1[lev].define(ba2d_hc, dm_hc, 2, src.nGrow());
-        surface_state_2[lev].define(ba2d_hc, dm_hc, 2, src.nGrow());
-        surface_state_interp[lev].define(ba2d_hc, dm_hc, 2, src.nGrow());
+        surface_state_1[lev].define(ba2d_0, dm, 2, src.nGrow());
+        surface_state_2[lev].define(ba2d_0, dm, 2, src.nGrow());
+        surface_state_interp[lev].define(ba2d_0, dm, 2, src.nGrow());
 
         bool regrid_forces_file_read = true;
         SurfaceDataInterpolation(lev, t_new[0], z_phys_nd, regrid_forces_file_read);
@@ -462,15 +463,8 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     if (solverChoice.lsm_type != LandSurfaceType::None &&
         solverChoice.rad_type != RadiationType::None)
     {
-        BoxList m_bl = ba.boxList();
-        for (auto& b : m_bl) {
-            int kmin = b.smallEnd(2);
-            b.setRange(2,kmin);
-        }
-        BoxArray m_ba(std::move(m_bl));
-
-        sw_lw_fluxes[lev] = std::make_unique<MultiFab>(m_ba, dm, 6, 0); // DIR/DIF VIS/NIR (4), NET SW (1), LW (1)
-        solar_zenith[lev] = std::make_unique<MultiFab>(m_ba, dm, 1, 0);
+        sw_lw_fluxes[lev] = std::make_unique<MultiFab>(ba2d[lev], dm, 6, 0); // DIR/DIF VIS/NIR (4), NET SW (1), LW (1)
+        solar_zenith[lev] = std::make_unique<MultiFab>(ba2d[lev], dm, 1, 0);
 
         sw_lw_fluxes[lev]->setVal(0.);
         solar_zenith[lev]->setVal(0.);
@@ -494,29 +488,26 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     // NOTE: the logic below will BREAK if we have any grids not touching the bottom boundary
     //
     {
-    lmask_lev[lev].resize(1);
-    auto ngv = lev_new[Vars::cons].nGrowVect(); ngv[2] = 0;
-    BoxList bl2d_mask = ba.boxList();
-    for (auto& b : bl2d_mask) { b.setRange(2,b.smallEnd(2)); }
-    BoxArray ba2d_mask(std::move(bl2d_mask));
-    lmask_lev[lev][0] = std::make_unique<iMultiFab>(ba2d_mask,dm,1,ngv);
-    lmask_lev[lev][0]->setVal(1);
-    lmask_lev[lev][0]->FillBoundary(geom[lev].periodicity());
+        lmask_lev[lev].resize(1);
+        auto ngv = lev_new[Vars::cons].nGrowVect(); ngv[2] = 0;
+        lmask_lev[lev][0] = std::make_unique<iMultiFab>(ba2d[lev],dm,1,ngv);
+        lmask_lev[lev][0]->setVal(1);
+        lmask_lev[lev][0]->FillBoundary(geom[lev].periodicity());
 
-    land_type_lev[lev].resize(1);
-    land_type_lev[lev][0] = std::make_unique<iMultiFab>(ba2d_mask,dm,1,ngv);
-    land_type_lev[lev][0]->setVal(0);
-    land_type_lev[lev][0]->FillBoundary(geom[lev].periodicity());
+        land_type_lev[lev].resize(1);
+        land_type_lev[lev][0] = std::make_unique<iMultiFab>(ba2d[lev],dm,1,ngv);
+        land_type_lev[lev][0]->setVal(0);
+        land_type_lev[lev][0]->FillBoundary(geom[lev].periodicity());
 
-    soil_type_lev[lev].resize(1);
-    soil_type_lev[lev][0] = std::make_unique<iMultiFab>(ba2d_mask,dm,1,ngv);
-    soil_type_lev[lev][0]->setVal(0);
-    soil_type_lev[lev][0]->FillBoundary(geom[lev].periodicity());
+        soil_type_lev[lev].resize(1);
+        soil_type_lev[lev][0] = std::make_unique<iMultiFab>(ba2d[lev],dm,1,ngv);
+        soil_type_lev[lev][0]->setVal(0);
+        soil_type_lev[lev][0]->FillBoundary(geom[lev].periodicity());
 
-    urb_frac_lev[lev].resize(1);
-    urb_frac_lev[lev][0] = std::make_unique<MultiFab>(ba2d_mask,dm,1,ngv);
-    urb_frac_lev[lev][0]->setVal(1.0);
-    urb_frac_lev[lev][0]->FillBoundary(geom[lev].periodicity());
+        urb_frac_lev[lev].resize(1);
+        urb_frac_lev[lev][0] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
+        urb_frac_lev[lev][0]->setVal(1.0);
+        urb_frac_lev[lev][0]->FillBoundary(geom[lev].periodicity());
     }
 
     // Read in tables needed for windfarm simulations

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -228,10 +228,10 @@ ERF::WriteCheckpointFile () const
         }
 
         IntVect ng = mapfac[lev][MapFacType::m_x]->nGrowVect();
-        BoxList bl2d_mf = ba2d[lev].boxList();
-        for (auto& b : bl2d_mf) { b.setRange(2,0); }
-        BoxArray ba2d_mf(std::move(bl2d_mf));
-        MultiFab mf_m(ba2d_mf,dmap[lev],1,ng);
+        BoxList bl2d_0 = ba2d[lev].boxList();
+        for (auto& b : bl2d_0) { b.setRange(2,0); }
+        BoxArray ba2d_0(std::move(bl2d_0));
+        MultiFab mf_m(ba2d_0,dmap[lev],1,ng);
         MultiFab::Copy(mf_m,*mapfac[lev][MapFacType::m_x],0,0,1,ng);
         VisMF::Write(mf_m, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_mx"));
 
@@ -243,7 +243,7 @@ ERF::WriteCheckpointFile () const
 #endif
 
         ng = mapfac[lev][MapFacType::u_x]->nGrowVect();
-        MultiFab mf_u(convert(ba2d_mf,IntVect(1,0,0)),dmap[lev],1,ng);
+        MultiFab mf_u(convert(ba2d_0,IntVect(1,0,0)),dmap[lev],1,ng);
         MultiFab::Copy(mf_u,*mapfac[lev][MapFacType::u_x],0,0,1,ng);
         VisMF::Write(mf_u, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_ux"));
 
@@ -255,7 +255,7 @@ ERF::WriteCheckpointFile () const
 #endif
 
         ng = mapfac[lev][MapFacType::v_x]->nGrowVect();
-        MultiFab mf_v(convert(ba2d_mf,IntVect(0,1,0)),dmap[lev],1,ng);
+        MultiFab mf_v(convert(ba2d_0,IntVect(0,1,0)),dmap[lev],1,ng);
         MultiFab::Copy(mf_v,*mapfac[lev][MapFacType::v_x],0,0,1,ng);
         VisMF::Write(mf_v, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MapFactor_vx"));
 
@@ -359,8 +359,8 @@ ERF::WriteCheckpointFile () const
         // Write lat/lon if it exists
         if (lat_m[lev] && lon_m[lev] && solverChoice.has_lat_lon) {
             amrex::Print() << "Writing Lat/Lon variables at level " << lev << std::endl;
-            MultiFab lat(ba2d[lev],dmap[lev],1,ngv);
-            MultiFab lon(ba2d[lev],dmap[lev],1,ngv);
+            MultiFab lat(ba2d_0,dmap[lev],1,ngv);
+            MultiFab lon(ba2d_0,dmap[lev],1,ngv);
             MultiFab::Copy(lat,*lat_m[lev],0,0,1,ngv);
             MultiFab::Copy(lon,*lon_m[lev],0,0,1,ngv);
             VisMF::Write(lat, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "LAT"));
@@ -372,8 +372,8 @@ ERF::WriteCheckpointFile () const
         // Write sinPhi and cosPhi if it exists
         if (cosPhi_m[lev] && sinPhi_m[lev] && solverChoice.variable_coriolis) {
             amrex::Print() << "Writing Coriolis factors at level " << lev << std::endl;
-            MultiFab sphi(ba2d[lev],dmap[lev],1,ngv);
-            MultiFab cphi(ba2d[lev],dmap[lev],1,ngv);
+            MultiFab sphi(ba2d_0,dmap[lev],1,ngv);
+            MultiFab cphi(ba2d_0,dmap[lev],1,ngv);
             MultiFab::Copy(sphi,*sinPhi_m[lev],0,0,1,ngv);
             MultiFab::Copy(cphi,*cosPhi_m[lev],0,0,1,ngv);
             VisMF::Write(sphi, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "SinPhi"));
@@ -391,7 +391,7 @@ ERF::WriteCheckpointFile () const
                 MultiFab::Copy(tmp1d,*mf_C2H,0,0,1,0);
                 VisMF::Write(tmp1d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "C2H"));
 
-                MultiFab tmp2d(ba2d[0],dmap[0],1,mf_MUB->nGrowVect());
+                MultiFab tmp2d(ba2d_0,dmap[0],1,mf_MUB->nGrowVect());
 
                 MultiFab::Copy(tmp2d,*mf_MUB,0,0,1,mf_MUB->nGrowVect());
                 VisMF::Write(tmp2d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MUB"));
@@ -767,10 +767,10 @@ ERF::ReadCheckpointFile ()
 
 
         IntVect ng = mapfac[lev][MapFacType::m_x]->nGrowVect();
-        BoxList bl2d_mf = ba2d[lev].boxList();
-        for (auto& b : bl2d_mf) { b.setRange(2,0); }
-        BoxArray ba2d_mf(std::move(bl2d_mf));
-        MultiFab mf_m(ba2d_mf,dmap[lev],1,ng);
+        BoxList bl2d_0 = ba2d[lev].boxList();
+        for (auto& b : bl2d_0) { b.setRange(2,0); }
+        BoxArray ba2d_0(std::move(bl2d_0));
+        MultiFab mf_m(ba2d_0,dmap[lev],1,ng);
 
         std::string MapFacMFileName(restart_chkfile + "/Level_0/MapFactor_mx_H");
         if (amrex::FileExists(MapFacMFileName)) {
@@ -788,7 +788,7 @@ ERF::ReadCheckpointFile ()
 #endif
 
         ng = mapfac[lev][MapFacType::u_x]->nGrowVect();
-        MultiFab mf_u(convert(ba2d_mf,IntVect(1,0,0)),dmap[lev],1,ng);
+        MultiFab mf_u(convert(ba2d_0,IntVect(1,0,0)),dmap[lev],1,ng);
 
         std::string MapFacUFileName(restart_chkfile + "/Level_0/MapFactor_ux_H");
         if (amrex::FileExists(MapFacUFileName)) {
@@ -806,7 +806,7 @@ ERF::ReadCheckpointFile ()
 #endif
 
         ng = mapfac[lev][MapFacType::v_x]->nGrowVect();
-        MultiFab mf_v(convert(ba2d_mf,IntVect(0,1,0)),dmap[lev],1,ng);
+        MultiFab mf_v(convert(ba2d_0,IntVect(0,1,0)),dmap[lev],1,ng);
 
         std::string MapFacVFileName(restart_chkfile + "/Level_0/MapFactor_vx_H");
         if (amrex::FileExists(MapFacVFileName)) {
@@ -901,10 +901,11 @@ ERF::ReadCheckpointFile ()
         IntVect ngv = ng; ngv[2] = 0;
 
         // Read lat/lon if it exists
-        if (solverChoice.has_lat_lon) {
+        std::string LatFileName(restart_chkfile + "/Level_0/LAT_H");
+        if (amrex::FileExists(LMaskFileName)) {
             amrex::Print() << "Reading Lat/Lon variables" << std::endl;
-            MultiFab lat(ba2d[lev],dmap[lev],1,ngv);
-            MultiFab lon(ba2d[lev],dmap[lev],1,ngv);
+            MultiFab lat(ba2d_0,dmap[lev],1,ngv);
+            MultiFab lon(ba2d_0,dmap[lev],1,ngv);
             VisMF::Read(lat, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "LAT"));
             VisMF::Read(lon, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "LON"));
             lat_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dmap[lev],1,ngv);
@@ -915,10 +916,11 @@ ERF::ReadCheckpointFile ()
 
 #ifdef ERF_USE_NETCDF
         // Read sinPhi and cosPhi if it exists
-        if (solverChoice.variable_coriolis) {
+        std::string VarCorFileName(restart_chkfile + "/Level_0/SinPhi_H");
+        if (amrex::FileExists(VarCorFileName)) {
             amrex::Print() << "Reading Coriolis factors" << std::endl;
-            MultiFab sphi(ba2d[lev],dmap[lev],1,ngv);
-            MultiFab cphi(ba2d[lev],dmap[lev],1,ngv);
+            MultiFab sphi(ba2d_0,dmap[lev],1,ngv);
+            MultiFab cphi(ba2d_0,dmap[lev],1,ngv);
             VisMF::Read(sphi, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "SinPhi"));
             VisMF::Read(cphi, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "CosPhi"));
             sinPhi_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dmap[lev],1,ngv);

--- a/Source/Initialization/ERF_InitFromMetgrid.cpp
+++ b/Source/Initialization/ERF_InitFromMetgrid.cpp
@@ -230,7 +230,6 @@ ERF::init_from_metgrid (int lev)
         }
     }
 
-    solverChoice.has_lat_lon = true;
     lat_m[lev]    = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
     sinPhi_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
     cosPhi_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -418,12 +418,15 @@ ERF::init_from_wrfinput (int lev,
           int i_lo = boxes_at_level[lev][0].smallEnd(0); int i_hi = boxes_at_level[lev][0].bigEnd(0);
           int j_lo = boxes_at_level[lev][0].smallEnd(1); int j_hi = boxes_at_level[lev][0].bigEnd(1);
 
+          BoxList bl2d_0 = ba2d[lev].boxList();
+          for (auto& b : bl2d_0) { b.setRange(2,0); }
+          BoxArray ba2d_0(std::move(bl2d_0));
+
           // Initialize Latitude & Coriolis factors
           if ( var_name == "XLAT_V" ) {
-              solverChoice.has_lat_lon = true;
-              lat_m[lev]    = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
-              sinPhi_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
-              cosPhi_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
+              lat_m[lev]    = std::make_unique<MultiFab>(ba2d_0,dm,1,ngv);
+              sinPhi_m[lev] = std::make_unique<MultiFab>(ba2d_0,dm,1,ngv);
+              cosPhi_m[lev] = std::make_unique<MultiFab>(ba2d_0,dm,1,ngv);
               for ( MFIter mfi(*(lat_m[lev]), TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
                   Box gtbx = mfi.growntilebox();
                   const Array4<      Real>& sin_arr = (sinPhi_m[lev])->array(mfi);
@@ -445,7 +448,7 @@ ERF::init_from_wrfinput (int lev,
 
           // Initialize Longitude
           if ( var_name == "XLONG_U" ) {
-              lon_m[lev] = std::make_unique<MultiFab>(ba2d[lev],dm,1,ngv);
+              lon_m[lev] = std::make_unique<MultiFab>(ba2d_0,dm,1,ngv);
               for ( MFIter mfi(*(lon_m[lev]), TilingIfNotGPU()); mfi.isValid(); ++mfi ) {
                   Box gtbx = mfi.growntilebox();
                   const Array4<      Real>& dst_arr = (lon_m[lev])->array(mfi);

--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -348,7 +348,8 @@ void make_mom_sources (Real time,
                     zmom_src_arr(i, j, k) += coriolis_factor * rho_u_loc * cphi_loc;
                 });
             }
-            else if (var_coriolis && has_lat_lon) {
+            else if (var_coriolis && (sinPhi_mf) && (cosPhi_mf)) {
+                int klo = mfi.validbox().smallEnd(2);
                 ParallelFor(tbx, tby, tbz,
                 [=] AMREX_GPU_DEVICE (int i, int j, int k)
                 {


### PR DESCRIPTION
# Summary
This PR corrects an issue with variable Coriolis and restart, which was incorrectly not activated upon restart even though it was used during the initial wrong. This PR also tries to clean up the 2D BA from the changes for surface layer and lsm.



## Notes
A formal change should be made in one of two ways:
1. Revert the ba2d structure to `k==0` and allocate all 2D vars this way. We then need to revamp almost all MFIter loops in surf layer and elsewhere to NOT be over a 2D structure so we can cycle if `k!= klo`.
2. Allocate al 2D structures with the current ba2d approach but pass `int k = mfi.validbox().smallEnd(2)` around so we access the right element.