### PR TITLE
Rayleigh Damp At Level

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -689,8 +689,8 @@ private:
     void initHSE ();
     void initHSE (int lev);
 
-    //! Initialize Rayleigh damping profiles
-    void initRayleigh ();
+    //! Initialize Rayleigh damping profiles at a level
+    void initRayleigh_at_level (const int& lev);
 
     //! Initialize sponge profiles
     void initSponge ();

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -364,7 +364,7 @@ ERF::ERF_shared ()
     // Stresses
     Tau.resize(nlevs_max);
     Tau_corr.resize(nlevs_max);
-    SFS_hfx1_lev.resize(nlevs_max); SFS_hfx2_lev.resize(nlevs_max); SFS_hfx3_lev.resize(nlevs_max);
+    SFS_hfx1_lev.resize(nlevs_max);  SFS_hfx2_lev.resize(nlevs_max);  SFS_hfx3_lev.resize(nlevs_max);
     SFS_diss_lev.resize(nlevs_max);
     SFS_q1fx1_lev.resize(nlevs_max); SFS_q1fx2_lev.resize(nlevs_max); SFS_q1fx3_lev.resize(nlevs_max);
     SFS_q2fx3_lev.resize(nlevs_max);
@@ -476,6 +476,14 @@ ERF::ERF_shared ()
         sinPhi_m[lev] = nullptr;
         cosPhi_m[lev] = nullptr;
     }
+
+    // Rayleigh damping
+    h_rayleigh_ptrs.resize(nlevs_max);
+    d_rayleigh_ptrs.resize(nlevs_max);
+    h_sinesq_ptrs.resize(nlevs_max);
+    d_sinesq_ptrs.resize(nlevs_max);
+    h_sinesq_stag_ptrs.resize(nlevs_max);
+    d_sinesq_stag_ptrs.resize(nlevs_max);
 
     // Initialize tagging criteria for mesh refinement
     refinement_criteria_setup();
@@ -1271,7 +1279,9 @@ ERF::InitData_post ()
     if (solverChoice.dampingChoice.rayleigh_damp_U ||solverChoice.dampingChoice.rayleigh_damp_V ||
         solverChoice.dampingChoice.rayleigh_damp_W ||solverChoice.dampingChoice.rayleigh_damp_T)
     {
-        initRayleigh();
+        for (int lev = 0; lev <= finest_level; lev++) {
+            initRayleigh_at_level(lev);
+        }
         if (solverChoice.init_type == InitType::Input_Sounding)
         {
             // Overwrite ubar, vbar, and thetabar with input profiles;

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -520,6 +520,15 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
                                                    sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
     }
 
+    // ********************************************************************************************
+    // Set up the Rayleigh damping vectors at this (new) level
+    // ********************************************************************************************
+    if (solverChoice.dampingChoice.rayleigh_damp_U ||solverChoice.dampingChoice.rayleigh_damp_V ||
+        solverChoice.dampingChoice.rayleigh_damp_W ||solverChoice.dampingChoice.rayleigh_damp_T)
+    {
+        initRayleigh_at_level(lev);
+    }
+
 #ifdef ERF_USE_PARTICLES
     // particleData.Redistribute();
 #endif
@@ -787,6 +796,15 @@ ERF::RemakeLevel (int lev, Real time, const BoxArray& ba, const DistributionMapp
                                                    Hwave[lev].get(),Lwave[lev].get(),eddyDiffs_lev[lev].get(),
                                                    lsm_data[lev], lsm_data_name, lsm_flux[lev], lsm_flux_name,
                                                    sst_lev[lev], tsk_lev[lev], lmask_lev[lev]);
+    }
+
+    // ********************************************************************************************
+    // Set up the Rayleigh damping vectors at this (new) level
+    // ********************************************************************************************
+    if (solverChoice.dampingChoice.rayleigh_damp_U ||solverChoice.dampingChoice.rayleigh_damp_V ||
+        solverChoice.dampingChoice.rayleigh_damp_W ||solverChoice.dampingChoice.rayleigh_damp_T)
+    {
+        initRayleigh_at_level(lev);
     }
 
 #ifdef ERF_USE_PARTICLES

--- a/Source/Initialization/ERF_InitRayleigh.cpp
+++ b/Source/Initialization/ERF_InitRayleigh.cpp
@@ -11,76 +11,65 @@ using namespace amrex;
  * the effects of Rayleigh Damping.
  */
 void
