### PR TITLE
Bugfix: SDM Input Conflict

### DIFF
--- a/Exec/CanonicalTests/RICO/input_sdm
+++ b/Exec/CanonicalTests/RICO/input_sdm
@@ -89,7 +89,7 @@ erf.moisture_model  = "SuperDroplets"
 erf.buoyancy_type   = 1
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.aerosols = NH4HSO4

--- a/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SDM
+++ b/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SDM
@@ -65,7 +65,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Longs"
 super_droplets_moisture.aerosols = NaCl

--- a/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SDM_multi_injections_unimodal_NaCl
+++ b/Exec/RegTests/Bubble/inputs_BF02_moist_bubble_SDM_multi_injections_unimodal_NaCl
@@ -64,7 +64,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.multiplicity_type = "constant"

--- a/Exec/RegTests/MultiSpeciesBubble/inputs_dry_bubble.01species
+++ b/Exec/RegTests/MultiSpeciesBubble/inputs_dry_bubble.01species
@@ -64,7 +64,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.species = water

--- a/Exec/RegTests/MultiSpeciesBubble/inputs_dry_bubble.02species
+++ b/Exec/RegTests/MultiSpeciesBubble/inputs_dry_bubble.02species
@@ -64,7 +64,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.species = water agua

--- a/Exec/RegTests/MultiSpeciesBubble/inputs_moist_bubble.01species
+++ b/Exec/RegTests/MultiSpeciesBubble/inputs_moist_bubble.01species
@@ -66,7 +66,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.species = water

--- a/Exec/RegTests/MultiSpeciesBubble/inputs_moist_bubble.02species
+++ b/Exec/RegTests/MultiSpeciesBubble/inputs_moist_bubble.02species
@@ -65,7 +65,7 @@ erf.alpha_T          = 0.0 # [m^2/s]
 erf.alpha_C          = 0.0
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.species = water agua

--- a/Exec/RegTests/SDM_Congestus3D/input_sdm
+++ b/Exec/RegTests/SDM_Congestus3D/input_sdm
@@ -58,7 +58,7 @@ erf.moisture_model  = "SuperDroplets"
 erf.buoyancy_type   = 1
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.aerosols = NH4HSO4

--- a/Exec/RegTests/SineMassFlux/input_test_init
+++ b/Exec/RegTests/SineMassFlux/input_test_init
@@ -67,7 +67,7 @@ erf.Pr_t      = 0.33333333333333
 erf.Sc_t      = 0.33333333333333
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.include_coalescence = true
 super_droplets_moisture.density_scaling = true

--- a/Exec/RegTests/SineMassFlux/inputs_SDM_condBE
+++ b/Exec/RegTests/SineMassFlux/inputs_SDM_condBE
@@ -63,7 +63,7 @@ erf.Pr_t      = 0.33333333333333
 erf.Sc_t      = 0.33333333333333
 
 #sdm parameters
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.include_coalescence = false
 super_droplets_moisture.prescribed_advection = true

--- a/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
+++ b/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
@@ -51,7 +51,7 @@ void SuperDropletsMoist::readInputs ()
 
     // initial distribution type
     m_init_type = SDMoistInit::uniform;
-    pp.query("initial_distribution_type", m_init_type);
+    pp.query("distribution_type", m_init_type);
 
     // minimum radius for rain
     m_r_rain = Real(4.0e-5); // 40 micrometers

--- a/Tests/test_files/SDM_Box3D_Cond/SDM_Box3D_Cond.i
+++ b/Tests/test_files/SDM_Box3D_Cond/SDM_Box3D_Cond.i
@@ -82,7 +82,7 @@ erf.buoyancy_type   = 1
 # Super Droplets Options
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.advect_with_flow = false
 super_droplets_moisture.advect_with_gravity = false

--- a/Tests/test_files/SDM_Box3D_Recycling/SDM_Box3D_Recycling.i
+++ b/Tests/test_files/SDM_Box3D_Recycling/SDM_Box3D_Recycling.i
@@ -81,7 +81,7 @@ erf.alpha_C          = 0.0
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.include_coalescence = false
 super_droplets_moisture.include_phase_change = false

