### PR TITLE
Morrison Real Width

### DIFF
--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -504,20 +504,32 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         // Store timestep
         Real dt = dt_advance;
 
+        // Bounds
         auto domain = m_geom.Domain();
         int i_lo = domain.smallEnd(0);
         int i_hi = domain.bigEnd(0);
         int j_lo = domain.smallEnd(1);
         int j_hi = domain.bigEnd(1);
 
+        // Check if CPP or FORT answer is used
+        bool run_morr_cpp        = true;
+        bool use_morr_cpp_answer = true;
+        pp.query("use_morr_cpp_answer", use_morr_cpp_answer);
+        bool run_morr_fort = !use_morr_cpp_answer;
+        std::string filename = std::string("output_cpp") + std::to_string(use_morr_cpp_answer) + ".txt";
+
         // Loop through the grids
         for (MFIter mfi(*mic_fab_vars[MicVar_Morr::qcl],TileNoZ()); mfi.isValid(); ++mfi)
         {
           auto box = mfi.tilebox();
+
+#ifndef ERF_USE_MORR_FORT
+          // NOTE: Trimming the box with FORTRAN breaks the pointer dereferencing
           if (box.smallEnd(0) == i_lo) { box.growLo(0,-m_real_width); }
           if (box.bigEnd(0)   == i_hi) { box.growHi(0,-m_real_width); }
           if (box.smallEnd(1) == j_lo) { box.growLo(1,-m_real_width); }
           if (box.bigEnd(1)   == j_hi) { box.growHi(1,-m_real_width); }
+#endif
 
           if (!box.ok()) { // Avoid going farther if the box is inverted (i.e., ilo > ihi or jlo > jhi).
               continue;
@@ -1035,15 +1047,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
           set_morrison_ndcnst_c(m_ndcnst);
 #endif
 
-          bool run_morr_cpp = true;
 
-          bool use_morr_cpp_answer = true;
-          pp.query("use_morr_cpp_answer", use_morr_cpp_answer);
-          //Print() << "use_morr_cpp_answer" << use_morr_cpp_answer <<std::endl;
-
-          bool run_morr_fort = !use_morr_cpp_answer;
-
-          std::string filename = std::string("output_cpp") + std::to_string(use_morr_cpp_answer) + ".txt";
 
           if(run_morr_cpp) {
 

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -512,11 +512,15 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         int j_hi = domain.bigEnd(1);
 
         // Check if CPP or FORT answer is used
+        ParmParse pp("erf");
         bool run_morr_cpp        = true;
         bool use_morr_cpp_answer = true;
         pp.query("use_morr_cpp_answer", use_morr_cpp_answer);
         bool run_morr_fort = !use_morr_cpp_answer;
         std::string filename = std::string("output_cpp") + std::to_string(use_morr_cpp_answer) + ".txt";
+
+        // Allow user to override constant droplet concentration from inputs file
+        pp.query("morrison_ndcnst", m_ndcnst);
 
         // Loop through the grids
         for (MFIter mfi(*mic_fab_vars[MicVar_Morr::qcl],TileNoZ()); mfi.isValid(); ++mfi)
@@ -1037,17 +1041,10 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
           m_do_radar_ref = false; // Disable radar reflectivity by default
           Box boxD(box); boxD.makeSlab(2,0);
 
-          ParmParse pp("erf");
-
-          // Allow user to override constant droplet concentration from inputs file
-          pp.query("morrison_ndcnst", m_ndcnst);
-
 #ifdef ERF_USE_MORR_FORT
           // If using Fortran version, update the Fortran module variable as well
           set_morrison_ndcnst_c(m_ndcnst);
 #endif
-
-
 
           if(run_morr_cpp) {
 

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -520,6 +520,8 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
         std::string filename = std::string("output_cpp") + std::to_string(use_morr_cpp_answer) + ".txt";
 
         // Allow user to override constant droplet concentration from inputs file
+        // Constant droplet concentration (if INUM = 1)
+        Real m_ndcnst = Real(250.0);  // Droplet number concentration (cm^-3)
         pp.query("morrison_ndcnst", m_ndcnst);
 
         // Loop through the grids
@@ -762,9 +764,6 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
           Real m_lammaxr, m_lamminr;    // Rain lambda limits
           Real m_lammaxs, m_lammins;    // Snow lambda limits
           Real m_lammaxg, m_lamming;    // Graupel lambda limits
-
-          // Constant droplet concentration (if INUM = 1)
-          Real m_ndcnst = Real(250.0);  // Droplet number concentration (cm^-3)
 
           // CCN spectra parameters (for IACT = 1)
           [[maybe_unused]] Real m_k1;          // Exponent in CCN activation formula

--- a/Source/TimeIntegration/ERF_AdvanceMicrophysics.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceMicrophysics.cpp
@@ -9,9 +9,7 @@ void ERF::advance_microphysics (int lev,
                                 const Real& time )
 {
     if (solverChoice.moisture_type != MoistureType::None) {
-        if (solverChoice.moisture_type != MoistureType::Morrison) {
-            micro->Set_RealWidth(lev, real_width);
-        }
+        micro->Set_RealWidth(lev, real_width);
         micro->Update_Micro_Vars_Lev(lev, cons);
         micro->Advance(lev, dt_advance, iteration, time, solverChoice, vars_new, z_phys_nd, phys_bc_type);
         micro->Update_State_Vars_Lev(lev, cons);


### PR DESCRIPTION
# Summary
A previous PR removed the `real_width` trimming of the microphysics boxes with Morrison. This was done to avoid errors with pointer dereferencing when comparing CPP and FORTRAN code side-by-side. However, the trimming of the boxes is beneficial to realistic simulations. The approach is to now query in Morrison (outside the MFIter) if the CPP answer will be used and guard the box trimming with `ifndef ERF_USE_MORR_FORT` --- i.e., we  do not trim the box with realistic simulations if the code is compiled with FORTRAN support.