### PR TITLE
Refactor Kessler microphysics for testing

### DIFF
--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -1,13 +1,16 @@
 #include <ERF_EOS.H>
 #include <ERF_TileNoZ.H>
-#include "ERF_Kessler.H"
+
 #include "ERF_DataStruct.H"
+#include "ERF_Kessler.H"
+#include "ERF_KesslerUtils.H"
 
 using namespace amrex;
 
 /**
  * Compute Precipitation-related Microphysics quantities.
  */
+
 void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 {
     bool do_cond = m_do_cond;
@@ -29,7 +32,6 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
         Real dtn  = dt;
         Real coef = dtn/m_dzmin;
 
-        // Saturation and evaporation calculations go first
         for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
             auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
@@ -46,7 +48,6 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
             if (tbx.smallEnd(1) == j_lo) { tbx.growLo(1,-m_real_width); }
             if (tbx.bigEnd(1)   == j_hi) { tbx.growHi(1,-m_real_width); }
 
-            // Expose for GPU
             Real d_fac_cond = m_fac_cond;
 
             ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -55,78 +56,34 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 qc_array(i,j,k) = std::max(Real(0), qc_array(i,j,k));
                 qp_array(i,j,k) = std::max(Real(0), qp_array(i,j,k));
 
-                //------- Autoconversion/accretion
-                Real qcc, auto_r, accrr;
-                Real qsat, dtqsat;
-                Real dq_clwater_to_rain, dq_rain_to_vapor, dq_clwater_to_vapor, dq_vapor_to_clwater;
-
+                Real qsat_local, dtqsat_local;
                 Real pressure = pres_array(i,j,k);
-                erf_qsatw(tabs_array(i,j,k), pressure, qsat);
-                erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat);
+                erf_qsatw(tabs_array(i,j,k), pressure, qsat_local);
+                erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat_local);
 
-                if (qsat <= Real(0)) {
+                if (qsat_local <= Real(0)) {
                     amrex::Warning("qsat computed as non-positive; setting to Real(0)!");
-                    qsat = Real(0);
+                    qsat_local = Real(0);
                 }
 
-                // If there is precipitating water (i.e. rain), and the cell is not saturated
-                // then the rain water can evaporate leading to extraction of latent heat, hence
-                // reducing temperature and creating negative buoyancy
+                const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
+                    qv_array(i,j,k), qc_array(i,j,k), qp_array(i,j,k), rho_array(i,j,k),
+                    pressure, qsat_local, dtqsat_local, dtn, do_cond);
 