-ERF::initRayleigh ()
+ERF::initRayleigh_at_level (const int& lev)
 {
     const int khi = geom[0].Domain().bigEnd(2);
     solverChoice.dampingChoice.rayleigh_ztop = (solverChoice.terrain_type == TerrainType::None) ?  geom[0].ProbHi(2) : zlevels_stag[0][khi+1];
 
-    h_rayleigh_ptrs.resize(max_level+1);
-    d_rayleigh_ptrs.resize(max_level+1);
+    // These have 4 components: ubar, vbar, wbar, thetabar
+    h_rayleigh_ptrs[lev].resize(Rayleigh::nvars);
+    d_rayleigh_ptrs[lev].resize(Rayleigh::nvars);
 
-    h_sinesq_ptrs.resize(max_level+1);
-    d_sinesq_ptrs.resize(max_level+1);
+    const int zlen_rayleigh = geom[lev].Domain().length(2);
 
-    h_sinesq_stag_ptrs.resize(max_level+1);
-    d_sinesq_stag_ptrs.resize(max_level+1);
-
-    for (int lev = 0; lev <= finest_level; lev++)
-    {
-        // These have 4 components: ubar, vbar, wbar, thetabar
-        h_rayleigh_ptrs[lev].resize(Rayleigh::nvars);
-        d_rayleigh_ptrs[lev].resize(Rayleigh::nvars);
-
-        const int zlen_rayleigh = geom[lev].Domain().length(2);
-
-        // Allocate space for these 1D vectors
-        for (int n = 0; n < Rayleigh::nvars; n++) {
-            h_rayleigh_ptrs[lev][n].resize(zlen_rayleigh, 0.0_rt);
-            d_rayleigh_ptrs[lev][n].resize(zlen_rayleigh, 0.0_rt);
-        }
-
-        h_sinesq_ptrs[lev].resize(zlen_rayleigh);
-        d_sinesq_ptrs[lev].resize(zlen_rayleigh);
-
-        h_sinesq_stag_ptrs[lev].resize(zlen_rayleigh+1);
-        d_sinesq_stag_ptrs[lev].resize(zlen_rayleigh+1);
-
-        Real ztop     = solverChoice.dampingChoice.rayleigh_ztop;
-        Real zdamp    = solverChoice.dampingChoice.rayleigh_zdamp;
-
-        for (int k = 0; k < zlen_rayleigh; k++) {
-            Real z = 0.5 * (zlevels_stag[lev][k] + zlevels_stag[lev][k+1]);
-            if (z > (ztop - zdamp)) {
-                Real zfrac = 1.0 - (ztop - z) / zdamp;
-                Real s = std::sin(PIoTwo*zfrac);
-                h_sinesq_ptrs[lev][k] = s*s;
-            } else {
-                h_sinesq_ptrs[lev][k] = 0.0;
-            }
-        }
-
-        for (int k = 0; k < zlen_rayleigh+1; k++) {
-            Real z = zlevels_stag[lev][k];
-            if (z > (ztop - zdamp)) {
-                Real zfrac = 1.0 - (ztop - z) / zdamp;
-                Real s = std::sin(PIoTwo*zfrac);
-                h_sinesq_stag_ptrs[lev][k] = s*s;
-            } else {
-                h_sinesq_stag_ptrs[lev][k] = 0.0;
-            }
-        }
-
-        // Init the host vectors for the reference states
-        prob->erf_init_rayleigh(h_rayleigh_ptrs[lev], geom[lev], z_phys_nd[lev], solverChoice.dampingChoice.rayleigh_zdamp);
-
-        // Copy from host vectors to device vectors
-        for (int n = 0; n < Rayleigh::nvars; n++) {
-            Gpu::copy(Gpu::hostToDevice, h_rayleigh_ptrs[lev][n].begin(), h_rayleigh_ptrs[lev][n].end(),
-                      d_rayleigh_ptrs[lev][n].begin());
-        }
-        Gpu::copy(Gpu::hostToDevice, h_sinesq_ptrs[lev].begin(), h_sinesq_ptrs[lev].end(), d_sinesq_ptrs[lev].begin());
-        Gpu::copy(Gpu::hostToDevice, h_sinesq_stag_ptrs[lev].begin(), h_sinesq_stag_ptrs[lev].end(), d_sinesq_stag_ptrs[lev].begin());
+    // Allocate space for these 1D vectors
+    for (int n = 0; n < Rayleigh::nvars; n++) {
+        h_rayleigh_ptrs[lev][n].resize(zlen_rayleigh, 0.0_rt);
+        d_rayleigh_ptrs[lev][n].resize(zlen_rayleigh, 0.0_rt);
     }
+
+    h_sinesq_ptrs[lev].resize(zlen_rayleigh);
+    d_sinesq_ptrs[lev].resize(zlen_rayleigh);
+
+    h_sinesq_stag_ptrs[lev].resize(zlen_rayleigh+1);
+    d_sinesq_stag_ptrs[lev].resize(zlen_rayleigh+1);
+
+    Real ztop     = solverChoice.dampingChoice.rayleigh_ztop;
+    Real zdamp    = solverChoice.dampingChoice.rayleigh_zdamp;
+
+    for (int k = 0; k < zlen_rayleigh; k++) {
+        Real z = 0.5 * (zlevels_stag[lev][k] + zlevels_stag[lev][k+1]);
+        if (z > (ztop - zdamp)) {
+            Real zfrac = 1.0 - (ztop - z) / zdamp;
+            Real s = std::sin(PIoTwo*zfrac);
+            h_sinesq_ptrs[lev][k] = s*s;
+        } else {
+            h_sinesq_ptrs[lev][k] = 0.0;
+        }
+    }
+
+    for (int k = 0; k < zlen_rayleigh+1; k++) {
+        Real z = zlevels_stag[lev][k];
+        if (z > (ztop - zdamp)) {
+            Real zfrac = 1.0 - (ztop - z) / zdamp;
+            Real s = std::sin(PIoTwo*zfrac);
+            h_sinesq_stag_ptrs[lev][k] = s*s;
+        } else {
+            h_sinesq_stag_ptrs[lev][k] = 0.0;
+        }
+    }
+
+    // Init the host vectors for the reference states
+    prob->erf_init_rayleigh(h_rayleigh_ptrs[lev], geom[lev], z_phys_nd[lev],
+                            solverChoice.dampingChoice.rayleigh_zdamp);
+
+    // Copy from host vectors to device vectors
+    for (int n = 0; n < Rayleigh::nvars; n++) {
+        Gpu::copy(Gpu::hostToDevice, h_rayleigh_ptrs[lev][n].begin(), h_rayleigh_ptrs[lev][n].end(),
+                  d_rayleigh_ptrs[lev][n].begin());
+    }
+    Gpu::copy(Gpu::hostToDevice, h_sinesq_ptrs[lev].begin(), h_sinesq_ptrs[lev].end(), d_sinesq_ptrs[lev].begin());
+    Gpu::copy(Gpu::hostToDevice, h_sinesq_stag_ptrs[lev].begin(), h_sinesq_stag_ptrs[lev].end(), d_sinesq_stag_ptrs[lev].begin());
 }
 
 /**

--- a/Source/Prob/ERF_InitCustomPertVels_TurbulentInflow.H
+++ b/Source/Prob/ERF_InitCustomPertVels_TurbulentInflow.H
@@ -27,12 +27,13 @@
     Real pert_periods_V = 5.0; pp_for_pert_vels.query("pert_periods_V", pert_periods_V);
     Real pert_ref_height = 100.0; pp_for_pert_vels.query("pert_ref_height", pert_ref_height);
 
-    const Real* prob_lo = geomdata.ProbLo();
-    const Real* prob_hi = geomdata.ProbHi();
-
     // helper vars
-    Real aval = pert_periods_U * 2.0 * PI / (prob_hi[1] - prob_lo[1]);
-    Real bval = pert_periods_V * 2.0 * PI / (prob_hi[0] - prob_lo[0]);
+    const Real prob_lo_x = geomdata.ProbLo(0);
+    const Real prob_lo_y = geomdata.ProbLo(1);
+    const Real prob_hi_x = geomdata.ProbHi(0);
+    const Real prob_hi_y = geomdata.ProbHi(1);
+    Real aval = pert_periods_U * 2.0 * PI / (prob_hi_y - prob_lo_y);
+    Real bval = pert_periods_V * 2.0 * PI / (prob_hi_x - prob_lo_x);
     Real ufac = pert_deltaU * std::exp(0.5) / pert_ref_height;
     Real vfac = pert_deltaV * std::exp(0.5) / pert_ref_height;
 


### PR DESCRIPTION
# Summary
The initialization of Rayleigh damping coeffs is now done by level so that if a fine level is created from coarse or remade the pointers will be valid for use in the dycore. Also, fix a shadow declaration with turbulent inflow initialization of velocities.