### PR TITLE
Fix Helicity Ghost Cells

### DIFF
--- a/Source/ERF_Tagging.cpp
+++ b/Source/ERF_Tagging.cpp
@@ -198,20 +198,14 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
 
         // This allows dynamic refinement based on the value of the z-component of vorticity
         } else if (ref_tags[j].Field() == "vorticity" ) {
-            Vector<MultiFab> mf_cc_vel(1);
-            mf_cc_vel[0].define(grids[levc], dmap[levc], AMREX_SPACEDIM, IntVect(1,1,1));
-            average_face_to_cellcenter(mf_cc_vel[0],0,Array<const MultiFab*,3>{&U_new, &V_new, &W_new});
-
-            // Impose bc's at domain boundaries at all levels
-            FillBdyCCVels(mf_cc_vel[0],geom[levc]);
-
-            mf->setVal(0.);
+            MultiFab mf_cc_vel(grids[levc], dmap[levc], AMREX_SPACEDIM, IntVect(1,1,1));
+            average_face_to_cellcenter(mf_cc_vel,0,Array<const MultiFab*,3>{&U_new, &V_new, &W_new}, 1);
 
             for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
                 const Box& bx = mfi.tilebox();
                 auto& dfab = (*mf)[mfi];
-                auto& sfab = mf_cc_vel[0][mfi];
+                auto& sfab = mf_cc_vel[mfi];
                 auto& zfab = (*z_phys_cc[levc])[mfi];
                 derived::erf_dervortz(bx, dfab, 0, 1, sfab, zfab, Geom(levc), time, nullptr, levc);
             }
@@ -222,7 +216,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
         {
             for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
-                const Box& bx = mfi.growntilebox();
+                const Box& bx = mfi.tilebox();
                 auto& dfab = (*mf)[mfi];
                 auto& sfab = vars_new[levc][Vars::cons][mfi];
                 auto& zfab = (*z_phys_cc[levc])[mfi];
@@ -235,11 +229,14 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
         // This allows dynamic refinement based on the value of updraft helicity
         } else if (ref_tags[j].Field() == "helicity")
         {
+            MultiFab mf_cc_vel(grids[levc], dmap[levc], AMREX_SPACEDIM, IntVect(1,1,1));
+            average_face_to_cellcenter(mf_cc_vel,0,Array<const MultiFab*,3>{&U_new, &V_new, &W_new}, 1);
+
             for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
             {
-                const Box& bx = mfi.growntilebox();
+                const Box& bx = mfi.tilebox();
                 auto& dfab = (*mf)[mfi];
-                auto& sfab = vars_new[levc][Vars::cons][mfi];
+                auto& sfab = mf_cc_vel[mfi];
                 auto& zfab = (*z_phys_cc[levc])[mfi];
 
                 derived::erf_derhelicity(bx, dfab, 0, 1, sfab, zfab, Geom(levc), time, nullptr, levc);
@@ -250,7 +247,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
                 solverChoice.moisture_type == MoistureType::SAM) {
                 for (MFIter mfi(*mf, TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
-                    const Box& bx = mfi.growntilebox();
+                    const Box& bx = mfi.tilebox();
                     auto& dfab = (*mf)[mfi];
                     auto& sfab = vars_new[levc][Vars::cons][mfi];
                     auto& zfab = (*z_phys_cc[levc])[mfi];

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -404,7 +404,7 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             average_face_to_cellcenter(mf_cc_vel[lev],0,
                                        Array<const MultiFab*,3>{&vars_new[lev][Vars::xvel],
                                                                 &vars_new[lev][Vars::yvel],
-                                                                &vars_new[lev][Vars::zvel]});
+                                                                &vars_new[lev][Vars::zvel]}, 1);
         } // lev
     } // if (vel or vort)
 


### PR DESCRIPTION
# Summary
The helicity computation requires vertical vorticity to be computed, which involves lateral derivatives of the CC velocity across `2dx_h` to be computed. Therefore, we must have valid ghost cell data to avoid erroneous computations.

Additionally, a copy-paste error was made that passed the CC state (instead of CC vels) to the helicity computation in ERF_Tagging.

## Notes
The following approach is taken:
1. Request `1` ghost cell in each direction when calling `average_to_cellcenter`. The velocities should have their ghost cell data populated so directly averaging in one ghost cell layer is a natural solution.
2. Send CC vel to calculate helicity in tagging
3. The  `FillBdyCCVels` now seem superfluous. The call in tagging was deleted but the code block located [here](https://github.com/AMLattanzi/ERF/blob/0919f41ab7953a3dd3342d8556dfc58dcd1af8b7/Source/IO/ERF_Plotfile.cpp#L411-L433) seems like it could also be deleted. 
4. Some mixing and matching in tagging between filling destination data on the `tilebox` versus the `growntilebox`. Was a bit more consistent in filling data on the `tilebox` but allow data in the ghost cells to be used for said computations.
 