### PR TITLE
Restore broken regression test for WOA-EB

### DIFF
--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -303,15 +303,18 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
                     const RealVect bcent_eb {w_bcent(i,j,k,0), w_bcent(i,j,k,1), w_bcent(i,j,k,2)};
 
-                    // const Real Dirichlet_u {zero};
-                    // const Real Dirichlet_v {zero};
-                    const Real Dirichlet_u = (u_volfrac(i  ,j,k  ) * u_arr(i  ,j,k  ) + u_volfrac(i+1,j,k  ) * u_arr(i+1,j,k  )
-                                            + u_volfrac(i+1,j,k-1) * u_arr(i+1,j,k-1) + u_volfrac(i  ,j,k-1) * u_arr(i  ,j,k-1))
-                                            / (u_volfrac(i,j,k) + u_volfrac(i+1,j,k) + u_volfrac(i+1,j,k-1) + u_volfrac(i,j,k-1));
-                    const Real Dirichlet_v = (v_volfrac(i,j  ,k  ) * v_arr(i,j  ,k  ) + v_volfrac(i,j+1,k  ) * v_arr(i,j+1,k  )
-                                            + v_volfrac(i,j+1,k-1) * v_arr(i,j+1,k-1) + v_volfrac(i,j  ,k-1) * v_arr(i,j  ,k-1))
-                                            / (v_volfrac(i,j,k) + v_volfrac(i,j+1,k) + v_volfrac(i,j+1,k-1) + v_volfrac(i,j,k-1));
+                    Real Dirichlet_u {zero};
+                    Real Dirichlet_v {zero};
                     const Real Dirichlet_w {zero};
+                    if (l_surface_layer) {
+                        Dirichlet_u = (u_volfrac(i  ,j,k  ) * u_arr(i  ,j,k  ) + u_volfrac(i+1,j,k  ) * u_arr(i+1,j,k  )
+                                        + u_volfrac(i+1,j,k-1) * u_arr(i+1,j,k-1) + u_volfrac(i  ,j,k-1) * u_arr(i  ,j,k-1))
+                                        / (u_volfrac(i,j,k) + u_volfrac(i+1,j,k) + u_volfrac(i+1,j,k-1) + u_volfrac(i,j,k-1));
+                        Dirichlet_v = (v_volfrac(i,j  ,k  ) * v_arr(i,j  ,k  ) + v_volfrac(i,j+1,k  ) * v_arr(i,j+1,k  )
+                                        + v_volfrac(i,j+1,k-1) * v_arr(i,j+1,k-1) + v_volfrac(i,j  ,k-1) * v_arr(i,j  ,k-1))
+                                        / (v_volfrac(i,j,k) + v_volfrac(i,j+1,k) + v_volfrac(i,j+1,k-1) + v_volfrac(i,j,k-1));
+
+                    }
 
                     GpuArray<Real,AMREX_SPACEDIM> slopes_u;
                     GpuArray<Real,AMREX_SPACEDIM> slopes_v;

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -205,9 +205,6 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
             rho_v_rhs(i,j,k) -= diffContrib;
 
-            // Apply EB boundary contribution for both no-slip and surface-layer wall models.
-            // (Previously this block was incorrectly gated on `l_no_slip`, which prevented
-            //  SurfaceLayer stresses (tau_eb23) from contributing to the y-momentum RHS.)
             if (!l_constraint_y && v_cellflg(i,j,k).isSingleValued()) {
 
                 Real axm = v_afrac_x(i  ,j  ,k  );


### PR DESCRIPTION
This PR fixes an error in the regression test for `RegTests/WitchOfAgnesi/inputs_EB_x` introduced by the previous PR #3140. I confirmed that the solution matches the result from PR #3147 (commit f2b2da87) merged on May 4, 2026.