### PR TITLE
SAM Reflectivity

### DIFF
--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -570,7 +570,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         calculate_derived("scalar",      vars_new[lev][Vars::cons], derived::erf_derscalar);
         calculate_derived("soundspeed",  vars_new[lev][Vars::cons], derived::erf_dersoundspeed);
 
-        if (solverChoice.moisture_type == MoistureType::Morrison) {
+        if (solverChoice.moisture_type == MoistureType::Morrison ||
+            solverChoice.moisture_type == MoistureType::SAM) {
             calculate_derived("reflectivity",      vars_new[lev][Vars::cons], derived::erf_derreflectivity);
             calculate_derived("max_reflectivity",  vars_new[lev][Vars::cons], derived::erf_dermaxreflectivity);
         }


### PR DESCRIPTION
# Summary
Any micro model with cold precipitating components can call the reflectivity computation. Allow SAM for testing and comparison with Morrison.