### PR TITLE
Fix SDM MoistureComponentIndices: explicit -1 for cloud ice

### DIFF
--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -194,6 +194,7 @@ struct SolverChoice {
             moisture_indices = MoistureComponentIndices(
                 RhoQ1_comp,  // water vapor
                 RhoQ2_comp,  // cloud water
+                -1,          // cloud ice
                 RhoQ3_comp   // rain
             );
         }


### PR DESCRIPTION
SDM was passing only three positional args to MoistureComponentIndices, so RhoQ3 (rain) landed in qi instead of qr; adding an explicit -1 for cloud ice routes RhoQ3 to qr.