### PR TITLE
Fix colliding concurrency group names in GitHub CI

### DIFF
--- a/.github/workflows/gcc-rrtmgp.yml
+++ b/.github/workflows/gcc-rrtmgp.yml
@@ -3,7 +3,7 @@ name: Linux GCC NetCDF RRTMGP
 on: [push, pull_request, workflow_dispatch]
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
+  group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc-rrtmgp
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/windows-mpi.yml
+++ b/.github/workflows/windows-mpi.yml
@@ -3,7 +3,7 @@ name: Windows
 on: [push, pull_request]
 
 concurrency:
-  group: ${{ github.ref }}-${{ github.head_ref }}-windows
+  group: ${{ github.ref }}-${{ github.head_ref }}-windows-mpi
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Concurrency group names need to be unique so a workflow only cancels its own jobs and not jobs in the other workflow