### PR TITLE
Kessler testing and fixes

### DIFF
--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -53,7 +53,7 @@ public:
     void
     Define (SolverChoice& sc) override
     {
-        m_fac_cond = lcond / sc.c_p;
+        m_fac_cond = L_v / sc.c_p;
         m_axis     = sc.ave_plane;
         m_do_cond  = (!sc.use_shoc);
     }

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -11,6 +11,7 @@
 #include <AMReX_MultiFabUtil.H>
 
 #include "ERF_Constants.H"
+#include "ERF_KesslerUtils.H"
 #include "ERF_MicrophysicsUtils.H"
 #include "ERF_IndexDefines.H"
 #include "ERF_DataStruct.H"
@@ -143,7 +144,7 @@ private:
     int n_qstate_moist_size = 3;
 
     // CFL MAX for vertical advection
-    static constexpr amrex::Real CFL_MAX = myhalf;
+    static constexpr amrex::Real CFL_MAX = kessler_sedimentation_cfl_max;
 
     // MicVar map (Qmoist indices -> MicVar enum)
     amrex::Vector<int> MicVarMap;

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -68,7 +68,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 
                 const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
                     qv_array(i,j,k), qc_array(i,j,k), qp_array(i,j,k), rho_array(i,j,k),
-                    pressure, qsat_local, dtqsat_local, dtn, do_cond);
+                    pressure, qsat_local, dtqsat_local, dtn, do_cond, d_fac_cond);
 
                 qv_array(i,j,k) += -source_terms.dq_vapor_to_cloud
                                  +  source_terms.dq_cloud_to_vapor
@@ -163,11 +163,13 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                         kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
                     const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
-                    fz_array(i,j,k) = kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
+                    const Real max_flux = face_state.rho * face_state.qp / coef;
+                    fz_array(i,j,k) = amrex::min(
+                        kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
 
                     if(k==k_lo){
                         rain_accum_array(i,j,k) = rain_accum_array(i,j,k)
-                                                + face_state.rho * face_state.qp * terminal_velocity * dtn / Real(1000.0) * Real(1000.0);
+                                                + fz_array(i,j,k) * dtn / Real(1000.0) * Real(1000.0);
                     }
                 });
 
@@ -175,14 +177,20 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 {
                     Real dJinv = (dJ_array) ? Real(1)/dJ_array(i,j,k) : Real(1);
 
-                    if (kessler_is_small_sedimentation_value(fz_array(i,j,k+1))) {
-                        fz_array(i,j,k+1) = Real(0);
+                    // Threshold local face-flux copies only. Neighboring cells share fz
+                    // faces, so the cell update must not mutate fz while applying the
+                    // small-value cutoff.
+                    Real f_hi = fz_array(i,j,k+1);
+                    Real f_lo = fz_array(i,j,k  );
+
+                    if (kessler_is_small_sedimentation_value(f_hi)) {
+                        f_hi = Real(0);
                     }
-                    if (kessler_is_small_sedimentation_value(fz_array(i,j,k  ))) {
-                        fz_array(i,j,k  ) = Real(0);
+                    if (kessler_is_small_sedimentation_value(f_lo)) {
+                        f_lo = Real(0);
                     }
                     Real dq_sed = kessler_sedimentation_tendency(
-                        fz_array(i,j,k+1), fz_array(i,j,k), rho_array(i,j,k), dJinv, coef);
+                        f_hi, f_lo, rho_array(i,j,k), dJinv, coef);
                     if (kessler_is_small_sedimentation_value(dq_sed)) {
                         dq_sed = Real(0);
                     }
@@ -223,7 +231,8 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat);
 
                 const KesslerSaturationAdjustment saturation_adjustment =
-                    kessler_saturation_adjustment(qv_array(i,j,k), qc_array(i,j,k), qsat, dtqsat, do_cond);
+                    kessler_saturation_adjustment(qv_array(i,j,k), qc_array(i,j,k), qsat, dtqsat,
+                                                  do_cond, d_fac_cond);
 
                 qv_array(i,j,k) += -saturation_adjustment.dq_vapor_to_cloud
                                  +  saturation_adjustment.dq_cloud_to_vapor;

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -114,14 +114,23 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
             });
         }
 
-        auto const& ma_fz_arr = fz.const_arrays();
+        auto const& ma_rho_arr = mic_fab_vars[MicVar_Kess::rho]->const_arrays();
+        auto const& ma_qp_arr = mic_fab_vars[MicVar_Kess::qp]->const_arrays();
         GpuTuple<Real> max = ParReduce(TypeList<ReduceOpMax>{},
                                        TypeList<Real>{},
                                        fz, IntVect(0),
                                        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
                                        -> GpuTuple<Real>
                                        {
-                                           return { ma_fz_arr[box_no](i,j,k) };
+                                           const auto& rho_arr = ma_rho_arr[box_no];
+                                           const auto& qp_arr = ma_qp_arr[box_no];
+                                           const Real rho_km1 = (k == k_lo) ? rho_arr(i,j,k) : rho_arr(i,j,k-1);
+                                           const Real rho_k = (k == k_hi+1) ? rho_arr(i,j,k-1) : rho_arr(i,j,k);
+                                           const Real qp_km1 = (k == k_lo) ? qp_arr(i,j,k) : qp_arr(i,j,k-1);
+                                           const Real qp_k = (k == k_hi+1) ? qp_arr(i,j,k-1) : qp_arr(i,j,k);
+                                           const KesslerFaceState face_state =
+                                               kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
+                                           return { kessler_terminal_velocity(face_state.rho, face_state.qp) };
                                        });
         int n_substep = kessler_num_sedimentation_substeps(get<0>(max), dt, m_dzmin);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_substep >= 1,

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -116,23 +116,26 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 
         auto const& ma_rho_arr = mic_fab_vars[MicVar_Kess::rho]->const_arrays();
         auto const& ma_qp_arr = mic_fab_vars[MicVar_Kess::qp]->const_arrays();
-        GpuTuple<Real> max = ParReduce(TypeList<ReduceOpMax>{},
-                                       TypeList<Real>{},
-                                       fz, IntVect(0),
-                                       [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
-                                       -> GpuTuple<Real>
-                                       {
-                                           const auto& rho_arr = ma_rho_arr[box_no];
-                                           const auto& qp_arr = ma_qp_arr[box_no];
-                                           const Real rho_km1 = (k == k_lo) ? rho_arr(i,j,k) : rho_arr(i,j,k-1);
-                                           const Real rho_k = (k == k_hi+1) ? rho_arr(i,j,k-1) : rho_arr(i,j,k);
-                                           const Real qp_km1 = (k == k_lo) ? qp_arr(i,j,k) : qp_arr(i,j,k-1);
-                                           const Real qp_k = (k == k_hi+1) ? qp_arr(i,j,k-1) : qp_arr(i,j,k);
-                                           const KesslerFaceState face_state =
-                                               kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
-                                           return { kessler_terminal_velocity(face_state.rho, face_state.qp) };
-                                       });
-        int n_substep = kessler_num_sedimentation_substeps(get<0>(max), dt, m_dzmin);
+        // The sedimentation CFL is based on terminal velocity, not precipitating
+        // mass flux. fz stores rho * Vt * qp for the flux update below.
+        GpuTuple<Real> max_terminal_velocity = ParReduce(TypeList<ReduceOpMax>{},
+                                                         TypeList<Real>{},
+                                                         fz, IntVect(0),
+                                                         [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept
+                                                         -> GpuTuple<Real>
+                                                         {
+                                                             const auto& rho_arr = ma_rho_arr[box_no];
+                                                             const auto& qp_arr = ma_qp_arr[box_no];
+                                                             const Real rho_km1 = (k == k_lo) ? rho_arr(i,j,k) : rho_arr(i,j,k-1);
+                                                             const Real rho_k = (k == k_hi+1) ? rho_arr(i,j,k-1) : rho_arr(i,j,k);
+                                                             const Real qp_km1 = (k == k_lo) ? qp_arr(i,j,k) : qp_arr(i,j,k-1);
+                                                             const Real qp_k = (k == k_hi+1) ? qp_arr(i,j,k-1) : qp_arr(i,j,k);
+                                                             const KesslerFaceState face_state =
+                                                                 kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
+                                                             return { kessler_terminal_velocity(face_state.rho, face_state.qp) };
+                                                         });
+        int n_substep = kessler_num_sedimentation_substeps(get<0>(max_terminal_velocity),
+                                                           dt, m_dzmin);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(n_substep >= 1,
                                          "Kessler: Number of precipitation substeps must be greater than 0!");
         coef /= Real(n_substep);

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -107,7 +107,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 const Real qp_km1 = (k == k_lo) ? qp_array(i,j,k) : qp_array(i,j,k-1);
                 const Real qp_k = (k == k_hi+1) ? qp_array(i,j,k-1) : qp_array(i,j,k);
                 const KesslerFaceState face_state =
-                    kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
+                    kessler_face_state(k, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
                 const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
                 fz_array(i,j,k) = kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
@@ -131,7 +131,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                                                              const Real qp_km1 = (k == k_lo) ? qp_arr(i,j,k) : qp_arr(i,j,k-1);
                                                              const Real qp_k = (k == k_hi+1) ? qp_arr(i,j,k-1) : qp_arr(i,j,k);
                                                              const KesslerFaceState face_state =
-                                                                 kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
+                                                                 kessler_face_state(k, k_hi, rho_km1, rho_k, qp_km1, qp_k);
                                                              return { kessler_terminal_velocity(face_state.rho, face_state.qp) };
                                                          });
         int n_substep = kessler_num_sedimentation_substeps(get<0>(max_terminal_velocity),
@@ -159,17 +159,24 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                     const Real rho_k = (k == k_hi+1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
                     const Real qp_km1 = (k == k_lo) ? qp_array(i,j,k) : qp_array(i,j,k-1);
                     const Real qp_k = (k == k_hi+1) ? qp_array(i,j,k-1) : qp_array(i,j,k);
+                    const int donor_k = kessler_face_donor_k(k, k_hi);
                     const KesslerFaceState face_state =
-                        kessler_face_state(k, k_lo, k_hi, rho_km1, rho_k, qp_km1, qp_k);
+                        kessler_face_state(k, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
                     const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
-                    const Real max_flux = face_state.rho * face_state.qp / coef;
+                    const Real donor_detJ = (dJ_array) ? dJ_array(i,j,donor_k) : Real(1);
+                    // Limit the outgoing donor-face flux by the donor cell's available
+                    // detJ-weighted precipitating water. This prevents over-removal for detJ < 1
+                    // before the nonnegative qp clip.
+                    const Real max_flux = face_state.rho * face_state.qp * donor_detJ / coef;
                     fz_array(i,j,k) = amrex::min(
                         kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
 
                     if(k==k_lo){
+                        // Convert precipitation mass per unit area [kg m^-2] to water depth [mm]:
+                        // divide by liquid-water density [kg m^-3], then multiply by mm per m.
                         rain_accum_array(i,j,k) = rain_accum_array(i,j,k)
-                                                + fz_array(i,j,k) * dtn / Real(1000.0) * Real(1000.0);
+                                                + kessler_rain_accumulation_increment(fz_array(i,j,k) * dtn);
                     }
                 });
 

--- a/Source/Microphysics/Kessler/ERF_KesslerUtils.H
+++ b/Source/Microphysics/Kessler/ERF_KesslerUtils.H
@@ -68,12 +68,12 @@ KesslerSaturationAdjustment kessler_saturation_adjustment (const amrex::Real qv,
                                                            const amrex::Real qc,
                                                            const amrex::Real qsat,
                                                            const amrex::Real dtqsat,
-                                                           const bool do_cond) noexcept
+                                                           const bool do_cond,
+                                                           const amrex::Real latent_over_cp) noexcept
 {
     KesslerSaturationAdjustment source_terms{amrex::Real(0), amrex::Real(0)};
 
-    // MUST MATCH: current AdvanceKessler latent-heat saturation factor.
-    const amrex::Real fac = (L_v / Cp_d) * dtqsat;
+    const amrex::Real fac = latent_over_cp * dtqsat;
 
     // MUST MATCH: current AdvanceKessler condensation branch behavior.
     if ((qv > qsat) && do_cond) {
@@ -107,8 +107,8 @@ KesslerFaceState kessler_face_state (const int k,
         face_state.rho = rho_km1;
         face_state.qp = qp_km1;
     } else {
-        face_state.rho = myhalf * (rho_km1 + rho_k);
-        face_state.qp = myhalf * (qp_km1 + qp_k);
+        face_state.rho = rho_k;
+        face_state.qp = qp_k;
     }
 
     // MUST MATCH: current AdvanceKessler nonnegative face qp clipping.
@@ -136,34 +136,47 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
                                               const amrex::Real qsat,
                                               const amrex::Real dtqsat,
                                               const amrex::Real dt,
-                                              const bool do_cond) noexcept
+                                              const bool do_cond,
+                                              const amrex::Real latent_over_cp) noexcept
 {
     // Units must match current AdvanceKessler: q* are mass fractions, rho is in
     // the production density units currently carried by Kessler, pressure is in
     // the current production mbar units, and dt is in seconds.
     const KesslerSaturationAdjustment saturation_adjustment =
-        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond);
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond, latent_over_cp);
     KesslerSourceTerms source_terms{
         saturation_adjustment.dq_vapor_to_cloud,
         saturation_adjustment.dq_cloud_to_vapor,
         amrex::Real(0),
         amrex::Real(0)};
 
-    if ((qp > amrex::Real(0)) && (qv < qsat)) {
+    const amrex::Real capacity = amrex::max(
+        amrex::Real(0), (qsat - qv) / (amrex::Real(1) + latent_over_cp * dtqsat));
+    const amrex::Real remaining_capacity = amrex::max(
+        amrex::Real(0), capacity - saturation_adjustment.dq_cloud_to_vapor);
+    const amrex::Real qv_eff = qv
+        - saturation_adjustment.dq_vapor_to_cloud
+        + saturation_adjustment.dq_cloud_to_vapor;
+
+    if ((qp > amrex::Real(0)) && (qsat > amrex::Real(0))
+        && (pressure_current_units > amrex::Real(0))
+        && (qv_eff < qsat) && (remaining_capacity > amrex::Real(0))) {
         // MUST MATCH: current AdvanceKessler rain-evaporation coefficients and exponents.
         const amrex::Real coeff = amrex::Real(1.6)
             + amrex::Real(124.9) * std::pow(amrex::Real(0.001) * rho * qp, amrex::Real(0.2046));
-        source_terms.dq_rain_to_vapor = amrex::Real(1) / (amrex::Real(0.001) * rho)
-            * (amrex::Real(1) - qv / qsat)
+        const amrex::Real raw_rain_to_vapor = amrex::Real(1) / (amrex::Real(0.001) * rho)
+            * (amrex::Real(1) - qv_eff / qsat)
             * coeff
             * std::pow(amrex::Real(0.001) * rho * qp, amrex::Real(0.525))
             / (amrex::Real(5.4e5) + amrex::Real(2.55e6) / (pressure_current_units * qsat))
             * dt;
-        source_terms.dq_rain_to_vapor = std::min({qp, source_terms.dq_rain_to_vapor});
+        source_terms.dq_rain_to_vapor = amrex::min(qp, amrex::min(raw_rain_to_vapor, remaining_capacity));
     }
 
     if (qc > amrex::Real(0)) {
         const amrex::Real qcc = qc;
+        const amrex::Real available_cloud = amrex::max(
+            amrex::Real(0), qc + saturation_adjustment.dq_vapor_to_cloud - saturation_adjustment.dq_cloud_to_vapor);
         amrex::Real auto_r = amrex::Real(0);
         if (qcc > qcw0) {
             // MUST MATCH: current AdvanceKessler autoconversion trigger.
@@ -174,7 +187,7 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
         amrex::Real accrr = amrex::Real(0);
         accrr = amrex::Real(2.2) * std::pow(qp, amrex::Real(0.875));
         source_terms.dq_cloud_to_rain = dt * (accrr * qcc + auto_r * (qcc - qcw0));
-        source_terms.dq_cloud_to_rain = std::min(source_terms.dq_cloud_to_rain, qc);
+        source_terms.dq_cloud_to_rain = amrex::min(source_terms.dq_cloud_to_rain, available_cloud);
     }
 
     return source_terms;

--- a/Source/Microphysics/Kessler/ERF_KesslerUtils.H
+++ b/Source/Microphysics/Kessler/ERF_KesslerUtils.H
@@ -28,6 +28,17 @@ struct KesslerFaceState {
     amrex::Real qp;
 };
 
+static constexpr amrex::Real kessler_sedimentation_cfl_max = myhalf;
+static constexpr amrex::Real kessler_water_depth_m_per_kg_m2 = amrex::Real(1.0) / rhor;
+static constexpr amrex::Real kessler_millimeters_per_meter = amrex::Real(1000.0);
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int kessler_face_donor_k (const int k,
+                          const int k_hi) noexcept
+{
+    return (k == k_hi + 1) ? k - 1 : k;
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real kessler_terminal_velocity (const amrex::Real rho,
                                        const amrex::Real qp) noexcept
@@ -53,7 +64,15 @@ int kessler_num_sedimentation_substeps (const amrex::Real current_reduced_value,
 {
     // MUST MATCH: current AdvanceKessler CFL_MAX precipitation substep formula.
     return static_cast<int>(std::ceil((current_reduced_value + std::numeric_limits<amrex::Real>::epsilon())
-                                      * (dt / dzmin) / myhalf));
+                                      * (dt / dzmin) / kessler_sedimentation_cfl_max));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real kessler_rain_accumulation_increment (const amrex::Real precip_mass_per_area) noexcept
+{
+    return precip_mass_per_area
+        * kessler_water_depth_m_per_kg_m2
+        * kessler_millimeters_per_meter;
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -90,7 +109,6 @@ KesslerSaturationAdjustment kessler_saturation_adjustment (const amrex::Real qv,
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 KesslerFaceState kessler_face_state (const int k,
-                                     const int k_lo,
                                      const int k_hi,
                                      const amrex::Real rho_km1,
                                      const amrex::Real rho_k,
@@ -99,11 +117,9 @@ KesslerFaceState kessler_face_state (const int k,
 {
     KesslerFaceState face_state{amrex::Real(0), amrex::Real(0)};
 
-    // MUST MATCH: current AdvanceKessler bottom/top face boundary behavior.
-    if (k == k_lo) {
-        face_state.rho = rho_k;
-        face_state.qp = qp_k;
-    } else if (k == k_hi + 1) {
+    // Downward sedimentation uses the upper-cell donor state at interior faces.
+    // The top boundary face uses the top cell below the boundary.
+    if (k == k_hi + 1) {
         face_state.rho = rho_km1;
         face_state.qp = qp_km1;
     } else {
@@ -154,6 +170,10 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
         amrex::Real(0), (qsat - qv) / (amrex::Real(1) + latent_over_cp * dtqsat));
     const amrex::Real remaining_capacity = amrex::max(
         amrex::Real(0), capacity - saturation_adjustment.dq_cloud_to_vapor);
+    // Saturation adjustment returns at most one nonzero phase-change direction:
+    // condensation reduces vapor in supersaturation, while cloud evaporation
+    // increases vapor in subsaturation. Rain evaporation uses the vapor state
+    // after that cloud adjustment.
     const amrex::Real qv_eff = qv
         - saturation_adjustment.dq_vapor_to_cloud
         + saturation_adjustment.dq_cloud_to_vapor;

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -39,6 +39,9 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjThermo.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjCell.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjMultiFab.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
 )
 build_erf_exe(${erf_exe_name})
 target_link_libraries(${erf_exe_name} PRIVATE GTest::gtest)

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
@@ -440,7 +440,7 @@ int reference_substeps_from_reduced_value (const amrex::Real reduced_value,
                                            const amrex::Real dz) noexcept
 {
     return static_cast<int>(std::ceil((reduced_value + std::numeric_limits<amrex::Real>::epsilon())
-                                      * (dt / dz) / myhalf));
+                                      * (dt / dz) / kessler_sedimentation_cfl_max));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -449,7 +449,7 @@ int reference_velocity_cfl_substeps (const amrex::Real terminal_velocity,
                                      const amrex::Real dz) noexcept
 {
     return static_cast<int>(std::ceil((terminal_velocity + std::numeric_limits<amrex::Real>::epsilon())
-                                      * (dt / dz) / myhalf));
+                                      * (dt / dz) / kessler_sedimentation_cfl_max));
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -641,6 +641,19 @@ inline void fill_detj_portable (amrex::MultiFab& detj)
         run_and_sync([=] {
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 arr(i,j,k) = amrex::Real(1.0) + amrex::Real(0.1) * (i + 2 * j + 3 * k);
+            });
+        });
+    }
+}
+
+inline void fill_compressed_detj_portable (amrex::MultiFab& detj)
+{
+    for (amrex::MFIter mfi(detj, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = detj.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                arr(i,j,k) = amrex::Real(0.25) + amrex::Real(0.25) * k;
             });
         });
     }

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
@@ -62,7 +62,7 @@ namespace kessler_test {
 
 constexpr amrex::Real kRdOcp = R_d / Cp_d;
 constexpr amrex::Real kSatAdjLatentOverCp = L_v / Cp_d;
-constexpr amrex::Real kThetaLatentOverCp = lcond / Cp_d;
+constexpr amrex::Real kThetaLatentOverCp = L_v / Cp_d;
 constexpr amrex::Real kDefaultDt = amrex::Real(1.0);
 
 enum StateDiffComp {
@@ -275,10 +275,11 @@ KesslerSaturationAdjustment reference_saturation_adjustment (const amrex::Real q
                                                              const amrex::Real qc,
                                                              const amrex::Real qsat,
                                                              const amrex::Real dtqsat,
-                                                             const bool do_cond) noexcept
+                                                             const bool do_cond,
+                                                             const amrex::Real latent_over_cp) noexcept
 {
     KesslerSaturationAdjustment source_terms{amrex::Real(0.0), amrex::Real(0.0)};
-    const amrex::Real denom = amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat;
+    const amrex::Real denom = amrex::Real(1.0) + latent_over_cp * dtqsat;
 
     if ((qv > qsat) && do_cond) {
         source_terms.dq_vapor_to_cloud = amrex::min(qv, (qv - qsat) / denom);
@@ -299,37 +300,48 @@ KesslerSourceTerms reference_warm_rain_sources (const amrex::Real qv,
                                                 const amrex::Real qsat,
                                                 const amrex::Real dtqsat,
                                                 const amrex::Real dt,
-                                                const bool do_cond) noexcept
+                                                const bool do_cond,
+                                                const amrex::Real latent_over_cp) noexcept
 {
     const KesslerSaturationAdjustment sat =
-        reference_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond);
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond, latent_over_cp);
     KesslerSourceTerms source_terms{
         sat.dq_vapor_to_cloud,
         sat.dq_cloud_to_vapor,
         amrex::Real(0.0),
         amrex::Real(0.0)};
 
-    if ((qp > amrex::Real(0.0)) && (qv < qsat)) {
+    const amrex::Real capacity = amrex::max(
+        amrex::Real(0.0), (qsat - qv) / (amrex::Real(1.0) + latent_over_cp * dtqsat));
+    const amrex::Real remaining_capacity = amrex::max(
+        amrex::Real(0.0), capacity - sat.dq_cloud_to_vapor);
+    const amrex::Real qv_eff = qv - sat.dq_vapor_to_cloud + sat.dq_cloud_to_vapor;
+
+    if ((qp > amrex::Real(0.0)) && (qsat > amrex::Real(0.0))
+        && (pressure_mbar > amrex::Real(0.0))
+        && (qv_eff < qsat) && (remaining_capacity > amrex::Real(0.0))) {
         // MUST MATCH: Kessler rain-evaporation closure coefficients.
         const amrex::Real scaled_mass = amrex::Real(0.001) * rho * qp;
         const amrex::Real coeff = amrex::Real(1.6)
             + amrex::Real(124.9) * std::pow(scaled_mass, amrex::Real(0.2046));
         const amrex::Real raw = amrex::Real(1.0) / (amrex::Real(0.001) * rho)
-            * (amrex::Real(1.0) - qv / qsat)
+            * (amrex::Real(1.0) - qv_eff / qsat)
             * coeff
             * std::pow(scaled_mass, amrex::Real(0.525))
             / (amrex::Real(5.4e5) + amrex::Real(2.55e6) / (pressure_mbar * qsat))
             * dt;
-        source_terms.dq_rain_to_vapor = amrex::min(qp, raw);
+        source_terms.dq_rain_to_vapor = amrex::min(qp, amrex::min(raw, remaining_capacity));
     }
 
     if (qc > amrex::Real(0.0)) {
+        const amrex::Real available_cloud = amrex::max(
+            amrex::Real(0.0), qc + sat.dq_vapor_to_cloud - sat.dq_cloud_to_vapor);
         // MUST MATCH: qcw0 and alphaelq Kessler autoconversion parameters.
         const amrex::Real auto_r = (qc > qcw0) ? alphaelq : amrex::Real(0.0);
         // MUST MATCH: Kessler accretion coefficient and exponent.
         const amrex::Real accretion_rate = amrex::Real(2.2) * std::pow(qp, amrex::Real(0.875));
         const amrex::Real raw = dt * (accretion_rate * qc + auto_r * (qc - qcw0));
-        source_terms.dq_cloud_to_rain = amrex::min(raw, qc);
+        source_terms.dq_cloud_to_rain = amrex::min(raw, available_cloud);
     }
 
     return source_terms;

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
@@ -25,14 +25,9 @@
 #include <ERF_DataStruct.H>
 #include <ERF_EOS.H>
 #include <ERF_IndexDefines.H>
+#include <ERF_Kessler.H>
 #include <ERF_KesslerUtils.H>
 #include <ERF_MicrophysicsUtils.H>
-
-// Test-only visibility for Kessler internal MultiFab state. This avoids
-// production accessors while keeping the task tests-only.
-#define private public
-#include <ERF_Kessler.H>
-#undef private
 
 namespace kessler_test {
 

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
@@ -152,6 +152,24 @@ inline amrex::Real formula_rel_tol (const amrex::Real expected)
     return formula_abs_tol(expected);
 }
 
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real portable_formula_abs_tol (const amrex::Real expected) noexcept
+{
+#ifdef AMREX_USE_FLOAT
+    const amrex::Real factor = amrex::Real(64.0);
+#else
+    const amrex::Real factor = amrex::Real(32.0);
+#endif
+    return factor * std::numeric_limits<amrex::Real>::epsilon() *
+           amrex::max(amrex::Real(1.0), amrex::Math::abs(expected));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real portable_formula_rel_tol (const amrex::Real expected) noexcept
+{
+    return portable_formula_abs_tol(expected);
+}
+
 // Absolute tolerance for pow-based helper comparisons.
 // Provenance: backend math-library variation for pow on CPU/GPU, floating-point
 // roundoff, and float-vs-double scaling.
@@ -526,6 +544,22 @@ inline void fill_conserved_state_portable (amrex::MultiFab& cons)
     }
 }
 
+// Keep device lambdas in namespace-scope helpers. CUDA rejects extended
+// device lambdas enclosed by GTest's private TestBody() member function.
+inline void fill_conserved_state_uniform_portable (amrex::MultiFab& cons,
+                                                   const PrimitiveState& state)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+}
+
 inline void fill_local_source_only_state_portable (amrex::MultiFab& cons)
 {
     for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
@@ -595,6 +629,24 @@ inline void fill_detj_portable (amrex::MultiFab& detj)
         run_and_sync([=] {
             amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 arr(i,j,k) = amrex::Real(1.0) + amrex::Real(0.1) * (i + 2 * j + 3 * k);
+            });
+        });
+    }
+}
+
+inline void fill_do_cond_false_rain_path_state_portable (amrex::MultiFab& cons)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const PrimitiveState state = (k == 3)
+                    ? make_primitive_state(amrex::Real(284.0), amrex::Real(850.0),
+                                           amrex::Real(7.0e-3), amrex::Real(2.0e-4), amrex::Real(0.0))
+                    : make_primitive_state(amrex::Real(288.0), amrex::Real(900.0),
+                                           amrex::Real(1.20e-2), qcw0 + amrex::Real(3.0e-4), amrex::Real(1.0e-3));
+                set_conserved_cell(arr, i, j, k, state);
             });
         });
     }
