### PR TITLE
Fix EB cut-cell edge metadata initialization

### DIFF
--- a/Source/EB/ERF_EBCutCell.H
+++ b/Source/EB/ERF_EBCutCell.H
@@ -390,17 +390,23 @@ struct eb_cut_cell_::path_data
           const amrex::RealVect& v_end)
   {
     constexpr amrex::Real tol = amrex::Real(1.e-15);
-    amrex::RealVect v_intersect;
-    amrex::Real    dist_intersect;
+    amrex::RealVect v_intersect{v_start};
+    amrex::Real    dist_intersect = std::numeric_limits<amrex::Real>::quiet_NaN();
     intersected = intersect_plane_edge(
       eb_point, eb_normal, v_start, v_end, v_intersect, dist_intersect
     );
     vIP = v_intersect;
     distIP = dist_intersect;
     edge_length = (v_start - v_end).vectorLength();
-    // check if intersection is at vertices
-    intersected_start = (amrex::Math::abs(dist_intersect) < tol);
-    intersected_end   = (amrex::Math::abs(edge_length - dist_intersect) < tol);
+    if (intersected) {
+      // check if intersection is at vertices
+      intersected_start = (amrex::Math::abs(dist_intersect) < tol);
+      intersected_end   = (amrex::Math::abs(edge_length - dist_intersect) < tol);
+    } else {
+      intersected_start = false;
+      intersected_end   = false;
+      distIP = amrex::Real(-1.0);
+    }
   }
 };
 


### PR DESCRIPTION
`intersect_plane_edge` returns 0 if the EB cutting plane is parallel to a given edge, the uninitialized dist_intersect value was used when tagging edge endpoints:
```
      intersected_start = (abs(dist_intersect) < tol);
      intersected_end   = (abs(edge_length - dist_intersect) < tol);
```
That undefined behavior explains the nondeterministic crashes we were seeing inside calc_edge_intersections.

The WitchOfAgnesi EB regression test now runs reliably on 4 MPI ranks.