### PR TITLE
Add SatAdj conservation unit test

### DIFF
--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
@@ -52,10 +52,22 @@ namespace satadj_test {
 constexpr amrex::Real kThermoTolFactor = amrex::Real(2.0e-5);
 constexpr amrex::Real kStateTolFactor = amrex::Real(5.0e-5);
 constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-1);
+constexpr amrex::Real kLatentEnergyTolFactor = amrex::Real(3.0e-3);
+constexpr amrex::Real kNormalizedWaterConservationTol = amrex::Real(8.0);
+constexpr amrex::Real kNormalizedLatentEnergyConservationTol = amrex::Real(8.0);
 #else
 constexpr amrex::Real kThermoTolFactor = amrex::Real(1.0e-12);
 constexpr amrex::Real kStateTolFactor = amrex::Real(1.0e-12);
 constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-2);
+constexpr amrex::Real kLatentEnergyTolFactor = amrex::Real(1.0e-3);
+// rho and qt are algebraically conserved by SatAdj. The observed public-flow
+// residuals in double precision are roundoff-sized, so keep these bounds very
+// tight while still allowing small architecture/compiler variation.
+constexpr amrex::Real kNormalizedWaterConservationTol = amrex::Real(1.0e-5);
+// The latent-energy invariant is still very accurate in double precision, but
+// it is reconstructed from conserved state using EOS calls after a finite-
+// residual Newton solve. Keep this tolerance separate from water conservation.
+constexpr amrex::Real kNormalizedLatentEnergyConservationTol = amrex::Real(1.0e-6);
 #endif
 
 constexpr amrex::Real kFacCond = lcond / Cp_d;
@@ -93,6 +105,24 @@ enum InvariantErrComp {
     InvariantErrQ2Ref,
     NumInvariantErrComps
 };
+
+enum ConservationErrComp {
+    ConservationErrRho = 0,
+    ConservationErrQt,
+    ConservationErrLatentEnergy,
+    ConservationErrInitialQcPositive,
+    ConservationErrFinalQcPositive,
+    ConservationErrFinalQcZero,
+    NumConservationErrComps
+};
+
+#ifdef AMREX_USE_FLOAT
+constexpr amrex::Real kQcCoveragePositiveMin = amrex::Real(1.0e-6);
+constexpr amrex::Real kQcCoverageNearZeroMax = amrex::Real(1.0e-6);
+#else
+constexpr amrex::Real kQcCoveragePositiveMin = amrex::Real(1.0e-12);
+constexpr amrex::Real kQcCoverageNearZeroMax = amrex::Real(1.0e-12);
+#endif
 
 AMREX_GPU_HOST_DEVICE
 AMREX_FORCE_INLINE
@@ -284,6 +314,66 @@ inline void fill_conserved_state_portable (amrex::MultiFab& cons)
     fill_conserved_state_portable(cons, true);
 }
 
+// The public-flow conservation contract is defined for physical SatAdj states
+// with qv and qc only. Keep the dedicated negative-qc repair coverage in the
+// scalar/reference tests, and use valid cloud-water states here so the new
+// MultiFab conservation test measures only phase-change conservation.
+inline void fill_conserved_state_conservation_portable (amrex::MultiFab& cons)
+{
+    CellState evap_then_recond;
+    const bool found = find_evaporation_then_recondensation_state(evap_then_recond);
+    AMREX_ALWAYS_ASSERT(found);
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const int selector = (i + 2 * j + 3 * k) % 4;
+
+                amrex::Real tabs;
+                amrex::Real pres_mbar;
+                amrex::Real qv;
+                amrex::Real qc;
+
+                if (selector == 0) {
+                    tabs = amrex::Real(290.0);
+                    pres_mbar = amrex::Real(900.0);
+                    qv = qsat(tabs, pres_mbar) + amrex::Real(6.0e-4);
+                    qc = amrex::Real(3.0e-4);
+                } else if (selector == 1) {
+                    tabs = amrex::Real(290.0);
+                    pres_mbar = amrex::Real(900.0);
+                    qv = amrex::Real(4.0e-3);
+                    qc = amrex::Real(1.0e-3);
+                } else if (selector == 2) {
+                    tabs = evap_then_recond.tabs;
+                    pres_mbar = evap_then_recond.pres_mbar;
+                    qv = evap_then_recond.qv;
+                    qc = evap_then_recond.qc;
+                } else {
+                    tabs = amrex::Real(285.0);
+                    pres_mbar = amrex::Real(880.0);
+                    qv = qsat(tabs, pres_mbar) + amrex::Real(2.0e-4);
+                    qc = amrex::Real(5.0e-5);
+                }
+
+                const amrex::Real pres_pa = amrex::Real(100.0) * pres_mbar;
+                const amrex::Real rho = getRhogivenTandPress(tabs, pres_pa, qv);
+                const amrex::Real theta = getThgivenTandP(tabs, pres_pa, kRdOcp);
+
+                arr(i,j,k,Rho_comp) = rho;
+                arr(i,j,k,RhoTheta_comp) = rho * theta;
+                arr(i,j,k,RhoKE_comp) = amrex::Real(0.0);
+                arr(i,j,k,RhoScalar_comp) = amrex::Real(0.0);
+                arr(i,j,k,RhoQ1_comp) = rho * qv;
+                arr(i,j,k,RhoQ2_comp) = rho * qc;
+            });
+        });
+    }
+}
+
 inline void compute_state_difference (const amrex::MultiFab& after,
                                       const amrex::MultiFab& before,
                                       amrex::MultiFab& err)
