### PR TITLE
Morrison bugs for real simulations

### DIFF
--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -523,6 +523,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
           if (box.smallEnd(1) == j_lo) { box.growLo(1,-m_real_width); }
           if (box.bigEnd(1)   == j_hi) { box.growHi(1,-m_real_width); }
 
+          if (!box.ok()) { // Avoid going farther if the box is inverted (i.e., ilo > ihi or jlo > jhi).
+              continue;
+          }
+
           // Get array data from class member variables
           auto const& theta_arr = mic_fab_vars[MicVar_Morr::theta]->array(mfi);
           auto const& qv_arr    = mic_fab_vars[MicVar_Morr::qv]->array(mfi);

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -469,7 +469,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
             // Goff-Gratch formula for ice at cold temperatures
             polysvp = std::pow(10.0, (-9.09718*(273.16/T-1.0) - 3.56654*std::log10(273.16/T) +
                                       0.876793*(1.0-T/273.16) + std::log10(6.1071))) * 100.0;
-            polysvp = 0.0;
         } // T
     } else {  // Water (lines ~5648-5665)
       if (T >= 202.0) {


### PR DESCRIPTION
This PR fixes what appears to be a leftover hard-coded debug value in the Morrison ice saturation vapor pressure calculation, which was causing problems in real simulations with a high model top and cold temperatures.

It also guards against an inverted Box, which can occur when the Morrison Advance region is shrunk by real_width without bounds checks. For now, processing is skipped if the Box is inverted, though implementing a Box intersection may be a better long-term fix.

Since I have limited experience with the microphysics code, I would especially appreciate review from those familiar with Morrison.