-                dq_clwater_to_rain  = Real(0);
-                dq_rain_to_vapor    = Real(0);
-                dq_vapor_to_clwater = Real(0);
-                dq_clwater_to_vapor = Real(0);
-
-                //Real fac = qsat*Real(4093.0)*L_v/(Cp_d*amrex::Math::powi<2>(tabs_array(i,j,k)-Real(36.0)));
-                //Real fac = qsat*L_v*L_v/(Cp_d*R_v*tabs_array(i,j,k)*tabs_array(i,j,k));
-                Real fac = (L_v/Cp_d)*dtqsat;
-
-                // If water vapor content exceeds saturation value, then vapor condenses to water and latent heat is released, increasing temperature
-                if ( (qv_array(i,j,k) > qsat) && do_cond ) {
-                    dq_vapor_to_clwater = std::min(qv_array(i,j,k), (qv_array(i,j,k)-qsat)/(Real(1) + fac));
-                }
-
-                // If water vapor is less than the saturated value, then the cloud water can evaporate,
-                // leading to evaporative cooling and reducing temperature
-                if ( (qv_array(i,j,k) < qsat) && (qc_array(i,j,k) > Real(0)) && do_cond ) {
-                    dq_clwater_to_vapor = std::min(qc_array(i,j,k), (qsat - qv_array(i,j,k))/(Real(1) + fac));
-                }
-
-                if (( qp_array(i,j,k) > Real(0)) && (qv_array(i,j,k) < qsat) ) {
-                    Real C = Real(1.6) + Real(124.9)*std::pow(Real(0.001)*rho_array(i,j,k)*qp_array(i,j,k),Real(0.2046));
-                    dq_rain_to_vapor = Real(1)/(Real(0.001)*rho_array(i,j,k))*(Real(1) - qv_array(i,j,k)/qsat)*C*std::pow(Real(0.001)*rho_array(i,j,k)*qp_array(i,j,k),Real(0.525))/
-                        (Real(5.4e5) + Real(2.55e6)/(pressure*qsat))*dtn;
-                    // The negative sign is to make this variable (vapor formed from evaporation)
-                    // a positive quantity (as qv/qs < 1)
-                    dq_rain_to_vapor = std::min({qp_array(i,j,k), dq_rain_to_vapor});
-
-                    // Removing latent heat due to evaporation from rain water to water vapor, reduces the (potential) temperature
-                }
-
-                // If there is cloud water present then do accretion and autoconversion to rain
-                if (qc_array(i,j,k) > Real(0)) {
-                    qcc = qc_array(i,j,k);
-
-                    auto_r = Real(0);
-                    if (qcc > qcw0) {
-                        auto_r = alphaelq;
-                    }
-
-                    accrr = Real(0);
-                    accrr = Real(2.2) * std::pow(qp_array(i,j,k) , Real(0.875));
-                    dq_clwater_to_rain = dtn *(accrr*qcc + auto_r*(qcc - qcw0));
-
-                    // If the amount of change is more than the amount of qc present, then dq = qc
-                    dq_clwater_to_rain = std::min(dq_clwater_to_rain, qc_array(i,j,k));
-                }
-
-                qv_array(i,j,k) += -dq_vapor_to_clwater + dq_clwater_to_vapor + dq_rain_to_vapor;
-                qc_array(i,j,k) +=  dq_vapor_to_clwater - dq_clwater_to_vapor - dq_clwater_to_rain;
-                qp_array(i,j,k) +=  dq_clwater_to_rain - dq_rain_to_vapor;
+                qv_array(i,j,k) += -source_terms.dq_vapor_to_cloud
+                                 +  source_terms.dq_cloud_to_vapor
+                                 +  source_terms.dq_rain_to_vapor;
+                qc_array(i,j,k) +=  source_terms.dq_vapor_to_cloud
+                                 -  source_terms.dq_cloud_to_vapor
+                                 -  source_terms.dq_cloud_to_rain;
+                qp_array(i,j,k) +=  source_terms.dq_cloud_to_rain
+                                 -  source_terms.dq_rain_to_vapor;
 
                 Real theta_over_T = theta_array(i,j,k)/tabs_array(i,j,k);
-                theta_array(i,j,k) += theta_over_T * d_fac_cond * (dq_vapor_to_clwater - dq_clwater_to_vapor - dq_rain_to_vapor);
+                theta_array(i,j,k) += theta_over_T * d_fac_cond
+                    * (source_terms.dq_vapor_to_cloud
+                       - source_terms.dq_cloud_to_vapor
+                       - source_terms.dq_rain_to_vapor);
 
                 qv_array(i,j,k) = std::max(Real(0), qv_array(i,j,k));
                 qc_array(i,j,k) = std::max(Real(0), qc_array(i,j,k));
@@ -136,7 +93,6 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
             });
         }
 
