### PR TITLE
Interp2DArrays bugfix

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1504,7 +1504,7 @@ ERF::InitData_post ()
     // If lev > 0, we need to fill bc's by interpolation from coarser grid
     for (int lev = 1; lev <= finest_level; ++lev)
     {
-        Interp2DArrays(lev,grids[lev],dmap[lev]);
+        Interp2DArrays(lev,ba2d[lev],dmap[lev]);
     } // lev
 
 #ifdef ERF_USE_WW3_COUPLING


### PR DESCRIPTION
This resolves a crash in Interp2DArrays by passing ba2d[lev] instead of grids[lev].

This was discovered after encountering a runtime error when running multilevel with init_type="metgrid". For this test case the relevant variables are
grids[lev]  BoxArray with k=0 - 99
ba2d[lev]  BoxArray with k=0 - 0

The multilevel metgrid test case advances normally with the bugfix.