### PR TITLE
Immersed Forcing Regtest Fix

### DIFF
--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -148,7 +148,7 @@ Problem::init_custom_pert (
     }
     else {
         Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
-                << " is not known, no state perturbations added. \n"
+                << " is not known, no state perturbations added. \n";
     }
 
     amrex::Gpu::streamSynchronize();
@@ -243,7 +243,7 @@ Problem::init_custom_pert_vels (
     }
     else {
         Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
-                << " is not known, no velocity perturbations added. \n"
+                << " is not known, no velocity perturbations added. \n";
     }
 
     amrex::Gpu::streamSynchronize();

--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -147,7 +147,7 @@ Problem::init_custom_pert (
 #include "Prob/ERF_InitCustomPert_Bomex.H"
     }
     else {
-        Print() << "Problem name" << " [" <<  my_prob_name_ci << "] " <<
+        Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
                 << " is not known, no state perturbations added. \n"
     }
 
@@ -242,7 +242,7 @@ Problem::init_custom_pert_vels (
 #include "Prob/ERF_InitCustomPertVels_Bomex.H"
     }
     else {
-        Print() << "Problem name" << " [" <<  my_prob_name_ci << "] " <<
+        Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
                 << " is not known, no velocity perturbations added. \n"
     }
 

--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -146,6 +146,10 @@ Problem::init_custom_pert (
     else if  (my_prob_name_ci == "sinusoidalmassflux") {
 #include "Prob/ERF_InitCustomPert_Bomex.H"
     }
+    else {
+        Print() << "Problem name" << " [" <<  my_prob_name_ci << "] " <<
+                << " is not known, no state perturbations added. \n"
+    }
 
     amrex::Gpu::streamSynchronize();
 }
@@ -236,6 +240,10 @@ Problem::init_custom_pert_vels (
     }
     else if  (my_prob_name_ci == "sinusoidalmassflux") {
 #include "Prob/ERF_InitCustomPertVels_Bomex.H"
+    }
+    else {
+        Print() << "Problem name" << " [" <<  my_prob_name_ci << "] " <<
+                << " is not known, no velocity perturbations added. \n"
     }
 
     amrex::Gpu::streamSynchronize();

--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -5,12 +5,12 @@
 using namespace amrex;
 
 std::unique_ptr<ProblemBase>
-amrex_probinit(const amrex_real* problo, const amrex_real* probhi)
+amrex_probinit (const amrex_real* problo, const amrex_real* probhi)
 {
     return std::make_unique<Problem>(problo, probhi);
 }
 