@@ -681,11 +733,12 @@ inline void compute_kessler_conservation_errors (const amrex::MultiFab& before,
                 const amrex::Real latent_before = rho_before * (tabs_before + kThetaLatentOverCp * qv_before);
                 const amrex::Real latent_after = rho_after * (tabs_after + kThetaLatentOverCp * qv_after);
 
-                err_arr(i,j,k,ConservationErrRho) = normalized_error(rho_after, rho_before, formula_rel_tol(rho_before));
+                err_arr(i,j,k,ConservationErrRho) = normalized_error(
+                    rho_after, rho_before, portable_formula_rel_tol(rho_before));
                 err_arr(i,j,k,ConservationErrTotalWater) = normalized_error(
-                    qtot_after, qtot_before, formula_rel_tol(qtot_before));
+                    qtot_after, qtot_before, portable_formula_rel_tol(qtot_before));
                 err_arr(i,j,k,ConservationErrLatentProxy) = normalized_error(
-                    latent_after, latent_before, formula_rel_tol(latent_before));
+                    latent_after, latent_before, portable_formula_rel_tol(latent_before));
             });
         });
     }

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerCommon.H
@@ -1,0 +1,829 @@
+#ifndef ERF_GTEST_KESSLER_COMMON_H_
+#define ERF_GTEST_KESSLER_COMMON_H_
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <AMReX_Array4.H>
+#include <AMReX_Box.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_MFIter.H>
+#include <AMReX_Math.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Reduce.H>
+
+#include <ERF_Constants.H>
+#include <ERF_DataStruct.H>
+#include <ERF_EOS.H>
+#include <ERF_IndexDefines.H>
+#include <ERF_KesslerUtils.H>
+#include <ERF_MicrophysicsUtils.H>
+
+// Test-only visibility for Kessler internal MultiFab state. This avoids
+// production accessors while keeping the task tests-only.
+#define private public
+#include <ERF_Kessler.H>
+#undef private
+
+namespace kessler_test {
+
+// Kessler unit-test contract
+// --------------------------
+// These tests check ERF's refactored Kessler helper surface and public flow.
+// The scalar tests cover functional-form contracts for the documented Kessler
+// closure formulas. The physical-property tests cover closure-independent
+// invariants that any reasonable warm-rain scheme should satisfy.
+//
+// Core invariants:
+//   1. Local source terms conserve qv + qc + qp before sedimentation.
+//   2. Sedimentation transfers precipitating water vertically and to
+//      rain_accum at the bottom.
+//   3. Public-flow column water budgets must include surface rain.
+//   4. Kessler_NoRain does not advance rain water or rain accumulation.
+//   5. qsat helper pressure inputs are in mbar / hPa.
+//   6. EOS pressure utilities use Pa.
+//
+// Portability:
+//   - Device kernels compute helper outputs or reduced error metrics only.
+//   - GTest EXPECT/ASSERT calls stay on the host.
+//   - No dynamic allocation is allowed inside device code.
+//   - Device coverage uses representative case tables, not single-sample smoke
+//     tests.
+//
+// Helper composition:
+//   - kessler_warm_rain_sources calls kessler_saturation_adjustment internally.
+//   - Tests that isolate rain evaporation must choose inputs where the
+//     saturation-adjustment terms are known, or account for the full composed
+//     source update.
+
+constexpr amrex::Real kRdOcp = R_d / Cp_d;
+constexpr amrex::Real kSatAdjLatentOverCp = L_v / Cp_d;
+constexpr amrex::Real kThetaLatentOverCp = lcond / Cp_d;
+constexpr amrex::Real kDefaultDt = amrex::Real(1.0);
+
+enum StateDiffComp {
+    StateDiffRho = 0,
+    StateDiffRhoTheta,
+    StateDiffQ1,
+    StateDiffQ2,
+    StateDiffQ3,
+    NumStateDiffComps
+};
+
+enum ConservationErrComp {
+    ConservationErrRho = 0,
+    ConservationErrTotalWater,
+    ConservationErrLatentProxy,
+    NumConservationErrComps
+};
+
+enum RainStateErrComp {
+    RainStateErrQp = 0,
+    RainStateErrRainAccum,
+    NumRainStateErrComps
+};
+
+struct PrimitiveState {
+    amrex::Real rho;
+    amrex::Real theta;
+    amrex::Real tabs;
+    amrex::Real pres_mbar;
+    amrex::Real qv;
+    amrex::Real qc;
+    amrex::Real qp;
+};
+
+struct ColumnBudget {
+    amrex::Real rho_sum;
+    amrex::Real total_water_sum;
+    amrex::Real latent_proxy_sum;
+    amrex::Real rain_accum_sum;
+};
+
+struct KernelCase {
+    amrex::Real qv;
+    amrex::Real qc;
+    amrex::Real qp;
+    amrex::Real rho;
+    amrex::Real pressure_mbar;
+    amrex::Real qsat;
+    amrex::Real dtqsat;
+    amrex::Real dt;
+    bool do_cond;
+    int face_k;
+    int face_k_lo;
+    int face_k_hi;
+    amrex::Real face_rho_km1;
+    amrex::Real face_rho_k;
+    amrex::Real face_qp_km1;
+    amrex::Real face_qp_k;
+    amrex::Real fz_hi;
+    amrex::Real fz_lo;
+    amrex::Real dJinv;
+    amrex::Real coef;
+    amrex::Real reduced_value;
+    amrex::Real substep_dt;
+    amrex::Real substep_dz;
+};
+
+// Machine-precision-scaled absolute tolerance for analytic formula checks.
+// Provenance: machine epsilon, float-vs-double scaling, and a small safety
+// factor for one to a few arithmetic operations.
+inline amrex::Real formula_abs_tol (const amrex::Real expected)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(64.0) * std::numeric_limits<amrex::Real>::epsilon() *
+           std::max(amrex::Real(1.0), std::abs(expected));
+#else
+    return amrex::Real(32.0) * std::numeric_limits<amrex::Real>::epsilon() *
+           std::max(amrex::Real(1.0), std::abs(expected));
+#endif
+}
+
+// Relative tolerance for smooth closed-form identities.
+// Provenance: machine epsilon, float-vs-double scaling, and a safety factor for
+// several multiplies/divides without transcendental functions.
+inline amrex::Real formula_rel_tol (const amrex::Real expected)
+{
+    return formula_abs_tol(expected);
+}
+
+// Absolute tolerance for pow-based helper comparisons.
+// Provenance: backend math-library variation for pow on CPU/GPU, floating-point
+// roundoff, and float-vs-double scaling.
+inline amrex::Real backend_math_abs_tol (const amrex::Real expected)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(4.0e3) * std::numeric_limits<amrex::Real>::epsilon() *
+           std::max(amrex::Real(1.0), std::abs(expected));
+#else
+    return amrex::Real(2.0e2) * std::numeric_limits<amrex::Real>::epsilon() *
+           std::max(amrex::Real(1.0), std::abs(expected));
+#endif
+}
+
+// Tolerance for exact-zero branches and clipped values.
+// Provenance: machine epsilon only; use this when the mathematical contract is
+// exactly zero but host/device roundoff may leave a tiny residual.
+inline amrex::Real exact_zero_or_near_zero_tol ()
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(64.0) * std::numeric_limits<amrex::Real>::epsilon();
+#else
+    return amrex::Real(32.0) * std::numeric_limits<amrex::Real>::epsilon();
+#endif
+}
+
+// Finite-difference tolerance for smooth derivative tests.
+// Provenance: O(h^2) truncation for a central difference, machine epsilon,
+// roundoff amplification by division through h, and float-vs-double scaling.
+inline amrex::Real finite_difference_tol (const amrex::Real scale,
+                                          const amrex::Real h)
+{
+#ifdef AMREX_USE_FLOAT
+    const amrex::Real truncation = amrex::Real(8.0) * std::abs(scale) * h * h;
+    const amrex::Real roundoff = amrex::Real(256.0) * std::numeric_limits<amrex::Real>::epsilon() *
+                                 std::max(amrex::Real(1.0), std::abs(scale)) / h;
+#else
+    const amrex::Real truncation = amrex::Real(4.0) * std::abs(scale) * h * h;
+    const amrex::Real roundoff = amrex::Real(64.0) * std::numeric_limits<amrex::Real>::epsilon() *
+                                 std::max(amrex::Real(1.0), std::abs(scale)) / h;
+#endif
+    return std::max({exact_zero_or_near_zero_tol(), truncation, roundoff});
+}
+
+// Column-budget tolerance for sums over many cells and sedimentation substeps.
+// Provenance: machine epsilon, float-vs-double scaling, and accumulation over
+// N terms with a conservative safety factor.
+inline amrex::Real property_accumulation_tol (const int num_terms,
+                                              const amrex::Real scale)
+{
+#ifdef AMREX_USE_FLOAT
+    const amrex::Real factor = amrex::Real(256.0);
+#else
+    const amrex::Real factor = amrex::Real(64.0);
+#endif
+    return factor * std::numeric_limits<amrex::Real>::epsilon() *
+           std::max(amrex::Real(1.0), std::abs(scale)) * std::max(1, num_terms);
+}
+
+inline amrex::Real derivative_step (const amrex::Real scale)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(2.0e-3) * std::max(amrex::Real(1.0), std::abs(scale));
+#else
+    return amrex::Real(1.0e-6) * std::max(amrex::Real(1.0), std::abs(scale));
+#endif
+}
+
+inline amrex::Real scaled_tol (const amrex::Real actual,
+                               const amrex::Real expected,
+                               const amrex::Real factor)
+{
+    return factor * std::max({amrex::Real(1.0), std::abs(actual), std::abs(expected)});
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real portable_scaled_tol (const amrex::Real actual,
+                                 const amrex::Real expected,
+                                 const amrex::Real factor)
+{
+    return factor * amrex::max(amrex::Real(1.0),
+                               amrex::max(amrex::Math::abs(actual), amrex::Math::abs(expected)));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real normalized_error (const amrex::Real actual,
+                              const amrex::Real expected,
+                              const amrex::Real factor)
+{
+    return amrex::Math::abs(actual - expected) / portable_scaled_tol(actual, expected, factor);
+}
+
+template <typename Function>
+inline amrex::Real central_difference (Function&& func,
+                                       const amrex::Real x,
+                                       const amrex::Real h)
+{
+    return (func(x + h) - func(x - h)) / (amrex::Real(2.0) * h);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+KesslerSaturationAdjustment reference_saturation_adjustment (const amrex::Real qv,
+                                                             const amrex::Real qc,
+                                                             const amrex::Real qsat,
+                                                             const amrex::Real dtqsat,
+                                                             const bool do_cond) noexcept
+{
+    KesslerSaturationAdjustment source_terms{amrex::Real(0.0), amrex::Real(0.0)};
+    const amrex::Real denom = amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat;
+
+    if ((qv > qsat) && do_cond) {
+        source_terms.dq_vapor_to_cloud = amrex::min(qv, (qv - qsat) / denom);
+    }
+    if ((qv < qsat) && (qc > amrex::Real(0.0)) && do_cond) {
+        source_terms.dq_cloud_to_vapor = amrex::min(qc, (qsat - qv) / denom);
+    }
+
+    return source_terms;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+KesslerSourceTerms reference_warm_rain_sources (const amrex::Real qv,
+                                                const amrex::Real qc,
+                                                const amrex::Real qp,
+                                                const amrex::Real rho,
+                                                const amrex::Real pressure_mbar,
+                                                const amrex::Real qsat,
+                                                const amrex::Real dtqsat,
+                                                const amrex::Real dt,
+                                                const bool do_cond) noexcept
+{
+    const KesslerSaturationAdjustment sat =
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond);
+    KesslerSourceTerms source_terms{
+        sat.dq_vapor_to_cloud,
+        sat.dq_cloud_to_vapor,
+        amrex::Real(0.0),
+        amrex::Real(0.0)};
+
+    if ((qp > amrex::Real(0.0)) && (qv < qsat)) {
+        // MUST MATCH: Kessler rain-evaporation closure coefficients.
+        const amrex::Real scaled_mass = amrex::Real(0.001) * rho * qp;
+        const amrex::Real coeff = amrex::Real(1.6)
+            + amrex::Real(124.9) * std::pow(scaled_mass, amrex::Real(0.2046));
+        const amrex::Real raw = amrex::Real(1.0) / (amrex::Real(0.001) * rho)
+            * (amrex::Real(1.0) - qv / qsat)
+            * coeff
+            * std::pow(scaled_mass, amrex::Real(0.525))
+            / (amrex::Real(5.4e5) + amrex::Real(2.55e6) / (pressure_mbar * qsat))
+            * dt;
+        source_terms.dq_rain_to_vapor = amrex::min(qp, raw);
+    }
+
+    if (qc > amrex::Real(0.0)) {
+        // MUST MATCH: qcw0 and alphaelq Kessler autoconversion parameters.
+        const amrex::Real auto_r = (qc > qcw0) ? alphaelq : amrex::Real(0.0);
+        // MUST MATCH: Kessler accretion coefficient and exponent.
+        const amrex::Real accretion_rate = amrex::Real(2.2) * std::pow(qp, amrex::Real(0.875));
+        const amrex::Real raw = dt * (accretion_rate * qc + auto_r * (qc - qcw0));
+        source_terms.dq_cloud_to_rain = amrex::min(raw, qc);
+    }
+
+    return source_terms;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void apply_local_sources (amrex::Real& qv,
+                          amrex::Real& qc,
+                          amrex::Real& qp,
+                          const KesslerSourceTerms& source_terms) noexcept
+{
+    qv += -source_terms.dq_vapor_to_cloud
+        +  source_terms.dq_cloud_to_vapor
+        +  source_terms.dq_rain_to_vapor;
+    qc +=  source_terms.dq_vapor_to_cloud
+        -  source_terms.dq_cloud_to_vapor
+        -  source_terms.dq_cloud_to_rain;
+    qp +=  source_terms.dq_cloud_to_rain
+        -  source_terms.dq_rain_to_vapor;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_terminal_velocity (const amrex::Real rho,
+                                         const amrex::Real qp) noexcept
+{
+    // MUST MATCH: Kessler terminal-velocity coefficient and exponents.
+    return amrex::Real(36.34)
+        * std::pow(amrex::Real(0.001) * rho * qp, amrex::Real(0.1346))
+        * std::pow(rho / amrex::Real(1.16), -myhalf);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_terminal_velocity_dqp (const amrex::Real rho,
+                                             const amrex::Real qp) noexcept
+{
+    const amrex::Real velocity = reference_terminal_velocity(rho, qp);
+    return amrex::Real(0.1346) * velocity / qp;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_terminal_velocity_drho (const amrex::Real rho,
+                                              const amrex::Real qp) noexcept
+{
+    const amrex::Real velocity = reference_terminal_velocity(rho, qp);
+    return (amrex::Real(0.1346) - myhalf) * velocity / rho;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real inverse_qp_from_terminal_velocity (const amrex::Real velocity,
+                                               const amrex::Real rho) noexcept
+{
+    // MUST MATCH: invert V = 36.34 * (0.001*rho*qp)^0.1346 * (rho/1.16)^(-1/2).
+    const amrex::Real density_factor = std::pow(rho / amrex::Real(1.16), myhalf);
+    const amrex::Real scaled = velocity * density_factor / amrex::Real(36.34);
+    return std::pow(scaled, amrex::Real(1.0) / amrex::Real(0.1346)) /
+           (amrex::Real(0.001) * rho);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_precip_flux (const amrex::Real rho,
+                                   const amrex::Real velocity,
+                                   const amrex::Real qp) noexcept
+{
+    return rho * velocity * qp;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_precip_flux_dqp (const amrex::Real rho,
+                                       const amrex::Real qp) noexcept
+{
+    const amrex::Real flux = reference_precip_flux(rho, reference_terminal_velocity(rho, qp), qp);
+    return (amrex::Real(1.0) + amrex::Real(0.1346)) * flux / qp;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_precip_flux_drho (const amrex::Real rho,
+                                        const amrex::Real qp) noexcept
+{
+    const amrex::Real flux = reference_precip_flux(rho, reference_terminal_velocity(rho, qp), qp);
+    return (myhalf + amrex::Real(0.1346)) * flux / rho;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_sedimentation_tendency (const amrex::Real fz_hi,
+                                              const amrex::Real fz_lo,
+                                              const amrex::Real rho,
+                                              const amrex::Real dJinv,
+                                              const amrex::Real coef) noexcept
+{
+    return dJinv * (amrex::Real(1.0) / rho) * (fz_hi - fz_lo) * coef;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int reference_substeps_from_reduced_value (const amrex::Real reduced_value,
+                                           const amrex::Real dt,
+                                           const amrex::Real dz) noexcept
+{
+    return static_cast<int>(std::ceil((reduced_value + std::numeric_limits<amrex::Real>::epsilon())
+                                      * (dt / dz) / myhalf));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int reference_velocity_cfl_substeps (const amrex::Real terminal_velocity,
+                                     const amrex::Real dt,
+                                     const amrex::Real dz) noexcept
+{
+    return static_cast<int>(std::ceil((terminal_velocity + std::numeric_limits<amrex::Real>::epsilon())
+                                      * (dt / dz) / myhalf));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+PrimitiveState make_primitive_state (const amrex::Real tabs,
+                                     const amrex::Real pres_mbar,
+                                     const amrex::Real qv,
+                                     const amrex::Real qc,
+                                     const amrex::Real qp)
+{
+    const amrex::Real pres_pa = amrex::Real(100.0) * pres_mbar;
+    const amrex::Real rho = getRhogivenTandPress(tabs, pres_pa, qv);
+    const amrex::Real theta = getThgivenTandP(tabs, pres_pa, kRdOcp);
+    return PrimitiveState{rho, theta, tabs, pres_mbar, qv, qc, qp};
+}
+
+inline void sync ()
+{
+#ifdef AMREX_USE_GPU
+    amrex::Gpu::streamSynchronize();
+#endif
+}
+
+template <typename F>
+inline void run_and_sync (F&& fn)
+{
+    std::forward<F>(fn)();
+    sync();
+}
+
+inline amrex::Geometry make_geometry (const int nx,
+                                      const int ny,
+                                      const int nz)
+{
+    amrex::Box domain(amrex::IntVect(AMREX_D_DECL(0, 0, 0)),
+                      amrex::IntVect(AMREX_D_DECL(nx - 1, ny - 1, nz - 1)));
+    amrex::RealBox real_box({AMREX_D_DECL(0.0, 0.0, 0.0)},
+                            {AMREX_D_DECL(static_cast<amrex::Real>(nx),
+                                          static_cast<amrex::Real>(ny),
+                                          static_cast<amrex::Real>(nz))});
+    amrex::Array<int, AMREX_SPACEDIM> periodicity{AMREX_D_DECL(1, 1, 0)};
+    return amrex::Geometry(domain, &real_box, amrex::CoordSys::cartesian, periodicity.data());
+}
+
+inline SolverChoice make_solver_choice (const MoistureType moisture_type,
+                                        const bool use_shoc)
+{
+    SolverChoice sc;
+    sc.c_p = Cp_d;
+    sc.rdOcp = kRdOcp;
+    sc.ave_plane = 2;
+    sc.moisture_type = moisture_type;
+    sc.use_shoc = use_shoc;
+
+    if (moisture_type == MoistureType::Kessler) {
+        sc.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, RhoQ3_comp);
+    } else if (moisture_type == MoistureType::Kessler_NoRain) {
+        sc.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp);
+    }
+
+    return sc;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void set_conserved_cell (const amrex::Array4<amrex::Real>& arr,
+                         const int i,
+                         const int j,
+                         const int k,
+                         const PrimitiveState& state)
+{
+    arr(i,j,k,Rho_comp) = state.rho;
+    arr(i,j,k,RhoTheta_comp) = state.rho * state.theta;
+    arr(i,j,k,RhoKE_comp) = amrex::Real(0.0);
+    arr(i,j,k,RhoScalar_comp) = amrex::Real(0.0);
+    arr(i,j,k,RhoQ1_comp) = state.rho * state.qv;
+    arr(i,j,k,RhoQ2_comp) = state.rho * state.qc;
+    arr(i,j,k,RhoQ3_comp) = state.rho * state.qp;
+}
+
+inline void fill_conserved_state_portable (amrex::MultiFab& cons)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const int selector = (i + 2 * j + 3 * k) % 4;
+                PrimitiveState state;
+                if (selector == 0) {
+                    state = make_primitive_state(amrex::Real(289.0), amrex::Real(900.0),
+                                                 amrex::Real(1.10e-2), amrex::Real(6.0e-4), amrex::Real(0.0));
+                } else if (selector == 1) {
+                    state = make_primitive_state(amrex::Real(287.0), amrex::Real(880.0),
+                                                 amrex::Real(8.4e-3), amrex::Real(1.8e-3), amrex::Real(4.0e-4));
+                } else if (selector == 2) {
+                    state = make_primitive_state(amrex::Real(285.0), amrex::Real(860.0),
+                                                 amrex::Real(7.0e-3), amrex::Real(5.0e-4), amrex::Real(1.5e-3));
+                } else {
+                    state = make_primitive_state(amrex::Real(291.0), amrex::Real(930.0),
+                                                 amrex::Real(1.20e-2), amrex::Real(1.0e-4), amrex::Real(2.5e-4));
+                }
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+}
+
+inline void fill_local_source_only_state_portable (amrex::MultiFab& cons)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const int selector = (i + 2 * j + 3 * k) % 4;
+                PrimitiveState state;
+                amrex::Real qsat_local;
+                if (selector == 0) {
+                    erf_qsatw(amrex::Real(290.0), amrex::Real(900.0), qsat_local);
+                    state = make_primitive_state(amrex::Real(290.0), amrex::Real(900.0),
+                                                 qsat_local + amrex::Real(2.0e-4), amrex::Real(5.0e-5), amrex::Real(0.0));
+                } else if (selector == 1) {
+                    erf_qsatw(amrex::Real(289.0), amrex::Real(900.0), qsat_local);
+                    state = make_primitive_state(amrex::Real(289.0), amrex::Real(900.0),
+                                                 qsat_local - amrex::Real(2.0e-4), amrex::Real(8.0e-5), amrex::Real(0.0));
+                } else if (selector == 2) {
+                    erf_qsatw(amrex::Real(286.0), amrex::Real(880.0), qsat_local);
+                    state = make_primitive_state(amrex::Real(286.0), amrex::Real(880.0),
+                                                 qsat_local, amrex::Real(1.0e-4), amrex::Real(0.0));
+                } else {
+                    erf_qsatw(amrex::Real(288.0), amrex::Real(910.0), qsat_local);
+                    state = make_primitive_state(amrex::Real(288.0), amrex::Real(910.0),
+                                                 qsat_local + amrex::Real(1.0e-4), amrex::Real(0.0), amrex::Real(0.0));
+                }
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+}
+
+inline void fill_conserved_column_state_portable (amrex::MultiFab& cons)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                PrimitiveState state;
+                if (k == 0) {
+                    state = make_primitive_state(amrex::Real(289.0), amrex::Real(900.0),
+                                                 amrex::Real(1.02e-2), amrex::Real(4.0e-4), amrex::Real(1.2e-3));
+                } else if (k == 1) {
+                    state = make_primitive_state(amrex::Real(287.0), amrex::Real(880.0),
+                                                 amrex::Real(9.0e-3), amrex::Real(8.0e-4), amrex::Real(1.6e-3));
+                } else if (k == 2) {
+                    state = make_primitive_state(amrex::Real(285.0), amrex::Real(860.0),
+                                                 amrex::Real(8.4e-3), amrex::Real(5.0e-4), amrex::Real(9.0e-4));
+                } else {
+                    // Top-cell qp is zero so the top precipitation flux term vanishes.
+                    state = make_primitive_state(amrex::Real(283.0), amrex::Real(840.0),
+                                                 amrex::Real(7.8e-3), amrex::Real(2.0e-4), amrex::Real(0.0));
+                }
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+}
+
+inline void fill_detj_portable (amrex::MultiFab& detj)
+{
+    for (amrex::MFIter mfi(detj, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = detj.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                arr(i,j,k) = amrex::Real(1.0) + amrex::Real(0.1) * (i + 2 * j + 3 * k);
+            });
+        });
+    }
+}
+
+inline void run_kessler_public_flow (Kessler& kessler,
+                                     SolverChoice& sc,
+                                     const amrex::Geometry& geom,
+                                     amrex::MultiFab& cons,
+                                     std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                                     std::unique_ptr<amrex::MultiFab>& detJ_cc,
+                                     const amrex::Real dt = kDefaultDt)
+{
+    run_and_sync([&] {
+        kessler.Define(sc);
+        kessler.Set_RealWidth(0);
+        kessler.Set_dzmin(geom.CellSize(2));
+        kessler.Init(cons, cons.boxArray(), geom, dt, z_phys_nd, detJ_cc);
+        kessler.Copy_State_to_Micro(cons);
+        kessler.Advance(dt, sc);
+        kessler.Copy_Micro_to_State(cons);
+    });
+}
+
+inline void copy_multifab (const amrex::MultiFab& src,
+                           amrex::MultiFab& dst)
+{
+    amrex::MultiFab::Copy(dst, src, 0, 0, src.nComp(), src.nGrowVect());
+}
+
+inline void compute_kessler_state_difference (const amrex::MultiFab& after,
+                                              const amrex::MultiFab& before,
+                                              amrex::MultiFab& err)
+{
+    for (amrex::MFIter mfi(after, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto after_arr = after.const_array(mfi);
+        auto before_arr = before.const_array(mfi);
+        auto err_arr = err.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                err_arr(i,j,k,StateDiffRho) = amrex::Math::abs(after_arr(i,j,k,Rho_comp)
+                                                              - before_arr(i,j,k,Rho_comp));
+                err_arr(i,j,k,StateDiffRhoTheta) = amrex::Math::abs(after_arr(i,j,k,RhoTheta_comp)
+                                                                   - before_arr(i,j,k,RhoTheta_comp));
+                err_arr(i,j,k,StateDiffQ1) = amrex::Math::abs(after_arr(i,j,k,RhoQ1_comp)
+                                                             - before_arr(i,j,k,RhoQ1_comp));
+                err_arr(i,j,k,StateDiffQ2) = amrex::Math::abs(after_arr(i,j,k,RhoQ2_comp)
+                                                             - before_arr(i,j,k,RhoQ2_comp));
+                err_arr(i,j,k,StateDiffQ3) = amrex::Math::abs(after_arr(i,j,k,RhoQ3_comp)
+                                                             - before_arr(i,j,k,RhoQ3_comp));
+            });
+        });
+    }
+}
+
+inline void compute_kessler_conservation_errors (const amrex::MultiFab& before,
+                                                 const amrex::MultiFab& after,
+                                                 amrex::MultiFab& err)
+{
+    for (amrex::MFIter mfi(after, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto before_arr = before.const_array(mfi);
+        auto after_arr = after.const_array(mfi);
+        auto err_arr = err.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const amrex::Real rho_before = before_arr(i,j,k,Rho_comp);
+                const amrex::Real rho_after = after_arr(i,j,k,Rho_comp);
+                const amrex::Real qtot_before = before_arr(i,j,k,RhoQ1_comp)
+                                              + before_arr(i,j,k,RhoQ2_comp)
+                                              + before_arr(i,j,k,RhoQ3_comp);
+                const amrex::Real qtot_after = after_arr(i,j,k,RhoQ1_comp)
+                                             + after_arr(i,j,k,RhoQ2_comp)
+                                             + after_arr(i,j,k,RhoQ3_comp);
+
+                const amrex::Real theta_before = before_arr(i,j,k,RhoTheta_comp) / rho_before;
+                const amrex::Real theta_after = after_arr(i,j,k,RhoTheta_comp) / rho_after;
+                const amrex::Real qv_before = before_arr(i,j,k,RhoQ1_comp) / rho_before;
+                const amrex::Real qv_after = after_arr(i,j,k,RhoQ1_comp) / rho_after;
+                const amrex::Real pres_pa = getPgivenRTh(before_arr(i,j,k,RhoTheta_comp), qv_before);
+                const amrex::Real tabs_before = getTgivenPandTh(pres_pa, theta_before, kRdOcp);
+                const amrex::Real tabs_after = getTgivenPandTh(pres_pa, theta_after, kRdOcp);
+                const amrex::Real latent_before = rho_before * (tabs_before + kThetaLatentOverCp * qv_before);
+                const amrex::Real latent_after = rho_after * (tabs_after + kThetaLatentOverCp * qv_after);
+
+                err_arr(i,j,k,ConservationErrRho) = normalized_error(rho_after, rho_before, formula_rel_tol(rho_before));
+                err_arr(i,j,k,ConservationErrTotalWater) = normalized_error(
+                    qtot_after, qtot_before, formula_rel_tol(qtot_before));
+                err_arr(i,j,k,ConservationErrLatentProxy) = normalized_error(
+                    latent_after, latent_before, formula_rel_tol(latent_before));
+            });
+        });
+    }
+}
+
+inline void compute_rain_state_difference (const amrex::MultiFab& after,
+                                           const amrex::MultiFab& before,
+                                           const amrex::MultiFab& rain_after,
+                                           const amrex::MultiFab& rain_before,
+                                           amrex::MultiFab& err)
+{
+    for (amrex::MFIter mfi(after, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto after_arr = after.const_array(mfi);
+        auto before_arr = before.const_array(mfi);
+        auto rain_after_arr = rain_after.const_array(mfi);
+        auto rain_before_arr = rain_before.const_array(mfi);
+        auto err_arr = err.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                err_arr(i,j,k,RainStateErrQp) = amrex::Math::abs(after_arr(i,j,k,RhoQ3_comp)
+                                                                - before_arr(i,j,k,RhoQ3_comp));
+                err_arr(i,j,k,RainStateErrRainAccum) = amrex::Math::abs(rain_after_arr(i,j,k)
+                                                                       - rain_before_arr(i,j,k));
+            });
+        });
+    }
+}
+
+inline amrex::Real sum_multifab_component (const amrex::MultiFab& mf,
+                                           const int comp)
+{
+    auto arrays = mf.const_arrays();
+    amrex::GpuTuple<amrex::Real> reduced = amrex::ParReduce(
+        amrex::TypeList<amrex::ReduceOpSum>{},
+        amrex::TypeList<amrex::Real>{},
+        mf, amrex::IntVect(0),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> amrex::GpuTuple<amrex::Real> {
+            return {arrays[box_no](i,j,k,comp)};
+        });
+    return amrex::get<0>(reduced);
+}
+
+inline amrex::Real sum_multifab_scalar (const amrex::MultiFab& mf)
+{
+    auto arrays = mf.const_arrays();
+    amrex::GpuTuple<amrex::Real> reduced = amrex::ParReduce(
+        amrex::TypeList<amrex::ReduceOpSum>{},
+        amrex::TypeList<amrex::Real>{},
+        mf, amrex::IntVect(0),
+        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k) noexcept -> amrex::GpuTuple<amrex::Real> {
+            return {arrays[box_no](i,j,k)};
+        });
+    return amrex::get<0>(reduced);
+}
+
+inline ColumnBudget compute_column_budget (const amrex::Geometry& geom,
+                                           const amrex::MultiFab& cons,
+                                           const amrex::MultiFab& rain_accum,
+                                           const amrex::MultiFab* detJ_cc = nullptr)
+{
+    amrex::MultiFab rho_sum(cons.boxArray(), cons.DistributionMap(), 1, 0);
+    amrex::MultiFab water_sum(cons.boxArray(), cons.DistributionMap(), 1, 0);
+    amrex::MultiFab latent_sum(cons.boxArray(), cons.DistributionMap(), 1, 0);
+    const amrex::Real dz = geom.CellSize(2);
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto cons_arr = cons.const_array(mfi);
+        auto rho_arr = rho_sum.array(mfi);
+        auto water_arr = water_sum.array(mfi);
+        auto latent_arr = latent_sum.array(mfi);
+        const auto detj_arr = detJ_cc ? detJ_cc->const_array(mfi) : amrex::Array4<const amrex::Real>{};
+
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                const amrex::Real rho = cons_arr(i,j,k,Rho_comp);
+                const amrex::Real rhotheta = cons_arr(i,j,k,RhoTheta_comp);
+                const amrex::Real qv = cons_arr(i,j,k,RhoQ1_comp) / rho;
+                const amrex::Real theta = rhotheta / rho;
+                const amrex::Real pressure_pa = getPgivenRTh(rhotheta, qv);
+                const amrex::Real tabs = getTgivenPandTh(pressure_pa, theta, kRdOcp);
+                const amrex::Real weight = dz * (detj_arr ? detj_arr(i,j,k) : amrex::Real(1.0));
+                rho_arr(i,j,k) = weight * rho;
+                water_arr(i,j,k) = weight * (cons_arr(i,j,k,RhoQ1_comp)
+                                           + cons_arr(i,j,k,RhoQ2_comp)
+                                           + cons_arr(i,j,k,RhoQ3_comp));
+                latent_arr(i,j,k) = weight * rho * (tabs + kThetaLatentOverCp * qv);
+            });
+        });
+    }
+
+    return ColumnBudget{
+        sum_multifab_scalar(rho_sum),
+        sum_multifab_scalar(water_sum),
+        sum_multifab_scalar(latent_sum),
+        sum_multifab_scalar(rain_accum)};
+}
+
+inline std::vector<KernelCase> make_kernel_cases ()
+{
+    return {
+        {amrex::Real(1.00e-2), amrex::Real(5.0e-4), amrex::Real(0.0), amrex::Real(1.16), amrex::Real(900.0),
+         amrex::Real(1.00e-2), amrex::Real(0.02), amrex::Real(1.0), true,
+         0, 0, 2, amrex::Real(1.16), amrex::Real(1.10), amrex::Real(2.0e-4), amrex::Real(4.0e-4),
+         amrex::Real(0.0), amrex::Real(0.0), amrex::Real(1.0), amrex::Real(0.5),
+         amrex::Real(0.0), amrex::Real(1.0), amrex::Real(1.0)},
+        {amrex::Real(1.15e-2), amrex::Real(8.0e-4), amrex::Real(2.5e-4), amrex::Real(1.20), amrex::Real(900.0),
+         amrex::Real(1.00e-2), amrex::Real(0.03), amrex::Real(1.5), true,
+         1, 0, 2, amrex::Real(1.18), amrex::Real(1.20), -amrex::Real(2.0e-4), amrex::Real(3.0e-4),
+         amrex::Real(4.0e-3), amrex::Real(1.0e-3), amrex::Real(0.8), amrex::Real(0.25),
+         amrex::Real(0.10), amrex::Real(1.5), amrex::Real(0.5)},
+        {amrex::Real(9.2e-3), amrex::Real(1.5e-3), amrex::Real(1.0e-3), amrex::Real(0.95), amrex::Real(850.0),
+         amrex::Real(1.05e-2), amrex::Real(0.04), amrex::Real(2.0), true,
+         3, 0, 2, amrex::Real(0.98), amrex::Real(1.02), amrex::Real(5.0e-4), amrex::Real(0.0),
+         amrex::Real(2.0e-3), amrex::Real(2.0e-3), amrex::Real(1.3), amrex::Real(0.4),
+         amrex::Real(0.40), amrex::Real(0.75), amrex::Real(0.25)},
+        {amrex::Real(9.4e-3), amrex::Real(2.0e-4), amrex::Real(2.0e-3), amrex::Real(1.30), amrex::Real(950.0),
+         amrex::Real(1.05e-2), amrex::Real(0.01), amrex::Real(0.5), false,
+         2, 0, 2, amrex::Real(1.25), amrex::Real(1.30), amrex::Real(3.0e-3), amrex::Real(1.0e-3),
+         amrex::Real(8.0e-3), amrex::Real(2.0e-3), amrex::Real(0.7), amrex::Real(0.125),
+         amrex::Real(0.80), amrex::Real(0.5), amrex::Real(0.25)}
+    };
+}
+
+inline std::string case_label (const KernelCase& test_case)
+{
+    return "qv=" + std::to_string(static_cast<double>(test_case.qv))
+         + " qc=" + std::to_string(static_cast<double>(test_case.qc))
+         + " qp=" + std::to_string(static_cast<double>(test_case.qp))
+         + " rho=" + std::to_string(static_cast<double>(test_case.rho));
+}
+
+} // namespace kessler_test
+
+#endif

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
@@ -1,0 +1,181 @@
+#include <vector>
+
+#include <AMReX_GpuContainers.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestKesslerCommon.H"
+
+// These tests exercise the AMReX-portable Kessler helper path. Setup and
+// error computation use ParallelFor so the same test code runs in CPU and GPU
+// builds. Host-side GTest assertions inspect reduced errors after
+// synchronization.
+
+using namespace kessler_test;
+
+namespace {
+
+struct KernelOutputs {
+    amrex::Real sat_cond;
+    amrex::Real sat_evap;
+    amrex::Real source_cond;
+    amrex::Real source_evap;
+    amrex::Real source_cloud_to_rain;
+    amrex::Real source_rain_to_vapor;
+    amrex::Real velocity;
+    amrex::Real flux;
+    amrex::Real face_rho;
+    amrex::Real face_qp;
+    amrex::Real sedimentation;
+    int is_small;
+    int substeps;
+};
+
+// Keep device lambdas in namespace-scope helpers. CUDA can reject extended
+// device lambdas enclosed by GTest's private TestBody() member function.
+void launch_helper_kernel (const int ncases,
+                           const KernelCase* cases_ptr,
+                           KernelOutputs* outputs_ptr)
+{
+    amrex::ParallelFor(ncases, [=] AMREX_GPU_DEVICE (int idx) noexcept {
+        const KernelCase test_case = cases_ptr[idx];
+        const KesslerSaturationAdjustment sat = kessler_saturation_adjustment(
+            test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat, test_case.do_cond);
+        const KesslerSourceTerms sources = kessler_warm_rain_sources(
+            test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+        const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
+        const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
+        const KesslerFaceState face = kessler_face_state(
+            test_case.face_k, test_case.face_k_lo, test_case.face_k_hi,
+            test_case.face_rho_km1, test_case.face_rho_k,
+            test_case.face_qp_km1, test_case.face_qp_k);
+        const amrex::Real sedimentation = kessler_sedimentation_tendency(
+            test_case.fz_hi, test_case.fz_lo, test_case.rho, test_case.dJinv, test_case.coef);
+        const bool is_small = kessler_is_small_sedimentation_value(test_case.reduced_value);
+        const int substeps = kessler_num_sedimentation_substeps(
+            test_case.reduced_value, test_case.substep_dt, test_case.substep_dz);
+
+        outputs_ptr[idx] = KernelOutputs{
+            sat.dq_vapor_to_cloud,
+            sat.dq_cloud_to_vapor,
+            sources.dq_vapor_to_cloud,
+            sources.dq_cloud_to_vapor,
+            sources.dq_cloud_to_rain,
+            sources.dq_rain_to_vapor,
+            velocity,
+            flux,
+            face.rho,
+            face.qp,
+            sedimentation,
+            static_cast<int>(is_small),
+            substeps};
+    });
+
+    kessler_test::sync();
+}
+
+std::vector<KernelCase> make_branch_coverage_cases ()
+{
+    std::vector<KernelCase> cases = make_kernel_cases();
+    cases.push_back(KernelCase{
+        amrex::Real(1.0e-2), amrex::Real(1.5e-3), amrex::Real(1.0e-6), amrex::Real(1.05), amrex::Real(900.0),
+        amrex::Real(1.1e-2), amrex::Real(0.02), amrex::Real(1.0), true,
+        1, 0, 2, amrex::Real(1.02), amrex::Real(1.05), amrex::Real(5.0e-7), amrex::Real(1.0e-6),
+        amrex::Real(9.0e-15), amrex::Real(8.0e-15), amrex::Real(1.0), amrex::Real(0.5),
+        amrex::Real(9.0e-15), amrex::Real(1.0), amrex::Real(1.0)});
+    cases.push_back(KernelCase{
+        amrex::Real(1.3e-2), amrex::Real(2.0e-3), amrex::Real(1.0e-2), amrex::Real(1.35), amrex::Real(950.0),
+        amrex::Real(1.0e-2), amrex::Real(0.03), amrex::Real(0.75), true,
+        2, 0, 2, amrex::Real(1.30), amrex::Real(1.35), amrex::Real(5.0e-3), amrex::Real(1.0e-2),
+        amrex::Real(4.0e-2), amrex::Real(5.0e-3), amrex::Real(1.1), amrex::Real(0.375),
+        amrex::Real(1.0e-14), amrex::Real(2.0), amrex::Real(0.25)});
+    return cases;
+}
+
+KernelOutputs host_reference (const KernelCase& test_case)
+{
+    const KesslerSaturationAdjustment sat = kessler_saturation_adjustment(
+        test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat, test_case.do_cond);
+    const KesslerSourceTerms sources = kessler_warm_rain_sources(
+        test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
+        test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+    const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
+    const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
+    const KesslerFaceState face = kessler_face_state(
+        test_case.face_k, test_case.face_k_lo, test_case.face_k_hi,
+        test_case.face_rho_km1, test_case.face_rho_k,
+        test_case.face_qp_km1, test_case.face_qp_k);
+
+    return KernelOutputs{
+        sat.dq_vapor_to_cloud,
+        sat.dq_cloud_to_vapor,
+        sources.dq_vapor_to_cloud,
+        sources.dq_cloud_to_vapor,
+        sources.dq_cloud_to_rain,
+        sources.dq_rain_to_vapor,
+        velocity,
+        flux,
+        face.rho,
+        face.qp,
+        kessler_sedimentation_tendency(test_case.fz_hi, test_case.fz_lo,
+                                       test_case.rho, test_case.dJinv, test_case.coef),
+        static_cast<int>(kessler_is_small_sedimentation_value(test_case.reduced_value)),
+        kessler_num_sedimentation_substeps(test_case.reduced_value,
+                                           test_case.substep_dt,
+                                           test_case.substep_dz)};
+}
+
+} // namespace
+
+// Motivation: Production Kessler calls these helpers from AMReX kernels. This
+// host/device equivalence sweep covers saturation no-op, condensation, cloud
+// evaporation, rain evaporation, autoconversion off/on, face branches,
+// threshold branches, and integer substep outputs across deterministic cases.
+TEST(KesslerKernel, HostDeviceHelperEquivalenceCoversBranches)
+{
+    const std::vector<KernelCase> cases = make_branch_coverage_cases();
+    std::vector<KernelOutputs> host_outputs(cases.size());
+
+    for (int idx = 0; idx < static_cast<int>(cases.size()); ++idx) {
+        host_outputs[idx] = host_reference(cases[idx]);
+    }
+
+    amrex::Gpu::DeviceVector<KernelCase> d_cases(cases.size());
+    amrex::Gpu::DeviceVector<KernelOutputs> d_outputs(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), d_cases.begin());
+
+    launch_helper_kernel(static_cast<int>(cases.size()), d_cases.data(), d_outputs.data());
+
+    std::vector<KernelOutputs> device_outputs(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost, d_outputs.begin(), d_outputs.end(), device_outputs.begin());
+
+    for (int idx = 0; idx < static_cast<int>(cases.size()); ++idx) {
+        SCOPED_TRACE(case_label(cases[idx]));
+
+        EXPECT_NEAR(device_outputs[idx].sat_cond, host_outputs[idx].sat_cond,
+                    formula_abs_tol(host_outputs[idx].sat_cond));
+        EXPECT_NEAR(device_outputs[idx].sat_evap, host_outputs[idx].sat_evap,
+                    formula_abs_tol(host_outputs[idx].sat_evap));
+        EXPECT_NEAR(device_outputs[idx].source_cond, host_outputs[idx].source_cond,
+                    formula_abs_tol(host_outputs[idx].source_cond));
+        EXPECT_NEAR(device_outputs[idx].source_evap, host_outputs[idx].source_evap,
+                    formula_abs_tol(host_outputs[idx].source_evap));
+        EXPECT_NEAR(device_outputs[idx].source_cloud_to_rain, host_outputs[idx].source_cloud_to_rain,
+                    backend_math_abs_tol(host_outputs[idx].source_cloud_to_rain));
+        EXPECT_NEAR(device_outputs[idx].source_rain_to_vapor, host_outputs[idx].source_rain_to_vapor,
+                    backend_math_abs_tol(host_outputs[idx].source_rain_to_vapor));
+        EXPECT_NEAR(device_outputs[idx].velocity, host_outputs[idx].velocity,
+                    backend_math_abs_tol(host_outputs[idx].velocity));
+        EXPECT_NEAR(device_outputs[idx].flux, host_outputs[idx].flux,
+                    backend_math_abs_tol(host_outputs[idx].flux));
+        EXPECT_NEAR(device_outputs[idx].face_rho, host_outputs[idx].face_rho,
+                    formula_abs_tol(host_outputs[idx].face_rho));
+        EXPECT_NEAR(device_outputs[idx].face_qp, host_outputs[idx].face_qp,
+                    formula_abs_tol(host_outputs[idx].face_qp));
+        EXPECT_NEAR(device_outputs[idx].sedimentation, host_outputs[idx].sedimentation,
+                    formula_abs_tol(host_outputs[idx].sedimentation));
+        EXPECT_EQ(device_outputs[idx].is_small, host_outputs[idx].is_small);
+        EXPECT_EQ(device_outputs[idx].substeps, host_outputs[idx].substeps);
+    }
+}

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
@@ -40,10 +40,12 @@ void launch_helper_kernel (const int ncases,
     amrex::ParallelFor(ncases, [=] AMREX_GPU_DEVICE (int idx) noexcept {
         const KernelCase test_case = cases_ptr[idx];
         const KesslerSaturationAdjustment sat = kessler_saturation_adjustment(
-            test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat, test_case.do_cond);
+            test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat,
+            test_case.do_cond, kSatAdjLatentOverCp);
         const KesslerSourceTerms sources = kessler_warm_rain_sources(
             test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
-            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond,
+            kSatAdjLatentOverCp);
         const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
         const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
         const KesslerFaceState face = kessler_face_state(
@@ -96,10 +98,12 @@ std::vector<KernelCase> make_branch_coverage_cases ()
 KernelOutputs host_reference (const KernelCase& test_case)
 {
     const KesslerSaturationAdjustment sat = kessler_saturation_adjustment(
-        test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat, test_case.do_cond);
+        test_case.qv, test_case.qc, test_case.qsat, test_case.dtqsat,
+        test_case.do_cond, kSatAdjLatentOverCp);
     const KesslerSourceTerms sources = kessler_warm_rain_sources(
         test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
-        test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+        test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond,
+        kSatAdjLatentOverCp);
     const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
     const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
     const KesslerFaceState face = kessler_face_state(

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
@@ -49,7 +49,7 @@ void launch_helper_kernel (const int ncases,
         const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
         const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
         const KesslerFaceState face = kessler_face_state(
-            test_case.face_k, test_case.face_k_lo, test_case.face_k_hi,
+            test_case.face_k, test_case.face_k_hi,
             test_case.face_rho_km1, test_case.face_rho_k,
             test_case.face_qp_km1, test_case.face_qp_k);
         const amrex::Real sedimentation = kessler_sedimentation_tendency(
@@ -107,7 +107,7 @@ KernelOutputs host_reference (const KernelCase& test_case)
     const amrex::Real velocity = kessler_terminal_velocity(test_case.rho, test_case.qp);
     const amrex::Real flux = kessler_precip_flux(test_case.rho, velocity, test_case.qp);
     const KesslerFaceState face = kessler_face_state(
-        test_case.face_k, test_case.face_k_lo, test_case.face_k_hi,
+        test_case.face_k, test_case.face_k_hi,
         test_case.face_rho_km1, test_case.face_rho_k,
         test_case.face_qp_km1, test_case.face_qp_k);
 

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <array>
+#include <cmath>
 #include <memory>
 
 #include <AMReX_BoxArray.H>
@@ -85,16 +88,9 @@ inline KesslerFaceState reference_column_face_state (const std::array<PrimitiveS
                                                      const int face_k)
 {
     KesslerFaceState face_state{amrex::Real(0.0), amrex::Real(0.0)};
-    if (face_k == 0) {
-        face_state.rho = states[0].rho;
-        face_state.qp = states[0].qp;
-    } else if (face_k == 2) {
-        face_state.rho = states[1].rho;
-        face_state.qp = states[1].qp;
-    } else {
-        face_state.rho = states[1].rho;
-        face_state.qp = states[1].qp;
-    }
+    const int donor_k = kessler_face_donor_k(face_k, 1);
+    face_state.rho = states[donor_k].rho;
+    face_state.qp = states[donor_k].qp;
 
     face_state.qp = std::max(amrex::Real(0.0), face_state.qp);
     return face_state;
@@ -129,7 +125,7 @@ inline SedimentationColumnState advance_reference_sedimentation_column (
                 reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
         }
 
-        result.rain_accum += face_fluxes[0] * substep_dt / amrex::Real(1000.0) * amrex::Real(1000.0);
+        result.rain_accum += kessler_rain_accumulation_increment(face_fluxes[0] * substep_dt);
         for (int k = 0; k < 2; ++k) {
             amrex::Real dq_sed = reference_sedimentation_tendency(
                 face_fluxes[k + 1], face_fluxes[k], result.states[k].rho, amrex::Real(1.0), coef);
@@ -474,6 +470,37 @@ TEST(KesslerPhysicalProperties, KesslerPublicFlow_DetJWeightedColumnWaterBudgetI
     std::unique_ptr<amrex::MultiFab> detJ_cc = std::make_unique<amrex::MultiFab>(ba, dm, 1, 1);
     detJ_cc->setVal(amrex::Real(1.0));
     fill_detj_portable(*detJ_cc);
+
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0), detJ_cc.get());
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0), detJ_cc.get());
+
+    EXPECT_NEAR(before.total_water_sum,
+                after.total_water_sum + after.rain_accum_sum,
+                property_accumulation_tol(4, before.total_water_sum));
+}
+
+// Motivation: Compressed cells with detJ < 1 tighten the donor-cell water
+// capacity that can leave through a sedimentation face in one substep. The
+// detJ-weighted column water budget should still balance against surface rain.
+TEST(KesslerPhysicalProperties, KesslerPublicFlow_DetJWeightedColumnWaterBudgetIncludesSurfaceRainWithCompressedCells)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc = std::make_unique<amrex::MultiFab>(ba, dm, 1, 1);
+    detJ_cc->setVal(amrex::Real(1.0));
+    fill_compressed_detj_portable(*detJ_cc);
 
     Kessler kessler;
     SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -1,0 +1,450 @@
+#include <memory>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_MultiFab.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestKesslerCommon.H"
+
+using namespace kessler_test;
+
+namespace {
+
+void initialize_kessler (Kessler& kessler,
+                         SolverChoice& sc,
+                         const amrex::Geometry& geom,
+                         amrex::MultiFab& cons,
+                         std::unique_ptr<amrex::MultiFab>& z_phys_nd,
+                         std::unique_ptr<amrex::MultiFab>& detJ_cc)
+{
+    kessler.Define(sc);
+    kessler.Set_RealWidth(0);
+    kessler.Set_dzmin(geom.CellSize(2));
+    kessler.Init(cons, cons.boxArray(), geom, kDefaultDt, z_phys_nd, detJ_cc);
+}
+
+} // namespace
+
+// Motivation: Local warm-rain source terms exchange water among qv, qc, and
+// qp only. This closure-independent property must hold across representative
+// condensation, cloud-evaporation, rain-evaporation, autoconversion, and mixed
+// cases.
+TEST(KesslerPhysicalProperties, PhysicalProperties_LocalSourcesConserveTotalWater)
+{
+    struct LocalSourceCase {
+        amrex::Real qv;
+        amrex::Real qc;
+        amrex::Real qp;
+        amrex::Real rho;
+        amrex::Real pressure_mbar;
+        amrex::Real qsat;
+        amrex::Real dtqsat;
+        amrex::Real dt;
+        bool do_cond;
+    };
+
+    const std::array<LocalSourceCase, 6> cases = {{
+        {amrex::Real(1.2e-2), amrex::Real(4.0e-4), amrex::Real(0.0), amrex::Real(1.1), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true},
+        {amrex::Real(8.5e-3), amrex::Real(2.0e-3), amrex::Real(0.0), amrex::Real(1.0), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true},
+        {amrex::Real(9.0e-3), amrex::Real(5.0e-4), amrex::Real(1.0e-3), amrex::Real(1.1), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(10.0), true},
+        {amrex::Real(1.0e-2), qcw0 + amrex::Real(5.0e-4), amrex::Real(0.0), amrex::Real(1.0), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true},
+        {amrex::Real(1.0e-2), amrex::Real(8.0e-4), amrex::Real(1.5e-3), amrex::Real(1.0), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true},
+        {amrex::Real(9.3e-3), amrex::Real(1.5e-3), amrex::Real(1.2e-3), amrex::Real(1.1), amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(5.0), true}
+    }};
+
+    for (const LocalSourceCase& test_case : cases) {
+        SCOPED_TRACE("qv=" + std::to_string(static_cast<double>(test_case.qv)) +
+                     " qc=" + std::to_string(static_cast<double>(test_case.qc)) +
+                     " qp=" + std::to_string(static_cast<double>(test_case.qp)));
+        const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
+            test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+        amrex::Real qv = test_case.qv;
+        amrex::Real qc = test_case.qc;
+        amrex::Real qp = test_case.qp;
+        const amrex::Real total_before = qv + qc + qp;
+        apply_local_sources(qv, qc, qp, source_terms);
+        EXPECT_NEAR(qv + qc + qp, total_before, formula_abs_tol(total_before));
+    }
+}
+
+// Motivation: The local Kessler caps should keep qv, qc, and qp nonnegative
+// when the inputs are valid nonnegative mass fractions. This checks a physical
+// sanity property independently of the exact closure coefficients.
+TEST(KesslerPhysicalProperties, PhysicalProperties_LocalSourcesDoNotCreateNegativeSpeciesWhenCapsSuffice)
+{
+    const std::array<KernelCase, 4> cases = {make_kernel_cases()[0], make_kernel_cases()[1],
+                                             make_kernel_cases()[2], make_kernel_cases()[3]};
+
+    for (const KernelCase& test_case : cases) {
+        SCOPED_TRACE(case_label(test_case));
+        const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
+            test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+        amrex::Real qv = test_case.qv;
+        amrex::Real qc = test_case.qc;
+        amrex::Real qp = test_case.qp;
+        apply_local_sources(qv, qc, qp, source_terms);
+        EXPECT_GE(qv, -exact_zero_or_near_zero_tol());
+        EXPECT_GE(qc, -exact_zero_or_near_zero_tol());
+        EXPECT_GE(qp, -exact_zero_or_near_zero_tol());
+    }
+}
+
+// Motivation: Availability caps are independent physical constraints. This
+// protects the cloud-evaporation, cloud-to-rain, and rain-evaporation caps with
+// representative inputs that exercise each branch.
+TEST(KesslerPhysicalProperties, PhysicalProperties_WarmRainSourcesRespectAvailabilityCaps)
+{
+    const KesslerSourceTerms cloud_evap = kessler_warm_rain_sources(
+        amrex::Real(8.0e-3), amrex::Real(1.0e-4), amrex::Real(0.0), amrex::Real(1.0),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(1.0), true);
+    const KesslerSourceTerms cloud_to_rain = kessler_warm_rain_sources(
+        amrex::Real(1.0e-2), amrex::Real(2.0e-4), amrex::Real(1.0), amrex::Real(1.0),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true);
+    const KesslerSourceTerms rain_evap = kessler_warm_rain_sources(
+        amrex::Real(1.0e-3), amrex::Real(2.0e-4), amrex::Real(1.0e-4), amrex::Real(1.2),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(200.0), true);
+
+    EXPECT_LE(cloud_evap.dq_cloud_to_vapor, amrex::Real(1.0e-4) + formula_abs_tol(amrex::Real(1.0e-4)));
+    EXPECT_LE(cloud_to_rain.dq_cloud_to_rain, amrex::Real(2.0e-4) + formula_abs_tol(amrex::Real(2.0e-4)));
+    EXPECT_LE(rain_evap.dq_rain_to_vapor, amrex::Real(1.0e-4) + formula_abs_tol(amrex::Real(1.0e-4)));
+}
+
+// Motivation: For valid rho > 0 and qp >= 0, terminal velocity and precip flux
+// should be nonnegative. This is closure-independent physical sanity coverage.
+TEST(KesslerPhysicalProperties, PhysicalProperties_TerminalVelocityAndFluxAreNonnegativeForValidInputs)
+{
+    const std::array<amrex::Real, 3> rho_values = {amrex::Real(0.9), amrex::Real(1.16), amrex::Real(1.4)};
+    const std::array<amrex::Real, 4> qp_values = {
+        amrex::Real(0.0), amrex::Real(1.0e-6), amrex::Real(1.0e-3), amrex::Real(1.0e-2)};
+
+    for (const amrex::Real rho : rho_values) {
+        for (const amrex::Real qp : qp_values) {
+            SCOPED_TRACE("rho=" + std::to_string(static_cast<double>(rho)) +
+                         " qp=" + std::to_string(static_cast<double>(qp)));
+            const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
+            const amrex::Real flux = kessler_precip_flux(rho, velocity, qp);
+            EXPECT_GE(velocity, -exact_zero_or_near_zero_tol());
+            EXPECT_GE(flux, -exact_zero_or_near_zero_tol());
+        }
+    }
+}
+
+// Motivation: Sedimentation tendency should follow the sign of the flux
+// divergence with the current Kessler convention, and vanish for zero
+// divergence. This is a physical-property sign test, not a formula copy test.
+TEST(KesslerPhysicalProperties, PhysicalProperties_SedimentationTendencyHasFluxDivergenceSign)
+{
+    const amrex::Real positive = kessler_sedimentation_tendency(
+        amrex::Real(5.0e-3), amrex::Real(1.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
+    const amrex::Real zero = kessler_sedimentation_tendency(
+        amrex::Real(2.0e-3), amrex::Real(2.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
+    const amrex::Real negative = kessler_sedimentation_tendency(
+        amrex::Real(1.0e-3), amrex::Real(5.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
+
+    EXPECT_GT(positive, amrex::Real(0.0));
+    EXPECT_NEAR(zero, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+    EXPECT_LT(negative, amrex::Real(0.0));
+}
+
+// Motivation: Kessler_NoRain should not change qp or rain accumulation through
+// the public Init -> Copy_State_to_Micro -> Advance -> Copy_Micro_to_State
+// path, even if the conserved state carries rain water.
+TEST(KesslerPhysicalProperties, PhysicalProperties_KesslerNoRainDoesNotAdvanceRainWaterOrAccumulation)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab err(ba, dm, NumRainStateErrComps, 0);
+    cons.setVal(amrex::Real(0.0));
+    cons_before.setVal(amrex::Real(0.0));
+    err.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler_NoRain, false);
+
+    initialize_kessler(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+    run_and_sync([&] { kessler.Copy_State_to_Micro(cons); });
+    amrex::MultiFab rain_before(ba, dm, 1, 1);
+    copy_multifab(*kessler.Qmoist_Ptr(0), rain_before);
+    run_and_sync([&] {
+        kessler.Advance(kDefaultDt, sc);
+        kessler.Copy_Micro_to_State(cons);
+    });
+
+    compute_rain_state_difference(cons, cons_before, *kessler.Qmoist_Ptr(0), rain_before, err);
+
+    EXPECT_LE(err.max(RainStateErrQp), formula_abs_tol(cons_before.max(RhoQ3_comp)));
+    EXPECT_LE(err.max(RainStateErrRainAccum), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: This is a characterization test, not a correctness test. It
+// pins current behavior so that any future change must also address
+// `DISABLED_KesslerPublicFlow_LocalSourcesConserveTotalWaterAndLatentEnergyProxy`.
+TEST(KesslerPhysicalProperties, Characterization_KesslerPublicFlow_LocalSourcesLatentEnergyProxyCurrentBehavior)
+{
+    const amrex::Geometry geom = make_geometry(4, 3, 2);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_local_source_only_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
+    const int num_terms = geom.Domain().numPts();
+
+    EXPECT_NEAR(after.rho_sum, before.rho_sum, property_accumulation_tol(num_terms, before.rho_sum));
+    EXPECT_NEAR(after.total_water_sum + after.rain_accum_sum,
+                before.total_water_sum,
+                property_accumulation_tol(num_terms, before.total_water_sum));
+    EXPECT_GT(std::abs(after.latent_proxy_sum - before.latent_proxy_sum),
+              property_accumulation_tol(num_terms, before.latent_proxy_sum));
+}
+
+// Motivation: Expected behavior:
+//   In the no-sedimentation public-flow case, rho, rho*(qv+qc+qp), and the
+//   latent-energy proxy rho*[T + (lcond/cp) qv] should be conserved.
+// Observed current behavior:
+//   Current development conserves rho and total water here, but the latent-
+//   energy proxy exposes the saturation/theta latent-factor inconsistency.
+// Minimal reproducer:
+//   A 4x3x2 deterministic fixture with qp == 0 in every cell.
+// Why disabled:
+//   The current production latent factors are intentionally preserved.
+// Enable trigger:
+//   Production should adopt a consistent latent factor across saturation and
+//   theta updates.
+TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_LocalSourcesConserveTotalWaterAndLatentEnergyProxy)
+{
+    const amrex::Geometry geom = make_geometry(4, 3, 2);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_local_source_only_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
+    const int num_terms = geom.Domain().numPts();
+
+    EXPECT_NEAR(after.rho_sum, before.rho_sum, property_accumulation_tol(num_terms, before.rho_sum));
+    EXPECT_NEAR(after.total_water_sum + after.rain_accum_sum,
+                before.total_water_sum,
+                property_accumulation_tol(num_terms, before.total_water_sum));
+    EXPECT_NEAR(after.latent_proxy_sum,
+                before.latent_proxy_sum,
+                property_accumulation_tol(num_terms, before.latent_proxy_sum));
+}
+
+// Motivation: This is a characterization test, not a correctness test. It
+// pins current behavior so that any future change must also address
+// `DISABLED_KesslerPublicFlow_ColumnWaterBudgetIncludesSurfaceRain`.
+TEST(KesslerPhysicalProperties, Characterization_ColumnWaterBudgetCurrentBehavior)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
+    const amrex::Real lhs = before.total_water_sum;
+    const amrex::Real rhs = after.total_water_sum + after.rain_accum_sum;
+
+    EXPECT_GT(rhs, lhs);
+    EXPECT_GT(std::abs(lhs - rhs), property_accumulation_tol(4, lhs));
+}
+
+// Motivation: Expected behavior:
+//   In a flat column with zero top precipitation flux, total column water plus
+//   surface rain accumulation should be conserved.
+// Observed current behavior:
+//   Current development produces more final column water plus rain accumulation
+//   than the initial column water for this deterministic column fixture.
+// Minimal reproducer:
+//   A 1x1x4 flat column with top-cell qp == 0 and nonzero interior/bottom qp.
+// Why disabled:
+//   This is a suspected production bug and must not be weakened in a tests-only
+//   prompt.
+// Enable trigger:
+//   Production should satisfy the public-flow rain-budget contract for the
+//   deterministic column fixture.
+TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_ColumnWaterBudgetIncludesSurfaceRain)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
+    const amrex::Real lhs = before.total_water_sum;
+    const amrex::Real rhs = after.total_water_sum + after.rain_accum_sum;
+
+    EXPECT_NEAR(lhs, rhs, property_accumulation_tol(4, lhs));
+}
+
+// Motivation: Expected behavior:
+//   With detJ weighting present, initial sum detJ*rho*(qv+qc+qp)*dz should
+//   equal final detJ-weighted column water plus surface rain.
+// Observed current behavior:
+//   detJ-weighted rain-budget semantics are not yet documented by production.
+// Minimal reproducer:
+//   A 1x1x4 column with deterministic detJ values and zero top qp.
+// Why disabled:
+//   This remains a documentation-contract question pending physics-owner
+//   confirmation.
+// Enable trigger:
+//   Document and confirm the detJ-weighted rain-budget convention.
+TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_DetJWeightedColumnWaterBudgetIncludesSurfaceRain)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc = std::make_unique<amrex::MultiFab>(ba, dm, 1, 1);
+    detJ_cc->setVal(amrex::Real(1.0));
+    fill_detj_portable(*detJ_cc);
+
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0), detJ_cc.get());
+    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0), detJ_cc.get());
+
+    EXPECT_NEAR(before.total_water_sum,
+                after.total_water_sum + after.rain_accum_sum,
+                property_accumulation_tol(4, before.total_water_sum));
+}
+
+// Motivation: Kessler_NoRain through the public flow should leave rain water
+// and rain accumulation untouched. This protects the distinction between the
+// NoRain path and the full-rain path.
+TEST(KesslerPhysicalProperties, KesslerNoRain_PublicFlowDoesNotModifyRainWaterOrRainAccum)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab err(ba, dm, NumRainStateErrComps, 0);
+    cons.setVal(amrex::Real(0.0));
+    cons_before.setVal(amrex::Real(0.0));
+    err.setVal(amrex::Real(0.0));
+    fill_conserved_column_state_portable(cons);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler_NoRain, true);
+
+    initialize_kessler(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+    run_and_sync([&] { kessler.Copy_State_to_Micro(cons); });
+    amrex::MultiFab rain_before(ba, dm, 1, 1);
+    copy_multifab(*kessler.Qmoist_Ptr(0), rain_before);
+    run_and_sync([&] {
+        kessler.Advance(kDefaultDt, sc);
+        kessler.Copy_Micro_to_State(cons);
+    });
+    compute_rain_state_difference(cons, cons_before, *kessler.Qmoist_Ptr(0), rain_before, err);
+
+    EXPECT_LE(err.max(RainStateErrQp), formula_abs_tol(cons_before.max(RhoQ3_comp)));
+    EXPECT_LE(err.max(RainStateErrRainAccum), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: Full Kessler with SHOC condensation disabled still advances
+// warm-rain source terms and sedimentation. This protects the distinction
+// between `Kessler && !do_cond` and the NoRain early-return path.
+TEST(KesslerPhysicalProperties, KesslerFullRain_DoCondFalseStillRunsRainPath)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 4);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                PrimitiveState state = (k == 3)
+                    ? make_primitive_state(amrex::Real(284.0), amrex::Real(850.0), amrex::Real(7.0e-3), amrex::Real(2.0e-4), amrex::Real(0.0))
+                    : make_primitive_state(amrex::Real(288.0), amrex::Real(900.0), amrex::Real(1.20e-2), qcw0 + amrex::Real(3.0e-4), amrex::Real(1.0e-3));
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
+    copy_multifab(cons, cons_before);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, true);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    const amrex::Real qv_before = cons_before.max(RhoQ1_comp);
+    const amrex::Real qv_after = cons.max(RhoQ1_comp);
+    const amrex::Real qc_before = cons_before.max(RhoQ2_comp);
+    const amrex::Real qc_after = cons.max(RhoQ2_comp);
+    const amrex::Real rain_accum_after = kessler.Qmoist_Ptr(0)->max(0);
+
+    EXPECT_NEAR(qv_after, qv_before, property_accumulation_tol(4, qv_before));
+    EXPECT_LT(qc_after, qc_before);
+    EXPECT_GT(rain_accum_after, amrex::Real(0.0));
+}

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -416,19 +416,7 @@ TEST(KesslerPhysicalProperties, KesslerFullRain_DoCondFalseStillRunsRainPath)
     amrex::DistributionMapping dm(ba);
     amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
     cons.setVal(amrex::Real(0.0));
-
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& bx = mfi.tilebox();
-        auto arr = cons.array(mfi);
-        run_and_sync([=] {
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                PrimitiveState state = (k == 3)
-                    ? make_primitive_state(amrex::Real(284.0), amrex::Real(850.0), amrex::Real(7.0e-3), amrex::Real(2.0e-4), amrex::Real(0.0))
-                    : make_primitive_state(amrex::Real(288.0), amrex::Real(900.0), amrex::Real(1.20e-2), qcw0 + amrex::Real(3.0e-4), amrex::Real(1.0e-3));
-                set_conserved_cell(arr, i, j, k, state);
-            });
-        });
-    }
+    fill_do_cond_false_rain_path_state_portable(cons);
     amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
     copy_multifab(cons, cons_before);
 

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -25,6 +25,149 @@ void initialize_kessler (Kessler& kessler,
     kessler.Init(cons, cons.boxArray(), geom, kDefaultDt, z_phys_nd, detJ_cc);
 }
 