@@ -356,6 +446,100 @@ inline void compute_satadj_invariant_errors (const amrex::MultiFab& before,
                     / scaled_tol(rhoq1_ref, amrex::Real(20.0) * kStateTolFactor);
                 err_arr(i,j,k,InvariantErrQ2Ref) = amrex::Math::abs(after_arr(i,j,k,RhoQ2_comp) - rhoq2_ref)
                     / scaled_tol(rhoq2_ref, amrex::Real(20.0) * kStateTolFactor);
+            });
+        });
+    }
+}
+
+inline void compute_satadj_conservation_errors (const amrex::MultiFab& before,
+                                                const amrex::MultiFab& after,
+                                                amrex::MultiFab& err)
+{
+    // This helper checks the public SatAdj MultiFab flow as a conservation
+    // contract, not against a scalar gold implementation. SatAdj transports
+    // only non-precipitating water (qv and qc), so the conserved quantity here
+    // is rho * (qv + qc), not any precipitating-water budget.
+    //
+    // The cell solve itself updates qv and qc with algebraically conservative
+    // assignments. Any nonzero public-flow rho/qt residual observed here comes
+    // from floating-point roundoff in the conserved-to-primitive and
+    // primitive-to-conserved rho*q conversions around the SatAdj call, not
+    // from an intended source/sink in the scheme.
+
+    // SatAdj holds the diagnosed cell pressure fixed during each adjustment.
+    // Evaluate both the pre-state and post-state latent-energy invariant along
+    // that same fixed-pressure path:
+    //
+    // Condensation/recondensation:
+    //   T1 = T0 + A * (qv0 - qv1)
+    //   qc1 = qc0 + qv0 - qv1
+    //   A = L / cp
+    //
+    //   qv1 + qc1 - qv0 - qc0 = 0
+    //   T1 + A*qv1 - T0 - A*qv0 = 0
+    //
+    // All evaporation:
+    //   qv1 = qv0 + qc0
+    //   qc1 = 0
+    //   T1 = T0 - A*qc0
+    //
+    //   qv1 + qc1 - qv0 - qc0 = 0
+    //   T1 + A*qv1 - T0 - A*qv0 = 0
+    for (amrex::MFIter mfi(after, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto before_arr = before.const_array(mfi);
+        auto after_arr = after.const_array(mfi);
+        auto err_arr = err.array(mfi);
+
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const amrex::Real rho_before = before_arr(i,j,k,Rho_comp);
+                const amrex::Real rho_after = after_arr(i,j,k,Rho_comp);
+                const amrex::Real rhotheta_before = before_arr(i,j,k,RhoTheta_comp);
+                const amrex::Real rhotheta_after = after_arr(i,j,k,RhoTheta_comp);
+                const amrex::Real rhoqv_before = before_arr(i,j,k,RhoQ1_comp);
+                const amrex::Real rhoqv_after = after_arr(i,j,k,RhoQ1_comp);
+                const amrex::Real rhoqc_before = before_arr(i,j,k,RhoQ2_comp);
+                const amrex::Real rhoqc_after = after_arr(i,j,k,RhoQ2_comp);
+
+                const amrex::Real theta_before = rhotheta_before / rho_before;
+                const amrex::Real theta_after = rhotheta_after / rho_after;
+                const amrex::Real qv_before = rhoqv_before / rho_before;
+                const amrex::Real qv_after = rhoqv_after / rho_after;
+                const amrex::Real qc_before = rhoqc_before / rho_before;
+                const amrex::Real qc_after = rhoqc_after / rho_after;
+
+                const amrex::Real qt_before = rhoqv_before + rhoqc_before;
+                const amrex::Real qt_after = rhoqv_after + rhoqc_after;
+
+                const amrex::Real p_before = getPgivenRTh(rhotheta_before, qv_before);
+                const amrex::Real t_before = getTgivenPandTh(p_before, theta_before, kRdOcp);
+                const amrex::Real t_after_fixed_p = getTgivenPandTh(p_before, theta_after, kRdOcp);
+
+                const amrex::Real latent_before = rho_before * (t_before + kFacCond * qv_before);
+                const amrex::Real latent_after = rho_after * (t_after_fixed_p + kFacCond * qv_after);
+
+                err_arr(i,j,k,ConservationErrRho) = amrex::Math::abs(rho_after - rho_before)
+                    / scaled_tol(rho_before, kStateTolFactor);
+                err_arr(i,j,k,ConservationErrQt) = amrex::Math::abs(qt_after - qt_before)
+                    / scaled_tol(qt_before, amrex::Real(20.0) * kStateTolFactor);
+                // This public-flow check reconstructs temperature from
+                // before/after conserved states and compares against a solver
+                // that stops its fixed-pressure Newton solve at a finite
+                // residual. Use a scheme-scale latent-energy tolerance rather
+                // than a machine-precision thermodynamic one.
+                err_arr(i,j,k,ConservationErrLatentEnergy) = amrex::Math::abs(latent_after - latent_before)
+                    / scaled_tol(latent_before, kLatentEnergyTolFactor);
+
+                err_arr(i,j,k,ConservationErrInitialQcPositive) =
+                    qc_before > kQcCoveragePositiveMin ? amrex::Real(1.0) : amrex::Real(0.0);
+                err_arr(i,j,k,ConservationErrFinalQcPositive) =
+                    qc_after > kQcCoveragePositiveMin ? amrex::Real(1.0) : amrex::Real(0.0);
+                err_arr(i,j,k,ConservationErrFinalQcZero) =
+                    (qc_before > kQcCoveragePositiveMin &&
+                     amrex::Math::abs(qc_after) <= kQcCoverageNearZeroMax)
+                    ? amrex::Real(1.0)
+                    : amrex::Real(0.0);
             });
         });
     }

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
@@ -52,22 +52,14 @@ namespace satadj_test {
 constexpr amrex::Real kThermoTolFactor = amrex::Real(2.0e-5);
 constexpr amrex::Real kStateTolFactor = amrex::Real(5.0e-5);
 constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-1);
