### PR TITLE
[Dycore] Fix B Coeff W/ Sub-Stepping

### DIFF
--- a/Source/TimeIntegration/ERF_MakeFastCoeffs.cpp
+++ b/Source/TimeIntegration/ERF_MakeFastCoeffs.cpp
@@ -153,7 +153,8 @@ void make_fast_coeffs (int /*level*/,
                 coeffA_a(i,j,k) = D * (one/detJ(i,j,k-1)) * ( halfg - coeff_Q * theta_t_lo );
                 coeffC_a(i,j,k) = D * (one/detJ(i,j,k  )) * (-halfg + coeff_P * theta_t_hi );
 
-                coeffB_a(i,j,k) = one + D * (coeff_Q/detJ(i,j,k-1) - coeff_P/detJ(i,j,k)) * theta_t_mid;
+                coeffB_a(i,j,k) = one + D * ( (coeff_Q/detJ(i,j,k-1) - coeff_P/detJ(i,j,k)) * theta_t_mid
+                                            + halfg * (Real(1.0)/detJ(i,j,k-1) - Real(1.0)/detJ(i,j,k)) );
             });
 
         } else {


### PR DESCRIPTION
# Summary
The terrain derivation for acoustic substepping contained an error in the `B` coefficient. The term added here vanishes for constant vertical grid spacing and was accidentally omitted when going from no terrain to terrain.

## Details
Governing equations:
<img width="716" height="511" alt="image" src="https://github.com/user-attachments/assets/7087ee42-05dc-4deb-92dc-625106019c41" />

Non-vanishing `g` term on the `\Omega_{k-1/2}^{\tau + \delta \tau}` with terrain 
<img width="675" height="374" alt="image" src="https://github.com/user-attachments/assets/cee4ee9c-569c-4c31-8e90-b3ffdab9baff" />

New coefficients
<img width="647" height="201" alt="image" src="https://github.com/user-attachments/assets/70d343fa-dd1c-4d49-be01-45ab2ef3db54" />