+struct SedimentationColumnState {
+    std::array<PrimitiveState, 2> states;
+    amrex::Real rain_accum;
+};
+
+struct SedimentationColumnRegressionReference {
+    SedimentationColumnState velocity_reference;
+    SedimentationColumnState flux_like_reference;
+    int velocity_substeps;
+    int flux_like_substeps;
+};
+
+inline std::array<PrimitiveState, 2> make_velocity_cfl_sensitive_column_states ()
+{
+    amrex::Real qsat_bottom;
+    amrex::Real qsat_top;
+    erf_qsatw(amrex::Real(289.0), amrex::Real(900.0), qsat_bottom);
+    erf_qsatw(amrex::Real(288.0), amrex::Real(900.0), qsat_top);
+
+    return {
+        make_primitive_state(amrex::Real(289.0), amrex::Real(900.0),
+                             qsat_bottom + amrex::Real(2.0e-4), amrex::Real(0.0), amrex::Real(1.0e-3)),
+        make_primitive_state(amrex::Real(288.0), amrex::Real(900.0),
+                             qsat_top + amrex::Real(2.0e-4), amrex::Real(0.0), amrex::Real(0.0))
+    };
+}
+
+inline void fill_velocity_cfl_sensitive_column_state_portable (
+    amrex::MultiFab& cons,
+    const std::array<PrimitiveState, 2>& states)
+{
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                set_conserved_cell(arr, i, j, k, (k == 0) ? states[0] : states[1]);
+            });
+        });
+    }
+}
+
+inline void fill_reference_rain_accum_portable (amrex::MultiFab& rain_accum,
+                                                const amrex::Real bottom_rain_accum)
+{
+    for (amrex::MFIter mfi(rain_accum, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = rain_accum.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                arr(i,j,k) = (k == 0) ? bottom_rain_accum : amrex::Real(0.0);
+            });
+        });
+    }
+}
+
+inline KesslerFaceState reference_column_face_state (const std::array<PrimitiveState, 2>& states,
+                                                     const int face_k)
+{
+    KesslerFaceState face_state{amrex::Real(0.0), amrex::Real(0.0)};
+    if (face_k == 0) {
+        face_state.rho = states[0].rho;
+        face_state.qp = states[0].qp;
+    } else if (face_k == 2) {
+        face_state.rho = states[1].rho;
+        face_state.qp = states[1].qp;
+    } else {
+        face_state.rho = myhalf * (states[0].rho + states[1].rho);
+        face_state.qp = myhalf * (states[0].qp + states[1].qp);
+    }
+
+    face_state.qp = std::max(amrex::Real(0.0), face_state.qp);
+    return face_state;
+}
+
+// Provenance: pow roundoff in terminal velocity, arithmetic over a small fixed
+// column, accumulation over n substeps, and float-vs-double scaling.
+inline amrex::Real sedimentation_cfl_reference_tol (const int n_substeps,
+                                                    const amrex::Real scale)
+{
+    return std::max(backend_math_abs_tol(scale),
+                    property_accumulation_tol(2 * std::max(1, n_substeps), scale));
+}
+
+inline SedimentationColumnState advance_reference_sedimentation_column (
+    const std::array<PrimitiveState, 2>& initial_states,
+    const amrex::Real dt,
+    const amrex::Real dz,
+    const int n_substeps)
+{
+    SedimentationColumnState result{initial_states, amrex::Real(0.0)};
+    const amrex::Real substep_dt = dt / static_cast<amrex::Real>(n_substeps);
+    const amrex::Real coef = substep_dt / dz;
+
+    for (int nsub = 0; nsub < n_substeps; ++nsub) {
+        std::array<amrex::Real, 3> face_fluxes{};
+        for (int face_k = 0; face_k < 3; ++face_k) {
+            const KesslerFaceState face_state = reference_column_face_state(result.states, face_k);
+            const amrex::Real terminal_velocity = reference_terminal_velocity(face_state.rho, face_state.qp);
+            face_fluxes[face_k] = reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
+        }
+
+        result.rain_accum += face_fluxes[0] * substep_dt / amrex::Real(1000.0) * amrex::Real(1000.0);
+        for (int k = 0; k < 2; ++k) {
+            amrex::Real dq_sed = reference_sedimentation_tendency(
+                face_fluxes[k + 1], face_fluxes[k], result.states[k].rho, amrex::Real(1.0), coef);
+            if (kessler_is_small_sedimentation_value(dq_sed)) {
+                dq_sed = amrex::Real(0.0);
+            }
+            result.states[k].qp += dq_sed;
+            result.states[k].qp = std::max(amrex::Real(0.0), result.states[k].qp);
+        }
+    }
+
+    return result;
+}
+
+inline SedimentationColumnRegressionReference make_sedimentation_cfl_regression_reference (
+    const std::array<PrimitiveState, 2>& initial_states,
+    const amrex::Real dt,
+    const amrex::Real dz)
+{
+    amrex::Real max_terminal_velocity = amrex::Real(0.0);
+    amrex::Real max_flux_like_value = amrex::Real(0.0);
+    for (int face_k = 0; face_k < 3; ++face_k) {
+        const KesslerFaceState face_state = reference_column_face_state(initial_states, face_k);
+        const amrex::Real terminal_velocity = reference_terminal_velocity(face_state.rho, face_state.qp);
+        const amrex::Real flux_like_value = reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
+        max_terminal_velocity = std::max(max_terminal_velocity, terminal_velocity);
+        max_flux_like_value = std::max(max_flux_like_value, flux_like_value);
+    }
+
+    const int velocity_substeps = reference_velocity_cfl_substeps(max_terminal_velocity, dt, dz);
+    const int flux_like_substeps = reference_substeps_from_reduced_value(max_flux_like_value, dt, dz);
+
+    return {
+        advance_reference_sedimentation_column(initial_states, dt, dz, velocity_substeps),
+        advance_reference_sedimentation_column(initial_states, dt, dz, flux_like_substeps),
+        velocity_substeps,
+        flux_like_substeps
+    };
+}
+
 } // namespace
 
 // Motivation: Local warm-rain source terms exchange water among qv, qc, and