-constexpr amrex::Real kLatentEnergyTolFactor = amrex::Real(3.0e-3);
 constexpr amrex::Real kNormalizedWaterConservationTol = amrex::Real(8.0);
 constexpr amrex::Real kNormalizedLatentEnergyConservationTol = amrex::Real(8.0);
 #else
 constexpr amrex::Real kThermoTolFactor = amrex::Real(1.0e-12);
 constexpr amrex::Real kStateTolFactor = amrex::Real(1.0e-12);
 constexpr amrex::Real kAsymptoticRelTol = amrex::Real(2.0e-2);
-constexpr amrex::Real kLatentEnergyTolFactor = amrex::Real(1.0e-3);
-// rho and qt are algebraically conserved by SatAdj. The observed public-flow
-// residuals in double precision are roundoff-sized, so keep these bounds very
-// tight while still allowing small architecture/compiler variation.
-constexpr amrex::Real kNormalizedWaterConservationTol = amrex::Real(1.0e-5);
-// The latent-energy invariant is still very accurate in double precision, but
-// it is reconstructed from conserved state using EOS calls after a finite-
-// residual Newton solve. Keep this tolerance separate from water conservation.
-constexpr amrex::Real kNormalizedLatentEnergyConservationTol = amrex::Real(1.0e-6);
+constexpr amrex::Real kNormalizedWaterConservationTol = amrex::Real(1.0);
+constexpr amrex::Real kNormalizedLatentEnergyConservationTol = amrex::Real(1.0);
 #endif
 
 constexpr amrex::Real kFacCond = lcond / Cp_d;