-        // Precompute terminal velocity for substepping
         for ( MFIter mfi(fz, TilingIfNotGPU()); mfi.isValid(); ++mfi ){
             auto rho_array = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
             auto qp_array  = mic_fab_vars[MicVar_Kess::qp]->array(mfi);
@@ -146,36 +102,18 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 
             ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                Real rho_avg, qp_avg;
+                const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
+                const Real rho_k = (k == k_hi+1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
+                const Real qp_km1 = (k == k_lo) ? qp_array(i,j,k) : qp_array(i,j,k-1);
+                const Real qp_k = (k == k_hi+1) ? qp_array(i,j,k-1) : qp_array(i,j,k);
+                const KesslerFaceState face_state =
+                    kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
-                if (k==k_lo) {
-                    rho_avg = rho_array(i,j,k);
-                    qp_avg  = qp_array(i,j,k);
-                } else if (k==k_hi+1) {
-                    rho_avg = rho_array(i,j,k-1);
-                    qp_avg  = qp_array(i,j,k-1);
-                } else {
-                    rho_avg = myhalf*(rho_array(i,j,k-1) + rho_array(i,j,k)); // Convert to g/cm^3
-                    qp_avg = myhalf*(qp_array(i,j,k-1)  + qp_array(i,j,k));
-                }
-
-                qp_avg = std::max(Real(0), qp_avg);
-
-                Real V_terminal = Real(36.34)*std::pow(rho_avg*Real(0.001)*qp_avg, Real(0.1346))*std::pow(rho_avg/Real(1.16), -myhalf); // in m/s
-
-                // NOTE: Fz is the sedimentation flux from the advective operator.
-                //       In the terrain-following coordinate system, the z-deriv in
-                //       the divergence uses the normal velocity (Omega). However,
-                //       there are no u/v compReal(1)nts to the sedimentation velocity.
-                //       Therefore, we simply end up with a division by detJ when
-                //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-                fz_array(i,j,k) = rho_avg*V_terminal*qp_avg;
+                const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
+                fz_array(i,j,k) = kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
             });
-        } // mfi
+        }
 
-        // Compute number of substeps from maximum terminal velocity
-        Real wt_max;
-        int n_substep;
         auto const& ma_fz_arr = fz.const_arrays();
         GpuTuple<Real> max = ParReduce(TypeList<ReduceOpMax>{},
                                        TypeList<Real>{},
@@ -185,14 +123,12 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                                        {
                                            return { ma_fz_arr[box_no](i,j,k) };
                                        });
-        wt_max = get<0>(max) + std::numeric_limits<Real>::epsilon();
-        n_substep = int( std::ceil(wt_max * coef / CFL_MAX) );
+        int n_substep = kessler_num_sedimentation_substeps(get<0>(max), dt, m_dzmin);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_substep >= 1,
                                          "Kessler: Number of precipitation substeps must be greater than 0!");
         coef /= Real(n_substep);
         dtn  /= Real(n_substep);
 