@@ -185,6 +328,65 @@ TEST(KesslerPhysicalProperties, PhysicalProperties_KesslerNoRainDoesNotAdvanceRa
 
     EXPECT_LE(err.max(RainStateErrQp), formula_abs_tol(cons_before.max(RhoQ3_comp)));
     EXPECT_LE(err.max(RainStateErrRainAccum), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: The scalar substep helper test proves the terminal-velocity CFL
+// formula, but it does not prove `AdvanceKessler` passes terminal velocity into
+// that helper. This public-flow regression uses a column where velocity-based
+// and flux-like substep counts differ, then compares the production result to
+// an independent velocity-subcycled reference. It intentionally avoids the
+// shared-face threshold branch and does not assert the full column water budget.
+TEST(KesslerPhysicalProperties, KesslerPublicFlow_SedimentationSubstepsUseVelocityCFL)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 2);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab velocity_cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab flux_like_cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab velocity_rain(ba, dm, 1, 1);
+    amrex::MultiFab flux_like_rain(ba, dm, 1, 1);
+    amrex::MultiFab velocity_err(ba, dm, NumRainStateErrComps, 0);
+    amrex::MultiFab flux_like_err(ba, dm, NumRainStateErrComps, 0);
+    cons.setVal(amrex::Real(0.0));
+    velocity_cons.setVal(amrex::Real(0.0));
+    flux_like_cons.setVal(amrex::Real(0.0));
+    velocity_rain.setVal(amrex::Real(0.0));
+    flux_like_rain.setVal(amrex::Real(0.0));
+    velocity_err.setVal(amrex::Real(0.0));
+    flux_like_err.setVal(amrex::Real(0.0));
+
+    const std::array<PrimitiveState, 2> initial_states = make_velocity_cfl_sensitive_column_states();
+    fill_velocity_cfl_sensitive_column_state_portable(cons, initial_states);
+    const SedimentationColumnRegressionReference reference =
+        make_sedimentation_cfl_regression_reference(initial_states, kDefaultDt, geom.CellSize(2));
+
+    EXPECT_NE(reference.velocity_substeps, reference.flux_like_substeps);
+
+    fill_velocity_cfl_sensitive_column_state_portable(velocity_cons, reference.velocity_reference.states);
+    fill_velocity_cfl_sensitive_column_state_portable(flux_like_cons, reference.flux_like_reference.states);
+    fill_reference_rain_accum_portable(velocity_rain, reference.velocity_reference.rain_accum);
+    fill_reference_rain_accum_portable(flux_like_rain, reference.flux_like_reference.rain_accum);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, true);
+    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+
+    compute_rain_state_difference(cons, velocity_cons, *kessler.Qmoist_Ptr(0), velocity_rain, velocity_err);
+    compute_rain_state_difference(cons, flux_like_cons, *kessler.Qmoist_Ptr(0), flux_like_rain, flux_like_err);
+
+    const amrex::Real qp_scale = std::max(reference.velocity_reference.states[0].rho * reference.velocity_reference.states[0].qp,
+                                          reference.velocity_reference.states[1].rho * reference.velocity_reference.states[1].qp);
+    const amrex::Real qp_tol = sedimentation_cfl_reference_tol(reference.velocity_substeps, qp_scale);
+    const amrex::Real rain_tol = sedimentation_cfl_reference_tol(reference.velocity_substeps,
+                                                                 reference.velocity_reference.rain_accum);
+
+    EXPECT_LE(velocity_err.max(RainStateErrQp), qp_tol);
+    EXPECT_LE(velocity_err.max(RainStateErrRainAccum), rain_tol);
+    EXPECT_GT(std::max(flux_like_err.max(RainStateErrQp), flux_like_err.max(RainStateErrRainAccum)),
+              std::max(qp_tol, rain_tol));
 }
 
 // Motivation: This is a characterization test, not a correctness test. It

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -138,16 +138,16 @@ TEST(KesslerPhysicalProperties, PhysicalProperties_TerminalVelocityAndFluxAreNon
 // divergence. This is a physical-property sign test, not a formula copy test.
 TEST(KesslerPhysicalProperties, PhysicalProperties_SedimentationTendencyHasFluxDivergenceSign)
 {
-    const amrex::Real positive = kessler_sedimentation_tendency(
+    const amrex::Real positive_tendency = kessler_sedimentation_tendency(
         amrex::Real(5.0e-3), amrex::Real(1.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
-    const amrex::Real zero = kessler_sedimentation_tendency(
+    const amrex::Real zero_tendency = kessler_sedimentation_tendency(
         amrex::Real(2.0e-3), amrex::Real(2.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
-    const amrex::Real negative = kessler_sedimentation_tendency(
+    const amrex::Real negative_tendency = kessler_sedimentation_tendency(
         amrex::Real(1.0e-3), amrex::Real(5.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
 
-    EXPECT_GT(positive, amrex::Real(0.0));
-    EXPECT_NEAR(zero, amrex::Real(0.0), exact_zero_or_near_zero_tol());
-    EXPECT_LT(negative, amrex::Real(0.0));
+    EXPECT_GT(positive_tendency, amrex::Real(0.0));
+    EXPECT_NEAR(zero_tendency, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+    EXPECT_LT(negative_tendency, amrex::Real(0.0));
 }
 
 // Motivation: Kessler_NoRain should not change qp or rain accumulation through

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -92,8 +92,8 @@ inline KesslerFaceState reference_column_face_state (const std::array<PrimitiveS
         face_state.rho = states[1].rho;
         face_state.qp = states[1].qp;
     } else {
-        face_state.rho = myhalf * (states[0].rho + states[1].rho);
-        face_state.qp = myhalf * (states[0].qp + states[1].qp);
+        face_state.rho = states[1].rho;
+        face_state.qp = states[1].qp;
     }
 
     face_state.qp = std::max(amrex::Real(0.0), face_state.qp);
@@ -124,7 +124,9 @@ inline SedimentationColumnState advance_reference_sedimentation_column (
         for (int face_k = 0; face_k < 3; ++face_k) {
             const KesslerFaceState face_state = reference_column_face_state(result.states, face_k);
             const amrex::Real terminal_velocity = reference_terminal_velocity(face_state.rho, face_state.qp);
-            face_fluxes[face_k] = reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp);
+            const amrex::Real max_flux = face_state.rho * face_state.qp / coef;
+            face_fluxes[face_k] = amrex::min(
+                reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
         }
 
         result.rain_accum += face_fluxes[0] * substep_dt / amrex::Real(1000.0) * amrex::Real(1000.0);
@@ -203,7 +205,8 @@ TEST(KesslerPhysicalProperties, PhysicalProperties_LocalSourcesConserveTotalWate
                      " qp=" + std::to_string(static_cast<double>(test_case.qp)));
         const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
             test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
-            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond,
+            kSatAdjLatentOverCp);
         amrex::Real qv = test_case.qv;
         amrex::Real qc = test_case.qc;
         amrex::Real qp = test_case.qp;
@@ -225,7 +228,8 @@ TEST(KesslerPhysicalProperties, PhysicalProperties_LocalSourcesDoNotCreateNegati
         SCOPED_TRACE(case_label(test_case));
         const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
             test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
-            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond,
+            kSatAdjLatentOverCp);
         amrex::Real qv = test_case.qv;
         amrex::Real qc = test_case.qc;
         amrex::Real qp = test_case.qp;
@@ -243,13 +247,16 @@ TEST(KesslerPhysicalProperties, PhysicalProperties_WarmRainSourcesRespectAvailab
 {
     const KesslerSourceTerms cloud_evap = kessler_warm_rain_sources(
         amrex::Real(8.0e-3), amrex::Real(1.0e-4), amrex::Real(0.0), amrex::Real(1.0),
-        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(1.0), true);
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(1.0), true,
+        kSatAdjLatentOverCp);
     const KesslerSourceTerms cloud_to_rain = kessler_warm_rain_sources(
         amrex::Real(1.0e-2), amrex::Real(2.0e-4), amrex::Real(1.0), amrex::Real(1.0),
-        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true);
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true,
+        kSatAdjLatentOverCp);
     const KesslerSourceTerms rain_evap = kessler_warm_rain_sources(
         amrex::Real(1.0e-3), amrex::Real(2.0e-4), amrex::Real(1.0e-4), amrex::Real(1.2),
-        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(200.0), true);
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(200.0), true,
+        kSatAdjLatentOverCp);
 
     EXPECT_LE(cloud_evap.dq_cloud_to_vapor, amrex::Real(1.0e-4) + formula_abs_tol(amrex::Real(1.0e-4)));
     EXPECT_LE(cloud_to_rain.dq_cloud_to_rain, amrex::Real(2.0e-4) + formula_abs_tol(amrex::Real(2.0e-4)));
@@ -389,58 +396,22 @@ TEST(KesslerPhysicalProperties, KesslerPublicFlow_SedimentationSubstepsUseVeloci
               std::max(qp_tol, rain_tol));
 }
 
-// Motivation: This is a characterization test, not a correctness test. It
-// pins current behavior so that any future change must also address
-// `DISABLED_KesslerPublicFlow_LocalSourcesConserveTotalWaterAndLatentEnergyProxy`.
-TEST(KesslerPhysicalProperties, Characterization_KesslerPublicFlow_LocalSourcesLatentEnergyProxyCurrentBehavior)
-{
-    const amrex::Geometry geom = make_geometry(4, 3, 2);
-    amrex::BoxArray ba(geom.Domain());
-    amrex::DistributionMapping dm(ba);
-    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
-    cons.setVal(amrex::Real(0.0));
-    fill_local_source_only_state_portable(cons);
-    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
-    copy_multifab(cons, cons_before);
-
-    std::unique_ptr<amrex::MultiFab> z_phys_nd;
-    std::unique_ptr<amrex::MultiFab> detJ_cc;
-    Kessler kessler;
-    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
-    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
-
-    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
-    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
-    const int num_terms = geom.Domain().numPts();
-
-    EXPECT_NEAR(after.rho_sum, before.rho_sum, property_accumulation_tol(num_terms, before.rho_sum));
-    EXPECT_NEAR(after.total_water_sum + after.rain_accum_sum,
-                before.total_water_sum,
-                property_accumulation_tol(num_terms, before.total_water_sum));
-    EXPECT_GT(std::abs(after.latent_proxy_sum - before.latent_proxy_sum),
-              property_accumulation_tol(num_terms, before.latent_proxy_sum));
-}
-
 // Motivation: Expected behavior:
 //   In the no-sedimentation public-flow case, rho, rho*(qv+qc+qp), and the
-//   latent-energy proxy rho*[T + (lcond/cp) qv] should be conserved.
+//   latent-energy proxy rho*[T + (L_v/cp) qv] should be conserved.
 // Observed current behavior:
-//   Current development conserves rho and total water here, but the latent-
-//   energy proxy exposes the saturation/theta latent-factor inconsistency.
+//   The saturation solve and theta update should use the same latent factor.
 // Minimal reproducer:
 //   A 4x3x2 deterministic fixture with qp == 0 in every cell.
-// Why disabled:
-//   The current production latent factors are intentionally preserved.
-// Enable trigger:
-//   Production should adopt a consistent latent factor across saturation and
-//   theta updates.
-TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_LocalSourcesConserveTotalWaterAndLatentEnergyProxy)
+TEST(KesslerPhysicalProperties, KesslerPublicFlow_LocalSourcesConserveTotalWaterAndLatentEnergyProxy)
 {
     const amrex::Geometry geom = make_geometry(4, 3, 2);
     amrex::BoxArray ba(geom.Domain());
     amrex::DistributionMapping dm(ba);
     amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    amrex::MultiFab err(ba, dm, NumConservationErrComps, 0);
     cons.setVal(amrex::Real(0.0));
+    err.setVal(amrex::Real(0.0));
     fill_local_source_only_state_portable(cons);
     amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
     copy_multifab(cons, cons_before);
@@ -450,64 +421,18 @@ TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_LocalSourcesConserveT
     Kessler kessler;
     SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
     run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
+    compute_kessler_conservation_errors(cons_before, cons, err);
 
-    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
-    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
-    const int num_terms = geom.Domain().numPts();
-
-    EXPECT_NEAR(after.rho_sum, before.rho_sum, property_accumulation_tol(num_terms, before.rho_sum));
-    EXPECT_NEAR(after.total_water_sum + after.rain_accum_sum,
-                before.total_water_sum,
-                property_accumulation_tol(num_terms, before.total_water_sum));
-    EXPECT_NEAR(after.latent_proxy_sum,
-                before.latent_proxy_sum,
-                property_accumulation_tol(num_terms, before.latent_proxy_sum));
-}
-
-// Motivation: This is a characterization test, not a correctness test. It
-// pins current behavior so that any future change must also address
-// `DISABLED_KesslerPublicFlow_ColumnWaterBudgetIncludesSurfaceRain`.
-TEST(KesslerPhysicalProperties, Characterization_ColumnWaterBudgetCurrentBehavior)
-{
-    const amrex::Geometry geom = make_geometry(1, 1, 4);
-    amrex::BoxArray ba(geom.Domain());
-    amrex::DistributionMapping dm(ba);
-    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
-    cons.setVal(amrex::Real(0.0));
-    fill_conserved_column_state_portable(cons);
-    amrex::MultiFab cons_before(ba, dm, RhoQ3_comp + 1, 1);
-    copy_multifab(cons, cons_before);
-
-    std::unique_ptr<amrex::MultiFab> z_phys_nd;
-    std::unique_ptr<amrex::MultiFab> detJ_cc;
-    Kessler kessler;
-    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
-    run_kessler_public_flow(kessler, sc, geom, cons, z_phys_nd, detJ_cc);
-
-    const ColumnBudget before = compute_column_budget(geom, cons_before, *kessler.Qmoist_Ptr(0));
-    const ColumnBudget after = compute_column_budget(geom, cons, *kessler.Qmoist_Ptr(0));
-    const amrex::Real lhs = before.total_water_sum;
-    const amrex::Real rhs = after.total_water_sum + after.rain_accum_sum;
-
-    EXPECT_GT(rhs, lhs);
-    EXPECT_GT(std::abs(lhs - rhs), property_accumulation_tol(4, lhs));
+    EXPECT_LE(err.max(ConservationErrRho), amrex::Real(1.0));
+    EXPECT_LE(err.max(ConservationErrTotalWater), amrex::Real(1.0));
+    EXPECT_LE(err.max(ConservationErrLatentProxy), amrex::Real(1.0));
+    EXPECT_NEAR(sum_multifab_scalar(*kessler.Qmoist_Ptr(0)), amrex::Real(0.0), exact_zero_or_near_zero_tol());
 }
 
 // Motivation: Expected behavior:
 //   In a flat column with zero top precipitation flux, total column water plus
 //   surface rain accumulation should be conserved.
-// Observed current behavior:
-//   Current development produces more final column water plus rain accumulation
-//   than the initial column water for this deterministic column fixture.
-// Minimal reproducer:
-//   A 1x1x4 flat column with top-cell qp == 0 and nonzero interior/bottom qp.
-// Why disabled:
-//   This is a suspected production bug and must not be weakened in a tests-only
-//   prompt.
-// Enable trigger:
-//   Production should satisfy the public-flow rain-budget contract for the
-//   deterministic column fixture.
-TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_ColumnWaterBudgetIncludesSurfaceRain)
+TEST(KesslerPhysicalProperties, KesslerPublicFlow_ColumnWaterBudgetIncludesSurfaceRain)
 {
     const amrex::Geometry geom = make_geometry(1, 1, 4);
     amrex::BoxArray ba(geom.Domain());
@@ -532,19 +457,9 @@ TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_ColumnWaterBudgetIncl
     EXPECT_NEAR(lhs, rhs, property_accumulation_tol(4, lhs));
 }
 
-// Motivation: Expected behavior:
-//   With detJ weighting present, initial sum detJ*rho*(qv+qc+qp)*dz should
-//   equal final detJ-weighted column water plus surface rain.
-// Observed current behavior:
-//   detJ-weighted rain-budget semantics are not yet documented by production.
-// Minimal reproducer:
-//   A 1x1x4 column with deterministic detJ values and zero top qp.
-// Why disabled:
-//   This remains a documentation-contract question pending physics-owner
-//   confirmation.
-// Enable trigger:
-//   Document and confirm the detJ-weighted rain-budget convention.
-TEST(KesslerPhysicalProperties, DISABLED_KesslerPublicFlow_DetJWeightedColumnWaterBudgetIncludesSurfaceRain)
+// Motivation: With detJ weighting present, initial sum detJ*rho*(qv+qc+qp)*dz
+// should equal final detJ-weighted column water plus surface rain.
+TEST(KesslerPhysicalProperties, KesslerPublicFlow_DetJWeightedColumnWaterBudgetIncludesSurfaceRain)
 {
     const amrex::Geometry geom = make_geometry(1, 1, 4);
     amrex::BoxArray ba(geom.Domain());

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -547,16 +547,7 @@ TEST(KesslerScalar, CopyStateToMicro_PressureStoredInMbar)
     erf_dtqsatw(tabs, pres_mbar, dtqsat);
     const PrimitiveState state = make_primitive_state(
         tabs, pres_mbar, qsat + amrex::Real(2.0e-4), amrex::Real(5.0e-5), amrex::Real(0.0));
-
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& bx = mfi.tilebox();
-        auto arr = cons.array(mfi);
-        run_and_sync([=] {
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                set_conserved_cell(arr, i, j, k, state);
-            });
-        });
-    }
+    fill_conserved_state_uniform_portable(cons, state);
 
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;
@@ -604,15 +595,7 @@ TEST(KesslerScalar, CopyMicroToState_WritesQvQcQpAsRhoWeightedConservedScalars)
 
     const PrimitiveState state = make_primitive_state(
         amrex::Real(289.0), amrex::Real(910.0), amrex::Real(8.0e-3), amrex::Real(4.0e-4), amrex::Real(7.0e-4));
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& bx = mfi.tilebox();
-        auto arr = cons.array(mfi);
-        run_and_sync([=] {
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                set_conserved_cell(arr, i, j, k, state);
-            });
-        });
-    }
+    fill_conserved_state_uniform_portable(cons, state);
 
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;
@@ -646,15 +629,7 @@ TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
 
     const PrimitiveState state = make_primitive_state(
         amrex::Real(292.0), amrex::Real(940.0), amrex::Real(6.0e-3), amrex::Real(1.0e-4), amrex::Real(0.0));
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& bx = mfi.tilebox();
-        auto arr = cons.array(mfi);
-        run_and_sync([=] {
-            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                set_conserved_cell(arr, i, j, k, state);
-            });
-        });
-    }
+    fill_conserved_state_uniform_portable(cons, state);
 
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -1,0 +1,769 @@
+#include <array>
+#include <memory>
+#include <string>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_MultiFab.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestKesslerCommon.H"
+
+using namespace kessler_test;
+
+namespace {
+
+void expect_near_formula (const amrex::Real actual,
+                          const amrex::Real expected)
+{
+    EXPECT_NEAR(actual, expected, std::max(formula_abs_tol(expected), formula_rel_tol(expected)));
+}
+
+void expect_near_backend_math (const amrex::Real actual,
+                               const amrex::Real expected)
+{
+    EXPECT_NEAR(actual, expected, backend_math_abs_tol(expected));
+}
+
+void expect_source_terms_match (const KesslerSourceTerms& actual,
+                                const KesslerSourceTerms& expected)
+{
+    expect_near_formula(actual.dq_vapor_to_cloud, expected.dq_vapor_to_cloud);
+    expect_near_formula(actual.dq_cloud_to_vapor, expected.dq_cloud_to_vapor);
+    expect_near_backend_math(actual.dq_cloud_to_rain, expected.dq_cloud_to_rain);
+    expect_near_backend_math(actual.dq_rain_to_vapor, expected.dq_rain_to_vapor);
+}
+
+void expect_sat_adjustment_match (const KesslerSaturationAdjustment& actual,
+                                  const KesslerSaturationAdjustment& expected)
+{
+    expect_near_formula(actual.dq_vapor_to_cloud, expected.dq_vapor_to_cloud);
+    expect_near_formula(actual.dq_cloud_to_vapor, expected.dq_cloud_to_vapor);
+}
+
+} // namespace
+
+// Motivation: Saturation adjustment should be an exact identity at qv == qsat.
+// This protects the no-op branch and the physical contract that no phase
+// change occurs when the parcel is already saturated.
+TEST(KesslerScalar, SaturationAdjustment_NoOpAtSaturation)
+{
+    const amrex::Real qv = amrex::Real(1.0e-2);
+    const amrex::Real qc = amrex::Real(2.0e-3);
+    const amrex::Real qsat = qv;
+    const amrex::Real dtqsat = amrex::Real(0.02);
+
+    const KesslerSaturationAdjustment actual =
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+
+    EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+    EXPECT_NEAR(actual.dq_cloud_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: The smooth condensation branch has a closed-form update.
+// This checks the helper against an independent derivation away from caps and
+// threshold boundaries.
+TEST(KesslerScalar, SaturationAdjustment_CondensationMatchesIndependentReference)
+{
+    const amrex::Real qv = amrex::Real(1.2e-2);
+    const amrex::Real qc = amrex::Real(7.0e-4);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.03);
+
+    const KesslerSaturationAdjustment actual =
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+    const KesslerSaturationAdjustment expected =
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+
+    expect_sat_adjustment_match(actual, expected);
+}
+
+// Motivation: Subsaturated cloudy air should evaporate cloud water toward the
+// linearized saturation target. This protects the cloud-evaporation branch.
+TEST(KesslerScalar, SaturationAdjustment_CloudEvaporationMatchesIndependentReference)
+{
+    const amrex::Real qv = amrex::Real(9.0e-3);
+    const amrex::Real qc = amrex::Real(2.0e-3);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.02);
+
+    const KesslerSaturationAdjustment actual =
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+    const KesslerSaturationAdjustment expected =
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+
+    expect_sat_adjustment_match(actual, expected);
+}
+
+// Motivation: Cloud evaporation is limited by the available cloud water. This
+// protects the cap branch instead of relying on sign-only behavior.
+TEST(KesslerScalar, SaturationAdjustment_CloudEvaporationCappedByCloudWater)
+{
+    const amrex::Real qv = amrex::Real(7.0e-3);
+    const amrex::Real qc = amrex::Real(1.0e-4);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.01);
+
+    const KesslerSaturationAdjustment actual =
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+
+    EXPECT_NEAR(actual.dq_cloud_to_vapor, qc, formula_abs_tol(qc));
+    EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: When SHOC owns condensation, both saturation-adjustment source
+// terms must be suppressed even for supersaturated or subsaturated inputs.
+TEST(KesslerScalar, SaturationAdjustment_DoCondFalseSuppressesCondensationAndCloudEvaporation)
+{
+    const std::array<std::tuple<amrex::Real, amrex::Real, amrex::Real>, 2> cases = {{
+        {amrex::Real(1.2e-2), amrex::Real(6.0e-4), amrex::Real(1.0e-2)},
+        {amrex::Real(9.0e-3), amrex::Real(2.0e-3), amrex::Real(1.0e-2)}
+    }};
+
+    for (const auto& [qv, qc, qsat] : cases) {
+        SCOPED_TRACE("qv=" + std::to_string(static_cast<double>(qv)));
+        const KesslerSaturationAdjustment actual =
+            kessler_saturation_adjustment(qv, qc, qsat, amrex::Real(0.03), false);
+        EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+        EXPECT_NEAR(actual.dq_cloud_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+    }
+}
+
+// Motivation: The smooth condensation branch has analytic derivatives with
+// respect to qv, qsat, and dqsdT. This protects the algebraic form away from
+// caps and branch switches; the finite difference stays strictly inside the
+// smooth branch.
+TEST(KesslerScalar, SaturationAdjustment_AnalyticDerivativeInSmoothCondensationBranch)
+{
+    const amrex::Real qv = amrex::Real(1.12e-2);
+    const amrex::Real qc = amrex::Real(4.0e-4);
+    const amrex::Real qsat = amrex::Real(1.00e-2);
+    const amrex::Real dtqsat = amrex::Real(0.02);
+    const amrex::Real denom = amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat;
+
+    const amrex::Real h_qv = derivative_step(qv);
+    const amrex::Real h_qsat = derivative_step(qsat);
+    const amrex::Real h_dtqsat = derivative_step(dtqsat);
+
+    const auto branch = [=] (const amrex::Real qv_value,
+                             const amrex::Real qsat_value,
+                             const amrex::Real dtqsat_value) {
+        return kessler_saturation_adjustment(qv_value, qc, qsat_value, dtqsat_value, true).dq_vapor_to_cloud;
+    };
+
+    const amrex::Real d_dq_dqv = central_difference(
+        [=] (const amrex::Real value) { return branch(value, qsat, dtqsat); }, qv, h_qv);
+    const amrex::Real d_dq_dqsat = central_difference(
+        [=] (const amrex::Real value) { return branch(qv, value, dtqsat); }, qsat, h_qsat);
+    const amrex::Real d_dq_ddtqsat = central_difference(
+        [=] (const amrex::Real value) { return branch(qv, qsat, value); }, dtqsat, h_dtqsat);
+
+    const amrex::Real expected_dqv = amrex::Real(1.0) / denom;
+    const amrex::Real expected_dqsat = -amrex::Real(1.0) / denom;
+    const amrex::Real expected_ddtqsat =
+        -(qv - qsat) * kSatAdjLatentOverCp / (denom * denom);
+
+    EXPECT_NEAR(d_dq_dqv, expected_dqv, finite_difference_tol(expected_dqv, h_qv));
+    EXPECT_NEAR(d_dq_dqsat, expected_dqsat, finite_difference_tol(expected_dqsat, h_qsat));
+    EXPECT_NEAR(d_dq_ddtqsat, expected_ddtqsat, finite_difference_tol(expected_ddtqsat, h_dtqsat));
+}
+
+// Motivation: For valid qsat >= 0 and dqsdT >= 0, the condensation update
+// cannot be limited by the qv cap. This documents the contract instead of
+// forcing an invalid-state branch hit.
+TEST(KesslerScalar, SaturationAdjustment_CondensationQvCapUnreachableForValidPositiveQsat)
+{
+    const std::array<std::tuple<amrex::Real, amrex::Real, amrex::Real>, 4> cases = {{
+        {amrex::Real(1.2e-2), amrex::Real(1.0e-2), amrex::Real(0.0)},
+        {amrex::Real(1.2e-2), amrex::Real(1.0e-2), amrex::Real(0.01)},
+        {amrex::Real(8.0e-3), amrex::Real(0.0), amrex::Real(0.02)},
+        {amrex::Real(5.0e-3), amrex::Real(2.0e-3), amrex::Real(0.05)}
+    }};
+
+    for (const auto& [qv, qsat, dtqsat] : cases) {
+        SCOPED_TRACE("qv=" + std::to_string(static_cast<double>(qv)) +
+                     " qsat=" + std::to_string(static_cast<double>(qsat)));
+        const KesslerSaturationAdjustment actual =
+            kessler_saturation_adjustment(qv, amrex::Real(1.0e-3), qsat, dtqsat, true);
+        EXPECT_LE(actual.dq_vapor_to_cloud, qv + formula_abs_tol(qv));
+        EXPECT_NEAR(actual.dq_vapor_to_cloud,
+                    (qv > qsat) ? (qv - qsat) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat)
+                                : amrex::Real(0.0),
+                    formula_abs_tol(qv));
+    }
+}
+
+// Motivation: The local Kessler source update exchanges water among qv, qc,
+// and qp only. This protects the algebraic total-water conservation contract
+// before sedimentation.
+TEST(KesslerScalar, WarmRainSources_TotalWaterConservedByLocalSources)
+{
+    const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
+        amrex::Real(9.0e-3), amrex::Real(2.0e-3), amrex::Real(1.5e-3),
+        amrex::Real(1.1), amrex::Real(900.0), amrex::Real(1.0e-2),
+        amrex::Real(0.02), amrex::Real(2.0), true);
+
+    const amrex::Real source_sum =
+        (-source_terms.dq_vapor_to_cloud + source_terms.dq_cloud_to_vapor + source_terms.dq_rain_to_vapor)
+      + ( source_terms.dq_vapor_to_cloud - source_terms.dq_cloud_to_vapor - source_terms.dq_cloud_to_rain)
+      + ( source_terms.dq_cloud_to_rain - source_terms.dq_rain_to_vapor);
+
+    EXPECT_NEAR(source_sum, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: The autoconversion trigger uses qc > qcw0, not >=. The below,
+// equal, and above cases protect this threshold branch with independent values
+// instead of sign-only assertions.
+TEST(KesslerScalar, WarmRainSources_AutoconversionThresholdBelowEqualAbove)
+{
+    const std::array<amrex::Real, 3> qc_cases = {
+        qcw0 - amrex::Real(1.0e-6), qcw0, qcw0 + amrex::Real(1.0e-6)};
+
+    for (const amrex::Real qc : qc_cases) {
+        SCOPED_TRACE("qc=" + std::to_string(static_cast<double>(qc)));
+        const KesslerSourceTerms actual = kessler_warm_rain_sources(
+            amrex::Real(1.0e-2), qc, amrex::Real(0.0), amrex::Real(1.0),
+            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true);
+        const KesslerSourceTerms expected = reference_warm_rain_sources(
+            amrex::Real(1.0e-2), qc, amrex::Real(0.0), amrex::Real(1.0),
+            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true);
+        expect_source_terms_match(actual, expected);
+    }
+}
+
+// Motivation: Cloud-to-rain conversion cannot remove more cloud water than is
+// available. This protects the cap branch for the combined accretion and
+// autoconversion source.
+TEST(KesslerScalar, WarmRainSources_CloudToRainCappedByCloudWater)
+{
+    const amrex::Real qc = amrex::Real(2.0e-4);
+    const KesslerSourceTerms actual = kessler_warm_rain_sources(
+        amrex::Real(1.0e-2), qc, amrex::Real(1.0), amrex::Real(1.0),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true);
+
+    EXPECT_NEAR(actual.dq_cloud_to_rain, qc, formula_abs_tol(qc));
+}
+
+// Motivation: For fixed cloud water with autoconversion disabled, accretion is
+// monotone in rain water. This protects a physical monotonicity property of
+// the warm-rain closure.
+TEST(KesslerScalar, WarmRainSources_AccretionMonotoneInRainWater)
+{
+    const amrex::Real qv = amrex::Real(1.0e-2);
+    const amrex::Real qc = amrex::Real(8.0e-4);
+    const std::array<amrex::Real, 4> qp_values = {
+        amrex::Real(0.0), amrex::Real(1.0e-4), amrex::Real(5.0e-4), amrex::Real(1.5e-3)};
+
+    amrex::Real previous = -amrex::Real(1.0);
+    for (const amrex::Real qp : qp_values) {
+        SCOPED_TRACE("qp=" + std::to_string(static_cast<double>(qp)));
+        const KesslerSourceTerms actual = kessler_warm_rain_sources(
+            qv, qc, qp, amrex::Real(1.1), amrex::Real(900.0), qv, amrex::Real(0.02), amrex::Real(1.0), true);
+        EXPECT_GE(actual.dq_cloud_to_rain, amrex::Real(0.0));
+        if (previous >= amrex::Real(0.0)) {
+            EXPECT_GE(actual.dq_cloud_to_rain + formula_abs_tol(actual.dq_cloud_to_rain), previous);
+        }
+        previous = actual.dq_cloud_to_rain;
+    }
+}
+
+// Motivation: Rain evaporation requires both rain water and subsaturation.
+// This protects three distinct branch guards in the composed warm-rain helper.
+TEST(KesslerScalar, WarmRainSources_RainEvaporationRequiresRainAndSubsaturation)
+{
+    struct Case {
+        amrex::Real qp;
+        amrex::Real qv;
+        amrex::Real qsat;
+        bool expect_positive;
+    };
+
+    const std::array<Case, 3> cases = {{
+        {amrex::Real(0.0), amrex::Real(9.0e-3), amrex::Real(1.0e-2), false},
+        {amrex::Real(2.0e-3), amrex::Real(1.0e-2), amrex::Real(1.0e-2), false},
+        {amrex::Real(2.0e-3), amrex::Real(9.0e-3), amrex::Real(1.0e-2), true}
+    }};
+
+    for (const auto& test_case : cases) {
+        SCOPED_TRACE("qp=" + std::to_string(static_cast<double>(test_case.qp)) +
+                     " qv=" + std::to_string(static_cast<double>(test_case.qv)));
+        const KesslerSourceTerms actual = kessler_warm_rain_sources(
+            test_case.qv, amrex::Real(5.0e-4), test_case.qp, amrex::Real(1.1),
+            amrex::Real(900.0), test_case.qsat, amrex::Real(0.02), amrex::Real(2.0), true);
+        if (test_case.expect_positive) {
+            EXPECT_GT(actual.dq_rain_to_vapor, amrex::Real(0.0));
+        } else {
+            EXPECT_NEAR(actual.dq_rain_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+        }
+    }
+}
+
+// Motivation: Rain evaporation cannot exceed the available rain water. This
+// protects the availability cap in the rain-evaporation branch.
+TEST(KesslerScalar, WarmRainSources_RainEvaporationCappedByRainWater)
+{
+    const amrex::Real qp = amrex::Real(1.0e-4);
+    const KesslerSourceTerms actual = kessler_warm_rain_sources(
+        amrex::Real(1.0e-3), amrex::Real(5.0e-4), qp, amrex::Real(1.2),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(200.0), true);
+
+    EXPECT_NEAR(actual.dq_rain_to_vapor, qp, formula_abs_tol(qp));
+}
+
+// Motivation: For valid nonnegative inputs, all Kessler source magnitudes are
+// nonnegative. This is secondary physical-sanity coverage for the composed
+// helper, not the primary source-term verification.
+TEST(KesslerScalar, WarmRainSources_NoNegativeTendenciesForValidInputs)
+{
+    const std::array<KernelCase, 4> cases = {make_kernel_cases()[0], make_kernel_cases()[1],
+                                             make_kernel_cases()[2], make_kernel_cases()[3]};
+
+    for (const KernelCase& test_case : cases) {
+        SCOPED_TRACE(case_label(test_case));
+        const KesslerSourceTerms actual = kessler_warm_rain_sources(
+            test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+
+        EXPECT_GE(actual.dq_vapor_to_cloud, -exact_zero_or_near_zero_tol());
+        EXPECT_GE(actual.dq_cloud_to_vapor, -exact_zero_or_near_zero_tol());
+        EXPECT_GE(actual.dq_cloud_to_rain, -exact_zero_or_near_zero_tol());
+        EXPECT_GE(actual.dq_rain_to_vapor, -exact_zero_or_near_zero_tol());
+    }
+}
+
+// Motivation: The precipitation flux must be zero when qp == 0 even if one
+// avoids making a stronger claim about the terminal-velocity value itself.
+TEST(KesslerScalar, TerminalVelocity_ZeroRainGivesZeroFlux)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const amrex::Real velocity = kessler_terminal_velocity(rho, amrex::Real(0.0));
+    const amrex::Real flux = kessler_precip_flux(rho, velocity, amrex::Real(0.0));
+
+    EXPECT_NEAR(flux, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: Terminal velocity should be nondecreasing in rain water for
+// fixed positive density. This protects a basic physical monotonicity contract.
+TEST(KesslerScalar, TerminalVelocity_MonotoneInQp)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const std::array<amrex::Real, 4> qp_values = {
+        amrex::Real(1.0e-6), amrex::Real(1.0e-4), amrex::Real(1.0e-3), amrex::Real(1.0e-2)};
+
+    amrex::Real previous = -amrex::Real(1.0);
+    for (const amrex::Real qp : qp_values) {
+        const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
+        EXPECT_GE(velocity, amrex::Real(0.0));
+        if (previous >= amrex::Real(0.0)) {
+            EXPECT_GE(velocity + backend_math_abs_tol(velocity), previous);
+        }
+        previous = velocity;
+    }
+}
+
+// Motivation: The positive-domain terminal-velocity formula has analytic
+// derivatives in qp and rho. This protects the functional form away from qp ==
+// 0, where the derivative is singular.
+TEST(KesslerScalar, TerminalVelocity_AnalyticDerivativeInPositiveDomain)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const amrex::Real qp = amrex::Real(1.0e-2);
+    const amrex::Real h_rho = derivative_step(rho);
+    const amrex::Real h_qp = derivative_step(qp);
+
+    const amrex::Real d_dqp = central_difference(
+        [=] (const amrex::Real value) { return kessler_terminal_velocity(rho, value); }, qp, h_qp);
+    const amrex::Real d_drho = central_difference(
+        [=] (const amrex::Real value) { return kessler_terminal_velocity(value, qp); }, rho, h_rho);
+
+    const amrex::Real expected_dqp = reference_terminal_velocity_dqp(rho, qp);
+    const amrex::Real expected_drho = reference_terminal_velocity_drho(rho, qp);
+
+    EXPECT_NEAR(d_dqp, expected_dqp, finite_difference_tol(expected_dqp, h_qp));
+    EXPECT_NEAR(d_drho, expected_drho, finite_difference_tol(expected_drho, h_rho));
+}
+
+// Motivation: The terminal-velocity formula can be inverted analytically for
+// qp at fixed density. This roundtrip protects the power-law exponents.
+TEST(KesslerScalar, TerminalVelocity_InverseRoundtripQp)
+{
+    const amrex::Real rho = amrex::Real(1.25);
+    const std::array<amrex::Real, 3> qp_values = {
+        amrex::Real(2.0e-5), amrex::Real(5.0e-4), amrex::Real(2.0e-3)};
+
+    for (const amrex::Real qp : qp_values) {
+        SCOPED_TRACE("qp=" + std::to_string(static_cast<double>(qp)));
+        const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
+        const amrex::Real recovered_qp = inverse_qp_from_terminal_velocity(velocity, rho);
+        EXPECT_NEAR(recovered_qp, qp, backend_math_abs_tol(qp));
+    }
+}
+
+// Motivation: Precipitation flux is defined as rho * V * qp. This protects the
+// functional identity independently of the production helper composition.
+TEST(KesslerScalar, PrecipFlux_EqualsRhoTimesTerminalVelocityTimesQp)
+{
+    const amrex::Real rho = amrex::Real(1.2);
+    const amrex::Real qp = amrex::Real(1.0e-3);
+    const amrex::Real velocity = reference_terminal_velocity(rho, qp);
+    const amrex::Real expected = reference_precip_flux(rho, velocity, qp);
+    const amrex::Real actual = kessler_precip_flux(rho, kessler_terminal_velocity(rho, qp), qp);
+
+    expect_near_backend_math(actual, expected);
+}
+
+// Motivation: The positive-domain precipitation flux formula has analytic
+// derivatives in qp and rho. This protects the power-law composition of rho,
+// V, and qp away from qp == 0.
+TEST(KesslerScalar, PrecipFlux_AnalyticDerivativeInPositiveDomain)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const amrex::Real qp = amrex::Real(1.0e-2);
+    const amrex::Real h_rho = derivative_step(rho);
+    const amrex::Real h_qp = derivative_step(qp);
+
+    const amrex::Real d_dqp = central_difference(
+        [=] (const amrex::Real value) {
+            return kessler_precip_flux(rho, kessler_terminal_velocity(rho, value), value);
+        },
+        qp, h_qp);
+    const amrex::Real d_drho = central_difference(
+        [=] (const amrex::Real value) {
+            return kessler_precip_flux(value, kessler_terminal_velocity(value, qp), qp);
+        },
+        rho, h_rho);
+
+    const amrex::Real expected_dqp = reference_precip_flux_dqp(rho, qp);
+    const amrex::Real expected_drho = reference_precip_flux_drho(rho, qp);
+
+    EXPECT_NEAR(d_dqp, expected_dqp, finite_difference_tol(expected_dqp, h_qp));
+    EXPECT_NEAR(d_drho, expected_drho, finite_difference_tol(expected_drho, h_rho));
+}
+
+// Motivation: Face-state selection has three branches: bottom, top, and
+// interior. This protects the public sedimentation path's boundary logic.
+TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
+{
+    const KesslerFaceState bottom =
+        kessler_face_state(0, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+    const KesslerFaceState top =
+        kessler_face_state(3, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+    const KesslerFaceState interior =
+        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+
+    EXPECT_NEAR(bottom.rho, amrex::Real(1.1), formula_abs_tol(amrex::Real(1.1)));
+    EXPECT_NEAR(bottom.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
+    EXPECT_NEAR(top.rho, amrex::Real(1.0), formula_abs_tol(amrex::Real(1.0)));
+    EXPECT_NEAR(top.qp, amrex::Real(0.2), formula_abs_tol(amrex::Real(0.2)));
+    EXPECT_NEAR(interior.rho, amrex::Real(1.05), formula_abs_tol(amrex::Real(1.05)));
+    EXPECT_NEAR(interior.qp, amrex::Real(0.25), formula_abs_tol(amrex::Real(0.25)));
+}
+
+// Motivation: Face rain water is clipped nonnegative after branch selection.
+// This protects the physical sanity of the precipitating face state.
+TEST(KesslerScalar, FaceState_ClipsNegativeFaceRainWater)
+{
+    const KesslerFaceState actual =
+        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.1), -amrex::Real(0.2), -amrex::Real(0.1));
+
+    EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: The current face-state contract averages neighboring qp first,
+// then clips the averaged face value. This protects the branch order, not a
+// physically stronger invariant.
+TEST(KesslerScalar, FaceState_AveragesThenClips)
+{
+    // MUST MATCH: production face-state averaging and clipping order.
+    const KesslerFaceState actual =
+        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.0), -amrex::Real(0.2), amrex::Real(0.1));
+
+    EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: Equal face fluxes imply zero sedimentation tendency. This is the
+// identity branch for the flux-divergence update.
+TEST(KesslerScalar, SedimentationTendency_ZeroForEqualFaceFluxes)
+{
+    const amrex::Real actual = kessler_sedimentation_tendency(
+        amrex::Real(3.0e-3), amrex::Real(3.0e-3), amrex::Real(1.1), amrex::Real(1.0), amrex::Real(0.5));
+
+    EXPECT_NEAR(actual, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+}
+
+// Motivation: The sedimentation tendency should scale linearly with Jinv. This
+// protects the detJ weighting in the local divergence formula.
+TEST(KesslerScalar, SedimentationTendency_DetJScalesFluxDivergence)
+{
+    const amrex::Real base = kessler_sedimentation_tendency(
+        amrex::Real(4.0e-3), amrex::Real(1.0e-3), amrex::Real(1.0), amrex::Real(1.0), amrex::Real(0.5));
+    const amrex::Real doubled = kessler_sedimentation_tendency(
+        amrex::Real(4.0e-3), amrex::Real(1.0e-3), amrex::Real(1.0), amrex::Real(2.0), amrex::Real(0.5));
+
+    EXPECT_NEAR(doubled, amrex::Real(2.0) * base, formula_abs_tol(doubled));
+}
+
+// Motivation: The sedimentation zero threshold uses a strict < comparison.
+// This protects the documented cutoff branch on both sides of the boundary.
+TEST(KesslerScalar, SedimentationThreshold_StrictLessThanAbsoluteCutoff)
+{
+    // MUST MATCH: production sedimentation zero threshold.
+    const amrex::Real cutoff = amrex::Real(1.0e-14);
+
+    EXPECT_TRUE(kessler_is_small_sedimentation_value(cutoff - amrex::Real(1.0e-16)));
+    EXPECT_FALSE(kessler_is_small_sedimentation_value(cutoff));
+    EXPECT_FALSE(kessler_is_small_sedimentation_value(cutoff + amrex::Real(1.0e-16)));
+    EXPECT_TRUE(kessler_is_small_sedimentation_value(-cutoff + amrex::Real(1.0e-16)));
+}
+
+// Motivation: This tests the integer helper exactly as written for a supplied
+// reduced value. It does not claim the current call path uses the physically
+// correct reduced quantity.
+TEST(KesslerScalar, SubstepCount_IntegerFormulaForProvidedReducedValue)
+{
+    const amrex::Real reduced_value = amrex::Real(0.375);
+    const int actual = kessler_num_sedimentation_substeps(reduced_value, amrex::Real(2.0), amrex::Real(0.5));
+    const int expected = reference_substeps_from_reduced_value(reduced_value, amrex::Real(2.0), amrex::Real(0.5));
+
+    EXPECT_EQ(actual, expected);
+}
+
+// Motivation: Copy_State_to_Micro must store pressure in mbar / hPa because
+// qsat pressure inputs use mbar while EOS pressure utilities use Pa.
+TEST(KesslerScalar, CopyStateToMicro_PressureStoredInMbar)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 1);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+    fill_local_source_only_state_portable(cons);
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+
+    kessler.Define(sc);
+    kessler.Set_dzmin(geom.CellSize(2));
+    kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
+    run_and_sync([&] { kessler.Copy_State_to_Micro(cons); });
+
+    const amrex::Real rho = cons.max(Rho_comp);
+    const amrex::Real rhotheta = cons.max(RhoTheta_comp);
+    const amrex::Real qv = cons.max(RhoQ1_comp) / rho;
+    const amrex::Real expected_pres_mbar = getPgivenRTh(rhotheta, qv) * amrex::Real(0.01);
+    const amrex::Real actual_pres_mbar = kessler.mic_fab_vars[MicVar_Kess::pres]->max(0);
+
+    EXPECT_NEAR(actual_pres_mbar, expected_pres_mbar, formula_abs_tol(expected_pres_mbar));
+}
+
+// Motivation: Copy_Micro_to_State must write qv, qc, and qp back as rho-
+// weighted conserved scalars. This protects the public copy-back contract.
+TEST(KesslerScalar, CopyMicroToState_WritesQvQcQpAsRhoWeightedConservedScalars)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 1);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+
+    kessler.Define(sc);
+    kessler.Set_dzmin(geom.CellSize(2));
+    kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
+
+    const amrex::Real rho = amrex::Real(1.15);
+    const amrex::Real qv = amrex::Real(8.0e-3);
+    const amrex::Real qc = amrex::Real(4.0e-4);
+    const amrex::Real qp = amrex::Real(7.0e-4);
+
+    kessler.mic_fab_vars[MicVar_Kess::rho]->setVal(rho);
+    kessler.mic_fab_vars[MicVar_Kess::qv]->setVal(qv);
+    kessler.mic_fab_vars[MicVar_Kess::qcl]->setVal(qc);
+    kessler.mic_fab_vars[MicVar_Kess::qp]->setVal(qp);
+
+    run_and_sync([&] { kessler.Copy_Micro_to_State(cons); });
+
+    EXPECT_NEAR(cons.max(RhoQ1_comp), rho * qv, formula_abs_tol(rho * qv));
+    EXPECT_NEAR(cons.max(RhoQ2_comp), rho * qc, formula_abs_tol(rho * qc));
+    EXPECT_NEAR(cons.max(RhoQ3_comp), rho * qp, formula_abs_tol(rho * qp));
+}
+
+// Motivation: Copy_Micro_to_State writes the current microphysics theta back to
+// rho*theta. This is a documentation contract, not a claim that theta is a
+// roundtrip invariant through phase change.
+TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
+{
+    const amrex::Geometry geom = make_geometry(1, 1, 1);
+    amrex::BoxArray ba(geom.Domain());
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
+    cons.setVal(amrex::Real(0.0));
+
+    std::unique_ptr<amrex::MultiFab> z_phys_nd;
+    std::unique_ptr<amrex::MultiFab> detJ_cc;
+    Kessler kessler;
+    SolverChoice sc = make_solver_choice(MoistureType::Kessler, false);
+
+    kessler.Define(sc);
+    kessler.Set_dzmin(geom.CellSize(2));
+    kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
+
+    const amrex::Real rho = amrex::Real(1.08);
+    const amrex::Real theta = amrex::Real(302.5);
+    kessler.mic_fab_vars[MicVar_Kess::rho]->setVal(rho);
+    kessler.mic_fab_vars[MicVar_Kess::theta]->setVal(theta);
+
+    run_and_sync([&] { kessler.Copy_Micro_to_State(cons); });
+
+    EXPECT_NEAR(cons.max(RhoTheta_comp), rho * theta, formula_abs_tol(rho * theta));
+}
+
+// Motivation: This is a characterization test, not a correctness test. It
+// pins current behavior so that any future change must also address
+// `DISABLED_SubstepCountUsesTerminalVelocityCFL`.
+TEST(KesslerScalar, Characterization_SubstepCountCurrentlyUsesFluxLikeReducedValue)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const amrex::Real qp = amrex::Real(1.0e-3);
+    const amrex::Real dt = amrex::Real(1.0);
+    const amrex::Real dz = amrex::Real(1.0);
+    const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
+    const amrex::Real reduced_flux_like_value = kessler_precip_flux(rho, velocity, qp);
+
+    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz),
+              reference_substeps_from_reduced_value(reduced_flux_like_value, dt, dz));
+    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz), 1);
+}
+
+// Motivation: Full cloud and rain evaporation currently both use the original
+// subsaturation deficit. This is a characterization test, not a correctness
+// test. It pins current behavior so that any future change must also address
+// `DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsaturation`.
+TEST(KesslerScalar, Characterization_CloudAndRainEvaporationCurrentlyShareOriginalDeficit)
+{
+    const amrex::Real qv = amrex::Real(8.0e-3);
+    const amrex::Real qc = amrex::Real(4.0e-3);
+    const amrex::Real qp = amrex::Real(2.0e-3);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.02);
+    const amrex::Real rho = amrex::Real(1.0);
+    const amrex::Real dt = amrex::Real(80.0);
+    const KesslerSourceTerms actual = kessler_warm_rain_sources(
+        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true);
+    const amrex::Real linearized_capacity = (qsat - qv) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat);
+
+    EXPECT_GT(actual.dq_cloud_to_vapor + actual.dq_rain_to_vapor, linearized_capacity);
+}
+
+// Motivation: This is a characterization test, not a correctness test. It
+// pins current behavior so that any future change must also address
+// `DISABLED_SaturationThetaUsesConsistentLatentHeatFactor`.
+TEST(KesslerScalar, Characterization_SaturationThetaCurrentlyUseDifferentLatentFactors)
+{
+    EXPECT_NE(kSatAdjLatentOverCp, kThetaLatentOverCp);
+}
+
+// Motivation: This is a characterization test, not a correctness test. It
+// documents the current absolute sedimentation threshold so any future change
+// must also address a matching contract test.
+TEST(KesslerScalar, Characterization_SedimentationThresholdUsesAbsoluteOneEMinusFourteen)
+{
+    // MUST MATCH: production sedimentation zero threshold.
+    EXPECT_TRUE(kessler_is_small_sedimentation_value(amrex::Real(9.9e-15)));
+    EXPECT_FALSE(kessler_is_small_sedimentation_value(amrex::Real(1.0e-14)));
+}
+
+// Motivation: Rain accumulation currently preserves the exact
+// `/ Real(1000.0) * Real(1000.0)` cancellation expression. This is a
+// characterization test, not a correctness test.
+TEST(KesslerScalar, Characterization_RainAccumulationPreservesCurrentUnitCancellationExpression)
+{
+    const amrex::Real rho = amrex::Real(1.2);
+    const amrex::Real qp = amrex::Real(8.0e-4);
+    const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
+    const amrex::Real dt = amrex::Real(2.0);
+    const amrex::Real current_expression = rho * qp * velocity * dt / amrex::Real(1000.0) * amrex::Real(1000.0);
+
+    EXPECT_NEAR(current_expression, rho * qp * velocity * dt, backend_math_abs_tol(current_expression));
+}
+
+// Motivation: Expected behavior:
+//   The sedimentation substep count should be based on a terminal-velocity CFL,
+//   n = ceil((V_terminal + eps) * dt / dz / CFL_MAX).
+// Observed current behavior:
+//   The current call path reduces a flux-like value rho * V_terminal * qp.
+// Minimal reproducer:
+//   rho = 1.16, qp = 1.0e-3, dt = 1.0, dz = 1.0, CFL_MAX = 0.5.
+// Why disabled:
+//   Current development uses the reduced flux-like value, so the physical CFL
+//   contract does not hold yet.
+// Enable trigger:
+//   Production should reduce a terminal velocity rather than rho*V*qp.
+TEST(KesslerScalar, DISABLED_SubstepCountUsesTerminalVelocityCFL)
+{
+    const amrex::Real rho = amrex::Real(1.16);
+    const amrex::Real qp = amrex::Real(1.0e-3);
+    const amrex::Real dt = amrex::Real(1.0);
+    const amrex::Real dz = amrex::Real(1.0);
+    const amrex::Real velocity = reference_terminal_velocity(rho, qp);
+    const amrex::Real reduced_flux_like_value = reference_precip_flux(rho, velocity, qp);
+
+    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz),
+              reference_velocity_cfl_substeps(velocity, dt, dz));
+}
+
+// Motivation: Expected behavior:
+//   Total vapor supplied by cloud evaporation plus rain evaporation should not
+//   exceed the linearized subsaturation capacity.
+// Observed current behavior:
+//   Cloud evaporation and rain evaporation both consume the original deficit.
+// Minimal reproducer:
+//   qv = 8.0e-3, qc = 4.0e-3, qp = 2.0e-3, qsat = 1.0e-2, dtqsat = 0.02,
+//   rho = 1.0, dt = 80.0.
+// Why disabled:
+//   Current development allows both evaporation paths to contribute from the
+//   same original deficit.
+// Enable trigger:
+//   Production should re-evaluate subsaturation capacity after each phase
+//   change or otherwise enforce a shared-deficit contract.
+TEST(KesslerScalar, DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsaturation)
+{
+    const amrex::Real qv = amrex::Real(8.0e-3);
+    const amrex::Real qc = amrex::Real(4.0e-3);
+    const amrex::Real qp = amrex::Real(2.0e-3);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.02);
+    const amrex::Real rho = amrex::Real(1.0);
+    const amrex::Real dt = amrex::Real(80.0);
+    const KesslerSourceTerms actual = kessler_warm_rain_sources(
+        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true);
+    const amrex::Real linearized_capacity = (qsat - qv) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat);
+
+    EXPECT_LE(actual.dq_cloud_to_vapor + actual.dq_rain_to_vapor,
+              linearized_capacity + formula_abs_tol(linearized_capacity));
+}
+
+// Motivation: Expected behavior:
+//   Saturation adjustment and theta update should use thermodynamically
+//   consistent latent-heat-over-cp factors.
+// Observed current behavior:
+//   The saturation helper uses L_v / Cp_d while the theta update uses
+//   lcond / sc.c_p.
+// Minimal reproducer:
+//   Compare the two factors with the default dry-air cp.
+// Why disabled:
+//   Current development intentionally preserves the existing factors.
+// Enable trigger:
+//   Production should adopt one thermodynamically consistent latent factor for
+//   both the saturation and theta updates.
+TEST(KesslerScalar, DISABLED_SaturationThetaUsesConsistentLatentHeatFactor)
+{
+    EXPECT_EQ(kSatAdjLatentOverCp, kThetaLatentOverCp);
+}

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <memory>
 #include <string>