@@ -130,6 +122,32 @@ amrex::Real scaled_tol (const amrex::Real reference, const amrex::Real factor)
 {
     const amrex::Real magnitude = amrex::Math::abs(reference);
     return factor * (magnitude > amrex::Real(1.0) ? magnitude : amrex::Real(1.0));
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real water_budget_tol (const amrex::Real reference)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::max(amrex::Real(1.0e-8),
+                      amrex::Real(1.0e-5) * amrex::Math::abs(reference));
+#else
+    return amrex::max(amrex::Real(1.0e-14),
+                      amrex::Real(1.0e-12) * amrex::Math::abs(reference));
+#endif
+}
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real latent_energy_budget_tol (const amrex::Real reference)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::max(amrex::Real(1.0e-4),
+                      amrex::Real(1.0e-4) * amrex::Math::abs(reference));
+#else
+    return amrex::max(amrex::Real(1.0e-10),
+                      amrex::Real(1.0e-10) * amrex::Math::abs(reference));
+#endif
 }
 
 AMREX_GPU_HOST_DEVICE
@@ -522,14 +540,12 @@ inline void compute_satadj_conservation_errors (const amrex::MultiFab& before,
                 err_arr(i,j,k,ConservationErrRho) = amrex::Math::abs(rho_after - rho_before)
                     / scaled_tol(rho_before, kStateTolFactor);
                 err_arr(i,j,k,ConservationErrQt) = amrex::Math::abs(qt_after - qt_before)
-                    / scaled_tol(qt_before, amrex::Real(20.0) * kStateTolFactor);
-                // This public-flow check reconstructs temperature from
-                // before/after conserved states and compares against a solver
-                // that stops its fixed-pressure Newton solve at a finite
-                // residual. Use a scheme-scale latent-energy tolerance rather
-                // than a machine-precision thermodynamic one.
+                    / water_budget_tol(qt_before);
+                // Reconstruct temperature at the pre-adjustment fixed pressure
+                // and normalize against a physically meaningful latent-energy
+                // budget tolerance, not a generic scaled_tol floor of 1.
                 err_arr(i,j,k,ConservationErrLatentEnergy) = amrex::Math::abs(latent_after - latent_before)
-                    / scaled_tol(latent_before, kLatentEnergyTolFactor);
+                    / latent_energy_budget_tol(latent_before);
 
                 err_arr(i,j,k,ConservationErrInitialQcPositive) =
                     qc_before > kQcCoveragePositiveMin ? amrex::Real(1.0) : amrex::Real(0.0);

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <iostream>
 #include <vector>
 
 #include <AMReX_BoxArray.H>
@@ -171,6 +172,68 @@ TEST(SatAdjMultiFab, PublicFlowPreservesSatAdjInvariantsPortable)
     EXPECT_LE(err.max(InvariantErrRhoThetaRef), normalized_tol);
     EXPECT_LE(err.max(InvariantErrQ1Ref), normalized_tol);
     EXPECT_LE(err.max(InvariantErrQ2Ref), normalized_tol);
+}
+
+// Motivation: This is the end-to-end public-flow SatAdj conservation test.
+// It exercises Init -> Copy_State_to_Micro -> Advance -> Copy_Micro_to_State
+// on physical qv/qc states and checks the quantities SatAdj should conserve:
+//   - rho
+//   - rho * (qv + qc)
+//   - rho * [T + (L/cp) qv] at the pre-adjustment fixed pressure.
+//
+// SatAdj has no precipitating species, so precipitation-reaching-surface
+// conservation is intentionally out of scope here. The reported rho/qt
+// residuals are expected to be roundoff-sized because the public path converts
+// rho*q to q and back around the cell adjustment.
+TEST(SatAdjMultiFab, PublicFlowConservesWaterAndLatentEnergyPortable)
+{
+    const amrex::Geometry geom = make_geometry(4, 3, 2);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ2_comp + 1, 1);
+    amrex::MultiFab cons_initial(ba, dm, RhoQ2_comp + 1, 1);
+    amrex::MultiFab err(ba, dm, NumConservationErrComps, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    cons_initial.setVal(amrex::Real(0.0));
+    err.setVal(amrex::Real(0.0));
+
+    fill_conserved_state_conservation_portable(cons);
+    amrex::MultiFab::Copy(cons_initial, cons, 0, 0, cons.nComp(), cons.nGrowVect());
+
+    SatAdj satadj;
+    SolverChoice sc = make_solver_choice(false);
+    satadj.Define(sc);
+    satadj.Set_RealWidth(0);
+
+    run_public_flow(satadj, sc, geom, cons);
+    compute_satadj_conservation_errors(cons_initial, cons, err);
+
+    const amrex::Real rho_err = err.max(ConservationErrRho);
+    const amrex::Real qt_err = err.max(ConservationErrQt);
+    const amrex::Real latent_energy_err = err.max(ConservationErrLatentEnergy);
+    const amrex::Real initial_qc_coverage = err.max(ConservationErrInitialQcPositive);
+    const amrex::Real final_qc_coverage = err.max(ConservationErrFinalQcPositive);
+    const amrex::Real final_qc_zero_coverage = err.max(ConservationErrFinalQcZero);
+
+    std::cout << "SatAdj conservation normalized max errors: rho=" << rho_err
+              << ", qt=" << qt_err
+              << ", latent_energy=" << latent_energy_err
+              << "; coverage initial_qc=" << initial_qc_coverage
+              << ", final_qc=" << final_qc_coverage
+              << ", final_qc_zero=" << final_qc_zero_coverage
+              << std::endl;
+
+    EXPECT_LE(rho_err, kNormalizedWaterConservationTol)
+        << "Observed normalized max rho conservation error: " << rho_err;
+    EXPECT_LE(qt_err, kNormalizedWaterConservationTol)
+        << "Observed normalized max total-water conservation error: " << qt_err;
+    EXPECT_LE(latent_energy_err, kNormalizedLatentEnergyConservationTol)
+        << "Observed normalized max latent-energy conservation error: " << latent_energy_err;
+
+    EXPECT_GT(initial_qc_coverage, amrex::Real(0.5));
+    EXPECT_GT(final_qc_coverage, amrex::Real(0.5));
+    EXPECT_GT(final_qc_zero_coverage, amrex::Real(0.5));
 }
 
 // Motivation: Production SatAdj calls AdjustSatAdjCell from ParallelFor. This

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
@@ -1,5 +1,4 @@
 #include <memory>
