### PR TITLE
Get Prob Name Real

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2359,8 +2359,8 @@ ERF::ReadParameters ()
         init_string != "metgrid"  &&
         init_string != "ncfile") {
         pp_pn.get("prob_name", prob_name);
-        Print() << "Problem name (from inputs file) is " << prob_name << std::endl;
     }
+    Print() << "Problem name (from inputs file) is " << prob_name << std::endl;
 
     ParmParse pp(pp_prefix);
     ParmParse pp_amr("amr");

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2349,8 +2349,18 @@ void
 ERF::ReadParameters ()
 {
     std::string prob_name = "Unknown";
-    ParmParse pp_pn("erf"); pp_pn.queryAdd("prob_name", prob_name);
-    Print() << "Problem name (from inputs file) is " << prob_name << std::endl;
+
+    // Only get filename if not doing a real simulation
+    ParmParse pp_pn("erf");
+    std::string init_string = "unknown";
+    pp_pn.query("init_type",init_string);
+    init_string = toLower(init_string);
+    if (init_string != "wrfinput" &&
+        init_string != "metgrid"  &&
+        init_string != "ncfile") {
+        pp_pn.get("prob_name", prob_name);
+        Print() << "Problem name (from inputs file) is " << prob_name << std::endl;
+    }
 
     ParmParse pp(pp_prefix);
     ParmParse pp_amr("amr");

--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -691,7 +691,7 @@ protected:
         base_parms.T_0 = T_0;
     }
 
-    std::string name() { std::string prob_name; amrex::ParmParse pp("erf"); pp.query("prob_name",prob_name); return prob_name; }
+    std::string name() { std::string prob_name; amrex::ParmParse pp("erf"); pp.get("prob_name",prob_name); return prob_name; }
 };
 
 


### PR DESCRIPTION
# Summary
1. Default the prob name to `Unknown`.
2. Query the `init_type` in ReadParams. If init type does **not** involve a netcdf file, get the prob name since it is a canonical case.
3. Now we can use `get` and `query` from [PR 3134](https://github.com/erf-model/ERF/pull/3134).