### PR TITLE
Update gcc and cuda modules in LC GitLab testing

### DIFF
--- a/.gitlab/LC/jobs/matrix.yml
+++ b/.gitlab/LC/jobs/matrix.yml
@@ -1,6 +1,6 @@
 matrix_cuda_12.9.1:
   variables:
-    MODULE_LIST: cmake/3.30.5 ninja/1.11.1 gcc/10.3.1 cuda/12.9.1
+    MODULE_LIST: cmake/3.30.5 ninja/1.11.1 gcc/13.3.1 cuda/13.1.1
     ERF_ENABLE_CUDA: "ON"
     CUDA_ARCH: "90"
     BUILD_TYPE: "RelWithDebInfo"


### PR DESCRIPTION
AMReX now requires gcc >= 11.0 for C++20 support