-        // Substep the vertical advection
         for (int nsub(0); nsub<n_substep; ++nsub) {
             for ( MFIter mfi(*tabs, TilingIfNotGPU()); mfi.isValid(); ++mfi ){
                 auto rho_array = mic_fab_vars[MicVar_Kess::rho]->array(mfi);
@@ -205,60 +141,49 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 const Box& tbx = mfi.tilebox();
                 const Box& tbz = mfi.tilebox(IntVect(0,0,1),IntVect(0));
 
-                // Update vertical flux every substep
                 ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    Real rho_avg, qp_avg;
-                    if (k==k_lo) {
-                        rho_avg = rho_array(i,j,k);
-                        qp_avg  = qp_array(i,j,k);
-                    } else if (k==k_hi+1) {
-                        rho_avg = rho_array(i,j,k-1);
-                        qp_avg  = qp_array(i,j,k-1);
-                    } else {
-                        rho_avg = myhalf*(rho_array(i,j,k-1) + rho_array(i,j,k)); // Convert to g/cm^3
-                        qp_avg = myhalf*(qp_array(i,j,k-1)  + qp_array(i,j,k));
-                    }
+                    const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
+                    const Real rho_k = (k == k_hi+1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
+                    const Real qp_km1 = (k == k_lo) ? qp_array(i,j,k) : qp_array(i,j,k-1);
+                    const Real qp_k = (k == k_hi+1) ? qp_array(i,j,k-1) : qp_array(i,j,k);
+                    const KesslerFaceState face_state =
+                        kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
-                    qp_avg = std::max(Real(0), qp_avg);
-
-                    Real V_terminal = Real(36.34)*std::pow(rho_avg*Real(0.001)*qp_avg, Real(0.1346))*std::pow(rho_avg/Real(1.16), -myhalf); // in m/s
-
-                    // NOTE: Fz is the sedimentation flux from the advective operator.
-                    //       In the terrain-following coordinate system, the z-deriv in
-                    //       the divergence uses the normal velocity (Omega). However,
-                    //       there are no u/v compReal(1)nts to the sedimentation velocity.
-                    //       Therefore, we simply end up with a division by detJ when
-                    //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-                    fz_array(i,j,k) = rho_avg*V_terminal*qp_avg;
+                    const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
+                    fz_array(i,j,k) = kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
 
                     if(k==k_lo){
-                        rain_accum_array(i,j,k) = rain_accum_array(i,j,k) + rho_avg*qp_avg*V_terminal*dtn/Real(1000.0)*Real(1000.0); // Divide by rho_water and convert to mm
+                        rain_accum_array(i,j,k) = rain_accum_array(i,j,k)
+                                                + face_state.rho * face_state.qp * terminal_velocity * dtn / Real(1000.0) * Real(1000.0);
                     }
                 });
 
-                // Update precip every substep
                 ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    // Jacobian determinant
                     Real dJinv = (dJ_array) ? Real(1)/dJ_array(i,j,k) : Real(1);
 
-                    if(std::fabs(fz_array(i,j,k+1)) < 1e-14) fz_array(i,j,k+1) = Real(0);
-                    if(std::fabs(fz_array(i,j,k  )) < 1e-14) fz_array(i,j,k  ) = Real(0);
-                    Real dq_sed = dJinv * (Real(1)/rho_array(i,j,k)) * (fz_array(i,j,k+1) - fz_array(i,j,k)) * coef;
-                    if(std::fabs(dq_sed) < 1e-14) dq_sed = Real(0);
+                    if (kessler_is_small_sedimentation_value(fz_array(i,j,k+1))) {
+                        fz_array(i,j,k+1) = Real(0);
+                    }
+                    if (kessler_is_small_sedimentation_value(fz_array(i,j,k  ))) {
+                        fz_array(i,j,k  ) = Real(0);
+                    }
+                    Real dq_sed = kessler_sedimentation_tendency(
+                        fz_array(i,j,k+1), fz_array(i,j,k), rho_array(i,j,k), dJinv, coef);
+                    if (kessler_is_small_sedimentation_value(dq_sed)) {
+                        dq_sed = Real(0);
+                    }
 
                     qp_array(i,j,k) +=  dq_sed;
                     qp_array(i,j,k)  = std::max(Real(0), qp_array(i,j,k));
                 });
-            } // mfi
-        } // nsub
+            }
+        }
     }
