### PR TITLE
1) remove unused functions from ERF.H;  2) protect in FillPatcher aga…

### DIFF
--- a/Source/BoundaryConditions/ERF_FillPatcher.H
+++ b/Source/BoundaryConditions/ERF_FillPatcher.H
@@ -127,8 +127,12 @@ ERFFillPatcher::Fill (amrex::MultiFab& mf, amrex::Real time,
     AMREX_ALWAYS_ASSERT((time >= m_crse_times[0]-eps) && (time <= m_crse_times[1]+eps));
 
     // Time interpolation factors
-    amrex::Real fac_new = (time - m_crse_times[0]) / m_dt_crse;
-    amrex::Real fac_old = amrex::Real(1.0) - fac_new;
+    amrex::Real fac_new = 0.0;
+    amrex::Real fac_old = 1.0;
+    if (amrex::Math::abs(m_dt_crse) > eps) {
+        fac_new = (time - m_crse_times[0]) / m_dt_crse;
+        fac_old = 1.0 - fac_new;
+    }
 
     // Boundary condition operator
     cbc(*(m_cf_crse_data_old), 0, m_ncomp, amrex::IntVect(0), time, 0);

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -24,13 +24,21 @@ query_one_or_per_level (
   if (count == 0) {
     return 0; // nothing to do
   } else if (count == 1) {
+    // In this case, we assume the same value is used at every level
     return pp.query(query_string, query_var);
-  } else if (count == maxlev + 1) {
+  } else if (count >= maxlev + 1) {
+    // In this case, there may be more values than levels so we
+    // will just read the number of values we need and ignore the
+    // extra levels
     return pp.query(query_string, query_var, lev);
   } else {
+    // In this case, there is more than one value AND there
+    // are more levels than values; as an example, if max_level = 2
+    // but count = 2 so we have three levels but only two values --
+    // it is not clear how to interpret this so we abort
     amrex::Error(
       "For parmparse variable " + pp.prefixedName(query_string) +
-      ": if specified, specify once total or once for each level");
+      ": if specified, specify once total or at least once for each level");
     return 0; // avoid compiler warning
   }
 }
@@ -48,10 +56,18 @@ query_one_or_per_level_enum_case_insensitive (
   if (count == 0) {
     return 0; // nothing to do
   } else if (count == 1) {
+    // In this case, we assume the same value is used at every level
     return pp.query_enum_case_insensitive(query_string, query_var);
   } else if (count >= maxlev + 1) {
+    // In this case, there may be more values than levels so we
+    // will just read the number of values we need and ignore the
+    // extra levels
     return pp.query_enum_case_insensitive(query_string, query_var, lev);
   } else {
+    // In this case, there is more than one value AND there
+    // are more levels than values; as an example, if max_level = 2
+    // but count = 2 so we have three levels but only two values --
+    // it is not clear how to interpret this so we abort
     amrex::Error(
       "For parmparse variable " + pp.prefixedName(query_string) +
       ": if specified, specify once total or at least once for each level");

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -533,11 +533,6 @@ public:
     // Advance a block specified number of time steps
     void Evolve_MB (int MBstep, int max_block_step);
 
-    // get the current time values and dt
-    amrex::Real get_t_old (int lev) { return t_old[lev]; }
-    amrex::Real get_t_new (int lev) { return t_new[lev]; }
-    amrex::Real get_dt    (int lev) { return dt[lev];    }
-
     // Set parmparse prefix for MultiBlock
     void SetParmParsePrefix (std::string name) { pp_prefix = name; }
 


### PR DESCRIPTION
…inst divide by 0, 3) generalize ParmParse read so that we can allow more values than levels or a single value for all levels (but otherwise not more levels than values); previously the number of values had to be exactly 1 or the number of levels