-Problem::Problem(const Real* /*problo*/, const Real* /*probhi*/)
+Problem::Problem (const Real* /*problo*/, const Real* /*probhi*/)
 {
     ParmParse pp_prob("prob");
     Real rho_0 =   1.0; int found_rho0 = pp_prob.query("rho_0", rho_0);

--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -148,7 +148,7 @@ Problem::init_custom_pert (
     }
     else {
         Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
-                << " is not known, no state perturbations added. \n";
+                << "is not known, no state perturbations added. \n";
     }
 
     amrex::Gpu::streamSynchronize();
@@ -243,7 +243,7 @@ Problem::init_custom_pert_vels (
     }
     else {
         Print() << "Problem name" << " \"" <<  my_prob_name_ci << "\" "
-                << " is not known, no velocity perturbations added. \n";
+                << "is not known, no velocity perturbations added. \n";
     }
 
     amrex::Gpu::streamSynchronize();

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_building
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_building
@@ -6,10 +6,11 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
+erf.prob_name = "userdefined"
+    
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640
 amr.n_cell           =  128     128    128
-
 
 geometry.is_periodic = 1 1 0
 
@@ -56,7 +57,6 @@ erf.rayleigh_damp_T = true
 prob.dampcoef = 0.2 # [1/s] following FastEddy
 prob.zdamp = 300. # from model top"
 
-
 # INITIALIZATION 
 erf.init_type           = "input_sounding"
 erf.input_sounding_file = "input_sounding_CBL"
@@ -76,8 +76,3 @@ erf.rotational_time_period = 86400.0
 # Geostrophic wind 
 erf.abl_driver_type = "GeostrophicWind"
 erf.abl_geo_wind = 8.0 0.0 0.0
-
-# Higher values of perturbations lead to instability
-# Instability seems to be coming from BC
-prob.T_0_Pert_Mag    = 0.5 # [K]
-prob.pert_ref_height = 500. # [m]

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_building
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_building
@@ -5,8 +5,6 @@ stop_time = 1800
 amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
-
-erf.prob_name = "userdefined"
     
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain
@@ -6,6 +6,8 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
+erf.prob_name = "userdefined"
+
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640
 amr.n_cell           =  128     128    128
@@ -79,8 +81,3 @@ erf.rotational_time_period = 86400.0
 # Geostrophic wind 
 erf.abl_driver_type = "GeostrophicWind"
 erf.abl_geo_wind = 8.0 0.0 0.0
-
-# Higher values of perturbations lead to instability
-# Instability seems to be coming from BC
-prob.T_0_Pert_Mag    = 0.5 # [K]
-prob.pert_ref_height = 500. # [m]

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain
@@ -6,8 +6,6 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
-erf.prob_name = "userdefined"
-
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640
 amr.n_cell           =  128     128    128

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain_plusBuilding
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain_plusBuilding
@@ -6,8 +6,6 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
-erf.prob_name = "userdefined"
-
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640
 amr.n_cell           =  128     128    128

--- a/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain_plusBuilding
+++ b/Exec/RegTests/ImmersedForcingTest/inputs_if_terrain_plusBuilding
@@ -6,6 +6,8 @@ amrex.fpe_trap_invalid = 1
 
 fabarray.mfiter_tile_size = 1024 1024 1024
 
+erf.prob_name = "userdefined"
+
 # PROBLEM SIZE & GEOMETRY
 geometry.prob_extent =  640     640    640
 amr.n_cell           =  128     128    128
@@ -81,8 +83,3 @@ erf.rotational_time_period = 86400.0
 # Geostrophic wind 
 erf.abl_driver_type = "GeostrophicWind"
 erf.abl_geo_wind = 8.0 0.0 0.0
-
-# Higher values of perturbations lead to instability
-# Instability seems to be coming from BC
-prob.T_0_Pert_Mag    = 0.5 # [K]
-prob.pert_ref_height = 500. # [m]

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2349,18 +2349,8 @@ void
 ERF::ReadParameters ()
 {
     std::string prob_name = "Undefined";
-
-    // Only get filename if not doing a real simulation
-    ParmParse pp_pn("erf");
-    std::string init_string = "Undefined";
-    pp_pn.query("init_type",init_string);
-    init_string = toLower(init_string);
-    if (init_string != "wrfinput" &&
-        init_string != "metgrid"  &&
-        init_string != "ncfile") {
-        pp_pn.get("prob_name", prob_name);
-    }
-    Print() << "Problem name (from inputs file) is " << prob_name << std::endl;
+    pp_pn.queryAdd("prob_name", prob_name);
+    Print() << "Problem name (from inputs file) is: " << prob_name << std::endl;
 
     ParmParse pp(pp_prefix);
     ParmParse pp_amr("amr");

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2291,7 +2291,7 @@ ERF::init_only (int lev, Real elapsed_time)
                 (solverChoice.init_type == InitType::ConstantDensity) ||
                 (solverChoice.init_type == InitType::Isentropic     ) ||
                 (solverChoice.init_type == InitType::ConstantDensityLinearTheta     ) ||
-        (solverChoice.init_type == InitType::HindCast       ) ||
+                (solverChoice.init_type == InitType::HindCast       ) ||
                 (solverChoice.init_type == InitType::MoistBaseState ) ) {
         // Initialize a uniform density/entropy background field and base state
         // based on the problem-specified reference density and temperature
@@ -2348,11 +2348,11 @@ ERF::init_only (int lev, Real elapsed_time)
 void
 ERF::ReadParameters ()
 {
-    std::string prob_name = "Unknown";
+    std::string prob_name = "Undefined";
 
     // Only get filename if not doing a real simulation
     ParmParse pp_pn("erf");
-    std::string init_string = "unknown";
+    std::string init_string = "Undefined";
     pp_pn.query("init_type",init_string);
     init_string = toLower(init_string);
     if (init_string != "wrfinput" &&

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2349,6 +2349,7 @@ void
 ERF::ReadParameters ()
 {
     std::string prob_name = "Undefined";
+    ParmParse pp_pn("erf");
     pp_pn.queryAdd("prob_name", prob_name);
     Print() << "Problem name (from inputs file) is: " << prob_name << std::endl;
 

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2351,7 +2351,8 @@ ERF::ReadParameters ()
     std::string prob_name = "Undefined";
     ParmParse pp_pn("erf");
     pp_pn.queryAdd("prob_name", prob_name);
-    Print() << "Problem name (from inputs file) is: " << prob_name << std::endl;
+    Print() << "Problem name (from inputs file) is: "
+            << " \"" << prob_name << "\" " << std::endl;
 
     ParmParse pp(pp_prefix);
     ParmParse pp_amr("amr");

--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -691,7 +691,11 @@ protected:
         base_parms.T_0 = T_0;
     }
 
-    std::string name() { std::string prob_name; amrex::ParmParse pp("erf"); pp.get("prob_name",prob_name); return prob_name; }
+    std::string name() {
+        std::string prob_name;
+        amrex::ParmParse pp("erf");
+        pp.get("prob_name",prob_name); return prob_name;
+    }
 };
 
 


### PR DESCRIPTION
Retain the `queryadd` so cases that don't have a problem name --- i.e., they want null perturbations but not init from NC file --- can run without a prob name. Output that the problem is `Undefined` and no perts are added. We don't want to add problem names when no custom perts are desired.

@gardner48 this does remove the initial `get` but adds more robust output to the log file that explicitly shows no perturbations were added if a `prob_name` is not initially parsed. The log file will immediately tell you if the wrong problem is used.