### PR TITLE
Fixes For AMReX Bump

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -429,18 +429,18 @@ public:
     // Write subvolume of data into a different "plotfile"
     void WriteSubvolume (int isub, amrex::Vector<std::string> subvol_var_names);
 
-    void WriteMultiLevelPlotfileWithTerrain (const std::string &plotfilename,
+    void WriteMultiLevelPlotfileWithTerrain (const std::string plotfilename,
                                              int nlevels,
-                                             const amrex::Vector<const amrex::MultiFab*> &mf,
-                                             const amrex::Vector<const amrex::MultiFab*> &mf_nd,
-                                             const amrex::Vector<std::string> &varnames,
-                                             const amrex::Vector<amrex::Geometry>& my_geom,
+                                             const amrex::Vector<const amrex::MultiFab*>& mf,
+                                             const amrex::Vector<const amrex::MultiFab*>& mf_nd,
+                                             const amrex::Vector<std::string> varnames,
+                                             const amrex::Vector<amrex::Geometry> my_geom,
                                              amrex::Real time,
-                                             const amrex::Vector<int> &level_steps,
+                                             const amrex::Vector<int>& level_steps,
                                              const amrex::Vector<amrex::IntVect>& my_ref_ratio,
-                                             const std::string &versionName = "HyperCLaw-V1.1",
-                                             const std::string &levelPrefix = "Level_",
-                                             const std::string &mfPrefix = "Cell",
+                                             const std::string versionName = "HyperCLaw-V1.1",
+                                             const std::string levelPrefix = "Level_",
+                                             const std::string mfPrefix = "Cell",
                                              const amrex::Vector<std::string>& extra_dirs = amrex::Vector<std::string>()) const;
 
 

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1764,17 +1764,18 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 }
 
 void
-ERF::WriteMultiLevelPlotfileWithTerrain (const std::string& plotfilename, int nlevels,
+ERF::WriteMultiLevelPlotfileWithTerrain (const std::string plotfilename,
+                                         int nlevels,
                                          const Vector<const MultiFab*>& mf,
                                          const Vector<const MultiFab*>& mf_nd,
-                                         const Vector<std::string>& varnames,
-                                         const Vector<Geometry>& my_geom,
+                                         const Vector<std::string> varnames,
+                                         const Vector<Geometry> my_geom,
                                          Real time,
                                          const Vector<int>& level_steps,
                                          const Vector<IntVect>& rr,
-                                         const std::string &versionName,
-                                         const std::string &levelPrefix,
-                                         const std::string &mfPrefix,
+                                         const std::string versionName,
+                                         const std::string levelPrefix,
+                                         const std::string mfPrefix,
                                          const Vector<std::string>& extra_dirs) const
 {
     BL_PROFILE("WriteMultiLevelPlotfileWithTerrain()");


### PR DESCRIPTION
1. Pass by value to avoid implicit capture of `this` in lambda