### PR TITLE
PlaneAverage ML

### DIFF
--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -43,36 +43,31 @@ Morrison::Init (const MultiFab& cons_in,
         mic_fab_vars[ivar]->setVal(0.);
     }
 
-    // Set class data members
-    for ( MFIter mfi(cons_in, TileNoZ()); mfi.isValid(); ++mfi) {
-        const auto& box3d = mfi.tilebox();
+    // NOTE: For multi-level not all ranks will own a box.
+    //       Furthermore, the plane average allocates space
+    //       for the entire domain. We make this consistent.
+    nlev = m_geom.Domain().length(2);
+    zlo  = m_geom.Domain().smallEnd(2);
+    zhi  = m_geom.Domain().bigEnd(2);
 
-        const auto& lo = lbound(box3d);
-        const auto& hi = ubound(box3d);
+    // parameters
+    accrrc.resize({zlo},  {zhi});
+    accrsi.resize({zlo},  {zhi});
+    accrsc.resize({zlo},  {zhi});
+    coefice.resize({zlo}, {zhi});
+    evaps1.resize({zlo},  {zhi});
+    evaps2.resize({zlo},  {zhi});
+    accrgi.resize({zlo},  {zhi});
+    accrgc.resize({zlo},  {zhi});
+    evapg1.resize({zlo},  {zhi});
+    evapg2.resize({zlo},  {zhi});
+    evapr1.resize({zlo},  {zhi});
+    evapr2.resize({zlo},  {zhi});
 
-        nlev = box3d.length(2);
-        zlo  = lo.z;
-        zhi  = hi.z;
-
-        // parameters
-        accrrc.resize({zlo},  {zhi});
-        accrsi.resize({zlo},  {zhi});
-        accrsc.resize({zlo},  {zhi});
-        coefice.resize({zlo}, {zhi});
-        evaps1.resize({zlo},  {zhi});
-        evaps2.resize({zlo},  {zhi});
-        accrgi.resize({zlo},  {zhi});
-        accrgc.resize({zlo},  {zhi});
-        evapg1.resize({zlo},  {zhi});
-        evapg2.resize({zlo},  {zhi});
-        evapr1.resize({zlo},  {zhi});
-        evapr2.resize({zlo},  {zhi});
-
-        // data (input)
-        rho1d.resize({zlo}, {zhi});
-        pres1d.resize({zlo}, {zhi});
-        tabs1d.resize({zlo}, {zhi});
-    }
+    // data (input)
+    rho1d.resize({zlo}, {zhi});
+    pres1d.resize({zlo}, {zhi});
+    tabs1d.resize({zlo}, {zhi});
 
 #ifdef ERF_USE_MORR_FORT
     int morr_rimed_ice = 0; // This is used to set something called "ihail"

--- a/Source/Microphysics/SAM/ERF_InitSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_InitSAM.cpp
@@ -42,36 +42,31 @@ SAM::Init (const MultiFab& cons_in,
         mic_fab_vars[ivar]->setVal(0.);
     }
 
-    // Set class data members
-    for ( MFIter mfi(cons_in, TileNoZ()); mfi.isValid(); ++mfi) {
-        const auto& box3d = mfi.tilebox();
+    // NOTE: For multi-level not all ranks will own a box.
+    //       Furthermore, the plane average allocates space
+    //       for the entire domain. We make this consistent.
+    nlev = m_geom.Domain().length(2);
+    zlo  = m_geom.Domain().smallEnd(2);
+    zhi  = m_geom.Domain().bigEnd(2);
 
-        const auto& lo = lbound(box3d);
-        const auto& hi = ubound(box3d);
+    // parameters
+    accrrc.resize({zlo},  {zhi});
+    accrsi.resize({zlo},  {zhi});
+    accrsc.resize({zlo},  {zhi});
+    coefice.resize({zlo}, {zhi});
+    evaps1.resize({zlo},  {zhi});
+    evaps2.resize({zlo},  {zhi});
+    accrgi.resize({zlo},  {zhi});
+    accrgc.resize({zlo},  {zhi});
+    evapg1.resize({zlo},  {zhi});
+    evapg2.resize({zlo},  {zhi});
+    evapr1.resize({zlo},  {zhi});
+    evapr2.resize({zlo},  {zhi});
 
-        nlev = box3d.length(2);
-        zlo  = lo.z;
-        zhi  = hi.z;
-
-        // parameters
-        accrrc.resize({zlo},  {zhi});
-        accrsi.resize({zlo},  {zhi});
-        accrsc.resize({zlo},  {zhi});
-        coefice.resize({zlo}, {zhi});
-        evaps1.resize({zlo},  {zhi});
-        evaps2.resize({zlo},  {zhi});
-        accrgi.resize({zlo},  {zhi});
-        accrgc.resize({zlo},  {zhi});
-        evapg1.resize({zlo},  {zhi});
-        evapg2.resize({zlo},  {zhi});
-        evapr1.resize({zlo},  {zhi});
-        evapr2.resize({zlo},  {zhi});
-
-        // data (input)
-        rho1d.resize({zlo}, {zhi});
-        pres1d.resize({zlo}, {zhi});
-        tabs1d.resize({zlo}, {zhi});
-    }
+    // data (input)
+    rho1d.resize({zlo}, {zhi});
+    pres1d.resize({zlo}, {zhi});
+    tabs1d.resize({zlo}, {zhi});
 }
 
 