+#include <tuple>
 
 #include <AMReX_BoxArray.H>
 #include <AMReX_DistributionMapping.H>
@@ -478,11 +479,11 @@ TEST(KesslerScalar, PrecipFlux_AnalyticDerivativeInPositiveDomain)
 TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
 {
     const KesslerFaceState bottom =
-        kessler_face_state(0, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+        kessler_face_state(0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
     const KesslerFaceState top =
-        kessler_face_state(3, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+        kessler_face_state(3, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
     const KesslerFaceState interior =
-        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
+        kessler_face_state(1, 2, amrex::Real(1.0), amrex::Real(1.1), amrex::Real(0.2), amrex::Real(0.3));
 
     EXPECT_NEAR(bottom.rho, amrex::Real(1.1), formula_abs_tol(amrex::Real(1.1)));
     EXPECT_NEAR(bottom.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
@@ -492,12 +493,19 @@ TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
     EXPECT_NEAR(interior.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
 }
 
+TEST(KesslerScalar, FaceDonorK_BottomInteriorTopRule)
+{
+    EXPECT_EQ(kessler_face_donor_k(0, 2), 0);
+    EXPECT_EQ(kessler_face_donor_k(1, 2), 1);
+    EXPECT_EQ(kessler_face_donor_k(3, 2), 2);
+}
+
 // Motivation: Face rain water is clipped nonnegative after branch selection.
 // This protects the physical sanity of the precipitating face state.
 TEST(KesslerScalar, FaceState_ClipsNegativeFaceRainWater)
 {
     const KesslerFaceState actual =
-        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.1), -amrex::Real(0.2), -amrex::Real(0.1));
+        kessler_face_state(1, 2, amrex::Real(1.0), amrex::Real(1.1), -amrex::Real(0.2), -amrex::Real(0.1));
 
     EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
 }
@@ -509,7 +517,7 @@ TEST(KesslerScalar, FaceState_UsesUpperCellDonorThenClips)
 {
     // MUST MATCH: production interior donor-cell selection and clipping order.
     const KesslerFaceState actual =
-        kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.0), -amrex::Real(0.2), amrex::Real(0.1));
+        kessler_face_state(1, 2, amrex::Real(1.0), amrex::Real(1.0), -amrex::Real(0.2), amrex::Real(0.1));
 
     EXPECT_NEAR(actual.qp, amrex::Real(0.1), formula_abs_tol(amrex::Real(0.1)));
 }
@@ -714,18 +722,22 @@ TEST(KesslerScalar, Characterization_SedimentationThresholdUsesAbsoluteOneEMinus
     EXPECT_FALSE(kessler_is_small_sedimentation_value(amrex::Real(1.0e-14)));
 }
 
-// Motivation: Rain accumulation currently preserves the exact
-// `/ Real(1000.0) * Real(1000.0)` cancellation expression. This is a
-// characterization test, not a correctness test.
-TEST(KesslerScalar, Characterization_RainAccumulationPreservesCurrentUnitCancellationExpression)
+// Motivation: Rain accumulation converts precipitation mass per area to liquid
+// water depth in millimeters using ERF constants for water density and unit
+// conversion.
+TEST(KesslerScalar, RainAccumulationConvertsMassPerAreaToMillimeters)
 {
     const amrex::Real rho = amrex::Real(1.2);
     const amrex::Real qp = amrex::Real(8.0e-4);
     const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
     const amrex::Real dt = amrex::Real(2.0);
-    const amrex::Real current_expression = rho * qp * velocity * dt / amrex::Real(1000.0) * amrex::Real(1000.0);
+    const amrex::Real precip_mass_per_area = rho * qp * velocity * dt;
+    const amrex::Real current_expression = kessler_rain_accumulation_increment(precip_mass_per_area);
+    const amrex::Real expected = precip_mass_per_area
+        * (amrex::Real(1.0) / rhor)
+        * amrex::Real(1000.0);
 
-    EXPECT_NEAR(current_expression, rho * qp * velocity * dt, backend_math_abs_tol(current_expression));
+    EXPECT_NEAR(current_expression, expected, backend_math_abs_tol(current_expression));
 }
 
 // Motivation: The sedimentation substep count contract is a terminal-velocity

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -538,7 +538,25 @@ TEST(KesslerScalar, CopyStateToMicro_PressureStoredInMbar)
     amrex::DistributionMapping dm(ba);
     amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
     cons.setVal(amrex::Real(0.0));
-    fill_local_source_only_state_portable(cons);
+
+    const amrex::Real tabs = amrex::Real(290.0);
+    const amrex::Real pres_mbar = amrex::Real(900.0);
+    amrex::Real qsat;
+    amrex::Real dtqsat;
+    erf_qsatw(tabs, pres_mbar, qsat);
+    erf_dtqsatw(tabs, pres_mbar, dtqsat);
+    const PrimitiveState state = make_primitive_state(
+        tabs, pres_mbar, qsat + amrex::Real(2.0e-4), amrex::Real(5.0e-5), amrex::Real(0.0));
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
 
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;
@@ -548,15 +566,30 @@ TEST(KesslerScalar, CopyStateToMicro_PressureStoredInMbar)
     kessler.Define(sc);
     kessler.Set_dzmin(geom.CellSize(2));
     kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
-    run_and_sync([&] { kessler.Copy_State_to_Micro(cons); });
+    run_and_sync([&] {
+        kessler.Copy_State_to_Micro(cons);
+        kessler.Advance(kDefaultDt, sc);
+        kessler.Copy_Micro_to_State(cons);
+    });
 
-    const amrex::Real rho = cons.max(Rho_comp);
-    const amrex::Real rhotheta = cons.max(RhoTheta_comp);
-    const amrex::Real qv = cons.max(RhoQ1_comp) / rho;
-    const amrex::Real expected_pres_mbar = getPgivenRTh(rhotheta, qv) * amrex::Real(0.01);
-    const amrex::Real actual_pres_mbar = kessler.mic_fab_vars[MicVar_Kess::pres]->max(0);
+    const KesslerSourceTerms expected_sources = reference_warm_rain_sources(
+        state.qv, state.qc, state.qp, state.rho, state.pres_mbar, qsat, dtqsat, kDefaultDt, true);
+    amrex::Real qv_expected = state.qv;
+    amrex::Real qc_expected = state.qc;
+    amrex::Real qp_expected = state.qp;
+    apply_local_sources(qv_expected, qc_expected, qp_expected, expected_sources);
 
-    EXPECT_NEAR(actual_pres_mbar, expected_pres_mbar, formula_abs_tol(expected_pres_mbar));
+    amrex::Real theta_expected = state.theta;
+    theta_expected += (state.theta / state.tabs) * (lcond / sc.c_p)
+        * (expected_sources.dq_vapor_to_cloud
+           - expected_sources.dq_cloud_to_vapor
+           - expected_sources.dq_rain_to_vapor);
+
+    EXPECT_NEAR(cons.max(RhoQ1_comp), state.rho * qv_expected, formula_abs_tol(state.rho * qv_expected));
+    EXPECT_NEAR(cons.max(RhoQ2_comp), state.rho * qc_expected, formula_abs_tol(state.rho * qc_expected));
+    EXPECT_NEAR(cons.max(RhoQ3_comp), state.rho * qp_expected, exact_zero_or_near_zero_tol());
+    EXPECT_NEAR(cons.max(RhoTheta_comp), state.rho * theta_expected,
+                formula_abs_tol(state.rho * theta_expected));
 }
 
 // Motivation: Copy_Micro_to_State must write qv, qc, and qp back as rho-
@@ -569,6 +602,18 @@ TEST(KesslerScalar, CopyMicroToState_WritesQvQcQpAsRhoWeightedConservedScalars)
     amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
     cons.setVal(amrex::Real(0.0));
 
+    const PrimitiveState state = make_primitive_state(
+        amrex::Real(289.0), amrex::Real(910.0), amrex::Real(8.0e-3), amrex::Real(4.0e-4), amrex::Real(7.0e-4));
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;
     Kessler kessler;
@@ -578,21 +623,14 @@ TEST(KesslerScalar, CopyMicroToState_WritesQvQcQpAsRhoWeightedConservedScalars)
     kessler.Set_dzmin(geom.CellSize(2));
     kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
 
-    const amrex::Real rho = amrex::Real(1.15);
-    const amrex::Real qv = amrex::Real(8.0e-3);
-    const amrex::Real qc = amrex::Real(4.0e-4);
-    const amrex::Real qp = amrex::Real(7.0e-4);
+    run_and_sync([&] {
+        kessler.Copy_State_to_Micro(cons);
+        kessler.Copy_Micro_to_State(cons);
+    });
 
-    kessler.mic_fab_vars[MicVar_Kess::rho]->setVal(rho);
-    kessler.mic_fab_vars[MicVar_Kess::qv]->setVal(qv);
-    kessler.mic_fab_vars[MicVar_Kess::qcl]->setVal(qc);
-    kessler.mic_fab_vars[MicVar_Kess::qp]->setVal(qp);
-
-    run_and_sync([&] { kessler.Copy_Micro_to_State(cons); });
-
-    EXPECT_NEAR(cons.max(RhoQ1_comp), rho * qv, formula_abs_tol(rho * qv));
-    EXPECT_NEAR(cons.max(RhoQ2_comp), rho * qc, formula_abs_tol(rho * qc));
-    EXPECT_NEAR(cons.max(RhoQ3_comp), rho * qp, formula_abs_tol(rho * qp));
+    EXPECT_NEAR(cons.max(RhoQ1_comp), state.rho * state.qv, formula_abs_tol(state.rho * state.qv));
+    EXPECT_NEAR(cons.max(RhoQ2_comp), state.rho * state.qc, formula_abs_tol(state.rho * state.qc));
+    EXPECT_NEAR(cons.max(RhoQ3_comp), state.rho * state.qp, formula_abs_tol(state.rho * state.qp));
 }
 
 // Motivation: Copy_Micro_to_State writes the current microphysics theta back to