--- a/Tests/test_files/SDM_Box3D_VTerm/SDM_Box3D_VTerm.i
+++ b/Tests/test_files/SDM_Box3D_VTerm/SDM_Box3D_VTerm.i
@@ -79,7 +79,7 @@ erf.alpha_C          = 0.0
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.include_coalescence = false
 super_droplets_moisture.include_phase_change = false

--- a/Tests/test_files/SDM_Bubble2D_Adv/SDM_Bubble2D_Adv.i
+++ b/Tests/test_files/SDM_Bubble2D_Adv/SDM_Bubble2D_Adv.i
@@ -87,7 +87,7 @@ erf.alpha_C          = 0.0
 
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.include_phase_change = false
 super_droplets_moisture.include_coalescence = false

--- a/Tests/test_files/SDM_Bubble2D_Adv_InitSampling/SDM_Bubble2D_Adv_InitSampling.i
+++ b/Tests/test_files/SDM_Bubble2D_Adv_InitSampling/SDM_Bubble2D_Adv_InitSampling.i
@@ -87,7 +87,7 @@ erf.alpha_C          = 0.0
 
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.include_phase_change = false
 super_droplets_moisture.include_coalescence = false

--- a/Tests/test_files/SDM_Bubble2D_Adv_wInjection/SDM_Bubble2D_Adv_wInjection.i
+++ b/Tests/test_files/SDM_Bubble2D_Adv_wInjection/SDM_Bubble2D_Adv_wInjection.i
@@ -106,7 +106,7 @@ super_droplets_moisture.include_phase_change = false
 super_droplets_moisture.include_coalescence = false
 super_droplets_moisture.advect_with_gravity = false
 
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.multiplicity_type = "constant"
 super_droplets_moisture.recycle_particles = false

--- a/Tests/test_files/SDM_Congestus3D/SDM_Congestus3D.i
+++ b/Tests/test_files/SDM_Congestus3D/SDM_Congestus3D.i
@@ -93,7 +93,7 @@ erf.buoyancy_type   = 1
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.aerosols = NH42SO4

--- a/Tests/test_files/SDM_MultiSpecies_Bubble2D/SDM_MultiSpecies_Bubble2D.i
+++ b/Tests/test_files/SDM_MultiSpecies_Bubble2D/SDM_MultiSpecies_Bubble2D.i
@@ -125,7 +125,7 @@ erf.alpha_C          = 0.0
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.species = water agua

--- a/Tests/test_files/SDM_RICO3D/SDM_RICO3D.i
+++ b/Tests/test_files/SDM_RICO3D/SDM_RICO3D.i
@@ -108,7 +108,7 @@ erf.buoyancy_type   = 1
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
 
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.aerosols = NH4HSO4

--- a/Tests/test_files/SDM_RICO3D_InitSampling/SDM_RICO3D_InitSampling.i
+++ b/Tests/test_files/SDM_RICO3D_InitSampling/SDM_RICO3D_InitSampling.i
@@ -108,7 +108,7 @@ erf.buoyancy_type   = 1
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
 
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 1
 super_droplets_moisture.coalescence_kernel = "Halls"
 super_droplets_moisture.aerosols = NH4HSO4

--- a/Tests/test_files/SDM_SineMassFlux/SDM_SineMassFlux.i
+++ b/Tests/test_files/SDM_SineMassFlux/SDM_SineMassFlux.i
@@ -65,7 +65,7 @@ erf.Sc_t      = 0.33333333333333
 #sdm parameters
 super_droplets_moisture.stable_redistribute = true
 super_droplets_moisture.place_randomly_in_cells = false
-super_droplets_moisture.initial_distribution_type = "uniform"
+super_droplets_moisture.distribution_type = "uniform"
 super_droplets_moisture.diagnostics_interval = 100
 super_droplets_moisture.include_coalescence = false
 super_droplets_moisture.prescribed_advection = true


### PR DESCRIPTION
Fix conflict between `SuperDropletsMoist::readInputs()` and `SDInitProperties::readInputs()` for `initial_distribution_type` and update input files - this arose in #3114.