### PR TITLE
Fix SP-mesh compile errors and conversion warnings

### DIFF
--- a/.Exec_dev/Shoc/ERF_Prob.H
+++ b/.Exec_dev/Shoc/ERF_Prob.H
@@ -8,32 +8,32 @@
 #include "ERF_ProbCommon.H"
 
 struct ProbParm : ProbParmDefaults {
-  amrex::Real rho_0 = 0.0;
-  amrex::Real T_0   = 0.0;
-  amrex::Real A_0   = 1.0;
-  amrex::Real KE_0  = 0.1;  // initialize to calculated rho_hse times input KE
-  amrex::Real rhoKE_0 = -1; // alternatively, initialize to specified (rho*KE)
+  amrex::Real rho_0 = amrex::Real(0.0);
+  amrex::Real T_0   = amrex::Real(0.0);
+  amrex::Real A_0   = amrex::Real(1.0);
+  amrex::Real KE_0  = amrex::Real(0.1);  // initialize to calculated rho_hse times input KE
+  amrex::Real rhoKE_0 = amrex::Real(-1); // alternatively, initialize to specified (rho*KE)
 
-  amrex::Real KE_decay_height = -1;
-  amrex::Real KE_decay_order  =  1;
+  amrex::Real KE_decay_height = amrex::Real(-1);
+  amrex::Real KE_decay_order  = amrex::Real( 1);
 
-  amrex::Real U_0 = 0.0;
-  amrex::Real V_0 = 0.0;
-  amrex::Real W_0 = 0.0;
+  amrex::Real U_0 = amrex::Real(0.0);
+  amrex::Real V_0 = amrex::Real(0.0);
+  amrex::Real W_0 = amrex::Real(0.0);
 
   // random initial perturbations (legacy code)
-  amrex::Real U_0_Pert_Mag = 0.0;
-  amrex::Real V_0_Pert_Mag = 0.0;
-  amrex::Real W_0_Pert_Mag = 0.0;
-  amrex::Real T_0_Pert_Mag = 0.0; // perturbation to rho*Theta
+  amrex::Real U_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real V_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real W_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real T_0_Pert_Mag = amrex::Real(0.0); // perturbation to rho*Theta
   bool pert_rhotheta = true;
 
   // divergence-free initial perturbations
-  amrex::Real pert_deltaU = 0.0;
-  amrex::Real pert_deltaV = 0.0;
-  amrex::Real pert_periods_U = 5.0;
-  amrex::Real pert_periods_V = 5.0;
-  amrex::Real pert_ref_height = 100.0;
+  amrex::Real pert_deltaU = amrex::Real(0.0);
+  amrex::Real pert_deltaV = amrex::Real(0.0);
+  amrex::Real pert_periods_U = amrex::Real(5.0);
+  amrex::Real pert_periods_V = amrex::Real(5.0);
+  amrex::Real pert_ref_height = amrex::Real(100.0);
 
   // helper vars
   amrex::Real aval;

--- a/.Exec_dev/Shoc/ERF_Prob.cpp
+++ b/.Exec_dev/Shoc/ERF_Prob.cpp
@@ -35,10 +35,10 @@ Problem::Problem(const amrex::Real* problo, const amrex::Real* probhi)
   pp.query("pert_periods_U", parms.pert_periods_U);
   pp.query("pert_periods_V", parms.pert_periods_V);
   pp.query("pert_ref_height", parms.pert_ref_height);
-  parms.aval = parms.pert_periods_U * 2.0 * PI / (probhi[1] - problo[1]);
-  parms.bval = parms.pert_periods_V * 2.0 * PI / (probhi[0] - problo[0]);
-  parms.ufac = parms.pert_deltaU * std::exp(0.5) / parms.pert_ref_height;
-  parms.vfac = parms.pert_deltaV * std::exp(0.5) / parms.pert_ref_height;
+  parms.aval = parms.pert_periods_U * amrex::Real(2.0) * PI / (probhi[1] - problo[1]);
+  parms.bval = parms.pert_periods_V * amrex::Real(2.0) * PI / (probhi[0] - problo[0]);
+  parms.ufac = parms.pert_deltaU * std::exp(amrex::Real(0.5)) / parms.pert_ref_height;
+  parms.vfac = parms.pert_deltaV * std::exp(amrex::Real(0.5)) / parms.pert_ref_height;
 
   init_base_parms(parms.rho_0, parms.T_0);
 }
@@ -89,21 +89,21 @@ Problem::init_custom_pert (
     const Real* prob_lo = geomdata.ProbLo();
     const Real* prob_hi = geomdata.ProbHi();
     const Real* dx = geomdata.CellSize();
-    const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-    const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-    const Real z = (z_cc) ? z_cc(i,j,k) : prob_lo[2] + (k + 0.5) * dx[2];
+    const Real x = prob_lo[0] + (i + Real(0.5)) * dx[0];
+    const Real y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+    const Real z = (z_cc) ? z_cc(i,j,k) : prob_lo[2] + (k + Real(0.5)) * dx[2];
 
     // Define a point (xc,yc,zc) at the center of the domain
-    const Real xc = 0.5 * (prob_lo[0] + prob_hi[0]);
-    const Real yc = 0.5 * (prob_lo[1] + prob_hi[1]);
-    const Real zc = 0.5 * (prob_lo[2] + prob_hi[2]);
+    const Real xc = Real(0.5) * (prob_lo[0] + prob_hi[0]);
+    const Real yc = Real(0.5) * (prob_lo[1] + prob_hi[1]);
+    const Real zc = Real(0.5) * (prob_lo[2] + prob_hi[2]);
 
     const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
     // Add temperature perturbations
     if ((z <= parms_d.pert_ref_height) && (parms_d.T_0_Pert_Mag != 0.0)) {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        state_pert(i, j, k, RhoTheta_comp) = (rand_double*2.0 - 1.0)*parms_d.T_0_Pert_Mag;
+        state_pert(i, j, k, RhoTheta_comp) = (rand_double*Real(2.0) - Real(1.0))*parms_d.T_0_Pert_Mag;
         if (!parms_d.pert_rhotheta) {
             // we're perturbing theta, not rho*theta
             state_pert(i, j, k, RhoTheta_comp) *= r_hse(i,j,k);
@@ -111,7 +111,7 @@ Problem::init_custom_pert (
     }
 
     // Set scalar = A_0*exp(-10r^2), where r is distance from center of domain
-    state_pert(i, j, k, RhoScalar_comp) = parms_d.A_0 * exp(-10.*r*r);
+    state_pert(i, j, k, RhoScalar_comp) = parms_d.A_0 * exp(Real(-10.)*r*r);
 
     // Set an initial value for SGS KE
     if (state_pert.nComp() > RhoKE_comp) {
@@ -124,8 +124,8 @@ Problem::init_custom_pert (
         if (parms_d.KE_decay_height > 0) {
             // scale initial SGS kinetic energy with height
             state_pert(i, j, k, RhoKE_comp) *= max(
-                std::pow(1 - min(z/parms_d.KE_decay_height,1.0), parms_d.KE_decay_order),
-                1e-12);
+                std::pow(Real(1.0) - min(z/parms_d.KE_decay_height,Real(1.0)), parms_d.KE_decay_order),
+                Real(1e-12));
         }
     }
   });
@@ -150,24 +150,24 @@ Problem::init_custom_pert_vels (
   ParallelForRNG(xbx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
-    const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-    const Real z = (z_nd) ? 0.25*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
-                                 + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
-                               : prob_lo[2] + (k + 0.5) * dx[2];
+    const Real y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+    const Real z = (z_nd) ? Real(0.25)*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+                                       + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
+                               : prob_lo[2] + (k + Real(0.5)) * dx[2];
 
     // Set the x-velocity
     x_vel_pert(i, j, k) = parms_d.U_0;
     if ((z <= parms_d.pert_ref_height) && (parms_d.U_0_Pert_Mag != 0.0))
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real x_vel_prime = (rand_double*2.0 - 1.0)*parms_d.U_0_Pert_Mag;
+        Real x_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.U_0_Pert_Mag;
         x_vel_pert(i, j, k) += x_vel_prime;
     }
     if (parms_d.pert_deltaU != 0.0)
     {
         const amrex::Real yl = y - prob_lo[1];
         const amrex::Real zl = z / parms_d.pert_ref_height;
-        const amrex::Real damp = std::exp(-0.5 * zl * zl);
+        const amrex::Real damp = std::exp(Real(-0.5) * zl * zl);
         x_vel_pert(i, j, k) += parms_d.ufac * damp * z * std::cos(parms_d.aval * yl);
     }
   });
@@ -176,24 +176,24 @@ Problem::init_custom_pert_vels (
   ParallelForRNG(ybx, [=, parms_d=parms] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
-    const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-    const Real z = (z_nd) ? 0.25*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
-                                 + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
-                               : prob_lo[2] + (k + 0.5) * dx[2];
+    const Real x = prob_lo[0] + (i + Real(0.5)) * dx[0];
+    const Real z = (z_nd) ? Real(0.25)*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+                                       + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
+                               : prob_lo[2] + (k + Real(0.5)) * dx[2];
 
     // Set the y-velocity
     y_vel_pert(i, j, k) = parms_d.V_0;
     if ((z <= parms_d.pert_ref_height) && (parms_d.V_0_Pert_Mag != 0.0))
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real y_vel_prime = (rand_double*2.0 - 1.0)*parms_d.V_0_Pert_Mag;
+        Real y_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.V_0_Pert_Mag;
         y_vel_pert(i, j, k) += y_vel_prime;
     }
     if (parms_d.pert_deltaV != 0.0)
     {
         const amrex::Real xl = x - prob_lo[0];
         const amrex::Real zl = z / parms_d.pert_ref_height;
-        const amrex::Real damp = std::exp(-0.5 * zl * zl);
+        const amrex::Real damp = std::exp(Real(-0.5) * zl * zl);
         y_vel_pert(i, j, k) += parms_d.vfac * damp * z * std::cos(parms_d.bval * xl);
     }
   });
@@ -211,7 +211,7 @@ Problem::init_custom_pert_vels (
     else if (parms_d.W_0_Pert_Mag != 0.0)
     {
         Real rand_double = amrex::Random(engine); // Between 0.0 and 1.0
-        Real z_vel_prime = (rand_double*2.0 - 1.0)*parms_d.W_0_Pert_Mag;
+        Real z_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.W_0_Pert_Mag;
         z_vel_pert(i, j, k) = parms_d.W_0 + z_vel_prime;
     }
   });
@@ -243,7 +243,7 @@ Problem::update_w_subsidence (const Real& /*time*/,
     }
 
     // Linearly increase wbar to the cutoff_max and then linearly decrease to cutoff_min
-    Real D = 3.75e-6;
+    Real D = Real(3.75e-6);
     for (int k = 0; k <= khi; k++) {
         const Real z_w_face = (z_phys_nd) ? zlevels[k] : prob_lo[2] + k*dx[2];
         wbar[k] = -D * z_w_face;

--- a/.Exec_dev/Tornado/ERF_Prob.H
+++ b/.Exec_dev/Tornado/ERF_Prob.H
@@ -8,13 +8,13 @@
 #include "ERF_ProbCommon.H"
 
 struct ProbParm : ProbParmDefaults {
-    amrex::Real rho_0 = 1.0;
-    amrex::Real T_0   = 300.0;
-    amrex::Real V_0   = 1.0;
-    amrex::Real KE_0  = 0.1;
+    amrex::Real rho_0 = amrex::Real(1.0);
+    amrex::Real T_0   = amrex::Real(300.0);
+    amrex::Real V_0   = amrex::Real(1.0);
+    amrex::Real KE_0  = amrex::Real(0.1);
 
-    amrex::Real KE_decay_height = -1;
-    amrex::Real KE_decay_order  =  1;
+    amrex::Real KE_decay_height = amrex::Real(-1);
+    amrex::Real KE_decay_order  = amrex::Real( 1);
 }; // namespace ProbParm
 
 class Problem : public ProblemBase

--- a/.Exec_dev/Tornado/ERF_Prob.cpp
+++ b/.Exec_dev/Tornado/ERF_Prob.cpp
@@ -43,7 +43,7 @@ Problem::init_custom_pert (const amrex::Box&  bx,
         // Geom info
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real z   = (z_cc) ? z_cc(i,j,k) : prob_lo[2] + (k + 0.5) * dx[2];
+        const Real z   = (z_cc) ? z_cc(i,j,k) : prob_lo[2] + (k + Real(0.5)) * dx[2];
         const Real dz  = (z_cc) ? z - z_cc(i,j,0) : z - prob_lo[2];
 
         // Base KE value
@@ -52,8 +52,8 @@ Problem::init_custom_pert (const amrex::Box&  bx,
         // Vertical profile
         if (parms_d.KE_decay_height > 0) {
             state_pert(i, j, k, RhoKE_comp) *= max(
-                std::pow(1 - min(dz/parms_d.KE_decay_height,1.0), parms_d.KE_decay_order),
-                1e-12);
+                std::pow(Real(1.0) - min(dz/parms_d.KE_decay_height,Real(1.0)), parms_d.KE_decay_order),
+                Real(1e-12));
         }
     });
 }

