### PR TITLE
Issue 3022 Start

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -462,9 +462,9 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         {
             // Valid theta flux from LSM and over land
             Real Tflux;
-            int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+            int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
             if (lsm_t_flux_arr && is_land) {
-                Tflux = lsm_t_flux_arr(i,j,k);
+                Tflux = lsm_t_flux_arr(i,j,0);
             } else {
                 Tflux = flux_comp.compute_t_flux(i, j, k,
                                                  cons_arr, velx_arr, vely_arr,
@@ -489,9 +489,9 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             {
                 // Valid qv flux from LSM and over land
                 Real Qflux;
-                int is_land = (lmask_arr) ? lmask_arr(i,j,klo) : 1;
+                int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
                 if (lsm_q_flux_arr && is_land) {
-                    Qflux = lsm_q_flux_arr(i,j,k);
+                    Qflux = lsm_q_flux_arr(i,j,0);
                 } else {
                     Qflux = flux_comp.compute_q_flux(i, j, k,
                                                      cons_arr, velx_arr, vely_arr,
@@ -517,8 +517,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             {
                 // Valid tau13 from LSM and over land
                 Real stressx;
-                int is_land_hi = (lmask_arr) ? lmask_arr(i  ,j,klo) : 1;
-                int is_land_lo = (lmask_arr) ? lmask_arr(i-1,j,klo) : 1;
+                int is_land_hi = (lmask_arr) ? lmask_arr(i  ,j,0) : 1;
+                int is_land_lo = (lmask_arr) ? lmask_arr(i-1,j,0) : 1;
                 if (lsm_tau13_arr && (is_land_hi || is_land_lo)) {
                     stressx = 0.;
                     if (!is_land_hi || !is_land_lo) {
@@ -527,10 +527,10 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                                                                   umm_arr, um_arr, u_star_arr);
                     }
                     if (is_land_hi) {
-                        stressx += 0.5 * lsm_tau13_arr(i  ,j,k);
+                        stressx += 0.5 * lsm_tau13_arr(i  ,j,0);
                     }
                     if (is_land_lo) {
-                        stressx += 0.5 * lsm_tau13_arr(i-1,j,k);
+                        stressx += 0.5 * lsm_tau13_arr(i-1,j,0);
                     }
                 } else {
                     stressx = flux_comp.compute_u_flux(i, j, k,
@@ -549,8 +549,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             {
                 // Valid tau13 from LSM and over land
                 Real stressy;
-                int is_land_hi = (lmask_arr) ? lmask_arr(i,j  ,klo) : 1;
-                int is_land_lo = (lmask_arr) ? lmask_arr(i,j-1,klo) : 1;
+                int is_land_hi = (lmask_arr) ? lmask_arr(i,j  ,0) : 1;
+                int is_land_lo = (lmask_arr) ? lmask_arr(i,j-1,0) : 1;
                 if (lsm_tau23_arr && (is_land_hi || is_land_lo)) {
                     stressy = 0.;
                     if (!is_land_hi || !is_land_lo) {
@@ -559,10 +559,10 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                                                                   umm_arr, vm_arr, u_star_arr);
                     }
                     if (is_land_hi) {
-                        stressy += 0.5 * lsm_tau23_arr(i,j  ,k);
+                        stressy += 0.5 * lsm_tau23_arr(i,j  ,0);
                     }
                     if (is_land_lo) {
-                        stressy += 0.5 * lsm_tau23_arr(i,j-1,k);
+                        stressy += 0.5 * lsm_tau23_arr(i,j-1,0);
                     }
                 } else {
                     stressy = flux_comp.compute_v_flux(i, j, k,

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -877,14 +877,14 @@ private:
 #endif
 
     LandSurface lsm;
-    amrex::Vector<std::string> lsm_data_name;                // (ncomp)
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_data; // (lev,ncomp)
-    amrex::Vector<std::string> lsm_flux_name;                // (ncomp)
-    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_flux; // (lev,ncomp)
+    amrex::Vector<std::string> lsm_data_name;                // (ncomp) -- e.g., sw_dn_dir/dif_vis/nir, lw_dn, cos_zen
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_data; // (lev,ncomp) Data for LSM coupling
+    amrex::Vector<std::string> lsm_flux_name;                // (ncomp) -- e.g., hfx3, q1fx3, tau13, tau23
+    amrex::Vector<amrex::Vector<amrex::MultiFab*>> lsm_flux; // (lev,ncomp) Fluxes from LSM needed by DYCORE
 
     amrex::Vector<std::unique_ptr<IRadiation>> rad; // Radiation model at each level
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> qheating_rates;  // radiation heating rate source terms (SW, LW)
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> rad_fluxes;      // radiation fluxes (SW up/dn, LW up/dn)
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> qheating_rates;  // radiation heating rate source terms (SW, LW) (DYCORE)
+    amrex::Vector<std::unique_ptr<amrex::MultiFab>> rad_fluxes;      // radiation fluxes (SW up/dn, LW up/dn) (OUTPUT ONLY)
 #ifdef ERF_USE_SHOC
     amrex::Vector<std::unique_ptr<SHOCInterface>> shoc_interface; // SHOC model at each level
 #endif
@@ -892,10 +892,6 @@ private:
 #ifdef ERF_USE_P3
     amrex::Vector<std::unique_ptr<P3Interface>> p3_interface; // P3 model at each level
 #endif
-
-    // Containers for additional SLM inputs
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> sw_lw_fluxes; // Direct SW (visible, NIR), Diffuse SW (visible, NIR), LW flux
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> solar_zenith; // Solar zenith angle
 
     bool plot_rad = false;
     int rad_datalog_int = -1;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -186,8 +186,6 @@ ERF::ERF_shared ()
 
     qheating_rates.resize(nlevs_max);
     rad_fluxes.resize(nlevs_max);
-    sw_lw_fluxes.resize(nlevs_max);
-    solar_zenith.resize(nlevs_max);
 
     // NOTE: size lsm before readparams (chooses the model at all levels)
     lsm.ReSize(nlevs_max);

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -453,32 +453,6 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     }
 
     //*********************************************************
-    // Radiation fluxes for coupling to LSM
-    //*********************************************************
-
-    // NOTE: Finer levels do not need to coincide with the bottom domain boundary
-    //       at k=0. We make slabs here with the kmin for a given box. Therefore,
-    //       care must be taken before applying these fluxes to an LSM model. For
-
-    // Radiative fluxes for LSM
-    if (solverChoice.lsm_type != LandSurfaceType::None &&
-        solverChoice.rad_type != RadiationType::None)
-    {
-        BoxList m_bl = ba.boxList();
-        for (auto& b : m_bl) {
-            int kmin = b.smallEnd(2);
-            b.setRange(2,kmin);
-        }
-        BoxArray m_ba(std::move(m_bl));
-
-        sw_lw_fluxes[lev] = std::make_unique<MultiFab>(m_ba, dm, 6, 0); // DIR/DIF VIS/NIR (4), NET SW (1), LW (1)
-        solar_zenith[lev] = std::make_unique<MultiFab>(m_ba, dm, 1, 0);
-
-        sw_lw_fluxes[lev]->setVal(0.);
-        solar_zenith[lev]->setVal(0.);
-    }
-
-    //*********************************************************
     // Turbulent perturbation region initialization
     //*********************************************************
     if (solverChoice.pert_type == PerturbationType::Source ||

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
@@ -30,6 +30,10 @@ namespace LsmData_NOAHMP {
          sfc_alb_dif_nir,
          cos_zenith_angle,
          sw_flux_dn,
+         sw_flux_dn_dir_vis,
+         sw_flux_dn_dir_nir,
+         sw_flux_dn_dif_vis,
+         sw_flux_dn_dif_nir,
          lw_flux_dn,
          NumVars
   };

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -27,17 +27,21 @@ NOAHMP::Init (const int& lev,
     khi_lsm    = domain.smallEnd(2) - 1;
 
     LsmDataMap.resize(m_lsm_data_size);
-    LsmDataMap = {LsmData_NOAHMP::t_sfc           , LsmData_NOAHMP::sfc_emis       ,
-                  LsmData_NOAHMP::sfc_alb_dir_vis , LsmData_NOAHMP::sfc_alb_dir_nir,
-                  LsmData_NOAHMP::sfc_alb_dif_vis , LsmData_NOAHMP::sfc_alb_dif_nir,
-                  LsmData_NOAHMP::cos_zenith_angle, LsmData_NOAHMP::sw_flux_dn     ,
-                  LsmData_NOAHMP::lw_flux_dn                                        };
+    LsmDataMap = {LsmData_NOAHMP::t_sfc             , LsmData_NOAHMP::sfc_emis          ,
+                  LsmData_NOAHMP::sfc_alb_dir_vis   , LsmData_NOAHMP::sfc_alb_dir_nir   ,
+                  LsmData_NOAHMP::sfc_alb_dif_vis   , LsmData_NOAHMP::sfc_alb_dif_nir   ,
+                  LsmData_NOAHMP::cos_zenith_angle  , LsmData_NOAHMP::sw_flux_dn        ,
+                  LsmData_NOAHMP::sw_flux_dn_dir_vis, LsmData_NOAHMP::sw_flux_dn_dir_nir,
+                  LsmData_NOAHMP::sw_flux_dn_dif_vis, LsmData_NOAHMP::sw_flux_dn_dif_nir,
+                  LsmData_NOAHMP::lw_flux_dn        };
     LsmDataName.resize(m_lsm_data_size);
-    LsmDataName = {"t_sfc"           , "sfc_emis"        ,
-                   "sfc_alb_dir_vis" , "sfc_alb_dir_nir" ,
-                   "sfc_alb_dif_vis" , "sfc_alb_dif_nir" ,
-                   "cos_zenith_angle", "sw_flux_dn"      ,
-                   "lw_flux_dn"      };
+    LsmDataName = {"t_sfc"             , "sfc_emis"          ,
+                   "sfc_alb_dir_vis"   , "sfc_alb_dir_nir"   ,
+                   "sfc_alb_dif_vis"   , "sfc_alb_dif_nir"   ,
+                   "cos_zenith_angle"  , "sw_flux_dn"        ,
+                   "sw_flux_dn_dir_vis", "sw_flux_dn_dir_nir",
+                   "sw_flux_dn_dif_vis", "sw_flux_dn_dif_nir",
+                   "lw_flux_dn"        };
 
 
     LsmFluxMap.resize(m_lsm_flux_size);

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -96,8 +96,6 @@ public:
          amrex::MultiFab* cons_in,
          amrex::iMultiFab* lmask,
          amrex::MultiFab*  t_surf,
-         amrex::MultiFab* lsm_fluxes,
-         amrex::MultiFab* lsm_zenith,
          amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
          amrex::Vector<amrex::MultiFab*>& lsm_output_ptrs,
          amrex::MultiFab* qheating_rates,
@@ -107,8 +105,8 @@ public:
          amrex::MultiFab* lon_ptr) override
     {
         set_grids(level, step, time, dt, ba, geom,
-                  cons_in, lmask, t_surf, lsm_fluxes,
-                  lsm_zenith, lsm_input_ptrs, qheating_rates,
+                  cons_in, lmask, t_surf,
+                  lsm_input_ptrs, qheating_rates,
                   rad_fluxes, z_phys, lat_ptr, lon_ptr);
         rad_run_impl(lsm_output_ptrs);
     }
@@ -124,8 +122,6 @@ public:
                amrex::MultiFab* cons_in,
                amrex::iMultiFab* lmask,
                amrex::MultiFab*  t_surf,
-               amrex::MultiFab* lsm_fluxes,
-               amrex::MultiFab* lsm_zenith,
                amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
                amrex::MultiFab* qheating_rates,
                amrex::MultiFab* rad_fluxes,
@@ -250,7 +246,10 @@ private:
                                                     "sfc_alb_dif_vis", "sfc_alb_dif_nir"};
 
     // List of output parameter names
-    amrex::Vector<std::string> m_lsm_output_names = {"cos_zenith_angle", "sw_flux_dn", "lw_flux_dn"};
+    amrex::Vector<std::string> m_lsm_output_names = {"cos_zenith_angle"  , "sw_flux_dn"        ,
+                                                     "sw_flux_dn_dir_vis", "sw_flux_dn_dir_nir",
+                                                     "sw_flux_dn_dif_vis", "sw_flux_dn_dif_nir",
+                                                     "lw_flux_dn"};
 
     // T surf if no LSM is available
     amrex::Real m_rad_t_sfc = -1;
@@ -274,10 +273,6 @@ private:
     // Constant lat/lon if the above MFs are not valid
     amrex::Real m_lat_cons =  39.809860;
     amrex::Real m_lon_cons = -98.555183;
-
-    // Pointer to output data for LSM
-    amrex::MultiFab* m_lsm_fluxes = nullptr;
-    amrex::MultiFab* m_lsm_zenith = nullptr;
 
     // Holds output from KOKKOS views used in the datalog
     amrex::MultiFab datalog_mf;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -140,8 +140,6 @@ Radiation::set_grids (int& level,
                       MultiFab* cons_in,
                       iMultiFab* lmask,
                       MultiFab*  t_surf,
-                      MultiFab* lsm_fluxes,
-                      MultiFab* lsm_zenith,
                       Vector<MultiFab*>& lsm_input_ptrs,
                       MultiFab* qheating_rates,
                       MultiFab* rad_fluxes,
@@ -157,8 +155,6 @@ Radiation::set_grids (int& level,
     m_dt             = dt;
     m_geom           = geom;
     m_cons_in        = cons_in;
-    m_lsm_fluxes     = lsm_fluxes;
-    m_lsm_zenith     = lsm_zenith;
     m_qheating_rates = qheating_rates;
     m_rad_fluxes     = rad_fluxes;
     m_z_phys         = z_phys;
@@ -653,7 +649,6 @@ void
 Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
 {
     // Heating rate, fluxes, zenith, lsm ptrs
-    Vector<real2d_k> rrtmgp_out_vars = {sw_flux_dn, lw_flux_dn};
 
     Table2D<Real,Order::C> p_lay_tab(p_lay.data(), {0,0}, {static_cast<int>(p_lay.extent(0)),static_cast<int>(p_lay.extent(1))});
     Table2D<Real,Order::C> sw_heating_tab(sw_heating.data(), {0,0}, {static_cast<int>(sw_heating.extent(0)),static_cast<int>(sw_heating.extent(1))});
@@ -663,13 +658,19 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
     Table2D<Real,Order::C> lw_flux_up_tab(lw_flux_up.data(), {0,0}, {static_cast<int>(lw_flux_up.extent(0)),static_cast<int>(lw_flux_up.extent(1))});
     Table2D<Real,Order::C> lw_flux_dn_tab(lw_flux_dn.data(), {0,0}, {static_cast<int>(lw_flux_dn.extent(0)),static_cast<int>(lw_flux_dn.extent(1))});
 
-    Table1D<Real> sfc_flux_dir_vis_tab(sfc_flux_dir_vis.data(), {0}, {static_cast<int>(sfc_flux_dir_vis.extent(0))});
-    Table1D<Real> sfc_flux_dir_nir_tab(sfc_flux_dir_nir.data(), {0}, {static_cast<int>(sfc_flux_dir_nir.extent(0))});
-    Table1D<Real> sfc_flux_dif_vis_tab(sfc_flux_dif_vis.data(), {0}, {static_cast<int>(sfc_flux_dif_vis.extent(0))});
-    Table1D<Real> sfc_flux_dif_nir_tab(sfc_flux_dif_nir.data(), {0}, {static_cast<int>(sfc_flux_dif_nir.extent(0))});
+    TableData<Real,1> sfc_flux_sw_dn; sfc_flux_sw_dn.resize({0}, {static_cast<int>(sw_flux_dn.extent(0))});
+    TableData<Real,1> sfc_flux_lw_dn; sfc_flux_lw_dn.resize({0}, {static_cast<int>(lw_flux_dn.extent(0))});
+    Table1D<Real> sfc_flux_sw_dn_tab = sfc_flux_sw_dn.table();
+    Table1D<Real> sfc_flux_lw_dn_tab = sfc_flux_lw_dn.table();
+    Table1D<Real> sfc_flux_sw_dir_vis_tab(sfc_flux_dir_vis.data(), {0}, {static_cast<int>(sfc_flux_dir_vis.extent(0))});
+    Table1D<Real> sfc_flux_sw_dir_nir_tab(sfc_flux_dir_nir.data(), {0}, {static_cast<int>(sfc_flux_dir_nir.extent(0))});
+    Table1D<Real> sfc_flux_sw_dif_vis_tab(sfc_flux_dif_vis.data(), {0}, {static_cast<int>(sfc_flux_dif_vis.extent(0))});
+    Table1D<Real> sfc_flux_sw_dif_nir_tab(sfc_flux_dif_nir.data(), {0}, {static_cast<int>(sfc_flux_dif_nir.extent(0))});
     Table1D<Real>              mu0_tab(mu0.data(),              {0}, {static_cast<int>(mu0.extent(0))});
-
-    // Expose for device
+    Vector<Table1D<Real>> rrtmgp_out_vars = {mu0_tab                , sfc_flux_sw_dn_tab     ,
+                                             sfc_flux_sw_dir_vis_tab, sfc_flux_sw_dir_nir_tab,
+                                             sfc_flux_sw_dif_vis_tab, sfc_flux_sw_dif_nir_tab,
+                                             sfc_flux_lw_dn_tab     };
 
     for (MFIter mfi(*m_cons_in); mfi.isValid(); ++mfi) {
         const auto& vbx      = mfi.validbox();
@@ -700,66 +701,24 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
             f_arr(i,j,k,1) = sw_flux_dn_tab(icol,ilay);
             f_arr(i,j,k,2) = lw_flux_up_tab(icol,ilay);
             f_arr(i,j,k,3) = lw_flux_dn_tab(icol,ilay);
+
+            if (k==0) {
+                sfc_flux_sw_dn_tab(icol) = sw_flux_dn_tab(icol,ilay);
+                sfc_flux_lw_dn_tab(icol) = lw_flux_dn_tab(icol,ilay);
+            }
         });
-        if (m_lsm_fluxes) {
-            const Array4<Real>& lsm_arr =  m_lsm_fluxes->array(mfi);
-            ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                // map [i,j,k] 0-based to [icol, ilay] 0-based
-                const int icol = (j-jmin)*nx + (i-imin) + offset;
-
-                // SW fluxes for LSM
-                lsm_arr(i,j,k,0) = sfc_flux_dir_vis_tab(icol);
-                lsm_arr(i,j,k,1) = sfc_flux_dir_nir_tab(icol);
-                lsm_arr(i,j,k,2) = sfc_flux_dif_vis_tab(icol);
-                lsm_arr(i,j,k,3) = sfc_flux_dif_nir_tab(icol);
-
-                // Net SW flux for LSM
-                lsm_arr(i,j,k,4) = sfc_flux_dir_vis_tab(icol) + sfc_flux_dir_nir_tab(icol)
-                                 + sfc_flux_dif_vis_tab(icol) + sfc_flux_dif_nir_tab(icol);
-
-                // LW flux for LSM (at bottom surface)
-                lsm_arr(i,j,k,5) = lw_flux_dn_tab(icol,0);
-            });
-        }
-        if (m_lsm_zenith) {
-            const Array4<Real>& lsm_zenith_arr =  m_lsm_zenith->array(mfi);
-            ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-            {
-                // map [i,j,k] 0-based to [icol, ilay] 0-based
-                const int icol = (j-jmin)*nx + (i-imin) + offset;
-
-                // export cosine zenith angle for LSM
-                lsm_zenith_arr(i,j,k) = mu0_tab(icol);
-            });
-        }
         for (int ivar(0); ivar<lsm_output_ptrs.size(); ivar++) {
             if (lsm_output_ptrs[ivar]) {
+                auto rrtmgp_for_fill = rrtmgp_out_vars[ivar];
                 const Array4<Real>& lsm_out_arr = lsm_output_ptrs[ivar]->array(mfi);
-                if (ivar==0) {
-                    ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                    {
-                        // map [i,j,k] 0-based to [icol, ilay] 0-based
-                        const int icol   = (j-jmin)*nx + (i-imin) + offset;
+                ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                {
+                    // map [i,j,k] 0-based to [icol, ilay] 0-based
+                    const int icol   = (j-jmin)*nx + (i-imin) + offset;
 
-                        // export the desired variable at surface
-                        lsm_out_arr(i,j,k) = mu0_tab(icol);
-                    });
-                } else {
-                    auto rrtmgp_for_fill_k = rrtmgp_out_vars[ivar-1];
-                    amrex::Table2D<amrex::Real const, amrex::Order::C>
-                        rrtmgp_for_fill(rrtmgp_for_fill_k.data(),
-                                        {0,0}, {int(rrtmgp_for_fill_k.extent(0)),
-                                                int(rrtmgp_for_fill_k.extent(1))});
-                    ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
-                    {
-                        // map [i,j,k] 0-based to [icol, ilay] 0-based
-                        const int icol   = (j-jmin)*nx + (i-imin) + offset;
-
-                        // export the desired variable at surface
-                        lsm_out_arr(i,j,k) = rrtmgp_for_fill(icol,0);
-                    });
-                } // ivar
+                    // export the desired variable at surface
+                    lsm_out_arr(i,j,k) = rrtmgp_for_fill(icol);
+                });
             } // valid ptr
         } // ivar
     }// mfi

--- a/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
@@ -32,8 +32,6 @@ public:
          amrex::MultiFab* cons_in,
          amrex::iMultiFab* lmask,
          amrex::MultiFab*  t_surf,
-         amrex::MultiFab* lsm_fluxes,
-         amrex::MultiFab* lsm_zenith,
          amrex::Vector<amrex::MultiFab*>& lsm_input_ptrs,
          amrex::Vector<amrex::MultiFab*>& lsm_output_ptrs,
          amrex::MultiFab* qheating_rates,

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -22,7 +22,7 @@ void ERF::advance_radiation (int lev,
         Vector<MultiFab*> lsm_input_ptrs(lsm_input_names.size(),nullptr);
         for (int i(0); i<lsm_input_ptrs.size(); ++i) {
             int varIdx = lsm.Get_DataIdx(lev,lsm_input_names[i]);
-            lsm_input_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
+            if (varIdx >= 0) { lsm_input_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx); }
         }
 
         // RRTMGP output names and pointers
@@ -30,7 +30,7 @@ void ERF::advance_radiation (int lev,
         Vector<MultiFab*> lsm_output_ptrs(lsm_output_names.size(),nullptr);
         for (int i(0); i<lsm_output_ptrs.size(); ++i) {
             int varIdx = lsm.Get_DataIdx(lev,lsm_output_names[i]);
-            lsm_output_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx);
+            if (varIdx >= 0) { lsm_output_ptrs[i] = lsm.Get_Data_Ptr(lev,varIdx); }
         }
 
         // Enter radiation class driver
@@ -38,7 +38,6 @@ void ERF::advance_radiation (int lev,
         rad[lev]->Run(lev, istep[lev], time_for_rad, dt_advance,
                       cons.boxArray(), geom[lev], &(cons),
                       lmask_lev[lev][0].get(), t_surf,
-                      sw_lw_fluxes[lev].get(), solar_zenith[lev].get(),
                       lsm_input_ptrs, lsm_output_ptrs,
                       qheating_rates[lev].get(), rad_fluxes[lev].get(),
                       z_phys_nd[lev].get()     , lat_ptr, lon_ptr);


### PR DESCRIPTION
# Summary
This PR starts addressing the issue of coupling variables with NOAH-MP described in [Issue 3022](https://github.com/erf-model/ERF/issues/3022).

## Notes for SLM
@gardner48: The `sw_lw_fluxes` and `solar_zenith` are deleted. These variables were specific to SLM coupling. We move to a general coupling strategy that is described below. It follows the same paradigm as before (modulo the indexing maybe) and one may look at the NOAH-MP class to follow suite.

## Description
1. The LSM model knows its variables and how it couples. The standard is now `solar_zenith, sfc_sw_flux_dn, sfc_sw_flux_dir/dif/_vis/nir, sfc_lw_flux_dn`.
2.  The LSM model exports pointers to data it needs that coincides with RRTMGP output vars

## To Do
- [x] Run WPS with radiation and NOAH-MP (the dif/dir_vis/nir vars are not set up yet but things should run)
- [ ] @akashdhruv: Expose the unused vars noted above and populate them in NOAH-MP class. 