### PR TITLE
Make SatAdj microphysics testable and document its adjustment scheme

### DIFF
--- a/Docs/sphinx_doc/theory/Microphysics.rst
+++ b/Docs/sphinx_doc/theory/Microphysics.rst
@@ -217,8 +217,79 @@ The evaporation rate of rain is
 
 Saturation Adjustment (SatAdj) Microphysics Model
 -------------------------------------------------
-The saturation adjustment microphysics model is the simplest possible moisture model and only transports the
-water vapor mixing ratio, :math:`q_v`, and the cloud water mixing ration, :math:`q_c`. Evaporation, :math:`q_v \longrightarrow q_c`, and condensation, :math:`q_c \longrightarrow q_v`, are the only relevant mechanisms. The final saturation state, :math:`q_v = q_{vs}(T)` is obtained from Newton-Raphson iterations on the thermal temperature :math:`T`.
+The saturation adjustment microphysics model is a warm-cloud, cell-local adjustment scheme that only transports
+water vapor, :math:`q_v`, and cloud water, :math:`q_c`. It does not include rain, ice, sedimentation,
+autoconversion, accretion, or subgrid cloud fraction. Pressure is diagnosed from the local cell state and the
+saturation relation uses pressure in millibars.
+
+SatAdj uses the warm saturation relation
+
+.. math::
+  q_{sat}(T,p) = \epsilon \frac{e_s(T)}{p - e_s(T)},
+
+where :math:`\epsilon = R_d / R_v`, :math:`e_s(T)` is the saturation vapor pressure over liquid water, and
+:math:`p` is the cell pressure in mbar.
+
+During the adjustment, the conserved nonprecipitating water and local moist enthalpy proxy are
+
+.. math::
+  q_t = q_v + q_c,
+
+.. math::
+  T + \lambda q_v = \text{constant}, \qquad \lambda = L_v / c_p,
+
+or equivalently,
+
+.. math::
+  T - \lambda q_c = \text{constant}.
+
+The final state satisfies the complementarity conditions
+
+.. math::
+  q_c \ge 0,
+
+.. math::
+  q_v \le q_{sat}(T,p),
+
+.. math::
+  q_c \left(q_{sat}(T,p) - q_v\right) = 0.
+
+When the available moisture is sufficient to reach saturation, the adjusted temperature is obtained from a
+Newton solve of
+
+.. math::
+  F(T) = -T + T_i + \lambda \left(q_{v,i} - q_{sat}(T,p)\right) = 0,
+
+with derivative
+
+.. math::
+  F'(T) = -1 - \lambda \frac{d q_{sat}}{dT}.
+
+The implemented branch structure is
+
+.. code-block:: text
+
+  diagnose T, p, qv, qc from the cell state
+  if qv + qc > qsat(T, p):
+     if qc < 0: move negative qc into qv
+     solve F(T) = 0 with Newton iteration
+     set qv = qsat(T, p)
+     set qc = qt - qv
+  else:
+     evaporate all qc into qv
+     cool the cell by lambda * qc
+     if the cooled state is now supersaturated:
+        solve F(T) = 0 with Newton iteration
+        set qv = qsat(T, p)
+        set qc = qt - qv
+  update theta from the adjusted T and diagnosed pressure
+
+In the implementation, :math:`q_{sat}` and :math:`dq_{sat}/dT` are evaluated with ERF's internal thermodynamic
+utilities, pressure is passed in mbar for saturation calls, and pressure is converted back to Pa when
+recomputing :math:`\theta` from :math:`T`.
+
+When SHOC is enabled, SatAdj condensation is disabled so that SHOC owns the phase-change adjustment and ERF
+does not double-apply condensation tendencies.
 
 Predicted Particle Properties (P3) Microphysics Model
 ------------------------------------------------------

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.H
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.H
@@ -192,8 +192,10 @@ public:
         erf_qsatw(tabs, pres_mbar, qsat);
 
         if ((qv + qc) > qsat) {
+#if defined(AMREX_DEBUG)
             const amrex::Real qvprev = qv;
             const amrex::Real qcprev = qc;
+#endif
 
             if (qc < 0) {
                 qv += qc;
@@ -225,9 +227,11 @@ public:
 
             erf_qsatw(tabs, pres_mbar, qsat);
             if (qv > qsat) {
+#if defined(AMREX_DEBUG)
                 const amrex::Real qvprev = qv;
                 const amrex::Real qcprev = qc;
                 const amrex::Real Tprev = tabs;
+#endif
 
                 tabs = NewtonSolveSatTemperature(fac_cond, tabs, pres_mbar, qv, qsat);
 

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.H
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.H
@@ -131,42 +131,34 @@ public:
     AMREX_GPU_HOST_DEVICE
     AMREX_FORCE_INLINE
     static amrex::Real
-    NewtonIterSat (int& i, int& j, int& k,
-                   const amrex::Real& fac_cond,
-                   const amrex::Array4<amrex::Real>& tabs_array,
-                   const amrex::Array4<amrex::Real>& pres_array,
-                   const amrex::Array4<amrex::Real>& qv_array,
-                   const amrex::Array4<amrex::Real>& qc_array)
+    NewtonSolveSatTemperature (const amrex::Real fac_cond,
+                               const amrex::Real tabs_old,
+                               const amrex::Real pres_mbar,
+                               const amrex::Real qv_old,
+                               amrex::Real& qsat)
     {
-        // Solution tolerance
-        amrex::Real tol = amrex::Real(1.0e-8);
+        constexpr amrex::Real tol = amrex::Real(1.0e-8);
+        constexpr int max_niter = 20;
 
-        // Saturation moisture fractions
-        amrex::Real qsat, dqsat;
+        amrex::Real dqsat;
 
-        // Newton iteration vars
-        int  niter;
+        int  niter = 0;
         amrex::Real fff, dfff;
-        amrex::Real dtabs, delta_qv;
+        amrex::Real dtabs = one;
 
-        // Initial guess for temperature & pressure
-        amrex::Real tabs = tabs_array(i,j,k);
-        amrex::Real pres = pres_array(i,j,k);
-
-        niter = 0;
-        dtabs = 1;
+        amrex::Real tabs = tabs_old;
 
         //==================================================
         // Newton iteration to qv=qsat (cloud phase only)
         //==================================================
         do {
             // Saturation moisture fractions
-            erf_qsatw(tabs, pres, qsat);
-            erf_dtqsatw(tabs, pres, dqsat);
+            erf_qsatw(tabs, pres_mbar, qsat);
+            erf_dtqsatw(tabs, pres_mbar, dqsat);
 
             // Function for root finding:
             // 0 = -T_new + T_old + L_eff/C_p * (qv - qsat)
-            fff   = -tabs + tabs_array(i,j,k) + fac_cond*(qv_array(i,j,k) - qsat);
+            fff   = -tabs + tabs_old + fac_cond*(qv_old - qsat);
 
             // Derivative of function (T_new iterated on)
             dfff  = -one - fac_cond*dqsat;
@@ -177,20 +169,85 @@ public:
 
             // Update iteration
             niter = niter+1;
-        } while(std::abs(dtabs) > tol && niter < 20);
+        } while(std::abs(dtabs) > tol && niter < max_niter);
 
         // Update qsat from last iteration (dq = dq/dt * dt)
         qsat += dqsat*dtabs;
 
-        // Changes in each component
-        delta_qv = qv_array(i,j,k) - qsat;
-
-        // Partition the change in non-precipitating q
-        qv_array(i,j,k)  = qsat;
-        qc_array(i,j,k) += delta_qv;
-
-        // Return to temperature
         return tabs;
+    }
+
+    AMREX_GPU_HOST_DEVICE
+    AMREX_FORCE_INLINE
+    static void
+    AdjustSatAdjCell (const amrex::Real fac_cond,
+                      const amrex::Real rdOcp,
+                      amrex::Real& tabs,
+                      const amrex::Real pres_mbar,
+                      amrex::Real& theta,
+                      amrex::Real& qv,
+                      amrex::Real& qc)
+    {
+        amrex::Real qsat;
+        erf_qsatw(tabs, pres_mbar, qsat);
+
+        if ((qv + qc) > qsat) {
+            const amrex::Real qvprev = qv;
+            const amrex::Real qcprev = qc;
+
+            if (qc < 0) {
+                qv += qc;
+                qc = zero;
+            }
+
+            tabs = NewtonSolveSatTemperature(fac_cond, tabs, pres_mbar, qv, qsat);
+
+            const amrex::Real delta_qv = qv - qsat;
+            qv = qsat;
+            qc += delta_qv;
+
+#if defined(AMREX_DEBUG)
+            amrex::Real qsatnew;
+            erf_qsatw(tabs, pres_mbar, qsatnew);
+            AMREX_ASSERT(std::abs(qv-qsatnew) < 1e-12);
+            AMREX_ASSERT(std::abs(qv+qc-qvprev-qcprev) < 1e-14);
+#endif
+
+            theta = getThgivenTandP(tabs, amrex::Real(100.0)*pres_mbar, rdOcp);
+        } else {
+            const amrex::Real delta_qc = qc;
+
+            qv += qc;
+            qc = zero;
+
+            tabs -= fac_cond * delta_qc;
+            theta = getThgivenTandP(tabs, amrex::Real(100.0)*pres_mbar, rdOcp);
+
+            erf_qsatw(tabs, pres_mbar, qsat);
+            if (qv > qsat) {
+                const amrex::Real qvprev = qv;
+                const amrex::Real qcprev = qc;
+                const amrex::Real Tprev = tabs;
+
+                tabs = NewtonSolveSatTemperature(fac_cond, tabs, pres_mbar, qv, qsat);
+
+                const amrex::Real delta_qv = qv - qsat;
+                qv = qsat;
+                qc += delta_qv;
+
+#if defined(AMREX_DEBUG)
+                amrex::Real qsatnew;
+                erf_qsatw(tabs, pres_mbar, qsatnew);
+                AMREX_ASSERT(qv < qvprev);
+                AMREX_ASSERT(qc > qcprev);
+                AMREX_ASSERT(tabs > Tprev);
+                AMREX_ASSERT(std::abs(qv-qsatnew) < 1e-14);
+                AMREX_ASSERT(std::abs(qv+qc-qvprev-qcprev) < 1e-14);
+#endif
+
+                theta = getThgivenTandP(tabs, amrex::Real(100.0)*pres_mbar, rdOcp);
+            }
+        }
     }
 
 private:

--- a/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
+++ b/Source/Microphysics/SatAdj/ERF_SatAdj.cpp
@@ -38,87 +38,18 @@ void SatAdj::AdvanceSatAdj (const SolverChoice& /*solverChoice*/)
 
         ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            //------- Evaporation/condensation
-            Real qsat;
-            erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsat);
+            Real T  = tabs_array(i,j,k);
+            Real p  = pres_array(i,j,k);
+            Real th = theta_array(i,j,k);
+            Real qv = qv_array(i,j,k);
+            Real qc = qc_array(i,j,k);
 
-            // There is enough moisture to drive to equilibrium
-            if ((qv_array(i,j,k)+qc_array(i,j,k)) > qsat) {
-                Real qvprev = qv_array(i,j,k);
-                Real qcprev = qc_array(i,j,k);
+            AdjustSatAdjCell(d_fac_cond, rdOcp, T, p, th, qv, qc);
 
-                // clip qc but maintain total water
-                if (qc_array(i,j,k) < 0) {
-                    qv_array(i,j,k) += qc_array(i,j,k);
-                    qc_array(i,j,k)  = zero;
-                }
-
-                // Update temperature
-                tabs_array(i,j,k) = NewtonIterSat(i, j, k   ,
-                                                  d_fac_cond, tabs_array, pres_array,
-                                                  qv_array  , qc_array  );
-
-                Real qsatnew;
-                erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsatnew);
-
-                AMREX_ASSERT(std::abs(qv_array(i,j,k)-qsatnew) < 1e-12);
-
-                amrex::ignore_unused(qvprev);
-                amrex::ignore_unused(qcprev);
-                AMREX_ASSERT(std::abs(qv_array(i,j,k)+qc_array(i,j,k)-qvprev-qcprev) < 1e-14);
-
-                // Update theta (constant pressure)
-                theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
-
-            //
-            // We cannot blindly relax to qsat, but we can convert qc/qi -> qv.
-            // The concept here is that if we put all the moisture into qv and modify
-            // the temperature, we can then check if qv > qsat occurs (for final T/P/qv).
-            // If the reduction in T/qsat and increase in qv does trigger the
-            // aforementioned condition, we can do Newton iteration to drive qv = qsat.
-            //
-            } else {
-                // Changes in each component
-                Real delta_qc = qc_array(i,j,k);
-
-                // Partition the change in non-precipitating q
-                qv_array(i,j,k) += qc_array(i,j,k);
-                qc_array(i,j,k)  = zero;
-
-                // Update temperature (endothermic since we evap/sublime)
-                tabs_array(i,j,k) -= d_fac_cond * delta_qc;
-
-                // Update theta
-                theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
-
-                // Verify assumption that qv > qsat does not occur
-                erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsat);
-                if (qv_array(i,j,k) > qsat) {
-                    Real qvprev = qv_array(i,j,k);
-                    Real qcprev = qc_array(i,j,k);
-                    Real Tprev = tabs_array(i,j,k);
-
-                    // Update temperature
-                    tabs_array(i,j,k) = NewtonIterSat(i, j, k     ,
-                                                      d_fac_cond  , tabs_array, pres_array,
-                                                      qv_array    , qc_array  );
-
-                    Real qsatnew;
-                    erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsatnew);
-                    amrex::ignore_unused(qvprev);
-                    amrex::ignore_unused(qcprev);
-                    amrex::ignore_unused(Tprev);
-                    AMREX_ASSERT(qv_array(i,j,k) < qvprev);
-                    AMREX_ASSERT(qc_array(i,j,k) > qcprev);
-                    AMREX_ASSERT(tabs_array(i,j,k) > Tprev);
-                    AMREX_ASSERT(std::abs(qv_array(i,j,k)-qsatnew) < 1e-14);
-                    AMREX_ASSERT(std::abs(qv_array(i,j,k)+qc_array(i,j,k)-qvprev-qcprev) < 1e-14);
-
-                    // Update theta
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
-
-                }
-            }
+            tabs_array(i,j,k)  = T;
+            theta_array(i,j,k) = th;
+            qv_array(i,j,k)    = qv;
+            qc_array(i,j,k)    = qc;
         });
     }
 }

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -32,6 +32,9 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestMain.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestHelloWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjThermo.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjCell.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
 )
 build_erf_exe(${erf_exe_name})
 target_link_libraries(${erf_exe_name} PRIVATE GTest::gtest)

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCell.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCell.cpp
@@ -1,0 +1,164 @@
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestSatAdjCommon.H"
+
+using namespace satadj_test;
+
+namespace {
+
+void expect_theta_consistent (const CellState& state)
+{
+    const amrex::Real theta_expected =
+        getThgivenTandP(state.tabs, amrex::Real(100.0) * state.pres_mbar, kRdOcp);
+    EXPECT_NEAR(state.theta, theta_expected, scaled_tol(theta_expected, kStateTolFactor));
+}
+
+void expect_conservation (const CellState& initial, const CellState& final)
+{
+    const amrex::Real qt_initial = initial.qv + initial.qc;
+    const amrex::Real qt_final = final.qv + final.qc;
+    const amrex::Real moist_initial = initial.tabs + kFacCond * initial.qv;
+    const amrex::Real moist_final = final.tabs + kFacCond * final.qv;
+
+    EXPECT_NEAR(qt_final, qt_initial, scaled_tol(qt_initial, amrex::Real(20.0) * kStateTolFactor));
+    EXPECT_NEAR(moist_final, moist_initial, scaled_tol(moist_initial, amrex::Real(20.0) * kStateTolFactor));
+}
+
+void expect_total_water_conservation (const CellState& initial, const CellState& final)
+{
+    const amrex::Real qt_initial = initial.qv + initial.qc;
+    const amrex::Real qt_final = final.qv + final.qc;
+    EXPECT_NEAR(qt_final, qt_initial, scaled_tol(qt_initial, amrex::Real(20.0) * kStateTolFactor));
+}
+
+void expect_complementarity (const CellState& state)
+{
+    const amrex::Real qsat_final = qsat(state.tabs, state.pres_mbar);
+    EXPECT_GE(state.qc, -scaled_tol(state.qc, amrex::Real(20.0) * kStateTolFactor));
+    EXPECT_LE(state.qv, qsat_final + scaled_tol(qsat_final, amrex::Real(20.0) * kStateTolFactor));
+
+    if (state.qc > scaled_tol(amrex::Real(0.0), amrex::Real(100.0) * kStateTolFactor)) {
+        EXPECT_NEAR(state.qv, qsat_final, scaled_tol(qsat_final, amrex::Real(50.0) * kStateTolFactor));
+    }
+}
+
+} // namespace
+
+TEST(SatAdjCell, SaturatedNewtonSolve)
+{
+    const amrex::Real tabs = amrex::Real(290.0);
+    const amrex::Real pres_mbar = amrex::Real(900.0);
+    const amrex::Real qsat_initial = qsat(tabs, pres_mbar);
+    CellState state = make_cell_state(tabs, pres_mbar,
+                                      qsat_initial + amrex::Real(8.0e-4),
+                                      amrex::Real(4.0e-4));
+    const CellState initial = state;
+
+    adjust(state);
+
+    EXPECT_NEAR(state.qv, qsat(state.tabs, state.pres_mbar),
+                scaled_tol(state.qv, amrex::Real(50.0) * kStateTolFactor));
+    EXPECT_GE(state.qc, amrex::Real(0.0));
+    expect_conservation(initial, state);
+    expect_theta_consistent(state);
+}
+
+TEST(SatAdjCell, UnsaturatedAllEvaporationBranch)
+{
+    CellState state = make_cell_state(amrex::Real(290.0), amrex::Real(900.0),
+                                      amrex::Real(4.0e-3), amrex::Real(1.0e-3));
+    const CellState initial = state;
+
+    adjust(state);
+
+    EXPECT_EQ(state.qc, amrex::Real(0.0));
+    EXPECT_NEAR(state.qv, initial.qv + initial.qc,
+                scaled_tol(initial.qv + initial.qc, amrex::Real(5.0) * kStateTolFactor));
+    EXPECT_NEAR(state.tabs, initial.tabs - kFacCond * initial.qc,
+                scaled_tol(initial.tabs, amrex::Real(5.0) * kStateTolFactor));
+    EXPECT_LE(state.qv, qsat(state.tabs, state.pres_mbar) +
+                        scaled_tol(state.qv, amrex::Real(10.0) * kStateTolFactor));
+    expect_theta_consistent(state);
+}
+
+TEST(SatAdjCell, EvaporationThenRecondensationBranch)
+{
+    CellState state;
+    ASSERT_TRUE(find_evaporation_then_recondensation_state(state));
+    const CellState initial = state;
+
+    adjust(state);
+
+    EXPECT_GT(state.qc, amrex::Real(0.0));
+    EXPECT_NEAR(state.qv, qsat(state.tabs, state.pres_mbar),
+                scaled_tol(state.qv, amrex::Real(50.0) * kStateTolFactor));
+    expect_conservation(initial, state);
+    expect_theta_consistent(state);
+}
+
+TEST(SatAdjCell, SmallSupersaturationAsymptotic)
+{
+    const amrex::Real tabs = amrex::Real(290.0);
+    const amrex::Real pres_mbar = amrex::Real(900.0);
+    const amrex::Real qsat_initial = qsat(tabs, pres_mbar);
+    const amrex::Real dqsat_initial = dqsat_dt(tabs, pres_mbar);
+    const std::array<amrex::Real, 3> supersaturation = {
+        amrex::Real(1.0e-8), amrex::Real(1.0e-7), amrex::Real(1.0e-6)};
+
+    std::array<amrex::Real, 3> errors{};
+
+    for (int is = 0; is < static_cast<int>(supersaturation.size()); ++is) {
+        CellState state = make_cell_state(tabs, pres_mbar, qsat_initial + supersaturation[is], amrex::Real(0.0));
+        adjust(state);
+
+        const amrex::Real expected = supersaturation[is] / (amrex::Real(1.0) + kFacCond * dqsat_initial);
+        errors[is] = std::abs(state.qc - expected);
+
+        EXPECT_NEAR(state.qc, expected,
+                    std::max(std::abs(expected) * kAsymptoticRelTol,
+                             scaled_tol(expected, amrex::Real(10.0) * kStateTolFactor)));
+    }
+
+    EXPECT_LE(errors[0], errors[1] + scaled_tol(errors[1], amrex::Real(10.0) * kStateTolFactor));
+    EXPECT_LE(errors[1], errors[2] + scaled_tol(errors[2], amrex::Real(10.0) * kStateTolFactor));
+}
+
+TEST(SatAdjCell, Idempotence)
+{
+    const amrex::Real tabs = amrex::Real(290.0);
+    const amrex::Real pres_mbar = amrex::Real(900.0);
+    const amrex::Real qsat_initial = qsat(tabs, pres_mbar);
+    CellState first = make_cell_state(tabs, pres_mbar,
+                                      qsat_initial + amrex::Real(6.0e-4),
+                                      amrex::Real(5.0e-4));
+
+    adjust(first);
+    CellState second = first;
+    adjust(second);
+
+    EXPECT_NEAR(second.tabs, first.tabs, scaled_tol(first.tabs, amrex::Real(20.0) * kStateTolFactor));
+    EXPECT_NEAR(second.theta, first.theta, scaled_tol(first.theta, amrex::Real(20.0) * kStateTolFactor));
+    EXPECT_NEAR(second.qv, first.qv, scaled_tol(first.qv, amrex::Real(20.0) * kStateTolFactor));
+    EXPECT_NEAR(second.qc, first.qc, scaled_tol(first.qc, amrex::Real(20.0) * kStateTolFactor));
+    expect_complementarity(second);
+}
+
+TEST(SatAdjCell, NegativeQcRepair)
+{
+    const amrex::Real tabs = amrex::Real(288.0);
+    const amrex::Real pres_mbar = amrex::Real(850.0);
+    const amrex::Real qsat_initial = qsat(tabs, pres_mbar);
+    CellState state = make_cell_state(tabs, pres_mbar,
+                                      qsat_initial + amrex::Real(4.0e-4),
+                                      -amrex::Real(1.0e-4));
+    const CellState initial = state;
+
+    adjust(state);
+
+    EXPECT_GE(state.qc, amrex::Real(0.0));
+    expect_total_water_conservation(initial, state);
+    expect_complementarity(state);
+    expect_theta_consistent(state);
+}

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
@@ -1,0 +1,156 @@
+#ifndef ERF_GTEST_SATADJ_COMMON_H_
+#define ERF_GTEST_SATADJ_COMMON_H_
+
+#include <algorithm>
+#include <cmath>
+
+#include <AMReX_Array.H>
+#include <AMReX_Box.H>
+#include <AMReX_Geometry.H>
+
+#include <ERF_Constants.H>
+#include <ERF_DataStruct.H>
+#include <ERF_EOS.H>
+#include <ERF_IndexDefines.H>
+#include <ERF_MicrophysicsUtils.H>
+#include <ERF_SatAdj.H>
+
+namespace satadj_test {
+
+#ifdef AMREX_USE_FLOAT
+constexpr amrex::Real kThermoTolFactor = amrex::Real(2.0e-5);
+constexpr amrex::Real kStateTolFactor = amrex::Real(5.0e-5);
+constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-1);
+#else
+constexpr amrex::Real kThermoTolFactor = amrex::Real(1.0e-12);
+constexpr amrex::Real kStateTolFactor = amrex::Real(1.0e-12);
+constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-2);
+#endif
+
+constexpr amrex::Real kFacCond = lcond / Cp_d;
+constexpr amrex::Real kRdOcp = R_d / Cp_d;
+
+struct CellState {
+    amrex::Real tabs;
+    amrex::Real pres_mbar;
+    amrex::Real theta;
+    amrex::Real qv;
+    amrex::Real qc;
+};
+
+struct ConservedState {
+    amrex::Real rho;
+    amrex::Real rhotheta;
+    amrex::Real rhoqv;
+    amrex::Real rhoqc;
+};
+
+inline amrex::Real scaled_tol (const amrex::Real reference, const amrex::Real factor)
+{
+    return factor * std::max(amrex::Real(1), std::abs(reference));
+}
+
+inline amrex::Real qsat (const amrex::Real tabs, const amrex::Real pres_mbar)
+{
+    amrex::Real qsat_local;
+    erf_qsatw(tabs, pres_mbar, qsat_local);
+    return qsat_local;
+}
+
+inline amrex::Real dqsat_dt (const amrex::Real tabs, const amrex::Real pres_mbar)
+{
+    amrex::Real dqsat_local;
+    erf_dtqsatw(tabs, pres_mbar, dqsat_local);
+    return dqsat_local;
+}
+
+inline CellState make_cell_state (const amrex::Real tabs,
+                                  const amrex::Real pres_mbar,
+                                  const amrex::Real qv,
+                                  const amrex::Real qc)
+{
+    return CellState{tabs,
+                     pres_mbar,
+                     getThgivenTandP(tabs, amrex::Real(100.0) * pres_mbar, kRdOcp),
+                     qv,
+                     qc};
+}
+
+inline void adjust (CellState& state)
+{
+    SatAdj::AdjustSatAdjCell(kFacCond,
+                             kRdOcp,
+                             state.tabs,
+                             state.pres_mbar,
+                             state.theta,
+                             state.qv,
+                             state.qc);
+}
+
+inline ConservedState make_conserved_state (const CellState& state)
+{
+    const amrex::Real pres_pa = amrex::Real(100.0) * state.pres_mbar;
+    const amrex::Real rho = getRhogivenTandPress(state.tabs, pres_pa, state.qv);
+    const amrex::Real theta = getThgivenTandP(state.tabs, pres_pa, kRdOcp);
+
+    return ConservedState{rho, rho * theta, rho * state.qv, rho * state.qc};
+}
+
+inline CellState make_state_from_conserved (const amrex::Real rho,
+                                            const amrex::Real rhotheta,
+                                            const amrex::Real rhoqv,
+                                            const amrex::Real rhoqc)
+{
+    const amrex::Real qv = rhoqv / rho;
+    return CellState{getTgivenRandRTh(rho, rhotheta, qv),
+                     getPgivenRTh(rhotheta, qv) * amrex::Real(0.01),
+                     rhotheta / rho,
+                     qv,
+                     rhoqc / rho};
+}
+
+inline SolverChoice make_solver_choice (const bool use_shoc)
+{
+    SolverChoice sc;
+    sc.c_p = Cp_d;
+    sc.rdOcp = kRdOcp;
+    sc.use_shoc = use_shoc;
+    return sc;
+}
+
+inline bool find_evaporation_then_recondensation_state (CellState& state)
+{
+    const amrex::Real tabs = amrex::Real(285.0);
+    const amrex::Real pres_mbar = amrex::Real(900.0);
+    const amrex::Real qsat_initial = qsat(tabs, pres_mbar);
+    const amrex::Real qv = amrex::Real(0.8) * qsat_initial;
+
+    for (int iqc = 1; iqc <= 80; ++iqc) {
+        const amrex::Real qc = amrex::Real(iqc) * amrex::Real(1.0e-4);
+        if ((qv + qc) >= qsat_initial) {
+            break;
+        }
+
+        const amrex::Real tabs_all_evap = tabs - kFacCond * qc;
+        if ((qv + qc) > qsat(tabs_all_evap, pres_mbar)) {
+            state = make_cell_state(tabs, pres_mbar, qv, qc);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+inline amrex::Geometry make_geometry (const int nx, const int ny, const int nz)
+{
+    amrex::Box domain(amrex::IntVect(AMREX_D_DECL(0, 0, 0)),
+                      amrex::IntVect(AMREX_D_DECL(nx - 1, ny - 1, nz - 1)));
+    amrex::RealBox real_box({AMREX_D_DECL(0.0, 0.0, 0.0)},
+                            {AMREX_D_DECL(1.0, 1.0, 1.0)});
+    amrex::Array<int, AMREX_SPACEDIM> periodicity{AMREX_D_DECL(1, 1, 1)};
+    return amrex::Geometry(domain, &real_box, amrex::CoordSys::cartesian, periodicity.data());
+}
+
+} // namespace satadj_test
+
+#endif

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
@@ -1,0 +1,186 @@
+#include <memory>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_MultiFab.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestSatAdjCommon.H"
+
+using namespace satadj_test;
+
+#ifndef AMREX_USE_GPU
+namespace {
+
+CellState make_multifab_cell_state (const int i, const int j, const int k)
+{
+    const int selector = (i + 2 * j + 3 * k) % 4;
+
+    if (selector == 0) {
+        const amrex::Real tabs = amrex::Real(290.0);
+        const amrex::Real pres_mbar = amrex::Real(900.0);
+        return make_cell_state(tabs, pres_mbar,
+                               qsat(tabs, pres_mbar) + amrex::Real(6.0e-4),
+                               amrex::Real(3.0e-4));
+    }
+
+    if (selector == 1) {
+        return make_cell_state(amrex::Real(290.0), amrex::Real(900.0),
+                               amrex::Real(4.0e-3), amrex::Real(1.0e-3));
+    }
+
+    if (selector == 2) {
+        CellState state;
+        const bool found = find_evaporation_then_recondensation_state(state);
+        AMREX_ALWAYS_ASSERT(found);
+        return state;
+    }
+
+    const amrex::Real tabs = amrex::Real(288.0);
+    const amrex::Real pres_mbar = amrex::Real(850.0);
+    return make_cell_state(tabs, pres_mbar,
+                           qsat(tabs, pres_mbar) + amrex::Real(4.0e-4),
+                           -amrex::Real(1.0e-4));
+}
+
+void fill_conserved_state (amrex::MultiFab& cons)
+{
+    for (amrex::MFIter mfi(cons); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        auto arr = cons.array(mfi);
+
+        for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+            for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+                for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                    const CellState state = make_multifab_cell_state(i, j, k);
+                    const ConservedState conserved = make_conserved_state(state);
+
+                    arr(i,j,k,Rho_comp) = conserved.rho;
+                    arr(i,j,k,RhoTheta_comp) = conserved.rhotheta;
+                    arr(i,j,k,RhoKE_comp) = amrex::Real(0.0);
+                    arr(i,j,k,RhoScalar_comp) = amrex::Real(0.0);
+                    arr(i,j,k,RhoQ1_comp) = conserved.rhoqv;
+                    arr(i,j,k,RhoQ2_comp) = conserved.rhoqc;
+                }
+            }
+        }
+    }
+}
+
+void run_public_flow (SatAdj& satadj,
+                      const SolverChoice& sc,
+                      const amrex::Geometry& geom,
+                      amrex::MultiFab& cons)
+{
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    satadj.Init(cons, cons.boxArray(), geom, amrex::Real(1.0), z_phys_nd, detJ_cc);
+    satadj.Copy_State_to_Micro(cons);
+    satadj.Advance(amrex::Real(1.0), sc);
+    satadj.Copy_Micro_to_State(cons);
+}
+
+} // namespace
+
+TEST(SatAdjMultiFab, ShocNoOpKeepsStateUnchanged)
+{
+    const amrex::Geometry geom = make_geometry(2, 2, 1);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ2_comp + 1, 1);
+    amrex::MultiFab cons_initial(ba, dm, RhoQ2_comp + 1, 1);
+
+    cons.setVal(amrex::Real(0.0));
+    cons_initial.setVal(amrex::Real(0.0));
+    fill_conserved_state(cons);
+    amrex::MultiFab::Copy(cons_initial, cons, 0, 0, cons.nComp(), cons.nGrowVect());
+
+    SatAdj satadj;
+    SolverChoice sc = make_solver_choice(true);
+    satadj.Define(sc);
+    run_public_flow(satadj, sc, geom, cons);
+
+    for (amrex::MFIter mfi(cons); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        auto before = cons_initial.const_array(mfi);
+        auto after = cons.const_array(mfi);
+
+        for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+            for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+                for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                    EXPECT_NEAR(after(i,j,k,Rho_comp), before(i,j,k,Rho_comp),
+                                scaled_tol(before(i,j,k,Rho_comp), kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoTheta_comp), before(i,j,k,RhoTheta_comp),
+                                scaled_tol(before(i,j,k,RhoTheta_comp), kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoQ1_comp), before(i,j,k,RhoQ1_comp),
+                                scaled_tol(before(i,j,k,RhoQ1_comp), kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoQ2_comp), before(i,j,k,RhoQ2_comp),
+                                scaled_tol(before(i,j,k,RhoQ2_comp), kStateTolFactor));
+                }
+            }
+        }
+    }
+}
+
+TEST(SatAdjMultiFab, PublicFlowMatchesScalarHelper)
+{
+    const amrex::Geometry geom = make_geometry(4, 3, 2);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ2_comp + 1, 1);
+    amrex::MultiFab cons_initial(ba, dm, RhoQ2_comp + 1, 1);
+
+    cons.setVal(amrex::Real(0.0));
+    cons_initial.setVal(amrex::Real(0.0));
+    fill_conserved_state(cons);
+    amrex::MultiFab::Copy(cons_initial, cons, 0, 0, cons.nComp(), cons.nGrowVect());
+
+    SatAdj satadj;
+    SolverChoice sc = make_solver_choice(false);
+    satadj.Define(sc);
+    satadj.Set_RealWidth(0);
+    run_public_flow(satadj, sc, geom, cons);
+
+    for (amrex::MFIter mfi(cons); mfi.isValid(); ++mfi) {
+        const amrex::Box& box = mfi.validbox();
+        auto before = cons_initial.const_array(mfi);
+        auto after = cons.const_array(mfi);
+
+        for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+            for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+                for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                    CellState state = make_state_from_conserved(before(i,j,k,Rho_comp),
+                                                               before(i,j,k,RhoTheta_comp),
+                                                               before(i,j,k,RhoQ1_comp),
+                                                               before(i,j,k,RhoQ2_comp));
+                    adjust(state);
+
+                    const amrex::Real rho = before(i,j,k,Rho_comp);
+                    const amrex::Real qt_before = before(i,j,k,RhoQ1_comp) + before(i,j,k,RhoQ2_comp);
+                    const amrex::Real qt_after = after(i,j,k,RhoQ1_comp) + after(i,j,k,RhoQ2_comp);
+
+                    EXPECT_NEAR(after(i,j,k,Rho_comp), rho, scaled_tol(rho, kStateTolFactor));
+                    EXPECT_NEAR(qt_after, qt_before, scaled_tol(qt_before, amrex::Real(20.0) * kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoTheta_comp), rho * state.theta,
+                                scaled_tol(rho * state.theta, amrex::Real(20.0) * kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoQ1_comp), rho * state.qv,
+                                scaled_tol(rho * state.qv, amrex::Real(20.0) * kStateTolFactor));
+                    EXPECT_NEAR(after(i,j,k,RhoQ2_comp), rho * state.qc,
+                                scaled_tol(rho * state.qc, amrex::Real(20.0) * kStateTolFactor));
+                }
+            }
+        }
+    }
+}
+#else
+TEST(SatAdjMultiFab, ShocNoOpKeepsStateUnchanged)
+{
+    GTEST_SKIP() << "Host-side MultiFab verification is not enabled in GPU builds.";
+}
+
+TEST(SatAdjMultiFab, PublicFlowMatchesScalarHelper)
+{
+    GTEST_SKIP() << "Host-side MultiFab verification is not enabled in GPU builds.";
+}
+#endif

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjThermo.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjThermo.cpp
@@ -1,0 +1,48 @@
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestSatAdjCommon.H"
+
+using namespace satadj_test;
+
+TEST(SatAdjThermo, SaturationDerivativeConsistency)
+{
+    const std::array<amrex::Real, 5> temperatures = {
+        amrex::Real(240.0), amrex::Real(260.0), amrex::Real(273.15), amrex::Real(290.0), amrex::Real(310.0)};
+    const std::array<amrex::Real, 3> pressures = {
+        amrex::Real(500.0), amrex::Real(800.0), amrex::Real(1000.0)};
+
+    for (const amrex::Real pres_mbar : pressures) {
+        amrex::Real qsat_prev = -amrex::Real(1.0);
+
+        for (const amrex::Real tabs : temperatures) {
+            amrex::Real qsat_local;
+            amrex::Real dqsat_local;
+            erf_qsatw(tabs, pres_mbar, qsat_local);
+            erf_dtqsatw(tabs, pres_mbar, dqsat_local);
+
+            const amrex::Real esat = erf_esatw(tabs);
+            const amrex::Real expected = Rd_on_Rv * erf_dtesatw(tabs) * pres_mbar /
+                                         ((pres_mbar - esat) * (pres_mbar - esat));
+
+            EXPECT_NEAR(dqsat_local, expected, scaled_tol(expected, kThermoTolFactor));
+            EXPECT_GT(dqsat_local, amrex::Real(0.0));
+
+            if (qsat_prev > amrex::Real(0.0)) {
+                EXPECT_GT(qsat_local, qsat_prev);
+            }
+            qsat_prev = qsat_local;
+        }
+    }
+
+    for (const amrex::Real tabs : temperatures) {
+        amrex::Real qsat_prev = qsat(tabs, pressures.front());
+
+        for (int ip = 1; ip < static_cast<int>(pressures.size()); ++ip) {
+            const amrex::Real qsat_local = qsat(tabs, pressures[ip]);
+            EXPECT_LT(qsat_local, qsat_prev);
+            qsat_prev = qsat_local;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

This PR refactors Saturation Adjustment (SatAdj) microphysics to make the cell-local adjustment logic directly unit-testable while preserving ERF’s existing thermodynamic functions and AMReX hardware-portable execution model.

The main motivation is the SHOC port. When SHOC is enabled, SatAdj must not double-apply condensation, and the SatAdj logic needs meaningful tests so SHOC coupling can be validated with confidence.

## Changes

- Extracted the cell-local SatAdj adjustment into a scalar helper usable from both production AMReX kernels and unit tests.
- Kept the implementation hardware portable with `AMREX_GPU_HOST_DEVICE`, `AMREX_FORCE_INLINE`, `amrex::Real`, and AMReX kernel patterns.
- Preserved use of ERF thermodynamic and saturation utilities, including `erf_qsatw`, `erf_dtqsatw`, `erf_esatw`, `erf_dtesatw`, `getThgivenTandP`, `getTgivenRandRTh`, and `getPgivenRTh`.
- Added SatAdj unit and property tests under `Tests/Unit/Microphysics/SatAdj`.
- Added coverage for saturation derivative consistency, saturated Newton adjustment, unsaturated all-evaporation behavior, evaporation followed by recondensation, small-supersaturation asymptotics, idempotence, negative cloud-water repair, SHOC no-op behavior, and small `MultiFab` integration.
- Tightened low-risk performance details by operating on scalar locals inside the adjustment logic rather than repeatedly indexing `Array4` values during the Newton solve.
- Expanded the SatAdj documentation in `Docs/sphinx_doc/theory/Microphysics.rst`.

## Mathematical checks

The tests are based on symbolic identities derived with SymPy.

For the saturation mixing ratio,

```math
q_s(T,p) = \epsilon \frac{e_s(T)}{p - e_s(T)}
```

SymPy gives

```math
\frac{\partial q_s}{\partial T}
=
\epsilon \frac{p e_s'(T)}{(p - e_s(T))^2}
```

For the Newton residual,

```math
F(T)
=
-T + T_i + \lambda \left(q_{v,i} - q_s(T,p)\right)
```

SymPy gives

```math
F'(T)
=
-1 - \lambda \frac{\partial q_s}{\partial T}
```

The small-supersaturation test uses the linearized condensate amount

```math
\Delta q_c
\approx
\frac{s}{1 + \lambda \frac{\partial q_s}{\partial T}}
```

where `s` is the initial supersaturation.

## Documentation

The SatAdj documentation now describes:

- transported variables,
- condensation and evaporation directions,
- conserved total nonprecipitating water,
- the local moist enthalpy proxy conserved by the adjustment,
- the final complementarity state,
- the Newton residual and derivative,
- SHOC interaction,
- current scheme limitations.