@@ -606,6 +644,18 @@ TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
     amrex::MultiFab cons(ba, dm, RhoQ3_comp + 1, 1);
     cons.setVal(amrex::Real(0.0));
 
+    const PrimitiveState state = make_primitive_state(
+        amrex::Real(292.0), amrex::Real(940.0), amrex::Real(6.0e-3), amrex::Real(1.0e-4), amrex::Real(0.0));
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        auto arr = cons.array(mfi);
+        run_and_sync([=] {
+            amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                set_conserved_cell(arr, i, j, k, state);
+            });
+        });
+    }
+
     std::unique_ptr<amrex::MultiFab> z_phys_nd;
     std::unique_ptr<amrex::MultiFab> detJ_cc;
     Kessler kessler;
@@ -615,14 +665,13 @@ TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
     kessler.Set_dzmin(geom.CellSize(2));
     kessler.Init(cons, ba, geom, kDefaultDt, z_phys_nd, detJ_cc);
 
-    const amrex::Real rho = amrex::Real(1.08);
-    const amrex::Real theta = amrex::Real(302.5);
-    kessler.mic_fab_vars[MicVar_Kess::rho]->setVal(rho);
-    kessler.mic_fab_vars[MicVar_Kess::theta]->setVal(theta);
+    run_and_sync([&] {
+        kessler.Copy_State_to_Micro(cons);
+        kessler.Copy_Micro_to_State(cons);
+    });
 