--- a/.Exec_dev/TropicalCyclone/ERF_Prob.H
+++ b/.Exec_dev/TropicalCyclone/ERF_Prob.H
@@ -8,18 +8,18 @@
 #include "ERF_ProbCommon.H"
 
 struct ProbParm : ProbParmDefaults {
-    amrex::Real KE_0   = 0.1;
+    amrex::Real KE_0   = amrex::Real(0.1);
 
-    amrex::Real Xc_0  = 0.0;
-    amrex::Real Yc_0  = 0.0;
-    amrex::Real VMAX  = 15.0;   // Maximum horizontal velocity in vortex
-    amrex::Real RMAX  = 100.0;  // Radius of maximum winds
-    amrex::Real RZERO = 800.0;  // Radius of zero wind speed
-    amrex::Real ZZERO = 2000.0; // Height of zero wind speed
+    amrex::Real Xc_0  = amrex::Real(0.0);
+    amrex::Real Yc_0  = amrex::Real(0.0);
+    amrex::Real VMAX  = amrex::Real(15.0);   // Maximum horizontal velocity in vortex
+    amrex::Real RMAX  = amrex::Real(100.0);  // Radius of maximum winds
+    amrex::Real RZERO = amrex::Real(800.0);  // Radius of zero wind speed
+    amrex::Real ZZERO = amrex::Real(2000.0); // Height of zero wind speed
 
-    amrex::Real U_0 = 0.0;
-    amrex::Real V_0 = 0.0;
-    amrex::Real W_0 = 0.0;
+    amrex::Real U_0 = amrex::Real(0.0);
+    amrex::Real V_0 = amrex::Real(0.0);
+    amrex::Real W_0 = amrex::Real(0.0);
 
 }; // namespace ProbParm
 

--- a/.Exec_dev/TropicalCyclone/ERF_Prob.cpp
+++ b/.Exec_dev/TropicalCyclone/ERF_Prob.cpp
@@ -93,8 +93,8 @@ Problem::init_custom_pert_vels (
         const Real* dx = geomdata.CellSize();
 
         const Real x = prob_lo[0] + i * dx[0]; // face center
-        const Real y = prob_lo[1] + (j + 0.5) * dx[1]; // cell center
-        const Real z = prob_lo[2] + (k + 0.5) * dx[2]; // cell center
+        const Real y = prob_lo[1] + (j + Real(0.5)) * dx[1]; // cell center
+        const Real z = prob_lo[2] + (k + Real(0.5)) * dx[2]; // cell center
 
         if (z > z_0) {
             x_vel_pert(i, j, k) = 0.0;
@@ -106,9 +106,9 @@ Problem::init_custom_pert_vels (
                 // Rotunno & Emanuel 1987, Eqn. 37
                 const Real II = (z_0-z)/z_0;
                 const Real term1 = (v_max*v_max)*(rr/R_max)*(rr/R_max);
-                const Real term2 = std::pow(2*R_max/(rr+R_max),3) - std::pow(2*R_max/(R_0+R_max),3);
-                const Real term3 = fcor*fcor*(rr*rr)/4;
-                const Real term4 = fcor*rr/2 ;
+                const Real term2 = std::pow(Real(2)*R_max/(rr+R_max),3) - std::pow(Real(2)*R_max/(R_0+R_max),3);
+                const Real term3 = fcor*fcor*(rr*rr)/Real(4);
+                const Real term4 = fcor*rr/Real(2) ;
                 const Real v_tang = II*(std::sqrt(term1*term2 + term3) - term4);
                 const Real thet_angl = std::atan2(y-Yc,x-Xc);
                 x_vel_pert(i, j, k) = -std::abs(v_tang)*std::sin(thet_angl);
@@ -122,9 +122,9 @@ Problem::init_custom_pert_vels (
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
 
-        const Real x = prob_lo[0] + (i + 0.5) * dx[0]; // cell center
+        const Real x = prob_lo[0] + (i + Real(0.5)) * dx[0]; // cell center
         const Real y = prob_lo[1] + j * dx[1]; // face center
-        const Real z = prob_lo[2] + (k + 0.5) * dx[2]; // cell center
+        const Real z = prob_lo[2] + (k + Real(0.5)) * dx[2]; // cell center
 
         if (z > z_0) {
             y_vel_pert(i, j, k) = 0.0;
@@ -136,9 +136,9 @@ Problem::init_custom_pert_vels (
                 // Rotunno & Emanuel 1987, Eqn. 37
                 const Real II = (z_0-z)/z_0;
                 const Real term1 = (v_max*v_max)*(rr/R_max)*(rr/R_max);
-                const Real term2 = std::pow(2*R_max/(rr+R_max),3) - std::pow(2*R_max/(R_0+R_max),3);
-                const Real term3 = fcor*fcor*(rr*rr)/4;
-                const Real term4 = fcor*rr/2 ;
+                const Real term2 = std::pow(Real(2)*R_max/(rr+R_max),3) - std::pow(Real(2)*R_max/(R_0+R_max),3);
+                const Real term3 = fcor*fcor*(rr*rr)/Real(4);
+                const Real term4 = fcor*rr/Real(2) ;
                 const Real v_tang = II*(std::sqrt(term1*term2 + term3) - term4);
                 const Real thet_angl = std::atan2(y-Yc,x-Xc);
                 y_vel_pert(i, j, k) = std::abs(v_tang)*std::cos(thet_angl);

--- a/.Exec_dev/WindFarmTests/ERF_Prob.H
+++ b/.Exec_dev/WindFarmTests/ERF_Prob.H
@@ -8,27 +8,27 @@
 #include "ERF_ProbCommon.H"
 
 struct ProbParm : ProbParmDefaults {
-  amrex::Real rho_0 = 0.0;
-  amrex::Real T_0   = 0.0;
-  amrex::Real A_0   = 1.0;
-  amrex::Real KE_0 = 0.1;
+  amrex::Real rho_0 = amrex::Real(0.0);
+  amrex::Real T_0   = amrex::Real(0.0);
+  amrex::Real A_0   = amrex::Real(1.0);
+  amrex::Real KE_0 = amrex::Real(0.1);
 
-  amrex::Real U_0 = 0.0;
-  amrex::Real V_0 = 0.0;
-  amrex::Real W_0 = 0.0;
+  amrex::Real U_0 = amrex::Real(0.0);
+  amrex::Real V_0 = amrex::Real(0.0);
+  amrex::Real W_0 = amrex::Real(0.0);
 
   // random initial perturbations (legacy code)
-  amrex::Real U_0_Pert_Mag = 0.0;
-  amrex::Real V_0_Pert_Mag = 0.0;
-  amrex::Real W_0_Pert_Mag = 0.0;
-  amrex::Real T_0_Pert_Mag = 0.0; // perturbation to rho*Theta
+  amrex::Real U_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real V_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real W_0_Pert_Mag = amrex::Real(0.0);
+  amrex::Real T_0_Pert_Mag = amrex::Real(0.0); // perturbation to rho*Theta
 
   // divergence-free initial perturbations
-  amrex::Real pert_deltaU = 0.0;
-  amrex::Real pert_deltaV = 0.0;
-  amrex::Real pert_periods_U = 5.0;
-  amrex::Real pert_periods_V = 5.0;
-  amrex::Real pert_ref_height = 100.0;
+  amrex::Real pert_deltaU = amrex::Real(0.0);
+  amrex::Real pert_deltaV = amrex::Real(0.0);
+  amrex::Real pert_periods_U = amrex::Real(5.0);
+  amrex::Real pert_periods_V = amrex::Real(5.0);
+  amrex::Real pert_ref_height = amrex::Real(100.0);
 
   // helper vars
   amrex::Real aval;

--- a/.Exec_dev/WindFarmTests/ERF_Prob.cpp
+++ b/.Exec_dev/WindFarmTests/ERF_Prob.cpp
@@ -31,10 +31,10 @@ Problem::Problem(const Real* problo, const Real* probhi)
   pp.query("pert_periods_U", parms.pert_periods_U);
   pp.query("pert_periods_V", parms.pert_periods_V);
   pp.query("pert_ref_height", parms.pert_ref_height);
-  parms.aval = parms.pert_periods_U * 2.0 * PI / (probhi[1] - problo[1]);
-  parms.bval = parms.pert_periods_V * 2.0 * PI / (probhi[0] - problo[0]);
-  parms.ufac = parms.pert_deltaU * std::exp(0.5) / parms.pert_ref_height;
-  parms.vfac = parms.pert_deltaV * std::exp(0.5) / parms.pert_ref_height;
+  parms.aval = parms.pert_periods_U * Real(2.0) * PI / (probhi[1] - problo[1]);
+  parms.bval = parms.pert_periods_V * Real(2.0) * PI / (probhi[0] - problo[0]);
+  parms.ufac = parms.pert_deltaU * std::exp(Real(0.5)) / parms.pert_ref_height;
+  parms.vfac = parms.pert_deltaV * std::exp(Real(0.5)) / parms.pert_ref_height;
 
   init_base_parms(parms.rho_0, parms.T_0);
 }
@@ -58,25 +58,25 @@ Problem::init_custom_pert (
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-        const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-        const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+        const Real x = prob_lo[0] + (i + Real(0.5)) * dx[0];
+        const Real y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+        const Real z = prob_lo[2] + (k + Real(0.5)) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
-        const Real xc = 0.5 * (prob_lo[0] + prob_hi[0]);
-        const Real yc = 0.5 * (prob_lo[1] + prob_hi[1]);
-        const Real zc = 0.5 * (prob_lo[2] + prob_hi[2]);
+        const Real xc = Real(0.5) * (prob_lo[0] + prob_hi[0]);
+        const Real yc = Real(0.5) * (prob_lo[1] + prob_hi[1]);
+        const Real zc = Real(0.5) * (prob_lo[2] + prob_hi[2]);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
         // Add temperature perturbations
         if ((z <= parms_d.pert_ref_height) && (parms_d.T_0_Pert_Mag != 0.0)) {
             Real rand_double = Random(engine); // Between 0.0 and 1.0
-            state_pert(i, j, k, RhoTheta_comp) = (rand_double*2.0 - 1.0)*parms_d.T_0_Pert_Mag;
+            state_pert(i, j, k, RhoTheta_comp) = (rand_double*Real(2.0) - Real(1.0))*parms_d.T_0_Pert_Mag;
         }
 
         // Set scalar = A_0*exp(-10r^2), where r is distance from center of domain
-        state_pert(i, j, k, RhoScalar_comp) = parms_d.A_0 * exp(-10.*r*r);
+        state_pert(i, j, k, RhoScalar_comp) = parms_d.A_0 * exp(Real(-10.)*r*r);
 
         // Set an initial value for KE
         state_pert(i, j, k, RhoKE_comp) = parms_d.KE_0;
@@ -103,22 +103,22 @@ Problem::init_custom_pert_vels (
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + 0.5) * dx[1];
-        const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+        const Real y = prob_lo[1] + (j + Real(0.5)) * dx[1];
+        const Real z = prob_lo[2] + (k + Real(0.5)) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = parms_d.U_0;
         if ((z <= parms_d.pert_ref_height) && (parms_d.U_0_Pert_Mag != 0.0))
         {
             Real rand_double = Random(engine); // Between 0.0 and 1.0
-            Real x_vel_prime = (rand_double*2.0 - 1.0)*parms_d.U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
         if (parms_d.pert_deltaU != 0.0)
         {
             const Real yl = y - prob_lo[1];
             const Real zl = z / parms_d.pert_ref_height;
-            const Real damp = std::exp(-0.5 * zl * zl);
+            const Real damp = std::exp(Real(-0.5) * zl * zl);
             x_vel_pert(i, j, k) += parms_d.ufac * damp * z * std::cos(parms_d.aval * yl);
         }
     });
@@ -128,22 +128,22 @@ Problem::init_custom_pert_vels (
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + 0.5) * dx[0];
-        const Real z = prob_lo[2] + (k + 0.5) * dx[2];
+        const Real x = prob_lo[0] + (i + Real(0.5)) * dx[0];
+        const Real z = prob_lo[2] + (k + Real(0.5)) * dx[2];
 
         // Set the y-velocity
         y_vel_pert(i, j, k) = parms_d.V_0;
         if ((z <= parms_d.pert_ref_height) && (parms_d.V_0_Pert_Mag != 0.0))
         {
             Real rand_double = Random(engine); // Between 0.0 and 1.0
-            Real y_vel_prime = (rand_double*2.0 - 1.0)*parms_d.V_0_Pert_Mag;
+            Real y_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.V_0_Pert_Mag;
             y_vel_pert(i, j, k) += y_vel_prime;
         }
         if (parms_d.pert_deltaV != 0.0)
         {
             const Real xl = x - prob_lo[0];
             const Real zl = z / parms_d.pert_ref_height;
-            const Real damp = std::exp(-0.5 * zl * zl);
+            const Real damp = std::exp(Real(-0.5) * zl * zl);
             y_vel_pert(i, j, k) += parms_d.vfac * damp * z * std::cos(parms_d.bval * xl);
         }
     });
@@ -162,7 +162,7 @@ Problem::init_custom_pert_vels (
         else if (parms_d.W_0_Pert_Mag != 0.0)
         {
             Real rand_double = Random(engine); // Between 0.0 and 1.0
-            Real z_vel_prime = (rand_double*2.0 - 1.0)*parms_d.W_0_Pert_Mag;
+            Real z_vel_prime = (rand_double*Real(2.0) - Real(1.0))*parms_d.W_0_Pert_Mag;
             z_vel_pert(i, j, k) = parms_d.W_0 + z_vel_prime;
         }
     });

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -28,10 +28,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
         include:
           - cuda_ver: "12.2"
             cuda_pkg: 12-2

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -19,10 +19,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
 

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -42,10 +42,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,10 +19,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
 

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -27,10 +27,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
 

--- a/.github/workflows/windows-mpi.yml
+++ b/.github/workflows/windows-mpi.yml
@@ -20,10 +20,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
       - name: Checkout (with submodules)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,10 +18,8 @@ jobs:
         exclude:
           - particles: OFF
             particles_precision: SINGLE
-          # SP-mesh entries are temporarily disabled because the upstream
-          # SP-mesh build currently fails on non-particle code. Remove the
-          # guard below to re-enable SP-mesh + DP/SP particles once fixed.
           - mesh_precision: SINGLE
+            particles: OFF
 
     steps:
 

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
@@ -168,7 +168,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
-                    Real delta_i = (dom_lo.x - i);
+                    Real delta_i = static_cast<Real>(dom_lo.x - i);
                     dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp) ;
                 }
             },
