### PR TITLE
time handling in single precision

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -707,7 +707,7 @@ private:
     void setSpongeRefFromSounding (bool restarting);
 
     // a wrapper for estTimeStep()
-    void ComputeDt (int step = -1);
+    void ComputeDt (int step = -1, double cur_time_d = 0.0);
 
     // get plotfile name
     [[nodiscard]] std::string PlotFileName (int lev) const;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -658,6 +658,8 @@ ERF::Evolve ()
         timeStep(0, cur_time, iteration);
 
         cur_time += static_cast<double>(dt[0]);
+        // Sync t_new[0] from accurate double to prevent float32 accumulation drift in SP builds.
+        t_new[0] = static_cast<Real>(cur_time);
 
         Print() << "Coarse STEP " << step+1 << " ends." << " TIME = " << cur_time
                 << " DT = " << dt[0]  << std::endl;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -609,8 +609,8 @@ ERF::Evolve ()
     //
     // cur_time = t_new is elapsed time, not total time
     // stop_time is total time
-    //
-    Real cur_time = t_new[0];
+    // Tracked in double to avoid float32 drift over many timesteps in single-precision builds.
+    double cur_time = static_cast<double>(t_new[0]);
 
     // Take one coarse timestep by calling timeStep -- which recursively calls timeStep
     //      for finer levels (with or without subcycling)
@@ -622,7 +622,7 @@ ERF::Evolve ()
         }
         Print() << "\nCoarse STEP " << step+1 << " starts ..." << std::endl;
 
-        ComputeDt(step);
+        ComputeDt(step, cur_time);
 
         // Make sure we have read enough of the boundary plane data to make it through this timestep
         if (input_bndry_planes)
@@ -657,7 +657,7 @@ ERF::Evolve ()
         int iteration = 1;
         timeStep(0, cur_time, iteration);
 
-        cur_time  += dt[0];
+        cur_time += static_cast<double>(dt[0]);
 
         Print() << "Coarse STEP " << step+1 << " ends." << " TIME = " << cur_time
                 << " DT = " << dt[0]  << std::endl;

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -8,7 +8,7 @@ using namespace amrex;
  *
  */
 void
-ERF::ComputeDt (int step)
+ERF::ComputeDt (int step, double cur_time_d)
 {
     Vector<Real> dt_tmp(finest_level+1);
 
@@ -36,12 +36,12 @@ ERF::ComputeDt (int step)
     }
     //
     // Limit dt by the value of stop_time.
-    // Recall that stop_time is total time, but t_new is elapsed time,
-    //     so we must add start_time to t_new
+    // Use double-precision cur_time_d (passed from Evolve) to avoid float32 drift
+    // causing premature dt shortening in single-precision builds.
     //
     const Real eps = Real(1.e-3)*dt_0;
-    if (t_new[0] + dt_0 > (stop_time - start_time) - eps) {
-        dt_0 = (stop_time - start_time) - t_new[0];
+    if (cur_time_d + static_cast<double>(dt_0) > static_cast<double>(stop_time - start_time) - static_cast<double>(eps)) {
+        dt_0 = static_cast<Real>(static_cast<double>(stop_time - start_time) - cur_time_d);
     }
 
     dt[0] = dt_0;

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -36,8 +36,8 @@ ERF::ComputeDt (int step, double cur_time_d)
     }
     //
     // Limit dt by the value of stop_time.
-    // Use double-precision cur_time_d (passed from Evolve) to avoid float32 drift
-    // causing premature dt shortening in single-precision builds.
+    // Recall that stop_time is total time, but t_new is elapsed time,
+    //     so we must add start_time to t_new
     //
     const Real eps = Real(1.e-3)*dt_0;
     if (cur_time_d + static_cast<double>(dt_0) > static_cast<double>(stop_time - start_time) - static_cast<double>(eps)) {


### PR DESCRIPTION
When compiled in single precision, small rounding errors in the time step and current time can accumulate. For Bomex (6 hours with dt=0.3) the single precision run completes 20 time steps (6 seconds) earlier than the double precision run. This PR changes some times to doubles when in single precision and also syncs the current time after each time step so that it does not drift for the I/O and physics routines. These changes shouldn't change anything when compiled in double precision.

Tested by compiling in single and double precision and running Bomex.  No change to behavior of the double precision simulation.  Single precision simulation now tracks and reports time identical to the double precision simulation.