-    run_and_sync([&] { kessler.Copy_Micro_to_State(cons); });
-
-    EXPECT_NEAR(cons.max(RhoTheta_comp), rho * theta, formula_abs_tol(rho * theta));
+    EXPECT_NEAR(cons.max(RhoTheta_comp), state.rho * state.theta,
+                formula_abs_tol(state.rho * state.theta));
 }
 
 // Motivation: This is a characterization test, not a correctness test. It

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -649,23 +649,6 @@ TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
                 formula_abs_tol(state.rho * state.theta));
 }
 
-// Motivation: This is a characterization test, not a correctness test. It
-// pins current behavior so that any future change must also address
-// `DISABLED_SubstepCountUsesTerminalVelocityCFL`.
-TEST(KesslerScalar, Characterization_SubstepCountCurrentlyUsesFluxLikeReducedValue)
-{
-    const amrex::Real rho = amrex::Real(1.16);
-    const amrex::Real qp = amrex::Real(1.0e-3);
-    const amrex::Real dt = amrex::Real(1.0);
-    const amrex::Real dz = amrex::Real(1.0);
-    const amrex::Real velocity = kessler_terminal_velocity(rho, qp);
-    const amrex::Real reduced_flux_like_value = kessler_precip_flux(rho, velocity, qp);
-
-    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz),
-              reference_substeps_from_reduced_value(reduced_flux_like_value, dt, dz));
-    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz), 1);
-}
-
 // Motivation: Full cloud and rain evaporation currently both use the original
 // subsaturation deficit. This is a characterization test, not a correctness
 // test. It pins current behavior so that any future change must also address
@@ -718,19 +701,11 @@ TEST(KesslerScalar, Characterization_RainAccumulationPreservesCurrentUnitCancell
     EXPECT_NEAR(current_expression, rho * qp * velocity * dt, backend_math_abs_tol(current_expression));
 }
 
-// Motivation: Expected behavior:
-//   The sedimentation substep count should be based on a terminal-velocity CFL,
-//   n = ceil((V_terminal + eps) * dt / dz / CFL_MAX).
-// Observed current behavior:
-//   The current call path reduces a flux-like value rho * V_terminal * qp.
-// Minimal reproducer:
-//   rho = 1.16, qp = 1.0e-3, dt = 1.0, dz = 1.0, CFL_MAX = 0.5.
-// Why disabled:
-//   Current development uses the reduced flux-like value, so the physical CFL
-//   contract does not hold yet.
-// Enable trigger:
-//   Production should reduce a terminal velocity rather than rho*V*qp.
-TEST(KesslerScalar, DISABLED_SubstepCountUsesTerminalVelocityCFL)
+// Motivation: The sedimentation substep count contract is a terminal-velocity
+// CFL, n = ceil((V_terminal + eps) * dt / dz / CFL_MAX). A flux-like reduced
+// value rho * V_terminal * qp is dimensionally different and must not be used
+// as a drop-in replacement for the CFL quantity.
+TEST(KesslerScalar, SubstepCountUsesTerminalVelocityCFL)
 {
     const amrex::Real rho = amrex::Real(1.16);
     const amrex::Real qp = amrex::Real(1.0e-3);
@@ -739,7 +714,9 @@ TEST(KesslerScalar, DISABLED_SubstepCountUsesTerminalVelocityCFL)
     const amrex::Real velocity = reference_terminal_velocity(rho, qp);
     const amrex::Real reduced_flux_like_value = reference_precip_flux(rho, velocity, qp);
 
-    EXPECT_EQ(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz),
+    EXPECT_EQ(kessler_num_sedimentation_substeps(velocity, dt, dz),
+              reference_velocity_cfl_substeps(velocity, dt, dz));
+    EXPECT_NE(kessler_num_sedimentation_substeps(reduced_flux_like_value, dt, dz),
               reference_velocity_cfl_substeps(velocity, dt, dz));
 }
 

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -55,7 +55,7 @@ TEST(KesslerScalar, SaturationAdjustment_NoOpAtSaturation)
     const amrex::Real dtqsat = amrex::Real(0.02);
 
     const KesslerSaturationAdjustment actual =