@@ -186,7 +186,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
-                    Real delta_i = (i - dom_hi.x);
+                    Real delta_i = static_cast<Real>(i - dom_hi.x);
                     dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp) ;
                 }
             }
@@ -217,7 +217,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
-                    Real delta_j = (dom_lo.y - j);
+                    Real delta_j = static_cast<Real>(dom_lo.y - j);
                     dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp) ;
                 }
 
@@ -236,7 +236,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
-                    Real delta_j = (j - dom_hi.y);
+                    Real delta_j = static_cast<Real>(j - dom_hi.y);
                     dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
                 }
             }

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
@@ -226,7 +226,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
-                    Real delta_i = (dom_lo.x - i);
+                    Real delta_i = static_cast<Real>(dom_lo.x - i);
                     dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp);
                 }
             },
@@ -244,7 +244,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
-                    Real delta_i = (i - dom_hi.x);
+                    Real delta_i = static_cast<Real>(i - dom_hi.x);
                     dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp);
                 }
             }
@@ -275,7 +275,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (l_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
-                    Real delta_j = (dom_lo.y - j);
+                    Real delta_j = static_cast<Real>(dom_lo.y - j);
                     dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp);
                 }
 
@@ -294,7 +294,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 } else if (h_bc_type == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
-                    Real delta_j = (j - dom_hi.y);
+                    Real delta_j = static_cast<Real>(j - dom_hi.y);
                     dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
                 }
             }
@@ -445,7 +445,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                             delta_z*l_bc_neumann_vals_d[bc_comp][2]*dest_arr(i,j,dom_lo.z,Rho_comp);
                     }
                 } else if (l_bc_type == ERFBCType::hoextrap) {
-                    Real delta_k = (dom_lo.z - k);
+                    Real delta_k = static_cast<Real>(dom_lo.z - k);
                     dest_arr(i,j,k,dest_comp) = (one + delta_k) * dest_arr(i,j,dom_lo.z  ,dest_comp) -
                                                        delta_k  * dest_arr(i,j,dom_lo.z+1,dest_comp);
                 }
@@ -477,7 +477,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                             delta_z*l_bc_neumann_vals_d[bc_comp][5]*dest_arr(i,j,dom_hi.z,Rho_comp);
                     }
                 } else if (h_bc_type == ERFBCType::hoextrap){
-                    Real delta_k = (k - dom_hi.z);
+                    Real delta_k = static_cast<Real>(k - dom_hi.z);
                     dest_arr(i,j,k,dest_comp) = (one + delta_k)*dest_arr(i,j,dom_hi.z,dest_comp) - delta_k*dest_arr(i,j,dom_hi.z-1,dest_comp);
                 }
             }

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -62,7 +62,7 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
 
     // Set up fields and 2D MF/iMFs for averages
     //--------------------------------------------------------
-    m_maxlev = m_geom.size();
+    m_maxlev = static_cast<int>(m_geom.size());
 
     m_fields.resize(m_maxlev);
     m_rot_fields.resize(m_maxlev);
@@ -540,7 +540,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
 
     // Capture for device
     Real d_zref   = zref_tmp;
-    Real d_radius = m_radius;
+    Real d_radius = static_cast<Real>(m_radius);
     amrex::ignore_unused(d_radius);
 
     // Specify z_ref & compute k_indx (z_ref takes precedence)
@@ -611,7 +611,7 @@ MOSTAverage::set_norm_indices_T (const int& lev)
 
     // Capture for device
     Real d_zref   = zref_tmp;
-    Real d_radius = m_radius;
+    Real d_radius = static_cast<Real>(m_radius);
 
     const auto dxInv  = m_geom[lev].InvCellSizeArray();
     IntVect ng = m_k_indx[lev]->nGrowVect(); ng[2]=0;
@@ -1141,7 +1141,7 @@ MOSTAverage::compute_plane_averages (const int& lev)
 
     // Copy to host and sum across procs
     Gpu::copy(Gpu::deviceToHost, pavg.begin(), pavg.end(), plane_average.begin());
-    ParallelDescriptor::ReduceRealSum(plane_average.data(), plane_average.size());
+    ParallelDescriptor::ReduceRealSum(plane_average.data(), static_cast<int>(plane_average.size()));
 
     // No spatial variation with plane averages
     for (int iavg(0); iavg < m_navg; ++iavg){

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -728,7 +728,7 @@ void
 SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
                                            const Real& elapsed_time_since_start_low)
 {
-    int n_times_in_sst = m_sst_lev[lev].size();
+    int n_times_in_sst = static_cast<int>(m_sst_lev[lev].size());
 
     Real dT = m_low_time_interval;
 
@@ -745,7 +745,7 @@ SurfaceLayer::fill_tsurf_with_sst_and_tsk (const int& lev,
 
         // Do not over run the last sst file
         if (m_start_low_time + elapsed_time_since_start_low >= m_final_low_time) {
-            n_time_lo = m_sst_lev[lev].size()-1;
+            n_time_lo = static_cast<int>(m_sst_lev[lev].size())-1;
             n_time_hi = n_time_lo;
             alpha     = zero;
         }
@@ -953,8 +953,8 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
                                        + z_phys_arr(i  ,j+1,klo) + z_phys_arr(i+1,j+1,klo) );
         });
     }
-    ParallelDescriptor::ReduceRealSum(ustar_ptr, bx_lo.numPts());
-    ParallelDescriptor::ReduceRealSum(zsurf_ptr, bx_lo.numPts());
+    ParallelDescriptor::ReduceRealSum(ustar_ptr, static_cast<int>(bx_lo.numPts()));
+    ParallelDescriptor::ReduceRealSum(zsurf_ptr, static_cast<int>(bx_lo.numPts()));
 
     // Now work on all boxes (ustar has been filled above)
     constexpr Real small = Real(0.01);
