### PR TITLE
Rad Mem Temp

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -250,11 +250,11 @@ rrtmgp_initialize (gas_concs_t& gas_concs_k,
     load_cld_lutcoeff(*cloud_optics_lw_k, cloud_optics_file_lw);
 
     // Initialize kokkos rrtmgp pool allocator
-    const size_t nvar = 300;
-    const size_t nbnd = std::max(k_dist_sw_k->get_nband(),k_dist_lw_k->get_nband());
+    const size_t nvar = 12;
+    const size_t ngpt = std::max(k_dist_sw_k->get_ngpt(),k_dist_lw_k->get_ngpt());
     const size_t ncol = gas_concs_k.ncol;
     const size_t nlay = gas_concs_k.nlay;
-    auto my_size_ref = static_cast<unsigned long>(nvar * ncol * nlay * nbnd);
+    auto my_size_ref = static_cast<unsigned long>(nvar * ncol * nlay * ngpt);
     pool_t::init(my_size_ref);
 
     // We are now initialized!

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -1212,7 +1212,7 @@ Radiation::finalize_impl (Vector<MultiFab*>& lsm_output_ptrs)
     if (datalog_int > 0) {
         rrtmgp::compute_heating_rate(sw_clrsky_flux_up, sw_clrsky_flux_dn, r_lay, z_del, sw_clrsky_heating);
         rrtmgp::compute_heating_rate(lw_clrsky_flux_up, lw_clrsky_flux_dn, r_lay, z_del, lw_clrsky_heating);
-
+        Kokkos::fence();
         populateDatalogMF();
     }
 


### PR DESCRIPTION
# Summary
This PR is a temporary step towards merging [PR 3128](https://github.com/erf-model/ERF/pull/3128). All credit goes to @wang1202 for the great catch on memory reduction. The primary difference here is to reduce `nvar=12` based upon direct prints from the RRTMGP `mempoolsingleton` allocation. This optimized value, from simulations, keeps the high water mark just below the allocation size. 

## Notes
This PR simply provides a stepping stone for `PR 3128` so further review of the column chunking approach may be completed. 