-#include <iostream>
 #include <vector>
 
 #include <AMReX_BoxArray.H>
@@ -215,14 +214,6 @@ TEST(SatAdjMultiFab, PublicFlowConservesWaterAndLatentEnergyPortable)
     const amrex::Real initial_qc_coverage = err.max(ConservationErrInitialQcPositive);
     const amrex::Real final_qc_coverage = err.max(ConservationErrFinalQcPositive);
     const amrex::Real final_qc_zero_coverage = err.max(ConservationErrFinalQcZero);
-
-    std::cout << "SatAdj conservation normalized max errors: rho=" << rho_err
-              << ", qt=" << qt_err
-              << ", latent_energy=" << latent_energy_err
-              << "; coverage initial_qc=" << initial_qc_coverage
-              << ", final_qc=" << final_qc_coverage
-              << ", final_qc_zero=" << final_qc_zero_coverage
-              << std::endl;
 
     EXPECT_LE(rho_err, kNormalizedWaterConservationTol)
         << "Observed normalized max rho conservation error: " << rho_err;


### PR DESCRIPTION
## Summary

This PR adds a testing-only SatAdj unit test that verifies conservation through the public MultiFab microphysics flow:

`Init -> Copy_State_to_Micro -> Advance -> Copy_Micro_to_State`

The new test checks that SatAdj conserves the quantities it should conserve for its qv/qc-only saturation-adjustment contract:

- density,
- total non-precipitating water, `rho * (qv + qc)`,
- fixed-pressure latent-energy invariant, `rho * [T + (L/cp) qv]`.

The latent-energy check reconstructs the before and after temperatures using the pre-adjustment pressure, matching the fixed-pressure path used by the SatAdj cell adjustment.

The test also includes explicit coverage checks to ensure the conservation test actually exercises:

- non-zero initial `qc`,
- non-zero final `qc`,
- an all-evaporation case with final `qc` near zero.

SatAdj has no precipitating species, so this test intentionally does not introduce `qp`, rain accumulation, or surface-precipitation checks.

## BFB / testing-only note

This is a testing-only change. It modifies only SatAdj unit-test code and does not change production source, model numerics, physics, runtime behavior, or input options. Therefore, this PR is expected to be BFB for all ERF simulations.