-        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
 
     EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
     EXPECT_NEAR(actual.dq_cloud_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
@@ -72,9 +72,9 @@ TEST(KesslerScalar, SaturationAdjustment_CondensationMatchesIndependentReference
     const amrex::Real dtqsat = amrex::Real(0.03);
 
     const KesslerSaturationAdjustment actual =
-        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
     const KesslerSaturationAdjustment expected =
-        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
 
     expect_sat_adjustment_match(actual, expected);
 }
@@ -89,9 +89,9 @@ TEST(KesslerScalar, SaturationAdjustment_CloudEvaporationMatchesIndependentRefer
     const amrex::Real dtqsat = amrex::Real(0.02);
 
     const KesslerSaturationAdjustment actual =
-        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
     const KesslerSaturationAdjustment expected =
-        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        reference_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
 
     expect_sat_adjustment_match(actual, expected);
 }
@@ -106,7 +106,7 @@ TEST(KesslerScalar, SaturationAdjustment_CloudEvaporationCappedByCloudWater)
     const amrex::Real dtqsat = amrex::Real(0.01);
 
     const KesslerSaturationAdjustment actual =
-        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true);
+        kessler_saturation_adjustment(qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
 
     EXPECT_NEAR(actual.dq_cloud_to_vapor, qc, formula_abs_tol(qc));
     EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
@@ -124,7 +124,8 @@ TEST(KesslerScalar, SaturationAdjustment_DoCondFalseSuppressesCondensationAndClo
     for (const auto& [qv, qc, qsat] : cases) {
         SCOPED_TRACE("qv=" + std::to_string(static_cast<double>(qv)));
         const KesslerSaturationAdjustment actual =
-            kessler_saturation_adjustment(qv, qc, qsat, amrex::Real(0.03), false);
+            kessler_saturation_adjustment(qv, qc, qsat, amrex::Real(0.03), false,
+                                          kSatAdjLatentOverCp);
         EXPECT_NEAR(actual.dq_vapor_to_cloud, amrex::Real(0.0), exact_zero_or_near_zero_tol());
         EXPECT_NEAR(actual.dq_cloud_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
     }
@@ -149,7 +150,8 @@ TEST(KesslerScalar, SaturationAdjustment_AnalyticDerivativeInSmoothCondensationB
     const auto branch = [=] (const amrex::Real qv_value,
                              const amrex::Real qsat_value,
                              const amrex::Real dtqsat_value) {
-        return kessler_saturation_adjustment(qv_value, qc, qsat_value, dtqsat_value, true).dq_vapor_to_cloud;
+        return kessler_saturation_adjustment(qv_value, qc, qsat_value, dtqsat_value, true,
+                                             kSatAdjLatentOverCp).dq_vapor_to_cloud;
     };
 
     const amrex::Real d_dq_dqv = central_difference(
@@ -185,7 +187,8 @@ TEST(KesslerScalar, SaturationAdjustment_CondensationQvCapUnreachableForValidPos
         SCOPED_TRACE("qv=" + std::to_string(static_cast<double>(qv)) +
                      " qsat=" + std::to_string(static_cast<double>(qsat)));
         const KesslerSaturationAdjustment actual =
-            kessler_saturation_adjustment(qv, amrex::Real(1.0e-3), qsat, dtqsat, true);
+            kessler_saturation_adjustment(qv, amrex::Real(1.0e-3), qsat, dtqsat, true,
+                                          kSatAdjLatentOverCp);
         EXPECT_LE(actual.dq_vapor_to_cloud, qv + formula_abs_tol(qv));
         EXPECT_NEAR(actual.dq_vapor_to_cloud,
                     (qv > qsat) ? (qv - qsat) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat)
@@ -202,7 +205,7 @@ TEST(KesslerScalar, WarmRainSources_TotalWaterConservedByLocalSources)
     const KesslerSourceTerms source_terms = kessler_warm_rain_sources(
         amrex::Real(9.0e-3), amrex::Real(2.0e-3), amrex::Real(1.5e-3),
         amrex::Real(1.1), amrex::Real(900.0), amrex::Real(1.0e-2),
-        amrex::Real(0.02), amrex::Real(2.0), true);
+        amrex::Real(0.02), amrex::Real(2.0), true, kSatAdjLatentOverCp);
 
     const amrex::Real source_sum =
         (-source_terms.dq_vapor_to_cloud + source_terms.dq_cloud_to_vapor + source_terms.dq_rain_to_vapor)
@@ -224,10 +227,12 @@ TEST(KesslerScalar, WarmRainSources_AutoconversionThresholdBelowEqualAbove)
         SCOPED_TRACE("qc=" + std::to_string(static_cast<double>(qc)));
         const KesslerSourceTerms actual = kessler_warm_rain_sources(
             amrex::Real(1.0e-2), qc, amrex::Real(0.0), amrex::Real(1.0),
-            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true);
+            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true,
+            kSatAdjLatentOverCp);
         const KesslerSourceTerms expected = reference_warm_rain_sources(
             amrex::Real(1.0e-2), qc, amrex::Real(0.0), amrex::Real(1.0),
-            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true);
+            amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.02), amrex::Real(1.0), true,
+            kSatAdjLatentOverCp);
         expect_source_terms_match(actual, expected);
     }
 }
@@ -240,9 +245,31 @@ TEST(KesslerScalar, WarmRainSources_CloudToRainCappedByCloudWater)
     const amrex::Real qc = amrex::Real(2.0e-4);
     const KesslerSourceTerms actual = kessler_warm_rain_sources(
         amrex::Real(1.0e-2), qc, amrex::Real(1.0), amrex::Real(1.0),
-        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true);
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(10.0), true,
+        kSatAdjLatentOverCp);
 
     EXPECT_NEAR(actual.dq_cloud_to_rain, qc, formula_abs_tol(qc));
+}
+
+// Motivation: Cloud-to-rain conversion can only consume cloud water that
+// remains after saturation adjustment has already evaporated or condensed
+// cloud water. This protects the composed source ordering.
+TEST(KesslerScalar, WarmRainSources_CloudToRainCappedByRemainingCloudAfterSaturationAdjustment)
+{
+    const amrex::Real qv = amrex::Real(8.0e-3);
+    const amrex::Real qc = amrex::Real(4.0e-4);
+    const amrex::Real qp = amrex::Real(2.0e-2);
+    const amrex::Real qsat = amrex::Real(1.0e-2);
+    const amrex::Real dtqsat = amrex::Real(0.02);
+    const KesslerSourceTerms actual = kessler_warm_rain_sources(
+        qv, qc, qp, amrex::Real(1.0), amrex::Real(900.0), qsat, dtqsat, amrex::Real(20.0), true,
+        kSatAdjLatentOverCp);
+    const KesslerSaturationAdjustment sat = reference_saturation_adjustment(
+        qv, qc, qsat, dtqsat, true, kSatAdjLatentOverCp);
+    const amrex::Real available_cloud = amrex::max(
+        amrex::Real(0.0), qc + sat.dq_vapor_to_cloud - sat.dq_cloud_to_vapor);
+
+    EXPECT_NEAR(actual.dq_cloud_to_rain, available_cloud, formula_abs_tol(available_cloud));
 }
 
 // Motivation: For fixed cloud water with autoconversion disabled, accretion is
@@ -259,7 +286,8 @@ TEST(KesslerScalar, WarmRainSources_AccretionMonotoneInRainWater)
     for (const amrex::Real qp : qp_values) {
         SCOPED_TRACE("qp=" + std::to_string(static_cast<double>(qp)));
         const KesslerSourceTerms actual = kessler_warm_rain_sources(
-            qv, qc, qp, amrex::Real(1.1), amrex::Real(900.0), qv, amrex::Real(0.02), amrex::Real(1.0), true);
+            qv, qc, qp, amrex::Real(1.1), amrex::Real(900.0), qv, amrex::Real(0.02), amrex::Real(1.0),
+            true, kSatAdjLatentOverCp);
         EXPECT_GE(actual.dq_cloud_to_rain, amrex::Real(0.0));
         if (previous >= amrex::Real(0.0)) {
             EXPECT_GE(actual.dq_cloud_to_rain + formula_abs_tol(actual.dq_cloud_to_rain), previous);
@@ -268,29 +296,31 @@ TEST(KesslerScalar, WarmRainSources_AccretionMonotoneInRainWater)
     }
 }
 
-// Motivation: Rain evaporation requires both rain water and subsaturation.
-// This protects three distinct branch guards in the composed warm-rain helper.
-TEST(KesslerScalar, WarmRainSources_RainEvaporationRequiresRainAndSubsaturation)
+// Motivation: Rain evaporation requires rain water, subsaturation, and
+// remaining linearized capacity after cloud evaporation.
+TEST(KesslerScalar, WarmRainSources_RainEvaporationRequiresRainSubsaturationAndRemainingCapacity)
 {
     struct Case {
         amrex::Real qp;
         amrex::Real qv;
+        amrex::Real qc;
         amrex::Real qsat;
         bool expect_positive;
     };
 
     const std::array<Case, 3> cases = {{
-        {amrex::Real(0.0), amrex::Real(9.0e-3), amrex::Real(1.0e-2), false},
-        {amrex::Real(2.0e-3), amrex::Real(1.0e-2), amrex::Real(1.0e-2), false},
-        {amrex::Real(2.0e-3), amrex::Real(9.0e-3), amrex::Real(1.0e-2), true}
+        {amrex::Real(0.0), amrex::Real(9.0e-3), amrex::Real(0.0), amrex::Real(1.0e-2), false},
+        {amrex::Real(2.0e-3), amrex::Real(1.0e-2), amrex::Real(0.0), amrex::Real(1.0e-2), false},
+        {amrex::Real(2.0e-3), amrex::Real(9.0e-3), amrex::Real(0.0), amrex::Real(1.0e-2), true}
     }};
 
     for (const auto& test_case : cases) {
         SCOPED_TRACE("qp=" + std::to_string(static_cast<double>(test_case.qp)) +
                      " qv=" + std::to_string(static_cast<double>(test_case.qv)));
         const KesslerSourceTerms actual = kessler_warm_rain_sources(
-            test_case.qv, amrex::Real(5.0e-4), test_case.qp, amrex::Real(1.1),
-            amrex::Real(900.0), test_case.qsat, amrex::Real(0.02), amrex::Real(2.0), true);
+            test_case.qv, test_case.qc, test_case.qp, amrex::Real(1.1),
+            amrex::Real(900.0), test_case.qsat, amrex::Real(0.02), amrex::Real(2.0), true,
+            kSatAdjLatentOverCp);
         if (test_case.expect_positive) {
             EXPECT_GT(actual.dq_rain_to_vapor, amrex::Real(0.0));
         } else {
@@ -305,8 +335,9 @@ TEST(KesslerScalar, WarmRainSources_RainEvaporationCappedByRainWater)
 {
     const amrex::Real qp = amrex::Real(1.0e-4);
     const KesslerSourceTerms actual = kessler_warm_rain_sources(
-        amrex::Real(1.0e-3), amrex::Real(5.0e-4), qp, amrex::Real(1.2),
-        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(200.0), true);
+        amrex::Real(1.0e-3), amrex::Real(0.0), qp, amrex::Real(1.2),
+        amrex::Real(900.0), amrex::Real(1.0e-2), amrex::Real(0.01), amrex::Real(200.0), true,
+        kSatAdjLatentOverCp);
 
     EXPECT_NEAR(actual.dq_rain_to_vapor, qp, formula_abs_tol(qp));
 }
@@ -323,7 +354,8 @@ TEST(KesslerScalar, WarmRainSources_NoNegativeTendenciesForValidInputs)
         SCOPED_TRACE(case_label(test_case));
         const KesslerSourceTerms actual = kessler_warm_rain_sources(
             test_case.qv, test_case.qc, test_case.qp, test_case.rho, test_case.pressure_mbar,
-            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond);
+            test_case.qsat, test_case.dtqsat, test_case.dt, test_case.do_cond,
+            kSatAdjLatentOverCp);
 
         EXPECT_GE(actual.dq_vapor_to_cloud, -exact_zero_or_near_zero_tol());
         EXPECT_GE(actual.dq_cloud_to_vapor, -exact_zero_or_near_zero_tol());
@@ -456,8 +488,8 @@ TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
     EXPECT_NEAR(bottom.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
     EXPECT_NEAR(top.rho, amrex::Real(1.0), formula_abs_tol(amrex::Real(1.0)));
     EXPECT_NEAR(top.qp, amrex::Real(0.2), formula_abs_tol(amrex::Real(0.2)));
-    EXPECT_NEAR(interior.rho, amrex::Real(1.05), formula_abs_tol(amrex::Real(1.05)));
-    EXPECT_NEAR(interior.qp, amrex::Real(0.25), formula_abs_tol(amrex::Real(0.25)));
+    EXPECT_NEAR(interior.rho, amrex::Real(1.1), formula_abs_tol(amrex::Real(1.1)));
+    EXPECT_NEAR(interior.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
 }
 
 // Motivation: Face rain water is clipped nonnegative after branch selection.
@@ -470,16 +502,16 @@ TEST(KesslerScalar, FaceState_ClipsNegativeFaceRainWater)
     EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
 }
 
-// Motivation: The current face-state contract averages neighboring qp first,
-// then clips the averaged face value. This protects the branch order, not a
-// physically stronger invariant.
-TEST(KesslerScalar, FaceState_AveragesThenClips)
+// Motivation: Interior sedimentation faces use the upper-cell donor state for
+// downward precipitation transport, then clip the donor rain water
+// nonnegative.
+TEST(KesslerScalar, FaceState_UsesUpperCellDonorThenClips)
 {
-    // MUST MATCH: production face-state averaging and clipping order.
+    // MUST MATCH: production interior donor-cell selection and clipping order.
     const KesslerFaceState actual =
         kessler_face_state(1, 0, 2, amrex::Real(1.0), amrex::Real(1.0), -amrex::Real(0.2), amrex::Real(0.1));
 
-    EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
+    EXPECT_NEAR(actual.qp, amrex::Real(0.1), formula_abs_tol(amrex::Real(0.1)));
 }
 
 // Motivation: Equal face fluxes imply zero sedimentation tendency. This is the
@@ -564,14 +596,15 @@ TEST(KesslerScalar, CopyStateToMicro_PressureStoredInMbar)
     });
 
     const KesslerSourceTerms expected_sources = reference_warm_rain_sources(
-        state.qv, state.qc, state.qp, state.rho, state.pres_mbar, qsat, dtqsat, kDefaultDt, true);
+        state.qv, state.qc, state.qp, state.rho, state.pres_mbar, qsat, dtqsat, kDefaultDt, true,
+        kSatAdjLatentOverCp);
     amrex::Real qv_expected = state.qv;
     amrex::Real qc_expected = state.qc;
     amrex::Real qp_expected = state.qp;
     apply_local_sources(qv_expected, qc_expected, qp_expected, expected_sources);
 
     amrex::Real theta_expected = state.theta;
-    theta_expected += (state.theta / state.tabs) * (lcond / sc.c_p)
+    theta_expected += (state.theta / state.tabs) * (L_v / sc.c_p)
         * (expected_sources.dq_vapor_to_cloud
            - expected_sources.dq_cloud_to_vapor
            - expected_sources.dq_rain_to_vapor);
@@ -649,11 +682,10 @@ TEST(KesslerScalar, CopyMicroToState_WritesCurrentMicroThetaToRhoTheta)
                 formula_abs_tol(state.rho * state.theta));
 }
 
-// Motivation: Full cloud and rain evaporation currently both use the original
-// subsaturation deficit. This is a characterization test, not a correctness
-// test. It pins current behavior so that any future change must also address
-// `DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsaturation`.
-TEST(KesslerScalar, Characterization_CloudAndRainEvaporationCurrentlyShareOriginalDeficit)
+// Motivation: Cloud evaporation should consume the linearized subsaturation
+// capacity before rain evaporation can act. Once cloud evaporation exhausts
+// that capacity, rain evaporation must remain zero.
+TEST(KesslerScalar, WarmRainSources_CloudEvaporationConsumesSubsaturationBeforeRainEvaporation)
 {
     const amrex::Real qv = amrex::Real(8.0e-3);
     const amrex::Real qc = amrex::Real(4.0e-3);
@@ -663,18 +695,13 @@ TEST(KesslerScalar, Characterization_CloudAndRainEvaporationCurrentlyShareOrigin
     const amrex::Real rho = amrex::Real(1.0);
     const amrex::Real dt = amrex::Real(80.0);
     const KesslerSourceTerms actual = kessler_warm_rain_sources(
-        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true);
-    const amrex::Real linearized_capacity = (qsat - qv) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat);
+        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true,
+        kSatAdjLatentOverCp);
+    const amrex::Real linearized_capacity =
+        (qsat - qv) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat);
 
-    EXPECT_GT(actual.dq_cloud_to_vapor + actual.dq_rain_to_vapor, linearized_capacity);
-}
-
-// Motivation: This is a characterization test, not a correctness test. It
-// pins current behavior so that any future change must also address
-// `DISABLED_SaturationThetaUsesConsistentLatentHeatFactor`.
-TEST(KesslerScalar, Characterization_SaturationThetaCurrentlyUseDifferentLatentFactors)
-{
-    EXPECT_NE(kSatAdjLatentOverCp, kThetaLatentOverCp);
+    EXPECT_NEAR(actual.dq_cloud_to_vapor, linearized_capacity, formula_abs_tol(linearized_capacity));
+    EXPECT_NEAR(actual.dq_rain_to_vapor, amrex::Real(0.0), exact_zero_or_near_zero_tol());
 }
 
 // Motivation: This is a characterization test, not a correctness test. It
@@ -720,21 +747,10 @@ TEST(KesslerScalar, SubstepCountUsesTerminalVelocityCFL)
               reference_velocity_cfl_substeps(velocity, dt, dz));
 }
 
-// Motivation: Expected behavior:
-//   Total vapor supplied by cloud evaporation plus rain evaporation should not
-//   exceed the linearized subsaturation capacity.
-// Observed current behavior:
-//   Cloud evaporation and rain evaporation both consume the original deficit.
-// Minimal reproducer:
-//   qv = 8.0e-3, qc = 4.0e-3, qp = 2.0e-3, qsat = 1.0e-2, dtqsat = 0.02,
-//   rho = 1.0, dt = 80.0.
-// Why disabled:
-//   Current development allows both evaporation paths to contribute from the
-//   same original deficit.
-// Enable trigger:
-//   Production should re-evaluate subsaturation capacity after each phase
-//   change or otherwise enforce a shared-deficit contract.
-TEST(KesslerScalar, DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsaturation)
+// Motivation: Total vapor supplied by cloud evaporation plus rain evaporation
+// must not exceed the linearized subsaturation capacity. Rain evaporation may
+// only use the capacity remaining after cloud evaporation.
+TEST(KesslerScalar, CloudAndRainEvaporationDoNotBothConsumeSameSubsaturation)
 {
     const amrex::Real qv = amrex::Real(8.0e-3);
     const amrex::Real qc = amrex::Real(4.0e-3);
@@ -744,7 +760,8 @@ TEST(KesslerScalar, DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsatur
     const amrex::Real rho = amrex::Real(1.0);
     const amrex::Real dt = amrex::Real(80.0);
     const KesslerSourceTerms actual = kessler_warm_rain_sources(
-        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true);
+        qv, qc, qp, rho, amrex::Real(900.0), qsat, dtqsat, dt, true,
+        kSatAdjLatentOverCp);
     const amrex::Real linearized_capacity = (qsat - qv) / (amrex::Real(1.0) + kSatAdjLatentOverCp * dtqsat);
 
     EXPECT_LE(actual.dq_cloud_to_vapor + actual.dq_rain_to_vapor,
@@ -754,17 +771,7 @@ TEST(KesslerScalar, DISABLED_CloudAndRainEvaporationDoNotBothConsumeSameSubsatur
 // Motivation: Expected behavior:
 //   Saturation adjustment and theta update should use thermodynamically
 //   consistent latent-heat-over-cp factors.
-// Observed current behavior:
-//   The saturation helper uses L_v / Cp_d while the theta update uses
-//   lcond / sc.c_p.
-// Minimal reproducer:
-//   Compare the two factors with the default dry-air cp.
-// Why disabled:
-//   Current development intentionally preserves the existing factors.
-// Enable trigger:
-//   Production should adopt one thermodynamically consistent latent factor for
-//   both the saturation and theta updates.
-TEST(KesslerScalar, DISABLED_SaturationThetaUsesConsistentLatentHeatFactor)
+TEST(KesslerScalar, SaturationThetaUsesConsistentLatentHeatFactor)
 {
     EXPECT_EQ(kSatAdjLatentOverCp, kThetaLatentOverCp);
 }


### PR DESCRIPTION
## Summary

This PR adds a Kessler microphysics test suite and fixes the production bugs that the tests exposed.

The new tests cover scalar helper contracts, host/device helper behavior, public-flow conservation, rain accumulation, sedimentation, and Kessler_NoRain behavior. The shared test header documents the core contracts: local source terms conserve total water, sedimentation moves rain vertically and to `rain_accum`, public-flow water budgets include surface rain, pressure units are explicit, and GPU tests keep assertions on the host.

## What changed

### Tests

- Add Kessler scalar tests for saturation adjustment, warm-rain source terms, terminal velocity, precipitation flux, sedimentation helpers, copy-in/copy-out contracts, and documented thresholds.
- Add Kessler kernel tests for host/device helper equivalence.
- Add public-flow tests that run:

  `Init -> Copy_State_to_Micro -> Advance -> Copy_Micro_to_State`

  and check total water, latent-energy proxy behavior, surface rain accumulation, detJ-weighted column budgets, and NoRain behavior.
- Add compressed-cell detJ coverage with `detJ < 1`.

### Production fixes

- Use terminal velocity, not precipitating mass flux, for the sedimentation substep CFL.
- Use the upper-cell donor state for downward sedimentation faces.
- Limit sedimentation face flux by the donor cell’s detJ-weighted available rain water.
- Stop mutating shared `fz` face values while thresholding small sedimentation fluxes.
- Use one latent-over-cp factor, `L_v / sc.c_p`, for both saturation adjustment and theta update.
- Limit rain evaporation by the subsaturation left after cloud evaporation.
- Prevent cloud-to-rain conversion from consuming cloud water that saturation adjustment already evaporated.
- Convert rain accumulation from precipitation mass per area to millimeters with named constants.
- Replace the hidden `myhalf` sedimentation CFL divisor with a named Kessler CFL constant.

## Why this changes answers

This PR is expected to change bit-for-bit answers in Kessler cases. Those changes are intentional.

The old code used the stored precipitation flux `rho * Vt * qp` to choose the number of sedimentation substeps. That quantity has flux units, not velocity units. The new code still stores flux in `fz`, but it reduces maximum terminal velocity for the CFL count. This can change the number of rain substeps, rain transport, and rain accumulation. The old reduction returned `fz`; the new reduction recomputes terminal velocity. 

The old sedimentation update also wrote thresholded zeros back into shared `fz` faces. Neighboring cells share those faces, so the update could depend on traversal and backend behavior. The new code thresholds local face-flux copies only.

The old limiter capped face flux without detJ. For compressed cells with `detJ < 1`, that could remove more rain than the donor cell contained before the nonnegative clip hid the error. The new cap uses the donor cell’s detJ-weighted available rain water.

The old saturation adjustment used `L_v / Cp_d`, while theta used the solver heat capacity. The new code derives one factor from `L_v / sc.c_p` and passes it through the Kessler source path.

The old rain evaporation used the original vapor deficit. Cloud evaporation and rain evaporation could both consume the same subsaturation. The new code applies cloud evaporation first, then caps rain evaporation by the remaining linearized capacity.

These changes fix physical and mathematical defects. They should not be judged by bit-for-bit agreement with the old Kessler results.

## Notes for reviewers

The PR should be nearly performance netural:

- no new production `MultiFab` allocations,
- no new production kernel launches,
- no new production reductions beyond the existing sedimentation reduction changing what it reduces,
- no dynamic allocation in device code,
- helper functions remain `AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE`.

The empirical Kessler closure coefficients remain unchanged. Generic thermodynamic constants come from `ERF_Constants.H`.