@@ -1010,7 +1010,7 @@ SurfaceLayer::read_custom_roughness (const int& lev,
 
         // Broadcast the whole domain to every rank
         int ioproc = ParallelDescriptor::IOProcessorNumber();
-        int nnode = m_x.size();
+        int nnode = static_cast<int>(m_x.size());
         ParallelDescriptor::Bcast(&nnode, 1, ioproc);
 
         if (!ParallelDescriptor::IOProcessor()) {

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -746,7 +746,7 @@ struct SolverChoice {
         if (io_hurricane_eye_tracker) {
             pp.query("hurricane_eye_latitude", hurricane_eye_latitude);
             pp.query("hurricane_eye_longitude", hurricane_eye_longitude);
-            if(hurricane_eye_latitude == -1e10 or hurricane_eye_longitude == -1e10) {
+            if(hurricane_eye_latitude == amrex::Real(-1e10) or hurricane_eye_longitude == amrex::Real(-1e10)) {
                 amrex::Error("ERROR: You are using 'erf.io_hurricane_eye_tracker' to write out the files that track the eye of the hurricane"
                               " but have not provided the initial location of the eye of the hurricane to be tracked. There has to be two"
                               " options in the inputs - erf.hurricane_eye_latitude and erf.hurricane_eye_longitude that gives an approximate"

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -1456,14 +1456,14 @@ private:
     int
     NumDataLogs () noexcept
     {
-        return datalog.size();
+        return static_cast<int>(datalog.size());
     }
 
     AMREX_FORCE_INLINE
     int
     NumDerDataLogs () noexcept
     {
-        return der_datalog.size();
+        return static_cast<int>(der_datalog.size());
     }
 
 
@@ -1478,7 +1478,7 @@ private:
     int
     NumSamplePointLogs () noexcept
     {
-        return sampleptlog.size();
+        return static_cast<int>(sampleptlog.size());
     }
 
     AMREX_FORCE_INLINE
@@ -1492,7 +1492,7 @@ private:
     int
     NumSampleLineLogs () noexcept
     {
-        return samplelinelog.size();
+        return static_cast<int>(samplelinelog.size());
     }
 
     amrex::IntVect&
@@ -1505,7 +1505,7 @@ private:
     int
     NumSamplePoints () noexcept
     {
-        return samplepoint.size();
+        return static_cast<int>(samplepoint.size());
     }
 
     amrex::IntVect&
@@ -1518,7 +1518,7 @@ private:
     int
     NumSampleLines () noexcept
     {
-        return sampleline.size();
+        return static_cast<int>(sampleline.size());
     }
 
     static amrex::Real startCPUTime;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -266,15 +266,17 @@ ERF::ERF_shared ()
     // Get lo/hi indices for massflux calc
     if ((solverChoice.const_massflux_u != 0) || (solverChoice.const_massflux_v != 0)) {
         if (solverChoice.mesh_type == MeshType::ConstantDz) {
+            const bool zlo_unset = (solverChoice.const_massflux_layer_lo == amrex::Real(-1e34));
+            const bool zhi_unset = (solverChoice.const_massflux_layer_hi == amrex::Real( 1e34));
             const Real massflux_zlo = solverChoice.const_massflux_layer_lo - geom[0].ProbLo(2);
             const Real massflux_zhi = solverChoice.const_massflux_layer_hi - geom[0].ProbLo(2);
             const Real dz = geom[0].CellSize(2);
-            if (massflux_zlo == -1e34) {
+            if (zlo_unset) {
                 solverChoice.massflux_klo = geom[0].Domain().smallEnd(2);
             } else {
                 solverChoice.massflux_klo = static_cast<int>(std::ceil(massflux_zlo / dz - myhalf));
             }
-            if (massflux_zhi ==  1e34) {
+            if (zhi_unset) {
                 solverChoice.massflux_khi = geom[0].Domain().bigEnd(2);
             } else {
                 solverChoice.massflux_khi = static_cast<int>(std::floor(massflux_zhi / dz - myhalf));
@@ -2738,7 +2740,7 @@ ERF::ReadParameters ()
                     << "\", format should be " << datetime_format << std::endl;
                 exit(0);
             }
-            start_time = getEpochTime(start_datetime, datetime_format);
+            start_time = static_cast<amrex::Real>(getEpochTime(start_datetime, datetime_format));
 
 #ifdef ERF_USE_NETCDF
             if (solverChoice.init_type == InitType::WRFInput) {
@@ -2804,7 +2806,7 @@ ERF::ReadParameters ()
                 exit(0);
             }
 
-            stop_time = getEpochTime(stop_datetime, datetime_format);
+            stop_time = static_cast<amrex::Real>(getEpochTime(stop_datetime, datetime_format));
             Print() << "Stop  datetime : " << start_datetime << std::endl;
 
         } else {
@@ -2838,7 +2840,7 @@ ERF::ReadParameters ()
     if ((solverChoice.init_type == InitType::WRFInput) ||
         (solverChoice.init_type == InitType::Metgrid)  ||
         (solverChoice.init_type == InitType::NCFile) ) {
-        int num_files = nc_init_file[0].size();
+        int num_files = static_cast<int>(nc_init_file[0].size());
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(num_files>0, "A file name must be present at level 0 for init type WRFInput, Metgrid or NCFile.");
         for (int j = 0; j < num_files; j++) {
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!nc_init_file[0][j].empty(), "Valid file name must be present at level 0 for init type WRFInput, Metgrid or NCFile.");
@@ -3085,7 +3087,7 @@ ERF::MakeDiagnosticAverage (Vector<Real>& h_havg, MultiFab& S, int n)
     }
 
     // combine sums from different MPI ranks
-    ParallelDescriptor::ReduceRealSum(h_havg.dataPtr(), h_havg.size());
+    ParallelDescriptor::ReduceRealSum(h_havg.dataPtr(), static_cast<int>(h_havg.size()));
 
     // divide by the total number of cells we are averaging over
     for (int k = 0; k < size_z; ++k) {

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -185,7 +185,7 @@ ERF::WriteCheckpointFile () const
         std::vector<int> qmoist_indices;
         std::vector<std::string> qmoist_names;
         micro->Get_Qmoist_Restart_Vars(lev, solverChoice, qmoist_indices, qmoist_names);
-        int qmoist_nvar = qmoist_indices.size();
+        int qmoist_nvar = static_cast<int>(qmoist_indices.size());
         for (int var = 0; var < qmoist_nvar; var++) {
             const int ncomp  = 1;
             IntVect ng_moist = qmoist[lev][qmoist_indices[var]]->nGrowVect();
@@ -526,7 +526,7 @@ ERF::ReadCheckpointFile ()
         std::istringstream lis(line);
         int i = 0;
         while (lis >> word) {
-            dt[i++] = std::stod(word);
+            dt[i++] = static_cast<Real>(std::stod(word));
         }
     }
 
@@ -536,7 +536,7 @@ ERF::ReadCheckpointFile ()
         std::istringstream lis(line);
         int i = 0;
         while (lis >> word) {
-            t_new[i++] = std::stod(word);
+            t_new[i++] = static_cast<Real>(std::stod(word));
         }
     }
 
@@ -728,7 +728,7 @@ ERF::ReadCheckpointFile ()
         std::vector<int> qmoist_indices;
         std::vector<std::string> qmoist_names;
         micro->Get_Qmoist_Restart_Vars(lev, solverChoice, qmoist_indices, qmoist_names);
-        int qmoist_nvar = qmoist_indices.size();
+        int qmoist_nvar = static_cast<int>(qmoist_indices.size());
         for (int var = 0; var < qmoist_nvar; var++) {
             const int ncomp  = 1;
             IntVect ng_moist = qmoist[lev][qmoist_indices[var]]->nGrowVect();

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -320,7 +320,7 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
     auto dPlotTime0 = amrex::second();
 
     const Vector<std::string> varnames = PlotFileVarNames(plot_var_names);
-    const int ncomp_mf = varnames.size();
+    const int ncomp_mf = static_cast<int>(varnames.size());
 
     int ncomp_cons = vars_new[0][Vars::cons].nComp();
 
@@ -1954,7 +1954,7 @@ void
 ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string> plot_var_names)
 {
     const Vector<std::string> varnames = PlotFileVarNames(plot_var_names);
-    const int ncomp_mf = varnames.size();
+    const int ncomp_mf = static_cast<int>(varnames.size());
 
     if (ncomp_mf == 0) return;
 
@@ -2010,7 +2010,7 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real>& derdat = mf[lev].array(mfi);
                 const Array4<const int>& lmask_arr = lmask_lev[lev][0]->const_array(mfi);
                 ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                   derdat(i, j, k, mf_comp) = lmask_arr(i, j, 0);
+                   derdat(i, j, k, mf_comp) = static_cast<Real>(lmask_arr(i, j, 0));
                 });
             }
             mf_comp++;

--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -17,7 +17,7 @@ int closest_index (const Vector<Real>& vec, const Real value)
     auto const it = std::upper_bound(vec.begin(), vec.end(), value);
     AMREX_ALWAYS_ASSERT(it != vec.end());
 
-    const int idx = std::distance(vec.begin(), it);
+    const int idx = static_cast<int>(std::distance(vec.begin(), it));
     return std::max(idx - 1, 0);
 }
 
@@ -101,7 +101,7 @@ ReadBndryPlanes::interp_in_time (const Real& time)
             for (OrientationIter oit; oit != nullptr; ++oit) {
                 auto ori = oit();
                 if (ori.coordDir() < 2) {
-                    const int nlevels = m_data_n[ori]->size();
+                    const int nlevels = static_cast<int>(m_data_n[ori]->size());
                     for (int lev = 0; lev < nlevels; ++lev) {
                         const auto& datn   = (*m_data_n[ori])[lev];
                         const auto& datnp1 = (*m_data_np1[ori])[lev];
@@ -115,7 +115,7 @@ ReadBndryPlanes::interp_in_time (const Real& time)
             for (OrientationIter oit; oit != nullptr; ++oit) {
                 auto ori = oit();
                 if (ori.coordDir() < 2) {
-                    const int nlevels = m_data_n[ori]->size();
+                    const int nlevels = static_cast<int>(m_data_n[ori]->size());
                     for (int lev = 0; lev < nlevels; ++lev) {
                         const auto& datnp1 = (*m_data_np1[ori])[lev];
                         const auto& datnp2 = (*m_data_np2[ori])[lev];

--- a/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
+++ b/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
@@ -73,7 +73,7 @@ void SuperDropletsMoist::readInputs ()
     // get vapour/condensate species names
     m_species.clear();
     // add water
-    m_idx_w = m_species.size();
+    m_idx_w = static_cast<int>(m_species.size());
     m_species.push_back(Species::Name::H2O);
     // add other species
     std::string species_input = "species";
@@ -85,7 +85,7 @@ void SuperDropletsMoist::readInputs ()
             m_species.push_back(sp_name);
         }
     }
-    m_num_species = m_species.size();
+    m_num_species = static_cast<int>(m_species.size());
     m_qstate_nonmoist_size = (m_num_species-1)*2; // qv, qc for each
 
     // get aerosol names
@@ -99,7 +99,7 @@ void SuperDropletsMoist::readInputs ()
             m_aerosols.push_back(aero_name);
         }
     }
-    m_num_aerosols = m_aerosols.size();
+    m_num_aerosols = static_cast<int>(m_aerosols.size());
 
     // number of time steps between writing distribution  diagnostics to file
     m_diagnostics_iter = 1; //default

--- a/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistUtils.cpp
+++ b/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistUtils.cpp
@@ -322,8 +322,8 @@ void SuperDropletsMoist::AverageDownMicroVars (const int finest_level)
                          ? m_super_droplets->GetParGDB()->refRatio(lev-1)
                          : IntVect(2);
 
-        const int n = std::min<int>(m_mic_fab_vars[lev].size(),
-                                    m_mic_fab_vars[lev-1].size());
+        const int n = std::min<int>(static_cast<int>(m_mic_fab_vars[lev].size()),
+                                    static_cast<int>(m_mic_fab_vars[lev-1].size()));
         for (int v = 0; v < n; ++v) {
             if (!m_mic_fab_vars[lev][v] || !m_mic_fab_vars[lev-1][v]) continue;
             average_down( *m_mic_fab_vars[lev][v],

--- a/Source/Particles/ERFPCEvolve.cpp
+++ b/Source/Particles/ERFPCEvolve.cpp
@@ -158,14 +158,14 @@ void ERFPC::AdvectWithFlow ( MultiFab*                           a_umac,
                 // Advance in physical (x, y, z); pos(2) is zeta on disk so go
                 // through z_from_zeta / zeta_from_z around the update.
                 if (ipass == 0) {
-                    const Real x0 = p.pos(0);
-                    const Real y0 = p.pos(1);
-                    const Real zeta0 = p.pos(AMREX_SPACEDIM-1);
-                    const Real z_phys0 = ERF::ParticlePos::z_from_zeta(
-                        x0, y0, zeta0, plo, dxi, zheight);
-                    const Real x_h = x0 + Real(0.5)*a_dt*v[0];
-                    const Real y_h = y0 + Real(0.5)*a_dt*v[1];
-                    const Real z_h = z_phys0 + Real(0.5)*a_dt*v[2];
+                    const Real x0 = static_cast<Real>(p.pos(0));
+                    const Real y0 = static_cast<Real>(p.pos(1));
+                    const Real zeta0 = static_cast<Real>(p.pos(AMREX_SPACEDIM-1));
+                    const Real z_phys0 = static_cast<Real>(ERF::ParticlePos::z_from_zeta(
+                        x0, y0, zeta0, plo, dxi, zheight));
+                    const Real x_h = x0 + static_cast<Real>(Real(0.5)*a_dt*v[0]);
+                    const Real y_h = y0 + static_cast<Real>(Real(0.5)*a_dt*v[1]);
+                    const Real z_h = z_phys0 + static_cast<Real>(Real(0.5)*a_dt*v[2]);
                     v_ptr[0][i] = static_cast<ParticleReal>(x0);
                     v_ptr[1][i] = static_cast<ParticleReal>(y0);
                     v_ptr[2][i] = static_cast<ParticleReal>(zeta0);
@@ -174,14 +174,14 @@ void ERFPC::AdvectWithFlow ( MultiFab*                           a_umac,
                     p.pos(AMREX_SPACEDIM-1) = static_cast<ParticleReal>(
                         ERF::ParticlePos::zeta_from_z(x_h, y_h, z_h, plo, dxi, zheight, k_max));
                 } else {
-                    const Real x0 = v_ptr[0][i];
-                    const Real y0 = v_ptr[1][i];
-                    const Real zeta0 = v_ptr[2][i];
-                    const Real z_phys0 = ERF::ParticlePos::z_from_zeta(
-                        x0, y0, zeta0, plo, dxi, zheight);
-                    const Real x_n = x0 + a_dt*v[0];
-                    const Real y_n = y0 + a_dt*v[1];
-                    const Real z_n = z_phys0 + a_dt*v[2];
+                    const Real x0 = static_cast<Real>(v_ptr[0][i]);
+                    const Real y0 = static_cast<Real>(v_ptr[1][i]);
+                    const Real zeta0 = static_cast<Real>(v_ptr[2][i]);
+                    const Real z_phys0 = static_cast<Real>(ERF::ParticlePos::z_from_zeta(
+                        x0, y0, zeta0, plo, dxi, zheight));
+                    const Real x_n = x0 + static_cast<Real>(a_dt*v[0]);
+                    const Real y_n = y0 + static_cast<Real>(a_dt*v[1]);
+                    const Real z_n = z_phys0 + static_cast<Real>(a_dt*v[2]);
                     p.pos(0) = static_cast<ParticleReal>(x_n);
                     p.pos(1) = static_cast<ParticleReal>(y_n);
                     p.pos(AMREX_SPACEDIM-1) = static_cast<ParticleReal>(
@@ -269,11 +269,11 @@ void ERFPC::AdvectWithGravity (  int                                 a_lev,
 
             // Advance in physical z, then back to zeta.
             {
-                const Real x0 = p.pos(0);
-                const Real y0 = p.pos(1);
-                const Real z_phys0 = ERF::ParticlePos::z_from_zeta(
-                    x0, y0, p.pos(AMREX_SPACEDIM-1), plo, dxi, zheight);
-                const Real z_phys_n = z_phys0 + Real(0.5) * a_dt * vz_ptr[i];
+                const Real x0 = static_cast<Real>(p.pos(0));
+                const Real y0 = static_cast<Real>(p.pos(1));
+                const Real z_phys0 = static_cast<Real>(ERF::ParticlePos::z_from_zeta(
+                    x0, y0, static_cast<Real>(p.pos(AMREX_SPACEDIM-1)), plo, dxi, zheight));
+                const Real z_phys_n = z_phys0 + static_cast<Real>(Real(0.5) * a_dt * vz_ptr[i]);
                 p.pos(AMREX_SPACEDIM-1) = static_cast<ParticleReal>(
                     ERF::ParticlePos::zeta_from_z(x0, y0, z_phys_n, plo, dxi, zheight, k_max));
             }

--- a/Source/Particles/ERFPCParticleToMesh.H
+++ b/Source/Particles/ERFPCParticleToMesh.H
@@ -53,14 +53,14 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
             const auto& p = ptd.m_aos[i];
             if (p.id() <= 0) { return; }
 
-            const Real pval = value_func(ptd, i);
+            const Real pval = static_cast<Real>(value_func(ptd, i));
 
-            const Real lx = (p.pos(0) - plo[0]) * dxi[0] + Real(0.5);
+            const Real lx = static_cast<Real>((p.pos(0) - plo[0]) * dxi[0]) + Real(0.5);
             const int  ix = static_cast<int>(Math::floor(lx)) - 1;
             const Real wx1 = lx - static_cast<Real>(ix + 1);
             const Real wx0 = Real(1.0) - wx1;
 
-            const Real ly = (p.pos(1) - plo[1]) * dxi[1] + Real(0.5);
+            const Real ly = static_cast<Real>((p.pos(1) - plo[1]) * dxi[1]) + Real(0.5);
             const int  iy = static_cast<int>(Math::floor(ly)) - 1;
             const Real wy1 = ly - static_cast<Real>(iy + 1);
             const Real wy0 = Real(1.0) - wy1;
@@ -69,8 +69,8 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
                                                                * dxi[AMREX_SPACEDIM-1]));
             const int ix_p = static_cast<int>(Math::floor((p.pos(0) - plo[0]) * dxi[0]));
             const int iy_p = static_cast<int>(Math::floor((p.pos(1) - plo[1]) * dxi[1]));
-            const Real fx  = (p.pos(0) - plo[0]) * dxi[0] - static_cast<Real>(ix_p);
-            const Real fy  = (p.pos(1) - plo[1]) * dxi[1] - static_cast<Real>(iy_p);
+            const Real fx  = static_cast<Real>((p.pos(0) - plo[0]) * dxi[0]) - static_cast<Real>(ix_p);
+            const Real fy  = static_cast<Real>((p.pos(1) - plo[1]) * dxi[1]) - static_cast<Real>(iy_p);
 
             auto zface = [=] AMREX_GPU_DEVICE (int k_face) -> Real {
                 return zheight(ix_p  , iy_p  , k_face) * (Real(1.0)-fx) * (Real(1.0)-fy)
@@ -95,9 +95,9 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
             // Particle pos(2) is computational zeta; convert to physical z so
             // the cell-center comparison and weight span are in the same units
             // as zface() (which is built from the height array).
-            const Real p_z = ERF::ParticlePos::z_from_zeta(
+            const Real p_z = static_cast<Real>(ERF::ParticlePos::z_from_zeta(
                 p.pos(0), p.pos(1), p.pos(AMREX_SPACEDIM-1),
-                plo, dxi, zheight);
+                plo, dxi, zheight));
 
             int  kz_lo, kz_hi;
             Real wz_lo, wz_hi;

--- a/Source/Particles/ERFPCUtils.cpp
+++ b/Source/Particles/ERFPCUtils.cpp
@@ -202,8 +202,8 @@ void ERFPC::ConvertZetaToZ (const Vector<std::unique_ptr<MultiFab>>& a_z_phys_nd
                 ParticleType& p = p_pbox[i];
                 if (p.id() <= 0) { return; }
                 p.pos(AMREX_SPACEDIM-1) = static_cast<ParticleReal>(
-                    ERF::ParticlePos::z_from_zeta(p.pos(0), p.pos(1),
-                                                  p.pos(AMREX_SPACEDIM-1),
+                    ERF::ParticlePos::z_from_zeta(static_cast<Real>(p.pos(0)), static_cast<Real>(p.pos(1)),
+                                                  static_cast<Real>(p.pos(AMREX_SPACEDIM-1)),
                                                   plo, dxi, zheight));
             });
         }
@@ -233,8 +233,8 @@ void ERFPC::ConvertZToZeta (const Vector<std::unique_ptr<MultiFab>>& a_z_phys_nd
                 ParticleType& p = p_pbox[i];
                 if (p.id() <= 0) { return; }
                 p.pos(AMREX_SPACEDIM-1) = static_cast<ParticleReal>(
-                    ERF::ParticlePos::zeta_from_z(p.pos(0), p.pos(1),
-                                                  p.pos(AMREX_SPACEDIM-1),
+                    ERF::ParticlePos::zeta_from_z(static_cast<Real>(p.pos(0)), static_cast<Real>(p.pos(1)),
+                                                  static_cast<Real>(p.pos(AMREX_SPACEDIM-1)),
                                                   plo, dxi, zheight, k_max));
             });
         }

--- a/Source/Particles/ERF_SDInitialization.H
+++ b/Source/Particles/ERF_SDInitialization.H
@@ -73,12 +73,12 @@ struct SDDistributionParams {
  */
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real SD_erfinv_gpu(const amrex::Real x) {
-    amrex::Real a = 0.147;
+    amrex::Real a = amrex::Real(0.147);
     amrex::Real eps = std::numeric_limits<amrex::Real>::epsilon();
-    amrex::Real term = std::log(1 - x * x + eps);
-    amrex::Real p1 = 2 / (PI * a) + term / 2.0;
+    amrex::Real term = std::log(amrex::Real(1) - x * x + eps);
+    amrex::Real p1 = amrex::Real(2) / (PI * a) + term / amrex::Real(2);
     amrex::Real p2 = term / a;
-    amrex::Real sign = (x >= 0) ? 1.0 : -1.0;
+    amrex::Real sign = (x >= 0) ? amrex::Real(1) : amrex::Real(-1);
     return sign * std::sqrt(std::sqrt(p1 * p1 - p2) - p1);
 }
 
@@ -127,14 +127,14 @@ amrex::Real SD_sample_mass_gpu(const SDDistributionParams& params,
                 dry_r = std::exp(lnval);
                 // Log-normal PDF contribution for multiplicity weighting
                 amrex::Real term = std::exp(-std::log(dry_r/params.radius_mean)*std::log(dry_r/params.radius_mean)
-                                            /(2.0*params.sigma*params.sigma));
-                mult_contribution = (params.numdens * params.cell_volume) / (params.sigma * std::sqrt(2.0*PI)) * term;
+                                            /(amrex::Real(2)*params.sigma*params.sigma));
+                mult_contribution = (params.numdens * params.cell_volume) / (params.sigma * std::sqrt(amrex::Real(2)*PI)) * term;
             } else {
                 // Constant multiplicity: true log-normal via inverse CDF
                 // Map u from [0,1] to [cdf_min, cdf_max] for truncated distribution
                 amrex::Real u_trunc = params.cdf_min + u * (params.cdf_max - params.cdf_min);
                 // Inverse CDF: r = mu * exp(sigma * sqrt(2) * erfinv(2*u - 1))
-                amrex::Real z = SD_erfinv_gpu(2.0 * u_trunc - 1.0) * std::sqrt(2.0);
+                amrex::Real z = SD_erfinv_gpu(amrex::Real(2) * u_trunc - amrex::Real(1)) * std::sqrt(amrex::Real(2));
                 dry_r = params.radius_mean * std::exp(params.sigma * z);
                 mult_contribution = 0.0;  // Not used for constant multiplicity
             }

--- a/Source/Particles/ERF_SDInitialization.cpp
+++ b/Source/Particles/ERF_SDInitialization.cpp
@@ -17,7 +17,7 @@ void SDInitProperties::setDefaults ( const amrex::Geometry& a_geom,
         m_init_particle_p2[i] = a_geom.ProbHi(i);
     }
 
-    m_num_species = a_species_mat.size();
+    m_num_species = static_cast<int>(a_species_mat.size());
     m_mass_species_min.resize(m_num_species);
     m_mass_species_max.resize(m_num_species);
     m_mass_species_mean.resize(m_num_species);
@@ -48,7 +48,7 @@ void SDInitProperties::setDefaults ( const amrex::Geometry& a_geom,
         m_radius_species_geom_std[i] = two;
     }
 
-    m_num_aerosols = a_aerosol_mat.size();
+    m_num_aerosols = static_cast<int>(a_aerosol_mat.size());
     m_mass_aerosol_min.resize(m_num_aerosols);
     m_mass_aerosol_max.resize(m_num_aerosols);
     m_mass_aerosol_mean.resize(m_num_aerosols);
@@ -420,13 +420,13 @@ void SDInitProperties::getDistribution ( amrex::Vector<amrex::Real>& a_mass,
     a_mass.resize(a_np);
     AMREX_ALWAYS_ASSERT(static_cast<amrex::Long>(a_mult.size()) == a_np);
     if (a_init_type == SDDistributionType::mass_constant) {
-        std::uniform_real_distribution<> urd(zero, one);
+        std::uniform_real_distribution<amrex::Real> urd(zero, one);
         for (int n = 0; n < a_np; n++) {
             a_mass[n] = a_mass_mean;
             a_mult[n] += urd(a_rng); // initially this will be a non-integer; later we will rescale to an integer.
         }
     } else if (a_init_type == SDDistributionType::mass_exponential) {
-        std::uniform_real_distribution<> urd(zero, one);
+        std::uniform_real_distribution<amrex::Real> urd(zero, one);
         auto delta = a_mass_mean - a_mass_min;
         auto lnrng = std::log(a_mass_max) - std::log(a_mass_min);
         auto lnmin = std::log(a_mass_min);
@@ -436,7 +436,7 @@ void SDInitProperties::getDistribution ( amrex::Vector<amrex::Real>& a_mass,
             a_mult[n] += (m_numdens * a_dV) * std::exp(-a_mass[n] / delta);
         }
     } else if (a_init_type == SDDistributionType::radius_log_normal) {
-        std::uniform_real_distribution<> urd(zero, one);
+        std::uniform_real_distribution<amrex::Real> urd(zero, one);
         auto sigma = std::log(a_radius_gstd);
         auto mu = a_radius_mean;
         auto lnrng = std::log(a_radius_max) - std::log(a_radius_min);
@@ -446,14 +446,14 @@ void SDInitProperties::getDistribution ( amrex::Vector<amrex::Real>& a_mass,
             auto dry_r = std::exp(tmp);
             a_mass[n] = four_thirds_pi * dry_r * dry_r * dry_r * a_density;
             auto term = std::exp(-std::log(dry_r/mu)*std::log(dry_r/mu)/(two*sigma*sigma));
-            a_mult[n] += ( m_numdens * a_dV ) / (sigma*std::sqrt(2*PI)) * term;
+            a_mult[n] += ( m_numdens * a_dV ) / (sigma*std::sqrt(amrex::Real(2)*PI)) * term;
         }
     } else if (a_init_type == SDDistributionType::radius_lognormal_autorange) {
-        std::uniform_real_distribution<> urd(zero, one);
+        std::uniform_real_distribution<amrex::Real> urd(zero, one);
         auto sigma = std::log(a_radius_gstd);
         auto mu = a_radius_mean;
         // automatically find the min and max radius of superdroplets, using Dziekan & Pawlowska 2017
-        auto rmin = 1e-9;
+        auto rmin = amrex::Real(1e-9);
         auto rmax = one;
         auto dlnr = (std::log(rmax) - std::log(rmin)) / a_np;
         auto P_min = zero;
@@ -470,8 +470,8 @@ void SDInitProperties::getDistribution ( amrex::Vector<amrex::Real>& a_mass,
             if (P_min <= tol) {
                 rmin = rmin * amrex::Real(1.01);
             }
-            P_min = (1 + std::erf((std::log(rmin / mu)) / sigma / std::sqrt(2))) / 2;
-            P_max = (1 + std::erf((std::log(rmax / mu)) / sigma / std::sqrt(2))) / 2;
+            P_min = (one + std::erf((std::log(rmin / mu)) / sigma / std::sqrt(amrex::Real(2)))) / amrex::Real(2);
+            P_max = (one + std::erf((std::log(rmax / mu)) / sigma / std::sqrt(amrex::Real(2)))) / amrex::Real(2);
         }
         dlnr = (std::log(rmax) - std::log(rmin));
         amrex::Print() << "Range: rmin =" << rmin << ", rmax = " << rmax << ", dlnr = " << dlnr << "\n";
@@ -484,17 +484,17 @@ void SDInitProperties::getDistribution ( amrex::Vector<amrex::Real>& a_mass,
             auto dry_r = std::exp(tmp);
             tmp_mass[n] = four_thirds_pi * dry_r * dry_r * dry_r * a_density;
             auto term = std::exp(-std::log(dry_r/mu)*std::log(dry_r/mu)/(two*sigma*sigma));
-            tmp_mult[n] =  (m_numdens * a_dV)/ (sigma*std::sqrt(2*PI)) * term;
+            tmp_mult[n] =  (m_numdens * a_dV)/ (sigma*std::sqrt(amrex::Real(2)*PI)) * term;
         }
 
         // initialize the tail using approximate erfinv
         amrex::Print() << "Initializing tail: " << a_np_tail << " particles\n";
-        auto tail_mult = std::exp(-std::log(rmax/mu)*std::log(rmax/mu)/(two*sigma*sigma)) / (sigma*std::sqrt(2*PI));
+        auto tail_mult = std::exp(-std::log(rmax/mu)*std::log(rmax/mu)/(two*sigma*sigma)) / (sigma*std::sqrt(amrex::Real(2)*PI));
         for (int n = 0; n < a_np_tail; n++) {
             int sd_id = static_cast<int>(std::round(urd(a_rng) * a_np));
             auto tmp = P_max + (one - P_max) * urd(a_rng);
-            auto tmp2 = SD_erfinv(2 * tmp - 1);
-            auto dry_r = mu * std::exp(sigma * std::sqrt(2) * tmp2);
+            auto tmp2 = SD_erfinv(amrex::Real(2) * tmp - amrex::Real(1));
+            auto dry_r = mu * std::exp(sigma * std::sqrt(amrex::Real(2)) * tmp2);
             tmp_mass[sd_id] = four_thirds_pi * dry_r * dry_r * dry_r * a_density;
             // set the multiplicity to the same as for the 99th percentile aerosol
             tmp_mult[sd_id] = (m_numdens * a_dV) * tail_mult;

--- a/Source/Particles/ERF_SuperDropletPCAddParticles.cpp
+++ b/Source/Particles/ERF_SuperDropletPCAddParticles.cpp
@@ -251,7 +251,7 @@ void SuperDropletPC::addParticles ( int a_lev,
 
         int np = 0;
         {
-            int ncell = num_superdroplets[mfi].numPts();
+            int ncell = static_cast<int>(num_superdroplets[mfi].numPts());
             const int* in = num_superdroplets[mfi].dataPtr();
             int* out = offsets[mfi].dataPtr();
             np = Scan::PrefixSum<int>( ncell,
@@ -450,7 +450,7 @@ void SuperDropletPC::addParticles ( int a_lev,
                 } else {
                     mult_ptr[n] = num_to_add;
                 }
-                num_to_add -= mult_ptr[n];
+                num_to_add -= static_cast<Real>(mult_ptr[n]);
                 if (mult_ptr[n] == 0) { mult_ptr[n] = 1; }
 
                 // Species and aerosol masses already sampled directly into particle SoA
@@ -478,9 +478,9 @@ void SuperDropletPC::addParticles ( int a_lev,
             int start = offset_arr(i,j,k);
             for (int n = start; n < start+num_sd_this_cell; n++) {
                 auto& p = aos[n+size_old];
-                Real x = p.pos(0);
-                Real y = p.pos(1);
-                Real z = p.pos(2);
+                Real x = static_cast<Real>(p.pos(0));
+                Real y = static_cast<Real>(p.pos(1));
+                Real z = static_cast<Real>(p.pos(2));
                 Real r[3] = { (x-plo[0])/dx[0] - i,
                               (y-plo[1])/dx[1] - j,
                               (z-plo[2])/dx[2] - k };

--- a/Source/Particles/ERF_SuperDropletPCAdvection.cpp
+++ b/Source/Particles/ERF_SuperDropletPCAdvection.cpp
@@ -148,20 +148,20 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
             // Advance in physical (x, y, z); pos(2) is zeta on disk so go
             // through z_from_zeta / zeta_from_z around the update.
             if (advect_w_flow || advect_w_gravity) {
-                const Real x0 = p.pos(0);
-                const Real y0 = p.pos(1);
-                const Real z_phys0 = ERF::ParticlePos::z_from_zeta(
-                    x0, y0, p.pos(AMREX_SPACEDIM-1), ctx.plo, ctx.dxi, zheight);
+                const Real x0 = static_cast<Real>(p.pos(0));
+                const Real y0 = static_cast<Real>(p.pos(1));
+                const Real z_phys0 = static_cast<Real>(ERF::ParticlePos::z_from_zeta(
+                    x0, y0, p.pos(AMREX_SPACEDIM-1), ctx.plo, ctx.dxi, zheight));
                 Real x_n = x0;
                 Real y_n = y0;
                 Real z_n = z_phys0;
                 if (advect_w_flow) {
-                    x_n += a_dt * v[0];
-                    y_n += a_dt * v[1];
-                    z_n += a_dt * v[AMREX_SPACEDIM-1];
+                    x_n += static_cast<Real>(a_dt * v[0]);
+                    y_n += static_cast<Real>(a_dt * v[1]);
+                    z_n += static_cast<Real>(a_dt * v[AMREX_SPACEDIM-1]);
                 }
                 if (advect_w_gravity) {
-                    z_n -= a_dt * terminal_vel;
+                    z_n -= static_cast<Real>(a_dt * terminal_vel);
                 }
                 int qi = int(amrex::Math::floor((x_n - ctx.plo[0]) * ctx.dxi[0]));
                 int qj = int(amrex::Math::floor((y_n - ctx.plo[1]) * ctx.dxi[1]));

--- a/Source/Particles/ERF_SuperDropletPCCoalescence.cpp
+++ b/Source/Particles/ERF_SuperDropletPCCoalescence.cpp
@@ -464,7 +464,7 @@ void SuperDropletPC::Coalescence( int   a_lev,
             auto scaling_factor = myhalf*ns*(ns-1)/std::floor(myhalf*ns);
             auto scaled_prob = prob_sd_ij * scaling_factor;
 
-            auto gamma = coalescence_rate ( rnd_eng, (scaled_prob*a_dt) );
+            auto gamma = coalescence_rate ( rnd_eng, static_cast<Real>(scaled_prob*a_dt) );
             if (gamma > 0) {
                 amrex::Gpu::Atomic::Add(particle_collisions_ptr, gamma);
                 coal_rate_ptr[pi] = std::min(gamma,std::floor(mult_ptr[pi]/mult_ptr[pj]));

--- a/Source/Particles/ERF_SuperDropletPCDiagnostics.cpp
+++ b/Source/Particles/ERF_SuperDropletPCDiagnostics.cpp
@@ -121,15 +121,15 @@ void SuperDropletPC::Diagnostics( const int a_iter,
             reduce_ops.eval(np, r,
                 [=] AMREX_GPU_DEVICE (int i) -> ReduceTuple
                 {
-                    const Real n = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
-                    const Real radius = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::radius][i];
-                    const Real mass = ptd.m_rdata[SuperDropletsRealIdx::mass][i];
-                    const Real vx = ptd.m_rdata[SuperDropletsRealIdx::vx][i];
-                    const Real vy = ptd.m_rdata[SuperDropletsRealIdx::vy][i];
-                    const Real vz = ptd.m_rdata[SuperDropletsRealIdx::vz][i];
-                    const Real term_vel = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::term_vel][i];
+                    const Real n = static_cast<Real>(ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i]);
+                    const Real radius = static_cast<Real>(ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::radius][i]);
+                    const Real mass = static_cast<Real>(ptd.m_rdata[SuperDropletsRealIdx::mass][i]);
+                    const Real vx = static_cast<Real>(ptd.m_rdata[SuperDropletsRealIdx::vx][i]);
+                    const Real vy = static_cast<Real>(ptd.m_rdata[SuperDropletsRealIdx::vy][i]);
+                    const Real vz = static_cast<Real>(ptd.m_rdata[SuperDropletsRealIdx::vz][i]);
+                    const Real term_vel = static_cast<Real>(ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::term_vel][i]);
 #ifdef ERF_USE_ML_UPHYS_DIAGNOSTICS
-                    const Real cond_t = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::cond_tendency][i];
+                    const Real cond_t = static_cast<Real>(ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::cond_tendency][i]);
 #endif
 
                     return {
@@ -283,16 +283,16 @@ void SuperDropletPC::Diagnostics( const int a_iter,
     for (int is = 0; is < m_num_species; is++) {
         min_mass_species[is] = ReduceMin( *this,
                                           [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
-                                          { return ptd.m_runtime_rdata[ridx_s(is,na,ns)][i]; } );
+                                          { return static_cast<Real>(ptd.m_runtime_rdata[ridx_s(is,na,ns)][i]); } );
         max_mass_species[is] = ReduceMax( *this,
                                           [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
-                                          { return ptd.m_runtime_rdata[ridx_s(is,na,ns)][i]; } );
+                                          { return static_cast<Real>(ptd.m_runtime_rdata[ridx_s(is,na,ns)][i]); } );
         avg_mass_species[is] = ReduceSum( *this,
                                           [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
                                           {
                                               auto n = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
                                               auto m = ptd.m_runtime_rdata[ridx_s(is,na,ns)][i];
-                                              return n*m;
+                                              return static_cast<Real>(n*m);
                                           } );
     }
     ParallelDescriptor::ReduceRealMin(min_mass_species.data(),m_num_species);
@@ -315,16 +315,16 @@ void SuperDropletPC::Diagnostics( const int a_iter,
     for (int ia = 0; ia < m_num_aerosols; ia++) {
         min_mass_aerosols[ia] = ReduceMin( *this,
                                            [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
-                                           { return ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i]; } );
+                                           { return static_cast<Real>(ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i]); } );
         max_mass_aerosols[ia] = ReduceMax( *this,
                                            [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
-                                           { return ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i]; } );
+                                           { return static_cast<Real>(ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i]); } );
         avg_mass_aerosols[ia] = ReduceSum( *this,
                                            [=] AMREX_GPU_HOST_DEVICE (const SDTDType& ptd, const int i) -> Real
                                            {
                                                auto n = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
                                                auto m = ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i];
-                                               return n*m;
+                                               return static_cast<Real>(n*m);
                                            } );
     }
     ParallelDescriptor::ReduceRealMin(min_mass_aerosols.data(),m_num_aerosols);
@@ -443,7 +443,7 @@ void SuperDropletPC::ComputeDistributions( const int a_iter,
 
     // Set ln R grid
     for (int n = 0; n < Nr; n++) {
-        ln_R[n] = std::log(a_r_min) + n*(std::log(a_r_max)-std::log(a_r_min))/(Nr-1);
+        ln_R[n] = static_cast<Real>(std::log(a_r_min) + n*(std::log(a_r_max)-std::log(a_r_min))/(Nr-1));
     }
 
     const auto np = NumSuperDroplets();
@@ -467,7 +467,7 @@ void SuperDropletPC::ComputeDistributions( const int a_iter,
                                          auto mi = ptd.m_runtime_rdata[ridx_s(idx_w,na,ns)][i];
                                          auto ri = std::cbrt( mi / (four_thirds_pi*rho_w) );
                                          auto lnRi = std::log(ri);
-                                         return gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi));
+                                         return static_cast<Real>(gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi)));
                                      } );
         for (int ia = 0; ia < m_num_aerosols; ia++) {
             const auto rho = m_aerosol_mat[ia]->m_density;
@@ -479,7 +479,7 @@ void SuperDropletPC::ComputeDistributions( const int a_iter,
                                                 auto mi = ptd.m_runtime_rdata[ridx_a(ia,na,ns)][i];
                                                 auto ri = std::cbrt( mi / (four_thirds_pi*rho) );
                                                 auto lnRi = std::log(ri);
-                                                return gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi));
+                                                return static_cast<Real>(gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi)));
                                             } );
         }
         for (int ia = m_num_aerosols; ia < m_num_aerosols+m_num_species; ia++) {
@@ -493,7 +493,7 @@ void SuperDropletPC::ComputeDistributions( const int a_iter,
                                                 auto mi = ptd.m_runtime_rdata[ridx_s(is,na,ns)][i];
                                                 auto ri = std::cbrt( mi / (four_thirds_pi*rho) );
                                                 auto lnRi = std::log(ri);
-                                                return gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi));
+                                                return static_cast<Real>(gamma*ai*ni*mi*std::exp(-lambda*(lnR-lnRi)*(lnR-lnRi)));
                                             } );
         }
     }

--- a/Source/Particles/ERF_SuperDropletPCInitializations.cpp
+++ b/Source/Particles/ERF_SuperDropletPCInitializations.cpp
@@ -215,9 +215,9 @@ void SuperDropletPC::define (  const std::vector<Species::Name>& a_species_mat,
     m_aerosol_mat.clear();
 
     setSpeciesMaterial( a_species_mat );
-    m_num_species = m_species_mat.size();
+    m_num_species = static_cast<int>(m_species_mat.size());
     setAerosolMaterial( a_aerosol_mat );
-    m_num_aerosols = m_aerosol_mat.size();
+    m_num_aerosols = static_cast<int>(m_aerosol_mat.size());
 
     AMREX_ALWAYS_ASSERT(m_num_species  > 0);
     AMREX_ALWAYS_ASSERT(m_num_species  <= SupDropInit::num_species_max);
@@ -398,7 +398,7 @@ void SuperDropletPC::SetAttributes (MultiFab& a_rhoc /*!< mass density of conden
             const Real mass_condensate_cell = condensate_mass_density(iv[0],iv[1],iv[2],0) * cell_volume;
             const Real mass_condensate_sd = mass_condensate_cell / num_sd_per_cell;
 
-            Real mult_rnd = -ptrs.mult_ptr[i]/3 + 2*ptrs.mult_ptr[i]/3*Random(rnd_engine);
+            Real mult_rnd = static_cast<Real>(-ptrs.mult_ptr[i]/3 + 2*ptrs.mult_ptr[i]/3*Random(rnd_engine));
             ptrs.mult_ptr[i] += mult_rnd;
 
             ParticleReal species_mass_total = zero;
@@ -413,7 +413,7 @@ void SuperDropletPC::SetAttributes (MultiFab& a_rhoc /*!< mass density of conden
                 aerosol_mass_total += ptrs.ae_mass_ptrs[ctr][np];
             }
 
-            const Real mass_particle = mass_condensate_sd / ptrs.mult_ptr[i] + aerosol_mass_total + species_mass_total;
+            const Real mass_particle = static_cast<Real>(mass_condensate_sd / ptrs.mult_ptr[i] + aerosol_mass_total + species_mass_total);
             ptrs.mass_ptr[i] = mass_particle;
 
             Real radius_cubed = mass_particle / (four_thirds_pi*rho_w);

--- a/Source/Particles/ERF_SuperDropletPCMassChange.cpp
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.cpp
@@ -140,9 +140,9 @@ void SuperDropletPC::MassChange ( int                                         a_
                 }
             }
 
-            auto coeff_curv = vapour_mat_core.coeffCurv(temperature);
+            auto coeff_curv = vapour_mat_core.coeffCurv(static_cast<Real>(temperature));
             auto coeff_sol = vapour_mat_core.coeffVPSolute();
-            auto coeff_moldiff = vapour_mat_core.coeffMolecularDiffusion(temperature, pressure);
+            auto coeff_moldiff = vapour_mat_core.coeffMolecularDiffusion(static_cast<Real>(temperature), static_cast<Real>(pressure));
 
 #ifdef ERF_USE_ML_UPHYS_DIAGNOSTICS
             if (a_is_water) {
@@ -216,7 +216,7 @@ void SuperDropletPC::MassChange ( int                                         a_
 
         });
         Gpu::synchronize();
-        m_num_unconverged_particles += *(unconverged_particles.copyToHost());
+        m_num_unconverged_particles += static_cast<long>(*(unconverged_particles.copyToHost()));
     }); // end forEachParticleTile
 
 }

--- a/Source/Particles/ERF_SuperDropletPCUtils.cpp
+++ b/Source/Particles/ERF_SuperDropletPCUtils.cpp
@@ -12,8 +12,8 @@ void SuperDropletPC::initializeDeviceProperties()
 {
     if (m_device_props_initialized) return;
 
-    const int num_sp = m_species_mat.size();
-    const int num_ae = m_aerosol_mat.size();
+    const int num_sp = static_cast<int>(m_species_mat.size());
+    const int num_ae = static_cast<int>(m_aerosol_mat.size());
 
     m_sp_density.resize(num_sp);
     m_sp_solubility.resize(num_sp);
@@ -148,7 +148,7 @@ Real SuperDropletPC::TotalNumberOfParticles ()
                            {
                                 auto ai = ptd.m_runtime_idata[SuperDropletsIntIdxSoA_RT::active][i];
                                 auto ni = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
-                                return ai*ni;
+                                return static_cast<Real>(ai*ni);
                            });
     ParallelDescriptor::ReduceRealSum(&count, 1);
     return count;

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -186,7 +186,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
     int imax = domhi_x; // if (geom.isPeriodic(0)) imax += z_phys_nd.nGrowVect()[0];
     int jmax = domhi_y; // if (geom.isPeriodic(1)) jmax += z_phys_nd.nGrowVect()[1];
 
-    int nz = z_levels_h.size();
+    int nz = static_cast<int>(z_levels_h.size());
     Real z_top = z_levels_h[nz-1];
 
     Gpu::DeviceVector<Real> z_levels_d;
@@ -460,7 +460,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
 
                     // Fill levels using model from Sullivan et. al. 2014
                     int omega = 3; //Used to adjust how rapidly grid lines level out. omega=1 is BTF!
-                    z_arr(i,j,k) = z + (std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
+                    z_arr(i,j,k) = z + static_cast<Real>(std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
 
                     // Fill lateral boundaries and below the bottom surface
                     if (k == k0) {
@@ -501,7 +501,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                     } else {
                         // Fill levels using model from Sullivan et. al. 2014
                         int omega = 3; //Used to adjust how rapidly grid lines level out. omega=1 is BTF!
-                        z_arr(i,j,k) = z + (std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
+                        z_arr(i,j,k) = z + static_cast<Real>(std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
                     }
                 });
                 gbx.setBig(2,0);

--- a/Source/Utils/ERF_WeatherDataInterpolation.cpp
+++ b/Source/Utils/ERF_WeatherDataInterpolation.cpp
@@ -102,9 +102,9 @@ ERF::FillForecastStateMultiFabs(const int lev,
     }
 
 
-    int nx = xvec_h.size();
-    int ny = yvec_h.size();
-    int nz = zvec_h.size();
+    int nx = static_cast<int>(xvec_h.size());
+    int ny = static_cast<int>(yvec_h.size());
+    int nz = static_cast<int>(zvec_h.size());
 
     amrex::Real dxvec = (xvec_h[nx-1]-xvec_h[0])/(nx-1);
     amrex::Real dyvec = (yvec_h[ny-1]-yvec_h[0])/(ny-1);
@@ -353,7 +353,7 @@ ERF::WeatherDataInterpolation(const int lev,
     static amrex::Vector<Real> next_read_forecast_time;
     static amrex::Vector<Real> last_read_forecast_time;
 
-    const int nlevs = a_z_phys_nd.size();
+    const int nlevs = static_cast<int>(a_z_phys_nd.size());
 
     Real hindcast_data_interval = solverChoice.hindcast_data_interval_in_hrs*Real(3600.0);
 

--- a/Source/WindFarmParametrization/EWP/ERF_AdvanceEWP.cpp
+++ b/Source/WindFarmParametrization/EWP/ERF_AdvanceEWP.cpp
@@ -38,7 +38,7 @@ EWP::compute_power_output (const MultiFab& cons_in,
      get_turb_spec(rotor_rad, hub_height, thrust_coeff_standing,
                   wind_speed, thrust_coeff, power);
 
-     const int n_spec_table = wind_speed.size();
+     const int n_spec_table = static_cast<int>(wind_speed.size());
 
      Gpu::DeviceVector<Real> d_wind_speed(wind_speed.size());
      Gpu::DeviceVector<Real> d_power(wind_speed.size());
@@ -171,7 +171,7 @@ EWP::source_terms_cellcentered (const Geometry& geom,
 
         const Real* wind_speed_d     = d_wind_speed.dataPtr();
         const Real* thrust_coeff_d   = d_thrust_coeff.dataPtr();
-        const int n_spec_table = d_wind_speed.size();
+        const int n_spec_table = static_cast<int>(d_wind_speed.size());
 
         ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 

--- a/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
+++ b/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
@@ -110,7 +110,7 @@ Fitch::compute_power_output (const MultiFab& cons_in,
      get_turb_spec(rotor_rad, hub_height, thrust_coeff_standing,
                   wind_speed, thrust_coeff, power);
 
-     const int n_spec_table = wind_speed.size();
+     const int n_spec_table = static_cast<int>(wind_speed.size());
 
      Gpu::DeviceVector<Real> d_wind_speed(wind_speed.size());
      Gpu::DeviceVector<Real> d_power(wind_speed.size());
@@ -205,7 +205,7 @@ Fitch::source_terms_cellcentered (const Geometry& geom,
 
         const Real* wind_speed_d     = d_wind_speed.dataPtr();
         const Real* thrust_coeff_d   = d_thrust_coeff.dataPtr();
-        const int n_spec_table = d_wind_speed.size();
+        const int n_spec_table = static_cast<int>(d_wind_speed.size());
 
         ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);

--- a/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_AdvanceGeneralAD.cpp
+++ b/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_AdvanceGeneralAD.cpp
@@ -34,7 +34,7 @@ GeneralAD::compute_power_output (const Real& time)
      get_turb_spec(rotor_rad, hub_height, thrust_coeff_standing,
                   wind_speed, thrust_coeff, power);
 
-     const int n_spec_table = wind_speed.size();
+     const int n_spec_table = static_cast<int>(wind_speed.size());
   // Compute power based on the look-up table
 
     if (ParallelDescriptor::IOProcessor()){
@@ -45,8 +45,8 @@ GeneralAD::compute_power_output (const Real& time)
             Abort("Could not open file to write power output in ERF_AdvanceSimpleAD.cpp");
         }
         Real total_power = zero;
-        for(int it=0; it<xloc.size(); it++){
-            Real avg_vel = freestream_velocity[it]/(disk_cell_count[it] + 1e-10);
+        for(int it=0; it<static_cast<int>(xloc.size()); it++){
+            Real avg_vel = freestream_velocity[it]/(disk_cell_count[it] + Real(1e-10));
             Real turb_power = interpolate_1d(wind_speed.data(), power.data(), avg_vel, n_spec_table);
             total_power = total_power + turb_power;
         }
@@ -144,16 +144,16 @@ void GeneralAD::compute_freestream_velocity (const MultiFab& cons_in,
 
     // Reduce the data on every processor
     amrex::ParallelAllReduce::Sum(freestream_velocity.data(),
-                                  freestream_velocity.size(),
+                                  static_cast<int>(freestream_velocity.size()),
                                   amrex::ParallelContext::CommunicatorAll());
 
     amrex::ParallelAllReduce::Sum(freestream_phi.data(),
-                                  freestream_phi.size(),
+                                  static_cast<int>(freestream_phi.size()),
                                   amrex::ParallelContext::CommunicatorAll());
 
 
    amrex::ParallelAllReduce::Sum(disk_cell_count.data(),
-                                 disk_cell_count.size(),
+                                 static_cast<int>(disk_cell_count.size()),
                                  amrex::ParallelContext::CommunicatorAll());
 
     get_turb_loc(xloc, yloc);
@@ -265,19 +265,19 @@ compute_source_terms_Fn_Ft (const Real rad,
         Cn = Cl*std::cos(psi) + Cd*std::sin(psi);
         Ct = Cl*std::sin(psi) - Cd*std::cos(psi);
 
-        ftip = B*(rtip-rad)/(two*rad*std::sin(psi)+1e-10);
-        fhub = B*(rad-rhub)/(two*rad*std::sin(psi)+1e-10);
+        ftip = B*(rtip-rad)/(two*rad*std::sin(psi)+Real(1e-10));
+        fhub = B*(rad-rhub)/(two*rad*std::sin(psi)+Real(1e-10));
 
         AMREX_ALWAYS_ASSERT(std::fabs(std::exp(-fhub))<=one);
         AMREX_ALWAYS_ASSERT(std::fabs(std::exp(-ftip))<=one);
 
         F = two/PI*(std::acos(std::exp(-ftip)) + std::acos(std::exp(-fhub)) );
 
-        at_new = one/ ( Real(4.0)*F*std::sin(psi)*std::cos(psi)/(s*Ct+1e-10) - one );
-        an_new = one/ ( one + Real(4.0)*F*amrex::Math::powi<2>(std::sin(psi))/(s*Cn + 1e-10) );
+        at_new = one/ ( Real(4.0)*F*std::sin(psi)*std::cos(psi)/(s*Ct+Real(1e-10)) - one );
+        an_new = one/ ( one + Real(4.0)*F*amrex::Math::powi<2>(std::sin(psi))/(s*Cn + Real(1e-10)) );
         at_new = std::max(Real(0.), at_new);
 
-        if(std::fabs(at_new-at) < 1e-5 and std::fabs(an_new-an) < 1e-5) {
+        if(std::fabs(at_new-at) < Real(1e-5) and std::fabs(an_new-an) < Real(1e-5)) {
             //printf("Converged at, an = %d %0.15g %0.15g %0.15g\n",i, at, an, psi);
             at = at_new;
             an = an_new;
@@ -354,7 +354,7 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
       // The order of variables are - Vabs dVabsdt, dudt, dvdt, dTKEdt
       mf_vars_generalAD.setVal(0.0);
 
-     long unsigned int nturbs = xloc.size();
+     long unsigned int nturbs = static_cast<long unsigned int>(xloc.size());
 
     // This is the angle phi in Fig. 10 in Mirocha et. al. 2014
     // set_turb_disk angle in ERF_InitWindFarm.cpp sets this phi as
@@ -372,7 +372,7 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
     Real* d_freestream_velocity_ptr = d_freestream_velocity.data();
     Real* d_disk_cell_count_ptr     = d_disk_cell_count.data();
 
-    int n_bld_sections = bld_rad_loc.size();
+    int n_bld_sections = static_cast<int>(bld_rad_loc.size());
 
     Gpu::DeviceVector<Real>    d_bld_rad_loc(n_bld_sections);
     Gpu::DeviceVector<Real>    d_bld_twist(n_bld_sections);
@@ -390,7 +390,7 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
     Vector<Gpu::DeviceVector<Real>> d_bld_airfoil_Cl(n_bld_sections);
     Vector<Gpu::DeviceVector<Real>> d_bld_airfoil_Cd(n_bld_sections);
 
-    int n_pts_airfoil = bld_airfoil_aoa[0].size();
+    int n_pts_airfoil = static_cast<int>(bld_airfoil_aoa[0].size());
 
     for(int i=0;i<n_bld_sections;i++){
         d_bld_airfoil_aoa[i].resize(n_pts_airfoil);
@@ -420,7 +420,7 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
     auto d_bld_airfoil_Cl_ptr  = Cl.data();
     auto d_bld_airfoil_Cd_ptr  = Cd.data();
 
-    int n_spec_extra = velocity.size();
+    int n_spec_extra = static_cast<int>(velocity.size());
 
     Gpu::DeviceVector<Real> d_velocity(n_spec_extra);
     Gpu::DeviceVector<Real> d_rotor_RPM(n_spec_extra);
@@ -456,7 +456,7 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
             std::array<Real,2> Fn_and_Ft;
 
             for(long unsigned int it=0;it<nturbs;it++) {
-                 Real avg_vel  = d_freestream_velocity_ptr[it]/(d_disk_cell_count_ptr[it] + 1e-10);
+                 Real avg_vel  = d_freestream_velocity_ptr[it]/(d_disk_cell_count_ptr[it] + Real(1e-10));
                  Real phi = d_turb_disk_angle;
 
                 // This if check makes sure it is a point on the actuator disk

--- a/Source/WindFarmParametrization/Null/ERF_NullWindFarm.H
+++ b/Source/WindFarmParametrization/Null/ERF_NullWindFarm.H
@@ -147,11 +147,11 @@ bool find_if_marked (amrex::Real x1, amrex::Real x2, amrex::Real y1, amrex::Real
     // x = x1, x = x2, y = y1, y = y2. The intersections are
     // (xval1,y1), (xval2,y2), (x1,yval1) and (x2,yval2)
 
-    amrex::Real xval1 = x0 - (y1-y0)*ny/(nx+1e-10);
-    amrex::Real xval2 = x0 - (y2-y0)*ny/(nx+1e-10);
+    amrex::Real xval1 = x0 - (y1-y0)*ny/(nx+amrex::Real(1e-10));
+    amrex::Real xval2 = x0 - (y2-y0)*ny/(nx+amrex::Real(1e-10));
 
-    amrex::Real yval1 = y0 - (x1-x0)*nx/(ny+1e-10);
-    amrex::Real yval2 = y0 - (x2-x0)*nx/(ny+1e-10);
+    amrex::Real yval1 = y0 - (x1-x0)*nx/(ny+amrex::Real(1e-10));
+    amrex::Real yval2 = y0 - (x2-x0)*nx/(ny+amrex::Real(1e-10));
 
     if( xval1 >=x1 and xval1 <=x2 ) {
         if(std::pow((xval1-x0)*(xval1-x0) + (y1-y0)*(y1-y0) + (z-d_hub_height)*(z-d_hub_height),myhalf) < d_rotor_rad ) {

--- a/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
+++ b/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
@@ -31,7 +31,7 @@ SimpleAD::compute_power_output (const Real& time)
      get_turb_spec(rotor_rad, hub_height, thrust_coeff_standing,
                   wind_speed, thrust_coeff, power);
 
-     const int n_spec_table = wind_speed.size();
+     const int n_spec_table = static_cast<int>(wind_speed.size());
   // Compute power based on the look-up table
 
     if (ParallelDescriptor::IOProcessor()){
@@ -42,8 +42,8 @@ SimpleAD::compute_power_output (const Real& time)
             Abort("Could not open file to write power output in ERF_AdvanceSimpleAD.cpp");
         }
         Real total_power = zero;
-        for(int it=0; it<xloc.size(); it++){
-            Real avg_vel = freestream_velocity[it]/(disk_cell_count[it] + 1e-10);
+        for(int it=0; it<static_cast<int>(xloc.size()); it++){
+            Real avg_vel = freestream_velocity[it]/(disk_cell_count[it] + Real(1e-10));
             Real turb_power = interpolate_1d(wind_speed.data(), power.data(), avg_vel, n_spec_table);
             total_power = total_power + turb_power;
             //printf("avg vel and power is %d %0.15g, %0.15g\n", it, avg_vel, turb_power);
@@ -132,16 +132,16 @@ void SimpleAD::compute_freestream_velocity (const MultiFab& cons_in,
 
     // Reduce the data on every processor
     amrex::ParallelAllReduce::Sum(freestream_velocity.data(),
-                                  freestream_velocity.size(),
+                                  static_cast<int>(freestream_velocity.size()),
                                   amrex::ParallelContext::CommunicatorAll());
 
     amrex::ParallelAllReduce::Sum(freestream_phi.data(),
-                                  freestream_phi.size(),
+                                  static_cast<int>(freestream_phi.size()),
                                   amrex::ParallelContext::CommunicatorAll());
 
 
    amrex::ParallelAllReduce::Sum(disk_cell_count.data(),
-                                 disk_cell_count.size(),
+                                 static_cast<int>(disk_cell_count.size()),
                                  amrex::ParallelContext::CommunicatorAll());
 
     get_turb_loc(xloc, yloc);
@@ -186,7 +186,7 @@ SimpleAD::source_terms_cellcentered (const Geometry& geom,
       // The order of variables are - Vabs dVabsdt, dudt, dvdt, dTKEdt
       mf_vars_simpleAD.setVal(0.0);
 
-      long unsigned int nturbs = xloc.size();
+      long unsigned int nturbs = static_cast<long unsigned int>(xloc.size());
 
      Gpu::DeviceVector<Real> d_freestream_velocity(nturbs);
      Gpu::DeviceVector<Real> d_freestream_phi(nturbs);
@@ -213,7 +213,7 @@ SimpleAD::source_terms_cellcentered (const Geometry& geom,
 
     const Real* wind_speed_d     = d_wind_speed.dataPtr();
     const Real* thrust_coeff_d   = d_thrust_coeff.dataPtr();
-    const int n_spec_table = d_wind_speed.size();
+    const int n_spec_table = static_cast<int>(d_wind_speed.size());
 
     for ( MFIter mfi(cons_in,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
 
@@ -233,8 +233,8 @@ SimpleAD::source_terms_cellcentered (const Geometry& geom,
             int it = static_cast<int>(SMark_array(ii,jj,kk,1));
 
               if(it != -1) {
-                Real avg_vel  = d_freestream_velocity_ptr[it]/(d_disk_cell_count_ptr[it] + 1e-10);
-                Real phi      = d_freestream_phi_ptr[it]/(d_disk_cell_count_ptr[it] + 1e-10);
+                Real avg_vel  = d_freestream_velocity_ptr[it]/(d_disk_cell_count_ptr[it] + Real(1e-10));
+                Real phi      = d_freestream_phi_ptr[it]/(d_disk_cell_count_ptr[it] + Real(1e-10));
 
                 Real C_T = interpolate_1d(wind_speed_d, thrust_coeff_d, avg_vel, n_spec_table);
                 Real a;


### PR DESCRIPTION
Re-enables SP-mesh entries in the GitHub CI matrices by removing the temporary `- mesh_precision: SINGLE` guard exclude added in PR #3187, and fixes the SP-mesh compile errors and conversion warnings flagged by Clang and MSVC.

- Removed the SP-mesh guard exclude from `.github/workflows/gcc.yml`, `cuda-ci.yml`, `hip.yml`, `macos.yml`, `sycl.yml`, `windows.yml`, and `windows-mpi.yml` so SP-mesh + DP/SP-particles entries run again.
- Fixed mixed-type `amrex::min`/`amrex::max` template-deduction errors (`error C2672`) in `.Exec_dev/Shoc/ERF_Prob.cpp` and `.Exec_dev/Tornado/ERF_Prob.cpp` by promoting bare `1.0` / `1e-12` literals to `Real(...)`.
- Replaced the `== 1e34` / `== -1e10` SP-unsafe sentinel comparisons in `Source/ERF.cpp` (massflux klo/khi) and `Source/DataStructs/ERF_DataStruct.H` (hurricane eye lat/lon) with `Real`-typed equality checks, clearing the Clang `-Wliteral-range` "always false" warnings.
- Cleared `double` to `amrex::Real` and `amrex::ParticleReal` to `amrex::Real` narrowings (`C4244`, `C4305`) across `.Exec_dev/` problem decks, `Source/Particles/`, `Source/BoundaryConditions/`, `Source/Utils/ERF_TerrainMetrics.cpp`, `Source/WindFarmParametrization/`, and `Source/Microphysics/SuperDropletsMoist/`; the templated `Source/Particles/ERF_SDInitialization.H` switches to `std::uniform_real_distribution<amrex::Real>` so the auto-typed locals propagate `Real` end-to-end.
- Cleared `amrex::Long`/`size_t` to `int` narrowings (`C4244`, `C4267`) in `Source/ERF.H` (`Num*Logs`/`Sample*` accessors), `Source/ERF.cpp` (`getEpochTime`, `nc_init_file.size()`, `h_havg.size()`), `Source/IO/ERF_Checkpoint.cpp`, `Source/IO/ERF_Plotfile.cpp`, `Source/IO/ERF_ReadBndryPlanes.cpp`, `Source/BoundaryConditions/ERF_MOSTAverage.cpp`, `Source/BoundaryConditions/ERF_SurfaceLayer.cpp`, `Source/Utils/ERF_WeatherDataInterpolation.cpp`, and the EWP / Fitch / SimpleActuatorDisk / GeneralActuatorDisk wind-farm parametrizations.