@@ -108,7 +103,7 @@ SAM::Copy_State_to_Micro (const MultiFab& cons_in)
         auto pres_array  = mic_fab_vars[MicVar::pres]->array(mfi);
 
         // Get pressure, theta, temperature, density, and qt, qp
-        ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             rho_array(i,j,k)   = states_array(i,j,k,Rho_comp);
             theta_array(i,j,k) = states_array(i,j,k,RhoTheta_comp)/states_array(i,j,k,Rho_comp);

--- a/Source/Utils/ERF_PlaneAverage.H
+++ b/Source/Utils/ERF_PlaneAverage.H
@@ -184,8 +184,8 @@ template <typename IndexSelector>
 void
 PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFab& mfab)
 {
-    amrex::Real cnt_h = 0.0;
-    amrex::AsyncArray<amrex::Real> cnt_d(&cnt_h, 1);
+    amrex::Vector<amrex::Real> cnt_h(m_line_average.size(),0.);
+    amrex::AsyncArray<amrex::Real> cnt_d(cnt_h.data(), cnt_h.size());
     amrex::AsyncArray<amrex::Real> lavg(m_line_average.data(), m_line_average.size());
     amrex::Real* cnt_avg  = cnt_d.data();
     amrex::Real* line_avg = lavg.data();
@@ -228,7 +228,7 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
                             //       the devicereducesum since all threads won't participate.
                             //       This more performant than Gpu::Atomic::Add.
                             amrex::Real fac = (mask_arr(i,j,k)) ? 1.0 : 0.0;
-                            amrex::Gpu::deviceReduceSum(&cnt_avg[0], fac, handler);
+                            amrex::Gpu::deviceReduceSum(&cnt_avg[ind], fac, handler);
                             amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],
                                                         fab_arr(i, j, k, n) * fac, handler);
                         }
@@ -238,13 +238,13 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
         });
     }
 
-    cnt_d.copyToHost(&cnt_h, 1);
+    cnt_d.copyToHost(cnt_h.data(), cnt_h.size());
     lavg.copyToHost(m_line_average.data(), m_line_average.size());
-    amrex::ParallelDescriptor::ReduceRealSum(&cnt_h, 1);
+    amrex::ParallelDescriptor::ReduceRealSum(cnt_h.data(), cnt_h.size());
     amrex::ParallelDescriptor::ReduceRealSum(m_line_average.data(), m_line_average.size());
     for (int ind(0); ind<m_line_average.size(); ++ind) {
-        m_line_average[ind] /= cnt_h;
+        m_line_average[ind] /= cnt_h[ind];
     }
-    m_ncell_plane = static_cast<int>(cnt_h);
+    m_ncell_plane = static_cast<int>(cnt_h[0]);
 }
 #endif /* ERF_PlaneAverage.H */

