### PR TITLE
Fix anelastic AMR level creation on restart and mid-run regrid

### DIFF
--- a/Source/BoundaryConditions/ERF_FillCoarsePatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillCoarsePatch.cpp
@@ -61,6 +61,19 @@ ERF::FillCoarsePatch (int lev, Real time)
                          rW_new[lev-1],
                        Geom(lev).Domain(),
                        domain_bcs_type, c_vfrac);
+
+    // Fill ghost cells of coarse momentum before interpolation to fine level.
+    // VelocityToMomentum above fills only valid cells (IntVect{0} grow).  On restart
+    // from a non-AMR checkpoint, init_stuff initialises rU/rV/rW_new[lev-1] with large
+    // sentinel values for ALL cells including ghost cells; the checkpoint read then
+    // overwrites only valid cells.  InterpFromCoarseLevel (see comments below) ASSUMES
+    // ghost cells at lev-1 are already filled and uses them in its stencil near periodic
+    // boundaries.  Without this FillBoundary, those sentinel ghost cells contaminate the
+    // fine-level interpolation, producing unphysical velocities that blow up WENO5.
+    rU_new[lev-1].FillBoundary(geom[lev-1].periodicity());
+    rV_new[lev-1].FillBoundary(geom[lev-1].periodicity());
+    rW_new[lev-1].FillBoundary(geom[lev-1].periodicity());
+
     //
     // *****************************************************************
     // Interpolate all cell-centered variables from coarse to fine level

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -472,15 +472,9 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
 
     // ********************************************************************************************
     // For anelastic levels created from coarse (either on restart or during a run), project the
-    // interpolated velocity to enforce the divergence-free constraint.  This:
-    //   1. Initializes gradp[lev] via the pressure projection, handling both the pure-anelastic
-    //      case and the hybrid case (compressible lev-1, anelastic lev) where there is no coarse
-    //      gradp to interpolate.
-    //   2. Corrects rW (z-momentum) to satisfy the divergence-free constraint rather than relying
-    //      on spatial interpolation, which can be physically inconsistent.
-    //   3. Re-runs VelocityToMomentum + FillBoundary on the coarse level before registering in
-    //      the FillPatcher, ensuring any lingering sentinel ghost cells in the coarse momentum do
-    //      not contaminate the fine-level data.
+    // interpolated velocity to enforce the divergence-free constraint. This Initializes gradp[lev] 
+    // via the pressure projection, handling both the pure-anelastic case and the hybrid case 
+    // (compressible lev-1, anelastic lev) where there is no coarse gradp to interpolate.
     // FillPatchers must be constructed above before this call. pp_inc is scratch; zero afterward.
     // ********************************************************************************************
     if (solverChoice.anelastic[lev]) {

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -470,6 +470,25 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
            Define_ERFFillPatchers(lev);
     }
 
+    // ********************************************************************************************
+    // For anelastic levels created from coarse (either on restart or during a run), project the
+    // interpolated velocity to enforce the divergence-free constraint.  This:
+    //   1. Initializes gradp[lev] via the pressure projection, handling both the pure-anelastic
+    //      case and the hybrid case (compressible lev-1, anelastic lev) where there is no coarse
+    //      gradp to interpolate.
+    //   2. Corrects rW (z-momentum) to satisfy the divergence-free constraint rather than relying
+    //      on spatial interpolation, which can be physically inconsistent.
+    //   3. Re-runs VelocityToMomentum + FillBoundary on the coarse level before registering in
+    //      the FillPatcher, ensuring any lingering sentinel ghost cells in the coarse momentum do
+    //      not contaminate the fine-level data.
+    // FillPatchers must be constructed above before this call. pp_inc is scratch; zero afterward.
+    // ********************************************************************************************
+    if (solverChoice.anelastic[lev]) {
+        Real dummy_dt = 1.0;
+        project_initial_velocity(lev, time, dummy_dt);
+        pp_inc[lev].setVal(0.0);
+    }
+
     //********************************************************************************************
     // Land Surface Model
     // *******************************************************************************************

--- a/Source/LinearSolvers/ERF_PoissonSolve.cpp
+++ b/Source/LinearSolvers/ERF_PoissonSolve.cpp
@@ -82,8 +82,10 @@ void ERF::project_initial_velocity (int lev, Real time, Real l_dt)
         FPr_w[levc].RegisterCoarseData({&rW_new[levc], &rW_new[levc]}, {time, time+l_dt});
     }
 
-    Real l_time = 0.0;
-    project_momenta(lev, l_time, l_dt, tmp_mom);
+    // Use the same time that was registered in the FillPatcher above so that the
+    // FillSet assertion (time >= crse_times[0] && time <= crse_times[1]) is satisfied
+    // when called at non-zero simulation time (restart or mid-run regrid).
+    project_momenta(lev, time, l_dt, tmp_mom);
 
     MomentumToVelocity(vars_new[lev][Vars::xvel],
                        vars_new[lev][Vars::yvel],


### PR DESCRIPTION
Three bugs caused blow-up when MakeNewLevelFromCoarse created a new anelastic fine level, either on restart from a non-AMR checkpoint or during a run with dynamic refinement.

ERF_FillCoarsePatch.cpp:
  VelocityToMomentum fills only valid cells of the coarse momentum
  arrays (IntVect{0} grow).  On restart, init_stuff sets ghost cells
  of rU/rV/rW_new to large sentinel values; the checkpoint read
  overwrites only valid cells, leaving sentinels in ghost cells.
  InterpFromCoarseLevel assumes ghost cells at lev-1 are already
  filled and reads them in its stencil near periodic boundaries,
  contaminating fine-level momentum with sentinel values and causing
  catastrophic WENO5 blow-up.  Fix: call FillBoundary on rU/rV/rW
  [lev-1] after VelocityToMomentum and before InterpFromCoarseLevel.

ERF_MakeNewLevel.cpp:
  After FillCoarsePatch, call project_initial_velocity for anelastic
  fine levels.  This enforces the divergence-free constraint on the
  interpolated velocity (correctly initializing rW), initializes
  gradp[lev] via the pressure projection, and handles the hybrid case
  (compressible lev-1, anelastic lev) where there is no coarse gradp
  to interpolate from.  FillPatchers must be constructed before this
  call; pp_inc is zeroed afterward as it is only scratch space.

ERF_PoissonSolve.cpp (project_initial_velocity):
  The function registered coarse data in FPr at {time, time+l_dt}
  but then called project_momenta with hardcoded l_time=0.0.  The
  ERFFillPatcher::Fill assertion requires the requested time to lie
  within the registered bracket, which fails at any non-zero restart
  or regrid time.  Fix: pass time (not 0.0) to project_momenta so
  the registered bracket and the fill request are consistent.