-
 
     if (solverChoice.moisture_type == MoistureType::Kessler_NoRain) {
         if (!do_cond) { return; }
-        // get the temperature, density, theta, qt and qc from input
         for ( MFIter mfi(*tabs,TilingIfNotGPU()); mfi.isValid(); ++mfi) {
             auto qv_array    = mic_fab_vars[MicVar_Kess::qv]->array(mfi);
             auto qc_array    = mic_fab_vars[MicVar_Kess::qcl]->array(mfi);
@@ -273,48 +198,29 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
             if (tbx.smallEnd(1) == j_lo) { tbx.growLo(1,-m_real_width); }
             if (tbx.bigEnd(1)   == j_hi) { tbx.growHi(1,-m_real_width); }
 
-            // Expose for GPU
             Real d_fac_cond = m_fac_cond;
 
             ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 qc_array(i,j,k) = std::max(Real(0), qc_array(i,j,k));
 
-                //------- Autoconversion/accretion
                 Real qsat, dtqsat;
-                Real dq_clwater_to_vapor, dq_vapor_to_clwater;
 
                 Real pressure = pres_array(i,j,k);
                 erf_qsatw(tabs_array(i,j,k), pressure, qsat);
                 erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat);
 
-                // If there is precipitating water (i.e. rain), and the cell is not saturated
-                // then the rain water can evaporate leading to extraction of latent heat, hence
-                // reducing temperature and creating negative buoyancy
+                const KesslerSaturationAdjustment saturation_adjustment =
+                    kessler_saturation_adjustment(qv_array(i,j,k), qc_array(i,j,k), qsat, dtqsat, do_cond);
 
-                dq_vapor_to_clwater = Real(0);
-                dq_clwater_to_vapor = Real(0);
-
-                //Real fac = qsat*Real(4093.0)*L_v/(Cp_d*amrex::Math::powi<2>(tabs_array(i,j,k)-Real(36.0)));
-                //Real fac = qsat*L_v*L_v/(Cp_d*R_v*tabs_array(i,j,k)*tabs_array(i,j,k));
-                Real fac = (L_v/Cp_d)*dtqsat;
-
-                // If water vapor content exceeds saturation value, then vapor condenses to water and latent heat is released, increasing temperature
-                if (qv_array(i,j,k) > qsat){
-                    dq_vapor_to_clwater = std::min(qv_array(i,j,k), (qv_array(i,j,k)-qsat)/(Real(1) + fac));
-                }
-                // If water vapor is less than the saturated value, then the cloud water can evaporate, leading to evaporative cooling and
-                // reducing temperature
-                if (qv_array(i,j,k) < qsat && qc_array(i,j,k) > Real(0)){
-                    dq_clwater_to_vapor = std::min(qc_array(i,j,k), (qsat - qv_array(i,j,k))/(Real(1) + fac));
-                }
-
-                qv_array(i,j,k) += -dq_vapor_to_clwater + dq_clwater_to_vapor;
-                qc_array(i,j,k) +=  dq_vapor_to_clwater - dq_clwater_to_vapor;
+                qv_array(i,j,k) += -saturation_adjustment.dq_vapor_to_cloud
+                                 +  saturation_adjustment.dq_cloud_to_vapor;
+                qc_array(i,j,k) +=  saturation_adjustment.dq_vapor_to_cloud
+                                 -  saturation_adjustment.dq_cloud_to_vapor;
 
                 Real theta_over_T = theta_array(i,j,k)/tabs_array(i,j,k);
-
-                theta_array(i,j,k) += theta_over_T * d_fac_cond * (dq_vapor_to_clwater - dq_clwater_to_vapor);
+                theta_array(i,j,k) += theta_over_T * d_fac_cond
+                    * (saturation_adjustment.dq_vapor_to_cloud - saturation_adjustment.dq_cloud_to_vapor);
 
                 qv_array(i,j,k) = std::max(Real(0), qv_array(i,j,k));
                 qc_array(i,j,k) = std::max(Real(0), qc_array(i,j,k));

--- a/Source/Microphysics/Kessler/ERF_KesslerUtils.H
+++ b/Source/Microphysics/Kessler/ERF_KesslerUtils.H
@@ -1,0 +1,183 @@
+#ifndef ERF_KESSLER_UTILS_H_
+#define ERF_KESSLER_UTILS_H_
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+
+#include <ERF_Constants.H>
+#include <ERF_MicrophysicsUtils.H>
+
+struct KesslerSourceTerms {
+    amrex::Real dq_vapor_to_cloud;
+    amrex::Real dq_cloud_to_vapor;
+    amrex::Real dq_cloud_to_rain;
+    amrex::Real dq_rain_to_vapor;
+};
+
+struct KesslerSaturationAdjustment {
+    amrex::Real dq_vapor_to_cloud;
+    amrex::Real dq_cloud_to_vapor;
+};
+
+struct KesslerFaceState {
+    amrex::Real rho;
+    amrex::Real qp;
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real kessler_terminal_velocity (const amrex::Real rho,
+                                       const amrex::Real qp) noexcept
+{
+    // MUST MATCH: current AdvanceKessler terminal-velocity coefficients.
+    return amrex::Real(36.34)
+        * std::pow(rho * amrex::Real(0.001) * qp, amrex::Real(0.1346))
+        * std::pow(rho / amrex::Real(1.16), -myhalf);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real kessler_precip_flux (const amrex::Real rho,
+                                 const amrex::Real terminal_velocity,
+                                 const amrex::Real qp) noexcept
+{
+    return rho * terminal_velocity * qp;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int kessler_num_sedimentation_substeps (const amrex::Real current_reduced_value,
+                                        const amrex::Real dt,
+                                        const amrex::Real dzmin) noexcept
+{
+    // MUST MATCH: current AdvanceKessler CFL_MAX precipitation substep formula.
+    return static_cast<int>(std::ceil((current_reduced_value + std::numeric_limits<amrex::Real>::epsilon())
+                                      * (dt / dzmin) / myhalf));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool kessler_is_small_sedimentation_value (const amrex::Real value) noexcept
+{
+    // MUST MATCH: current AdvanceKessler sedimentation zero threshold literal.
+    return std::fabs(value) < 1e-14;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+KesslerSaturationAdjustment kessler_saturation_adjustment (const amrex::Real qv,
+                                                           const amrex::Real qc,
+                                                           const amrex::Real qsat,
+                                                           const amrex::Real dtqsat,
+                                                           const bool do_cond) noexcept
+{
+    KesslerSaturationAdjustment source_terms{amrex::Real(0), amrex::Real(0)};
+
+    // MUST MATCH: current AdvanceKessler latent-heat saturation factor.
+    const amrex::Real fac = (L_v / Cp_d) * dtqsat;
+
+    // MUST MATCH: current AdvanceKessler condensation branch behavior.
+    if ((qv > qsat) && do_cond) {
+        source_terms.dq_vapor_to_cloud = std::min(qv, (qv - qsat) / (amrex::Real(1) + fac));
+    }
+
+    // MUST MATCH: current AdvanceKessler cloud-evaporation branch behavior.
+    if ((qv < qsat) && (qc > amrex::Real(0)) && do_cond) {
+        source_terms.dq_cloud_to_vapor = std::min(qc, (qsat - qv) / (amrex::Real(1) + fac));
+    }
+
+    return source_terms;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+KesslerFaceState kessler_face_state (const int k,
+                                     const int k_lo,
+                                     const int k_hi,
+                                     const amrex::Real rho_km1,
+                                     const amrex::Real rho_k,
+                                     const amrex::Real qp_km1,
+                                     const amrex::Real qp_k) noexcept
+{
+    KesslerFaceState face_state{amrex::Real(0), amrex::Real(0)};
+
+    // MUST MATCH: current AdvanceKessler bottom/top face boundary behavior.
+    if (k == k_lo) {
+        face_state.rho = rho_k;
+        face_state.qp = qp_k;
+    } else if (k == k_hi + 1) {
+        face_state.rho = rho_km1;
+        face_state.qp = qp_km1;
+    } else {
+        face_state.rho = myhalf * (rho_km1 + rho_k);
+        face_state.qp = myhalf * (qp_km1 + qp_k);
+    }
+
+    // MUST MATCH: current AdvanceKessler nonnegative face qp clipping.
+    face_state.qp = std::max(amrex::Real(0), face_state.qp);
+    return face_state;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real kessler_sedimentation_tendency (const amrex::Real fz_hi,
+                                            const amrex::Real fz_lo,
+                                            const amrex::Real rho,
+                                            const amrex::Real dJinv,
+                                            const amrex::Real coef) noexcept
+{
+    // MUST MATCH: current AdvanceKessler sedimentation tendency arithmetic order.
+    return dJinv * (amrex::Real(1) / rho) * (fz_hi - fz_lo) * coef;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
+                                              const amrex::Real qc,
+                                              const amrex::Real qp,
+                                              const amrex::Real rho,
+                                              const amrex::Real pressure_current_units,
+                                              const amrex::Real qsat,
+                                              const amrex::Real dtqsat,
+                                              const amrex::Real dt,
+                                              const bool do_cond) noexcept
+{
+    // Units must match current AdvanceKessler: q* are mass fractions, rho is in
+    // the production density units currently carried by Kessler, pressure is in
+    // the current production mbar units, and dt is in seconds.
+    const KesslerSaturationAdjustment saturation_adjustment =
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond);
+    KesslerSourceTerms source_terms{
+        saturation_adjustment.dq_vapor_to_cloud,
+        saturation_adjustment.dq_cloud_to_vapor,
+        amrex::Real(0),
+        amrex::Real(0)};
+
+    if ((qp > amrex::Real(0)) && (qv < qsat)) {
+        // MUST MATCH: current AdvanceKessler rain-evaporation coefficients and exponents.
+        const amrex::Real coeff = amrex::Real(1.6)
+            + amrex::Real(124.9) * std::pow(amrex::Real(0.001) * rho * qp, amrex::Real(0.2046));
+        source_terms.dq_rain_to_vapor = amrex::Real(1) / (amrex::Real(0.001) * rho)
+            * (amrex::Real(1) - qv / qsat)
+            * coeff
+            * std::pow(amrex::Real(0.001) * rho * qp, amrex::Real(0.525))
+            / (amrex::Real(5.4e5) + amrex::Real(2.55e6) / (pressure_current_units * qsat))
+            * dt;
+        source_terms.dq_rain_to_vapor = std::min({qp, source_terms.dq_rain_to_vapor});
+    }
+
+    if (qc > amrex::Real(0)) {
+        const amrex::Real qcc = qc;
+        amrex::Real auto_r = amrex::Real(0);
+        if (qcc > qcw0) {
+            // MUST MATCH: current AdvanceKessler autoconversion trigger.
+            auto_r = alphaelq;
+        }
+
+        // MUST MATCH: current AdvanceKessler accretion coefficient and exponent.
+        amrex::Real accrr = amrex::Real(0);
+        accrr = amrex::Real(2.2) * std::pow(qp, amrex::Real(0.875));
+        source_terms.dq_cloud_to_rain = dt * (accrr * qcc + auto_r * (qcc - qcw0));
+        source_terms.dq_cloud_to_rain = std::min(source_terms.dq_cloud_to_rain, qc);
+    }
+
+    return source_terms;
+}
+
+#endif

--- a/Source/Microphysics/Kessler/Make.package
+++ b/Source/Microphysics/Kessler/Make.package
@@ -2,3 +2,4 @@ CEXE_sources += ERF_InitKessler.cpp
 CEXE_sources += ERF_UpdateKessler.cpp
 CEXE_sources += ERF_Kessler.cpp
 CEXE_headers += ERF_Kessler.H
+CEXE_headers += ERF_KesslerUtils.H


### PR DESCRIPTION
## Summary

This PR applies the production portion of a bit-for-bit validated refactor of the Kessler microphysics scheme.

`Kessler::AdvanceKessler` now uses small scalar AMReX-portable helpers for saturation adjustment, warm-rain source terms, sedimentation face state, terminal velocity, precipitation flux, substep count, and sedimentation tendency.

No physics changes are intended.

## What changed

- Added `ERF_KesslerUtils.H`.
- Refactored `AdvanceKessler` to use `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE` helper functions.
- Shared saturation-adjustment logic between the full Kessler path and `Kessler_NoRain`.
- Shared sedimentation face-state and tendency logic.
- Preserved the existing kernel structure, reductions, `MultiFab` allocation pattern, and update ordering.
- Kept bottom rain accumulation inline because extracting it changed `rain_accum` by one ULP in the BFB harness.

## What is intentionally not included

This PR does not include the temporary BFB scaffold used to validate the refactor. The BFB harness was used as validation scaffolding and was intentionally left out of the production refactor branch.

## Validation

BFB validation was performed on the scaffold branch before producing this clean production refactor.

BFB scaffold validation:
- Kessler-filtered unit run: 8/8 passed.
- Full unit executable: 54/54 passed.
- Bottom rain accumulation helper was attempted and reverted because it changed `rain_accum` by one ULP.
- GPU-specific validation was not run in that environment.

## Performance and portability

This refactor is intended to be performance-neutral.

- No new production `ParallelFor` launches.
- No new production reductions.
- No new production `MultiFab` allocations.
- No new data-layout changes.
- Helpers are `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE`.
- Helpers use `amrex::Real`.
- No dynamic allocation, virtual dispatch, or host-only calls were added to device paths.