--- a/Source/Utils/ERF_PlaneAverage.H
+++ b/Source/Utils/ERF_PlaneAverage.H
@@ -184,7 +184,7 @@ template <typename IndexSelector>
 void
 PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFab& mfab)
 {
-    amrex::Vector<amrex::Real> cnt_h(m_line_average.size(),0.);
+    amrex::Vector<amrex::Real> cnt_h(m_ncell_line,0.);
     amrex::AsyncArray<amrex::Real> cnt_d(cnt_h.data(), cnt_h.size());
     amrex::AsyncArray<amrex::Real> lavg(m_line_average.data(), m_line_average.size());
     amrex::Real* cnt_avg  = cnt_d.data();
@@ -223,12 +223,12 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
                 for (int j = lbx.smallEnd(1); j <= lbx.bigEnd(1); ++j) {
                     for (int i = lbx.smallEnd(0); i <= lbx.bigEnd(0); ++i) {
                         int ind = idxOp.getIndx(i, j, k) + offset;
+                        // NOTE: This factor is to avoid an if statement that will break
+                        //       the devicereducesum since all threads won't participate.
+                        //       This more performant than Gpu::Atomic::Add.
+                        amrex::Real fac = (mask_arr(i,j,k)) ? 1.0 : 0.0;
+                        amrex::Gpu::deviceReduceSum(&cnt_avg[ind], fac, handler);
                         for (int n = 0; n < ncomp; ++n) {
-                            // NOTE: This factor is to avoid an if statement that will break
-                            //       the devicereducesum since all threads won't participate.
-                            //       This more performant than Gpu::Atomic::Add.
-                            amrex::Real fac = (mask_arr(i,j,k)) ? 1.0 : 0.0;
-                            amrex::Gpu::deviceReduceSum(&cnt_avg[ind], fac, handler);
                             amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],
                                                         fab_arr(i, j, k, n) * fac, handler);
                         }
@@ -242,8 +242,10 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
     lavg.copyToHost(m_line_average.data(), m_line_average.size());
     amrex::ParallelDescriptor::ReduceRealSum(cnt_h.data(), cnt_h.size());
     amrex::ParallelDescriptor::ReduceRealSum(m_line_average.data(), m_line_average.size());
-    for (int ind(0); ind<m_line_average.size(); ++ind) {
-        m_line_average[ind] /= cnt_h[ind];
+    for (int ind(0); ind<m_ncell_line; ++ind) {
+        for (int n(0); n<ncomp; ++n) {
+            m_line_average[ncomp*ind + n] /= cnt_h[ind];
+        }
     }
     m_ncell_plane = static_cast<int>(cnt_h[0]);
 }

--- a/Source/Utils/ERF_PlaneAverage.H
+++ b/Source/Utils/ERF_PlaneAverage.H
@@ -106,8 +106,10 @@ PlaneAverage::PlaneAverage (const amrex::MultiFab* field_in,
     amrex::IntVect dom_lo(domain.loVect());
     amrex::IntVect dom_hi(domain.hiVect());
 
+    // Domain guarantees enough space and we usually average in z-dir (spans domain)
     m_ncell_line = dom_hi[m_axis] - dom_lo[m_axis] + 1 + m_ixtype[m_axis];
 
+    // First estimate is with domain (updated with MFiter later)
     m_ncell_plane = 1;
     auto period = m_geom.periodicity();
     for (int i = 0; i < AMREX_SPACEDIM; ++i) {
@@ -153,8 +155,9 @@ PlaneAverage::line_average (int comp, amrex::Gpu::HostVector<amrex::Real>& l_vec
 {
     AMREX_ALWAYS_ASSERT(comp >= 0 && comp < m_ncomp);
 
-    for (int i = 0; i < m_ncell_line; i++)
+    for (int i = 0; i < m_ncell_line; i++) {
         l_vec[i] = m_line_average[m_ncomp * i + comp];
+    }
 }
 
 void
@@ -181,8 +184,10 @@ template <typename IndexSelector>
 void
 PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFab& mfab)
 {
-    const amrex::Real denom = 1.0 / (amrex::Real)m_ncell_plane;
+    amrex::Real cnt_h = 0.0;
+    amrex::AsyncArray<amrex::Real> cnt_d(&cnt_h, 1);
     amrex::AsyncArray<amrex::Real> lavg(m_line_average.data(), m_line_average.size());
+    amrex::Real* cnt_avg  = cnt_d.data();
     amrex::Real* line_avg = lavg.data();
     const int ncomp = m_ncomp;
 
@@ -223,8 +228,9 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
                             //       the devicereducesum since all threads won't participate.
                             //       This more performant than Gpu::Atomic::Add.
                             amrex::Real fac = (mask_arr(i,j,k)) ? 1.0 : 0.0;
+                            amrex::Gpu::deviceReduceSum(&cnt_avg[0], fac, handler);
                             amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],
-                                                            fab_arr(i, j, k, n) * denom * fac, handler);
+                                                        fab_arr(i, j, k, n) * fac, handler);
                         }
                     }
                 }
@@ -232,7 +238,13 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
         });
     }
 
+    cnt_d.copyToHost(&cnt_h, 1);
     lavg.copyToHost(m_line_average.data(), m_line_average.size());
+    amrex::ParallelDescriptor::ReduceRealSum(&cnt_h, 1);
     amrex::ParallelDescriptor::ReduceRealSum(m_line_average.data(), m_line_average.size());
+    for (int ind(0); ind<m_line_average.size(); ++ind) {
+        m_line_average[ind] /= cnt_h;
+    }
+    m_ncell_plane = static_cast<int>(cnt_h);
 }
 #endif /* ERF_PlaneAverage.H */


### PR DESCRIPTION
# Summary
The `PlaneAverage` class is not correct for multi-level since its normalization constant is computed from the `domain`. The over-predicted normalization constant will make the averaged values too small and cause things like the `SAM & Morrison` microphysics to fail since they compute coefficients based upon average `rho, theta, qv`. 

## Solution
We cannot guarantee anything with regard to size or count of elements for `lev>0`. Therefore, this PR retains the estimate in the constructor for `m_ncell_plane` but then adds a direct count to the number of cells averaged, uses that to compute the average, and updates `m_ncell_plane`.