### PR TITLE
Squall Line Fix

### DIFF
--- a/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_Gabersek
+++ b/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_Gabersek
@@ -76,4 +76,5 @@ prob.rayleigh_V_0 = 1.0
 prob.rayleigh_W_0 = 0.0
 prob.rayleigh_T_0 = 300.0
 
-prob.use_empirical_sat_pressure = true
+prob.use_empirical_psat         = true
+prob.T_from_theta_in_moist_init = true

--- a/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_Morrison
+++ b/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_Morrison
@@ -74,4 +74,5 @@ prob.rayleigh_V_0 = 1.0
 prob.rayleigh_W_0 = 0.0
 prob.rayleigh_T_0 = 300.0
 
-prob.use_empirical_sat_pressure = true
+prob.use_empirical_psat         = true
+prob.T_from_theta_in_moist_init = true

--- a/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_SAM
+++ b/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_SAM
@@ -73,4 +73,5 @@ prob.rayleigh_V_0 = 1.0
 prob.rayleigh_W_0 = 0.0
 prob.rayleigh_T_0 = 300.0
 
-prob.use_empirical_sat_pressure = true
+prob.use_empirical_psat         = true
+prob.T_from_theta_in_moist_init = true

--- a/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_WRF
+++ b/Exec/CanonicalTests/SquallLine_2D/inputs_moisture_WRF
@@ -80,4 +80,5 @@ prob.rayleigh_V_0 = 1.0
 prob.rayleigh_W_0 = 0.0
 prob.rayleigh_T_0 = 300.0
 
-prob.use_empirical_sat_pressure = true
+prob.use_empirical_psat         = true
+prob.T_from_theta_in_moist_init = true


### PR DESCRIPTION
# Summary
The squall line was crashing due to the initial state. During the refactor, we need to specify key flags to get the correct HSE state.