### PR TITLE
Fix interpolation and add tests

### DIFF
--- a/Source/Utils/ERF_Interpolation.H
+++ b/Source/Utils/ERF_Interpolation.H
@@ -7,8 +7,21 @@
 #include "ERF_Interpolation_WENO_Z.H"
 
 /**
- * Interpolation operators used in construction of advective fluxes using non-WENO schemes
+ * Interpolation operators used in construction of advective fluxes using
+ * non-WENO centered/upwind schemes.
  */
+
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+bool
+isSupportedInterpolationAdvType (const AdvType adv_type) noexcept
+{
+    return adv_type == AdvType::Centered_2nd ||
+           adv_type == AdvType::Upwind_3rd   ||
+           adv_type == AdvType::Centered_4th ||
+           adv_type == AdvType::Upwind_5th   ||
+           adv_type == AdvType::Centered_6th;
+}
 
 AMREX_GPU_DEVICE
 AMREX_FORCE_INLINE
@@ -17,6 +30,10 @@ interpolatedVal (amrex::Real avg1,  amrex::Real avg2,  amrex::Real avg3,
                  amrex::Real diff1, amrex::Real diff2, amrex::Real diff3,
                  amrex::Real scaled_upw, const AdvType adv_type)
 {
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+        isSupportedInterpolationAdvType(adv_type),
+        "interpolatedVal only supports Centered_2nd, Upwind_3rd, Centered_4th, Upwind_5th, and Centered_6th");
+
     amrex::Real myInterpolatedVal(amrex::Real(0));
     if (adv_type == AdvType::Centered_2nd) {
         myInterpolatedVal = myhalf * avg1;
@@ -29,6 +46,10 @@ interpolatedVal (amrex::Real avg1,  amrex::Real avg2,  amrex::Real avg3,
                           -(scaled_upw/amrex::Real(60.0))*(diff3 - amrex::Real(5.0)*diff2 + amrex::Real(10.0)*diff1);
     } else if (adv_type == AdvType::Centered_6th) {
         myInterpolatedVal = (amrex::Real(37.0)/amrex::Real(60.0))*avg1 -(amrex::Real(2)/amrex::Real(15.0))*avg2 +(amrex::Real(1)/amrex::Real(60.0))*avg3;
+    } else {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            false,
+            "interpolatedVal only supports Centered_2nd, Upwind_3rd, Centered_4th, Upwind_5th, and Centered_6th");
     }
     return myInterpolatedVal;
 }
@@ -131,6 +152,8 @@ InterpolatePertFromCell (int i, int j, int k,
                          int qty_index, amrex::Real upw, Coord coordDir,
                          const AdvType adv_type, const amrex::Array4<const amrex::Real>& r0_arr)
 {
+    // Reconstruct the perturbation qty - r0_arr, so both averages and
+    // differences must be formed from perturbation quantities.
     amrex::Real avg1 = amrex::Real(0); amrex::Real avg2 = amrex::Real(0); amrex::Real avg3 = amrex::Real(0);
     amrex::Real diff1 = amrex::Real(0); amrex::Real diff2 = amrex::Real(0); amrex::Real diff3 = amrex::Real(0);
     amrex::Real scaled_upw = amrex::Real(0);
@@ -142,33 +165,39 @@ InterpolatePertFromCell (int i, int j, int k,
         avg1  = (qty(i  , j, k, qty_index) + qty(i-1, j, k, qty_index));
         avg1 -= (r0_arr(i,j,k) + r0_arr(i-1,j,k));
         diff1 = (qty(i  , j, k, qty_index) - qty(i-1, j, k, qty_index));
+        diff1 -= (r0_arr(i,j,k) - r0_arr(i-1,j,k));
         if (adv_type != AdvType::Centered_2nd)
         {
             avg2  = (qty(i+1, j, k, qty_index) + qty(i-2, j, k, qty_index));
             avg2 -= (r0_arr(i+1,j,k) + r0_arr(i-2,j,k));
             diff2 = (qty(i+1, j, k, qty_index) - qty(i-2, j, k, qty_index));
+            diff2 -= (r0_arr(i+1,j,k) - r0_arr(i-2,j,k));
         }
         if (adv_type == AdvType::Upwind_5th || adv_type == AdvType::Centered_6th)
         {
             avg3  = (qty(i+2, j, k, qty_index) + qty(i-3, j, k, qty_index));
             avg3 -= (r0_arr(i+2,j,k) + r0_arr(i-3,j,k));
             diff3 = (qty(i+2, j, k, qty_index) - qty(i-3, j, k, qty_index));
+            diff3 -= (r0_arr(i+2,j,k) - r0_arr(i-3,j,k));
         }
     } else if (coordDir == Coord::y) {
         avg1  = (qty(i, j  , k, qty_index) + qty(i, j-1, k, qty_index));
         avg1 -= (r0_arr(i,j,k) + r0_arr(i,j-1,k));
         diff1 = (qty(i, j  , k, qty_index) - qty(i, j-1, k, qty_index));
+        diff1 -= (r0_arr(i,j,k) - r0_arr(i,j-1,k));
         if (adv_type != AdvType::Centered_2nd)
         {
             avg2  = (qty(i, j+1, k, qty_index) + qty(i, j-2, k, qty_index));
             avg2 -= (r0_arr(i,j+1,k) + r0_arr(i,j-2,k));
             diff2 = (qty(i, j+1, k, qty_index) - qty(i, j-2, k, qty_index));
+            diff2 -= (r0_arr(i,j+1,k) - r0_arr(i,j-2,k));
         }
         if (adv_type == AdvType::Upwind_5th || adv_type == AdvType::Centered_6th)
         {
             avg3  = (qty(i, j+2, k, qty_index) + qty(i, j-3, k, qty_index));
             avg3 -= (r0_arr(i,j+2,k) + r0_arr(i,j-3,k));
             diff3 = (qty(i, j+2, k, qty_index) - qty(i, j-3, k, qty_index));
+            diff3 -= (r0_arr(i,j+2,k) - r0_arr(i,j-3,k));
         }
     } else {
         avg1  = (qty(i, j, k  , qty_index) + qty(i, j, k-1, qty_index));

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSKernel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Utils/Interpolation/ERF_GTestInterpolationScalar.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Utils/Interpolation/ERF_GTestInterpolationKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/Microphysics/ERF_GTestMicrophysicsUtilsScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/Microphysics/ERF_GTestMicrophysicsUtilsKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjThermo.cpp

--- a/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationCommon.H
+++ b/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationCommon.H
@@ -1,0 +1,373 @@
+#ifndef ERF_GTEST_INTERPOLATION_COMMON_H_
+#define ERF_GTEST_INTERPOLATION_COMMON_H_
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <string>
+
+#include <AMReX_Array4.H>
+#include <AMReX_Box.H>
+#include <AMReX_FArrayBox.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_IntVect.H>
+#include <AMReX_Math.H>
+
+#include <ERF_DataStruct.H>
+#include <ERF_IndexDefines.H>
+#include <ERF_Interpolation.H>
+
+namespace interpolation_test {
+
+// Interpolation unit-test contract
+// --------------------------------
+// These tests check finite-volume reconstruction contracts for ERF's
+// non-WENO interpolation helpers, not implementation accidents.
+//
+// Core invariants:
+//   1. Constant fields are preserved.
+//   2. Centered/upwind schemes satisfy their finite-volume polynomial
+//      exactness order.
+//   3. Zero upwind reduces odd upwind corrections to the next centered
+//      stencil.
+//   4. Positive and negative upwind signs are mirror-symmetric.
+//   5. InterpolatePertFromCell reconstructs qty - r0_arr.
+//   6. Kernel tests exercise AMReX device callability over branch-dense
+//      sample grids.
+//
+// Portability:
+//   - Device kernels compute values or normalized errors only.
+//   - GTest EXPECT/ASSERT calls stay on the host.
+//   - No dynamic allocation is allowed inside device code.
+//   - Device coverage uses representative case tables, not single-sample
+//     smoke tests.
+
+// Relative tolerance for direct value comparisons between independent host
+// references and production device-path reconstructions.
+// Provenance: machine epsilon, float-vs-double scaling, and a small safety
+// factor for a handful of adds/multiplies with asymmetric stencils.
+#ifdef AMREX_USE_FLOAT
+constexpr amrex::Real kValueRelTol = amrex::Real(3.0e-5);
+constexpr amrex::Real kIdentityRelTol = amrex::Real(2.0e-5);
+constexpr amrex::Real kPolynomialRelTol = amrex::Real(6.0e-5);
+constexpr amrex::Real kDeviceRelTol = amrex::Real(8.0e-5);
+#else
+constexpr amrex::Real kValueRelTol = amrex::Real(1.0e-12);
+constexpr amrex::Real kIdentityRelTol = amrex::Real(1.0e-12);
+constexpr amrex::Real kPolynomialRelTol = amrex::Real(2.0e-12);
+constexpr amrex::Real kDeviceRelTol = amrex::Real(5.0e-12);
+#endif
+
+constexpr int kQtyComp = 0;
+constexpr int kEvalLo = -1;
+constexpr int kEvalHi = 1;
+constexpr amrex::Real kPerturbationConstant = amrex::Real(10.0);
+
+constexpr std::array<AdvType, 5> kSupportedAdvTypes = {{
+    AdvType::Centered_2nd,
+    AdvType::Upwind_3rd,
+    AdvType::Centered_4th,
+    AdvType::Upwind_5th,
+    AdvType::Centered_6th}};
+
+constexpr std::array<int, 3> kRepresentativeUpwindSigns = {{-1, 0, 1}};
+
+constexpr std::array<AdvType, 9> kUnsupportedAdvTypes = {{
+    AdvType::Upwind_3rd_SL,
+    AdvType::Weno_3,
+    AdvType::Weno_3Z,
+    AdvType::Weno_5,
+    AdvType::Weno_5Z,
+    AdvType::Weno_3MZQ,
+    AdvType::Weno_7,
+    AdvType::Weno_7Z,
+    AdvType::Unknown}};
+
+struct StencilValues {
+    amrex::Real qm3;
+    amrex::Real qm2;
+    amrex::Real qm1;
+    amrex::Real q0;
+    amrex::Real q1;
+    amrex::Real q2;
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int signum (const amrex::Real value) noexcept
+{
+    return (value > amrex::Real(0)) - (value < amrex::Real(0));
+}
+
+inline std::string scheme_name (const AdvType adv_type)
+{
+    switch (adv_type) {
+    case AdvType::Centered_2nd: return "Centered_2nd";
+    case AdvType::Upwind_3rd:   return "Upwind_3rd";
+    case AdvType::Centered_4th: return "Centered_4th";
+    case AdvType::Upwind_5th:   return "Upwind_5th";
+    case AdvType::Centered_6th: return "Centered_6th";
+    case AdvType::Upwind_3rd_SL:return "Upwind_3rd_SL";
+    case AdvType::Weno_3:       return "Weno_3";
+    case AdvType::Weno_3Z:      return "Weno_3Z";
+    case AdvType::Weno_5:       return "Weno_5";
+    case AdvType::Weno_5Z:      return "Weno_5Z";
+    case AdvType::Weno_3MZQ:    return "Weno_3MZQ";
+    case AdvType::Weno_7:       return "Weno_7";
+    case AdvType::Weno_7Z:      return "Weno_7Z";
+    default:                    return "Unknown";
+    }
+}
+
+inline std::string direction_name (const Coord direction)
+{
+    switch (direction) {
+    case Coord::x: return "x";
+    case Coord::y: return "y";
+    default:       return "z";
+    }
+}
+
+inline amrex::Real scaled_tol (const amrex::Real actual,
+                               const amrex::Real expected,
+                               const amrex::Real factor)
+{
+    return factor * std::max({amrex::Real(1.0), std::abs(actual), std::abs(expected)});
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real portable_scaled_tol (const amrex::Real actual,
+                                 const amrex::Real expected,
+                                 const amrex::Real factor) noexcept
+{
+    return factor * amrex::max(amrex::Real(1.0),
+                               amrex::max(amrex::Math::abs(actual), amrex::Math::abs(expected)));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real normalized_error (const amrex::Real actual,
+                              const amrex::Real expected,
+                              const amrex::Real factor) noexcept
+{
+    return amrex::Math::abs(actual - expected) / portable_scaled_tol(actual, expected, factor);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real integer_power (const amrex::Real base, const int exponent) noexcept
+{
+    amrex::Real value = amrex::Real(1.0);
+    for (int n = 0; n < exponent; ++n) {
+        value *= base;
+    }
+    return value;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real finite_volume_cell_average_monomial (const int degree,
+                                                 const int cell_lo) noexcept
+{
+    if (degree == 0) {
+        return amrex::Real(1.0);
+    }
+
+    const int antiderivative_degree = degree + 1;
+    return (integer_power(amrex::Real(cell_lo + 1), antiderivative_degree) -
+            integer_power(amrex::Real(cell_lo), antiderivative_degree)) /
+           amrex::Real(antiderivative_degree);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+StencilValues make_monomial_stencil (const int degree) noexcept
+{
+    return StencilValues{
+        finite_volume_cell_average_monomial(degree, -3),
+        finite_volume_cell_average_monomial(degree, -2),
+        finite_volume_cell_average_monomial(degree, -1),
+        finite_volume_cell_average_monomial(degree, 0),
+        finite_volume_cell_average_monomial(degree, 1),
+        finite_volume_cell_average_monomial(degree, 2)};
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+StencilValues mirrored_stencil (const StencilValues& stencil) noexcept
+{
+    return StencilValues{stencil.q2, stencil.q1, stencil.q0,
+                         stencil.qm1, stencil.qm2, stencil.qm3};
+}
+
+// Reference coefficients are derived from finite-volume polynomial
+// moment conditions about the face x = 0. They intentionally avoid
+// calling interpolatedVal or using production avg/diff assembly.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real reference_reconstruction (const StencilValues& stencil,
+                                      const AdvType adv_type,
+                                      const int sigma) noexcept
+{
+    if (adv_type == AdvType::Centered_2nd) {
+        return myhalf * (stencil.qm1 + stencil.q0);
+    }
+
+    if (adv_type == AdvType::Upwind_3rd) {
+        return ((amrex::Real(-1.0) + amrex::Real(sigma)) / amrex::Real(12.0)) * stencil.q1 +
+               ((amrex::Real(7.0)  - amrex::Real(3.0 * sigma)) / amrex::Real(12.0)) * stencil.q0 +
+               ((amrex::Real(7.0)  + amrex::Real(3.0 * sigma)) / amrex::Real(12.0)) * stencil.qm1 +
+               ((amrex::Real(-1.0) - amrex::Real(sigma)) / amrex::Real(12.0)) * stencil.qm2;
+    }
+
+    if (adv_type == AdvType::Centered_4th) {
+        return (-amrex::Real(1.0) / amrex::Real(12.0)) * stencil.q1 +
+               ( amrex::Real(7.0) / amrex::Real(12.0)) * stencil.q0 +
+               ( amrex::Real(7.0) / amrex::Real(12.0)) * stencil.qm1 +
+               (-amrex::Real(1.0) / amrex::Real(12.0)) * stencil.qm2;
+    }
+
+    if (adv_type == AdvType::Upwind_5th) {
+        return ((amrex::Real(1.0)  - amrex::Real(sigma)) / amrex::Real(60.0)) * stencil.q2 +
+               ((-amrex::Real(8.0) + amrex::Real(5.0 * sigma)) / amrex::Real(60.0)) * stencil.q1 +
+               (( amrex::Real(37.0) - amrex::Real(10.0 * sigma)) / amrex::Real(60.0)) * stencil.q0 +
+               (( amrex::Real(37.0) + amrex::Real(10.0 * sigma)) / amrex::Real(60.0)) * stencil.qm1 +
+               ((-amrex::Real(8.0) - amrex::Real(5.0 * sigma)) / amrex::Real(60.0)) * stencil.qm2 +
+               (( amrex::Real(1.0) + amrex::Real(sigma)) / amrex::Real(60.0)) * stencil.qm3;
+    }
+
+    return ( amrex::Real(1.0) / amrex::Real(60.0)) * stencil.q2 +
+           (-amrex::Real(8.0) / amrex::Real(60.0)) * stencil.q1 +
+           ( amrex::Real(37.0) / amrex::Real(60.0)) * stencil.q0 +
+           ( amrex::Real(37.0) / amrex::Real(60.0)) * stencil.qm1 +
+           (-amrex::Real(8.0) / amrex::Real(60.0)) * stencil.qm2 +
+           ( amrex::Real(1.0) / amrex::Real(60.0)) * stencil.qm3;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int exactness_degree (const AdvType adv_type) noexcept
+{
+    if (adv_type == AdvType::Centered_2nd) return 1;
+    if (adv_type == AdvType::Upwind_3rd)   return 2;
+    if (adv_type == AdvType::Centered_4th) return 3;
+    if (adv_type == AdvType::Upwind_5th)   return 4;
+    return 5;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int leading_error_degree (const AdvType adv_type) noexcept
+{
+    return exactness_degree(adv_type) + 1;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real leading_error_expected (const AdvType adv_type,
+                                    const int sigma) noexcept
+{
+    if (adv_type == AdvType::Centered_2nd) return amrex::Real(1.0) / amrex::Real(3.0);
+    if (adv_type == AdvType::Upwind_3rd)   return amrex::Real(sigma) / amrex::Real(2.0);
+    if (adv_type == AdvType::Centered_4th) return -amrex::Real(4.0) / amrex::Real(5.0);
+    if (adv_type == AdvType::Upwind_5th)   return -amrex::Real(2.0) * amrex::Real(sigma);
+    return amrex::Real(36.0) / amrex::Real(7.0);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AdvType centered_reduction (const AdvType adv_type) noexcept
+{
+    return (adv_type == AdvType::Upwind_3rd) ? AdvType::Centered_4th : AdvType::Centered_6th;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+StencilValues load_direction_stencil (const amrex::Array4<const amrex::Real>& qty,
+                                      const int i, const int j, const int k,
+                                      const Coord direction,
+                                      const int comp = kQtyComp) noexcept
+{
+    if (direction == Coord::x) {
+        return StencilValues{qty(i-3,j,k,comp), qty(i-2,j,k,comp), qty(i-1,j,k,comp),
+                             qty(i  ,j,k,comp), qty(i+1,j,k,comp), qty(i+2,j,k,comp)};
+    }
+
+    if (direction == Coord::y) {
+        return StencilValues{qty(i,j-3,k,comp), qty(i,j-2,k,comp), qty(i,j-1,k,comp),
+                             qty(i,j  ,k,comp), qty(i,j+1,k,comp), qty(i,j+2,k,comp)};
+    }
+
+    return StencilValues{qty(i,j,k-3,comp), qty(i,j,k-2,comp), qty(i,j,k-1,comp),
+                         qty(i,j,k  ,comp), qty(i,j,k+1,comp), qty(i,j,k+2,comp)};
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void fill_avg_diff (const StencilValues& stencil,
+                    amrex::Real& avg1,  amrex::Real& avg2,  amrex::Real& avg3,
+                    amrex::Real& diff1, amrex::Real& diff2, amrex::Real& diff3) noexcept
+{
+    avg1  = stencil.q0 + stencil.qm1;
+    diff1 = stencil.q0 - stencil.qm1;
+    avg2  = stencil.q1 + stencil.qm2;
+    diff2 = stencil.q1 - stencil.qm2;
+    avg3  = stencil.q2 + stencil.qm3;
+    diff3 = stencil.q2 - stencil.qm3;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real directional_field_value (const int i,
+                                     const int j,
+                                     const int k) noexcept
+{
+    return amrex::Real(0.5)   * finite_volume_cell_average_monomial(5, i) -
+           amrex::Real(1.25)  * finite_volume_cell_average_monomial(4, i) +
+           amrex::Real(0.75)  * finite_volume_cell_average_monomial(3, j) -
+           amrex::Real(0.5)   * finite_volume_cell_average_monomial(2, j) +
+           amrex::Real(1.5)   * finite_volume_cell_average_monomial(4, k) +
+           amrex::Real(0.25)  * amrex::Real(i * j) -
+           amrex::Real(0.125) * amrex::Real(j * k) +
+           amrex::Real(0.0625)* amrex::Real(i * k) +
+           amrex::Real(3.0);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real perturbation_background (const Coord direction,
+                                     const int i,
+                                     const int j,
+                                     const int k) noexcept
+{
+    if (direction == Coord::x) {
+        const amrex::Real x = amrex::Real(i);
+        return integer_power(x, 3) + amrex::Real(0.25) * integer_power(x, 5);
+    }
+
+    if (direction == Coord::y) {
+        const amrex::Real y = amrex::Real(j);
+        return integer_power(y, 3) + amrex::Real(0.25) * integer_power(y, 5);
+    }
+
+    const amrex::Real z = amrex::Real(k);
+    return integer_power(z, 3) + amrex::Real(0.25) * integer_power(z, 5);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real density_quantity_value (const int i,
+                                    const int j,
+                                    const int k) noexcept
+{
+    return amrex::Real(2.0) +
+           amrex::Real(0.75) * finite_volume_cell_average_monomial(4, i) -
+           amrex::Real(0.5)  * finite_volume_cell_average_monomial(3, j) +
+           amrex::Real(0.25) * finite_volume_cell_average_monomial(2, k) +
+           amrex::Real(0.125) * amrex::Real(i - 2 * j + 3 * k);
+}
+
+inline amrex::Box stencil_box ()
+{
+    return amrex::Box(amrex::IntVect(-4, -4, -4), amrex::IntVect(4, 4, 4));
+}
+
+inline amrex::Box eval_box ()
+{
+    return amrex::Box(amrex::IntVect(kEvalLo, kEvalLo, kEvalLo),
+                      amrex::IntVect(kEvalHi, kEvalHi, kEvalHi));
+}
+
+inline void gpu_sync ()
+{
+    amrex::Gpu::streamSynchronize();
+}
+
+} // namespace interpolation_test
+
+#endif

--- a/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationKernel.cpp
+++ b/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationKernel.cpp
@@ -534,7 +534,7 @@ TEST(InterpolationKernel, LowerOrderSchemesIgnoreFarStencilSentinels)
     amrex::FArrayBox base_qty(stencil_box(), 1);
     amrex::FArrayBox modified_qty(stencil_box(), 1);
     fill_directional_qty(base_qty);
-    modified_qty.copy(base_qty);
+    fill_directional_qty(modified_qty);
     apply_far_sentinels(modified_qty);
 
     amrex::Gpu::DeviceVector<SentinelCase> device_cases(cases.size());
@@ -582,7 +582,7 @@ TEST(InterpolationKernel, FifthAndSixthOrderSchemesUseFarStencil)
     amrex::FArrayBox base_qty(stencil_box(), 1);
     amrex::FArrayBox modified_qty(stencil_box(), 1);
     fill_directional_qty(base_qty);
-    modified_qty.copy(base_qty);
+    fill_directional_qty(modified_qty);
     apply_far_sentinels(modified_qty);
 
     amrex::Gpu::DeviceVector<SentinelCase> device_cases(cases.size());

--- a/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationKernel.cpp
+++ b/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationKernel.cpp
@@ -1,0 +1,628 @@
+#include <array>
+#include <string>
+#include <vector>
+
+#include <AMReX_FArrayBox.H>
+#include <AMReX_GpuContainers.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestInterpolationCommon.H"
+
+using namespace interpolation_test;
+
+namespace {
+
+struct InterpolatedValCase {
+    StencilValues stencil;
+    AdvType adv_type;
+    int upwind;
+    int sample_index;
+};
+
+struct WrapperCase {
+    AdvType adv_type;
+    Coord direction;
+    int upwind;
+};
+
+struct SentinelCase {
+    AdvType adv_type;
+    Coord direction;
+    int upwind;
+};
+
+std::array<StencilValues, 3> asymmetric_stencils ()
+{
+    return {{
+        {amrex::Real(1.0),  amrex::Real(-2.5), amrex::Real(0.75),  amrex::Real(3.25),  amrex::Real(-1.125), amrex::Real(2.0)},
+        {amrex::Real(-4.0), amrex::Real(0.5),  amrex::Real(7.0),   amrex::Real(-3.0),  amrex::Real(1.5),    amrex::Real(2.25)},
+        {amrex::Real(2.0),  amrex::Real(2.5),  amrex::Real(-1.0),  amrex::Real(4.5),   amrex::Real(-3.75),  amrex::Real(0.125)}}};
+}
+
+std::vector<InterpolatedValCase> make_interpolated_val_cases ()
+{
+    std::vector<InterpolatedValCase> cases;
+    const auto stencils = asymmetric_stencils();
+
+    for (int sample_index = 0; sample_index < static_cast<int>(stencils.size()); ++sample_index) {
+        for (const AdvType adv_type : kSupportedAdvTypes) {
+            for (const int upwind : kRepresentativeUpwindSigns) {
+                cases.push_back(InterpolatedValCase{stencils[sample_index], adv_type, upwind, sample_index});
+            }
+        }
+    }
+
+    return cases;
+}
+
+std::vector<WrapperCase> make_wrapper_cases ()
+{
+    std::vector<WrapperCase> cases;
+    const std::array<Coord, 3> directions = {{Coord::x, Coord::y, Coord::z}};
+
+    for (const AdvType adv_type : kSupportedAdvTypes) {
+        for (const int upwind : kRepresentativeUpwindSigns) {
+            for (const Coord direction : directions) {
+                cases.push_back(WrapperCase{adv_type, direction, upwind});
+            }
+        }
+    }
+
+    return cases;
+}
+
+std::vector<WrapperCase> make_zero_upwind_wrapper_cases ()
+{
+    std::vector<WrapperCase> cases;
+    const std::array<Coord, 3> directions = {{Coord::x, Coord::y, Coord::z}};
+
+    for (const Coord direction : directions) {
+        cases.push_back(WrapperCase{AdvType::Upwind_3rd, direction, 0});
+        cases.push_back(WrapperCase{AdvType::Upwind_5th, direction, 0});
+    }
+
+    return cases;
+}
+
+std::vector<SentinelCase> make_lower_order_sentinel_cases ()
+{
+    std::vector<SentinelCase> cases;
+    const std::array<Coord, 3> directions = {{Coord::x, Coord::y, Coord::z}};
+    const std::array<AdvType, 3> schemes = {{AdvType::Centered_2nd, AdvType::Upwind_3rd, AdvType::Centered_4th}};
+
+    for (const AdvType adv_type : schemes) {
+        for (const int upwind : kRepresentativeUpwindSigns) {
+            for (const Coord direction : directions) {
+                cases.push_back(SentinelCase{adv_type, direction, upwind});
+            }
+        }
+    }
+
+    return cases;
+}
+
+std::vector<SentinelCase> make_high_order_sentinel_cases ()
+{
+    std::vector<SentinelCase> cases;
+    const std::array<Coord, 3> directions = {{Coord::x, Coord::y, Coord::z}};
+    const std::array<AdvType, 2> schemes = {{AdvType::Upwind_5th, AdvType::Centered_6th}};
+
+    for (const AdvType adv_type : schemes) {
+        for (const int upwind : kRepresentativeUpwindSigns) {
+            for (const Coord direction : directions) {
+                cases.push_back(SentinelCase{adv_type, direction, upwind});
+            }
+        }
+    }
+
+    return cases;
+}
+
+std::string sample_trace (const AdvType adv_type,
+                          const Coord direction,
+                          const int upwind,
+                          const int sample_index,
+                          const amrex::Real actual,
+                          const amrex::Real expected,
+                          const amrex::Real factor)
+{
+    return "scheme=" + scheme_name(adv_type) +
+           " direction=" + direction_name(direction) +
+           " upwind=" + std::to_string(upwind) +
+           " sample=" + std::to_string(sample_index) +
+           " actual=" + std::to_string(static_cast<double>(actual)) +
+           " expected=" + std::to_string(static_cast<double>(expected)) +
+           " normalized_error=" + std::to_string(static_cast<double>(normalized_error(actual, expected, factor)));
+}
+
+void fill_directional_qty (amrex::FArrayBox& qty)
+{
+    auto qty_arr = qty.array();
+    const amrex::Box box = qty.box();
+
+    for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+        for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+            for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                qty_arr(i, j, k, 0) = directional_field_value(i, j, k);
+            }
+        }
+    }
+}
+
+void fill_perturbation_boxes (amrex::FArrayBox& qty,
+                              amrex::FArrayBox& r0,
+                              const Coord direction)
+{
+    auto qty_arr = qty.array();
+    auto r0_arr = r0.array();
+    const amrex::Box box = qty.box();
+
+    for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+        for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+            for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                const amrex::Real background = perturbation_background(direction, i, j, k);
+                r0_arr(i, j, k, 0) = background;
+                qty_arr(i, j, k, 0) = background + kPerturbationConstant;
+            }
+        }
+    }
+}
+
+void fill_density_boxes (amrex::FArrayBox& cons_in,
+                         amrex::FArrayBox& r0)
+{
+    auto cons_arr = cons_in.array();
+    auto r0_arr = r0.array();
+    const amrex::Box box = cons_in.box();
+
+    for (int k = box.smallEnd(2); k <= box.bigEnd(2); ++k) {
+        for (int j = box.smallEnd(1); j <= box.bigEnd(1); ++j) {
+            for (int i = box.smallEnd(0); i <= box.bigEnd(0); ++i) {
+                const amrex::Real background = amrex::Real(1.0) +
+                    amrex::Real(0.5) * finite_volume_cell_average_monomial(4, i) -
+                    amrex::Real(0.25) * finite_volume_cell_average_monomial(3, j) +
+                    amrex::Real(0.125) * finite_volume_cell_average_monomial(2, k);
+
+                r0_arr(i, j, k, 0) = background;
+                cons_arr(i, j, k, 0) = background + density_quantity_value(i, j, k);
+            }
+        }
+    }
+}
+
+void apply_far_sentinels (amrex::FArrayBox& qty)
+{
+    auto qty_arr = qty.array();
+
+    qty_arr( 2, 0, 0, 0) += amrex::Real(1000.0);
+    qty_arr(-3, 0, 0, 0) -= amrex::Real(750.0);
+    qty_arr( 0, 2, 0, 0) += amrex::Real(900.0);
+    qty_arr( 0,-3, 0, 0) -= amrex::Real(650.0);
+    qty_arr( 0, 0, 2, 0) += amrex::Real(800.0);
+    qty_arr( 0, 0,-3, 0) -= amrex::Real(550.0);
+}
+
+void launch_interpolated_val_cases (const int ncases,
+                                    const InterpolatedValCase* cases_ptr,
+                                    amrex::Real* results_ptr)
+{
+    amrex::ParallelFor(ncases, [=] AMREX_GPU_DEVICE (int idx) noexcept {
+        const InterpolatedValCase test_case = cases_ptr[idx];
+        amrex::Real avg1 = amrex::Real(0.0);
+        amrex::Real avg2 = amrex::Real(0.0);
+        amrex::Real avg3 = amrex::Real(0.0);
+        amrex::Real diff1 = amrex::Real(0.0);
+        amrex::Real diff2 = amrex::Real(0.0);
+        amrex::Real diff3 = amrex::Real(0.0);
+
+        fill_avg_diff(test_case.stencil, avg1, avg2, avg3, diff1, diff2, diff3);
+        results_ptr[idx] = interpolatedVal(avg1, avg2, avg3, diff1, diff2, diff3,
+                                           amrex::Real(test_case.upwind), test_case.adv_type);
+    });
+
+    gpu_sync();
+}
+
+void launch_wrapper_cases (const amrex::Box& box,
+                           const amrex::Array4<const amrex::Real>& qty,
+                           const WrapperCase* cases_ptr,
+                           const int ncases,
+                           const amrex::Array4<amrex::Real>& output)
+{
+    amrex::ParallelFor(box, ncases, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
+        const WrapperCase test_case = cases_ptr[n];
+
+        if (test_case.direction == Coord::x) {
+            output(i, j, k, n) = InterpolateInX(i, j, k, qty, kQtyComp,
+                                                amrex::Real(test_case.upwind), test_case.adv_type);
+        } else if (test_case.direction == Coord::y) {
+            output(i, j, k, n) = InterpolateInY(i, j, k, qty, kQtyComp,
+                                                amrex::Real(test_case.upwind), test_case.adv_type);
+        } else {
+            output(i, j, k, n) = InterpolateInZ(i, j, k, qty, kQtyComp,
+                                                amrex::Real(test_case.upwind), test_case.adv_type);
+        }
+    });
+
+    gpu_sync();
+}
+
+void launch_perturbation_cases (const amrex::Box& box,
+                                const WrapperCase* cases_ptr,
+                                const int ncases,
+                                const amrex::Array4<const amrex::Real>& qty_x,
+                                const amrex::Array4<const amrex::Real>& r0_x,
+                                const amrex::Array4<const amrex::Real>& qty_y,
+                                const amrex::Array4<const amrex::Real>& r0_y,
+                                const amrex::Array4<const amrex::Real>& qty_z,
+                                const amrex::Array4<const amrex::Real>& r0_z,
+                                const amrex::Array4<amrex::Real>& output)
+{
+    amrex::ParallelFor(box, ncases, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
+        const WrapperCase test_case = cases_ptr[n];
+
+        if (test_case.direction == Coord::x) {
+            output(i, j, k, n) = InterpolatePertFromCell(i, j, k, qty_x, kQtyComp,
+                                                         amrex::Real(test_case.upwind), Coord::x,
+                                                         test_case.adv_type, r0_x);
+        } else if (test_case.direction == Coord::y) {
+            output(i, j, k, n) = InterpolatePertFromCell(i, j, k, qty_y, kQtyComp,
+                                                         amrex::Real(test_case.upwind), Coord::y,
+                                                         test_case.adv_type, r0_y);
+        } else {
+            output(i, j, k, n) = InterpolatePertFromCell(i, j, k, qty_z, kQtyComp,
+                                                         amrex::Real(test_case.upwind), Coord::z,
+                                                         test_case.adv_type, r0_z);
+        }
+    });
+
+    gpu_sync();
+}
+
+void launch_density_identity_cases (const amrex::Box& box,
+                                    const WrapperCase* cases_ptr,
+                                    const int ncases,
+                                    const amrex::Array4<const amrex::Real>& cons_in,
+                                    const amrex::Array4<const amrex::Real>& r0,
+                                    const amrex::Array4<amrex::Real>& generic_output,
+                                    const amrex::Array4<amrex::Real>& density_output)
+{
+    amrex::ParallelFor(box, ncases, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
+        const WrapperCase test_case = cases_ptr[n];
+
+        generic_output(i, j, k, n) = InterpolatePertFromCell(i, j, k, cons_in, Rho_comp,
+                                                             amrex::Real(test_case.upwind), test_case.direction,
+                                                             test_case.adv_type, r0);
+        density_output(i, j, k, n) = InterpolateDensityPertFromCellToFace(i, j, k, cons_in,
+                                                                          amrex::Real(test_case.upwind), test_case.direction,
+                                                                          test_case.adv_type, r0);
+    });
+
+    gpu_sync();
+}
+
+void launch_sentinel_cases (const int ncases,
+                            const SentinelCase* cases_ptr,
+                            const amrex::Array4<const amrex::Real>& base_qty,
+                            const amrex::Array4<const amrex::Real>& modified_qty,
+                            amrex::Real* base_results,
+                            amrex::Real* modified_results)
+{
+    amrex::ParallelFor(ncases, [=] AMREX_GPU_DEVICE (int idx) noexcept {
+        const SentinelCase test_case = cases_ptr[idx];
+
+        if (test_case.direction == Coord::x) {
+            base_results[idx] = InterpolateInX(0, 0, 0, base_qty, kQtyComp,
+                                               amrex::Real(test_case.upwind), test_case.adv_type);
+            modified_results[idx] = InterpolateInX(0, 0, 0, modified_qty, kQtyComp,
+                                                   amrex::Real(test_case.upwind), test_case.adv_type);
+        } else if (test_case.direction == Coord::y) {
+            base_results[idx] = InterpolateInY(0, 0, 0, base_qty, kQtyComp,
+                                               amrex::Real(test_case.upwind), test_case.adv_type);
+            modified_results[idx] = InterpolateInY(0, 0, 0, modified_qty, kQtyComp,
+                                                   amrex::Real(test_case.upwind), test_case.adv_type);
+        } else {
+            base_results[idx] = InterpolateInZ(0, 0, 0, base_qty, kQtyComp,
+                                               amrex::Real(test_case.upwind), test_case.adv_type);
+            modified_results[idx] = InterpolateInZ(0, 0, 0, modified_qty, kQtyComp,
+                                                   amrex::Real(test_case.upwind), test_case.adv_type);
+        }
+    });
+
+    gpu_sync();
+}
+
+} // namespace
+
+// Motivation: Production kernels assemble avg/diff terms and call
+// interpolatedVal on device. This sweep checks every supported scheme and
+// representative upwind sign against an independent finite-volume reference.
+TEST(InterpolationKernel, InterpolatedValMatchesIndependentReference)
+{
+    const std::vector<InterpolatedValCase> cases = make_interpolated_val_cases();
+    amrex::Gpu::DeviceVector<InterpolatedValCase> device_cases(cases.size());
+    amrex::Gpu::DeviceVector<amrex::Real> device_results(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::HostVector<amrex::Real> host_results(cases.size(), amrex::Real(0.0));
+
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_interpolated_val_cases(static_cast<int>(cases.size()), device_cases.data(), device_results.data());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     device_results.begin(), device_results.end(), host_results.begin());
+
+    for (int sample_index = 0; sample_index < static_cast<int>(cases.size()); ++sample_index) {
+        const InterpolatedValCase& test_case = cases[sample_index];
+        const amrex::Real expected = reference_reconstruction(test_case.stencil, test_case.adv_type, test_case.upwind);
+        const amrex::Real actual = host_results[sample_index];
+
+        EXPECT_LE(normalized_error(actual, expected, kDeviceRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, Coord::x, test_case.upwind,
+                            test_case.sample_index, actual, expected, kDeviceRelTol);
+    }
+}
+
+// Motivation: InterpolateInX/Y/Z are thin directional wrappers around the same
+// finite-volume reconstruction contract. This checks each wrapper on device
+// against the independent one-dimensional reference assembled from the same
+// cell values.
+TEST(InterpolationKernel, DirectionalWrappersMatchIndependentReference)
+{
+    const std::vector<WrapperCase> cases = make_wrapper_cases();
+    amrex::FArrayBox qty(stencil_box(), 1);
+    amrex::FArrayBox output(eval_box(), static_cast<int>(cases.size()));
+    fill_directional_qty(qty);
+
+    amrex::Gpu::DeviceVector<WrapperCase> device_cases(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_wrapper_cases(eval_box(), qty.const_array(), device_cases.data(),
+                         static_cast<int>(cases.size()), output.array());
+
+    const auto qty_arr = qty.const_array();
+    const auto output_arr = output.const_array();
+    int sample_index = 0;
+
+    for (int n = 0; n < static_cast<int>(cases.size()); ++n) {
+        for (int k = eval_box().smallEnd(2); k <= eval_box().bigEnd(2); ++k) {
+            for (int j = eval_box().smallEnd(1); j <= eval_box().bigEnd(1); ++j) {
+                for (int i = eval_box().smallEnd(0); i <= eval_box().bigEnd(0); ++i) {
+                    const WrapperCase& test_case = cases[n];
+                    const StencilValues stencil = load_direction_stencil(qty_arr, i, j, k, test_case.direction);
+                    const amrex::Real expected = reference_reconstruction(stencil, test_case.adv_type, test_case.upwind);
+                    const amrex::Real actual = output_arr(i, j, k, n);
+
+                    EXPECT_LE(normalized_error(actual, expected, kDeviceRelTol), amrex::Real(1.0))
+                        << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                                        sample_index, actual, expected, kDeviceRelTol);
+                    ++sample_index;
+                }
+            }
+        }
+    }
+}
+
+// Motivation: A zero upwind sign removes the odd upwind correction, so the
+// wrapper reductions must agree with centered fourth- and sixth-order references.
+TEST(InterpolationKernel, ZeroUpwindWrappersReduceToCentered)
+{
+    const std::vector<WrapperCase> cases = make_zero_upwind_wrapper_cases();
+    amrex::FArrayBox qty(stencil_box(), 1);
+    amrex::FArrayBox output(eval_box(), static_cast<int>(cases.size()));
+    fill_directional_qty(qty);
+
+    amrex::Gpu::DeviceVector<WrapperCase> device_cases(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_wrapper_cases(eval_box(), qty.const_array(), device_cases.data(),
+                         static_cast<int>(cases.size()), output.array());
+
+    const auto qty_arr = qty.const_array();
+    const auto output_arr = output.const_array();
+    int sample_index = 0;
+
+    for (int n = 0; n < static_cast<int>(cases.size()); ++n) {
+        for (int k = eval_box().smallEnd(2); k <= eval_box().bigEnd(2); ++k) {
+            for (int j = eval_box().smallEnd(1); j <= eval_box().bigEnd(1); ++j) {
+                for (int i = eval_box().smallEnd(0); i <= eval_box().bigEnd(0); ++i) {
+                    const WrapperCase& test_case = cases[n];
+                    const StencilValues stencil = load_direction_stencil(qty_arr, i, j, k, test_case.direction);
+                    const amrex::Real expected =
+                        reference_reconstruction(stencil, centered_reduction(test_case.adv_type), 0);
+                    const amrex::Real actual = output_arr(i, j, k, n);
+
+                    EXPECT_LE(normalized_error(actual, expected, kDeviceRelTol), amrex::Real(1.0))
+                        << sample_trace(test_case.adv_type, test_case.direction, 0,
+                                        sample_index, actual, expected, kDeviceRelTol);
+                    ++sample_index;
+                }
+            }
+        }
+    }
+}
+
+// Motivation: InterpolatePertFromCell reconstructs qty - r0_arr. With a
+// nonlinear background and qty = r0_arr + C, every supported scheme and every
+// direction must return exactly C. The pre-fix x/y upwind bug violated this,
+// including the x/upwind-3/+1 reproducer at i=j=k=0.
+TEST(InterpolationKernel, PerturbationConstantInvariantAllDirections)
+{
+    const std::vector<WrapperCase> cases = make_wrapper_cases();
+    amrex::FArrayBox qty_x(stencil_box(), 1);
+    amrex::FArrayBox r0_x(stencil_box(), 1);
+    amrex::FArrayBox qty_y(stencil_box(), 1);
+    amrex::FArrayBox r0_y(stencil_box(), 1);
+    amrex::FArrayBox qty_z(stencil_box(), 1);
+    amrex::FArrayBox r0_z(stencil_box(), 1);
+    amrex::FArrayBox output(eval_box(), static_cast<int>(cases.size()));
+
+    fill_perturbation_boxes(qty_x, r0_x, Coord::x);
+    fill_perturbation_boxes(qty_y, r0_y, Coord::y);
+    fill_perturbation_boxes(qty_z, r0_z, Coord::z);
+
+    amrex::Gpu::DeviceVector<WrapperCase> device_cases(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_perturbation_cases(eval_box(), device_cases.data(), static_cast<int>(cases.size()),
+                              qty_x.const_array(), r0_x.const_array(),
+                              qty_y.const_array(), r0_y.const_array(),
+                              qty_z.const_array(), r0_z.const_array(),
+                              output.array());
+
+    const auto output_arr = output.const_array();
+    int sample_index = 0;
+
+    for (int n = 0; n < static_cast<int>(cases.size()); ++n) {
+        for (int k = eval_box().smallEnd(2); k <= eval_box().bigEnd(2); ++k) {
+            for (int j = eval_box().smallEnd(1); j <= eval_box().bigEnd(1); ++j) {
+                for (int i = eval_box().smallEnd(0); i <= eval_box().bigEnd(0); ++i) {
+                    const WrapperCase& test_case = cases[n];
+                    const amrex::Real actual = output_arr(i, j, k, n);
+                    const amrex::Real expected = kPerturbationConstant;
+
+                    EXPECT_LE(normalized_error(actual, expected, kIdentityRelTol), amrex::Real(1.0))
+                        << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                                        sample_index, actual, expected, kIdentityRelTol);
+                    ++sample_index;
+                }
+            }
+        }
+    }
+}
+
+// Motivation: The density wrapper is a named specialization of the generic
+// perturbation helper at Rho_comp. This keeps that identity explicit on the
+// AMReX device path.
+TEST(InterpolationKernel, DensityWrapperMatchesGenericPerturbationHelper)
+{
+    const std::vector<WrapperCase> cases = make_wrapper_cases();
+    amrex::FArrayBox cons_in(stencil_box(), 1);
+    amrex::FArrayBox r0(stencil_box(), 1);
+    amrex::FArrayBox generic_output(eval_box(), static_cast<int>(cases.size()));
+    amrex::FArrayBox density_output(eval_box(), static_cast<int>(cases.size()));
+    fill_density_boxes(cons_in, r0);
+
+    amrex::Gpu::DeviceVector<WrapperCase> device_cases(cases.size());
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_density_identity_cases(eval_box(), device_cases.data(), static_cast<int>(cases.size()),
+                                  cons_in.const_array(), r0.const_array(),
+                                  generic_output.array(), density_output.array());
+
+    const auto generic_arr = generic_output.const_array();
+    const auto density_arr = density_output.const_array();
+    int sample_index = 0;
+
+    for (int n = 0; n < static_cast<int>(cases.size()); ++n) {
+        for (int k = eval_box().smallEnd(2); k <= eval_box().bigEnd(2); ++k) {
+            for (int j = eval_box().smallEnd(1); j <= eval_box().bigEnd(1); ++j) {
+                for (int i = eval_box().smallEnd(0); i <= eval_box().bigEnd(0); ++i) {
+                    const WrapperCase& test_case = cases[n];
+                    const amrex::Real expected = generic_arr(i, j, k, n);
+                    const amrex::Real actual = density_arr(i, j, k, n);
+
+                    EXPECT_LE(normalized_error(actual, expected, kIdentityRelTol), amrex::Real(1.0))
+                        << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                                        sample_index, actual, expected, kIdentityRelTol);
+                    ++sample_index;
+                }
+            }
+        }
+    }
+}
+
+// Motivation: 2nd/3rd/4th-order branches must ignore the +2/-3 stencil cells.
+// Changing only those far cells should leave the face value unchanged.
+TEST(InterpolationKernel, LowerOrderSchemesIgnoreFarStencilSentinels)
+{
+    const std::vector<SentinelCase> cases = make_lower_order_sentinel_cases();
+    amrex::FArrayBox base_qty(stencil_box(), 1);
+    amrex::FArrayBox modified_qty(stencil_box(), 1);
+    fill_directional_qty(base_qty);
+    modified_qty.copy(base_qty);
+    apply_far_sentinels(modified_qty);
+
+    amrex::Gpu::DeviceVector<SentinelCase> device_cases(cases.size());
+    amrex::Gpu::DeviceVector<amrex::Real> device_base(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::DeviceVector<amrex::Real> device_modified(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::HostVector<amrex::Real> host_base(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::HostVector<amrex::Real> host_modified(cases.size(), amrex::Real(0.0));
+
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_sentinel_cases(static_cast<int>(cases.size()), device_cases.data(),
+                          base_qty.const_array(), modified_qty.const_array(),
+                          device_base.data(), device_modified.data());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     device_base.begin(), device_base.end(), host_base.begin());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     device_modified.begin(), device_modified.end(), host_modified.begin());
+
+    const auto base_arr = base_qty.const_array();
+    const auto modified_arr = modified_qty.const_array();
+
+    for (int sample_index = 0; sample_index < static_cast<int>(cases.size()); ++sample_index) {
+        const SentinelCase& test_case = cases[sample_index];
+        const StencilValues base_stencil = load_direction_stencil(base_arr, 0, 0, 0, test_case.direction);
+        const StencilValues modified_stencil = load_direction_stencil(modified_arr, 0, 0, 0, test_case.direction);
+        const amrex::Real expected_base = reference_reconstruction(base_stencil, test_case.adv_type, test_case.upwind);
+        const amrex::Real expected_modified = reference_reconstruction(modified_stencil, test_case.adv_type, test_case.upwind);
+
+        EXPECT_LE(normalized_error(host_base[sample_index], expected_base, kDeviceRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_base[sample_index], expected_base, kDeviceRelTol);
+        EXPECT_LE(normalized_error(host_modified[sample_index], expected_modified, kDeviceRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_modified[sample_index], expected_modified, kDeviceRelTol);
+        EXPECT_LE(normalized_error(host_modified[sample_index], host_base[sample_index], kIdentityRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_modified[sample_index], host_base[sample_index], kIdentityRelTol);
+    }
+}
+
+// Motivation: 5th/6th-order branches must use the +2/-3 cells. Changing only
+// those far stencil entries should measurably change the face value.
+TEST(InterpolationKernel, FifthAndSixthOrderSchemesUseFarStencil)
+{
+    const std::vector<SentinelCase> cases = make_high_order_sentinel_cases();
+    amrex::FArrayBox base_qty(stencil_box(), 1);
+    amrex::FArrayBox modified_qty(stencil_box(), 1);
+    fill_directional_qty(base_qty);
+    modified_qty.copy(base_qty);
+    apply_far_sentinels(modified_qty);
+
+    amrex::Gpu::DeviceVector<SentinelCase> device_cases(cases.size());
+    amrex::Gpu::DeviceVector<amrex::Real> device_base(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::DeviceVector<amrex::Real> device_modified(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::HostVector<amrex::Real> host_base(cases.size(), amrex::Real(0.0));
+    amrex::Gpu::HostVector<amrex::Real> host_modified(cases.size(), amrex::Real(0.0));
+
+    amrex::Gpu::copy(amrex::Gpu::hostToDevice, cases.begin(), cases.end(), device_cases.begin());
+    launch_sentinel_cases(static_cast<int>(cases.size()), device_cases.data(),
+                          base_qty.const_array(), modified_qty.const_array(),
+                          device_base.data(), device_modified.data());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     device_base.begin(), device_base.end(), host_base.begin());
+    amrex::Gpu::copy(amrex::Gpu::deviceToHost,
+                     device_modified.begin(), device_modified.end(), host_modified.begin());
+
+    const auto base_arr = base_qty.const_array();
+    const auto modified_arr = modified_qty.const_array();
+
+    for (int sample_index = 0; sample_index < static_cast<int>(cases.size()); ++sample_index) {
+        const SentinelCase& test_case = cases[sample_index];
+        const StencilValues base_stencil = load_direction_stencil(base_arr, 0, 0, 0, test_case.direction);
+        const StencilValues modified_stencil = load_direction_stencil(modified_arr, 0, 0, 0, test_case.direction);
+        const amrex::Real expected_base = reference_reconstruction(base_stencil, test_case.adv_type, test_case.upwind);
+        const amrex::Real expected_modified = reference_reconstruction(modified_stencil, test_case.adv_type, test_case.upwind);
+        const amrex::Real expected_delta = std::abs(expected_modified - expected_base);
+        const amrex::Real actual_delta = std::abs(host_modified[sample_index] - host_base[sample_index]);
+
+        EXPECT_LE(normalized_error(host_base[sample_index], expected_base, kDeviceRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_base[sample_index], expected_base, kDeviceRelTol);
+        EXPECT_LE(normalized_error(host_modified[sample_index], expected_modified, kDeviceRelTol), amrex::Real(1.0))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_modified[sample_index], expected_modified, kDeviceRelTol);
+        EXPECT_GT(expected_delta, scaled_tol(expected_modified, expected_base, kIdentityRelTol))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, expected_modified, expected_base, kIdentityRelTol);
+        EXPECT_GT(actual_delta, scaled_tol(host_modified[sample_index], host_base[sample_index], kIdentityRelTol))
+            << sample_trace(test_case.adv_type, test_case.direction, test_case.upwind,
+                            sample_index, host_modified[sample_index], host_base[sample_index], kIdentityRelTol);
+    }
+}

--- a/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationScalar.cpp
+++ b/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationScalar.cpp
@@ -1,0 +1,154 @@
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include "ERF_GTestInterpolationCommon.H"
+
+using namespace interpolation_test;
+
+namespace {
+
+struct ReferenceCase {
+    AdvType adv_type;
+    int sigma;
+};
+
+inline void expect_near_relative (const amrex::Real actual,
+                                  const amrex::Real expected,
+                                  const amrex::Real factor)
+{
+    EXPECT_NEAR(actual, expected, scaled_tol(actual, expected, factor));
+}
+
+std::array<StencilValues, 3> asymmetric_stencils ()
+{
+    return {{
+        {amrex::Real(1.0),  amrex::Real(-2.5), amrex::Real(0.75),  amrex::Real(3.25),  amrex::Real(-1.125), amrex::Real(2.0)},
+        {amrex::Real(-4.0), amrex::Real(0.5),  amrex::Real(7.0),   amrex::Real(-3.0),  amrex::Real(1.5),    amrex::Real(2.25)},
+        {amrex::Real(2.0),  amrex::Real(2.5),  amrex::Real(-1.0),  amrex::Real(4.5),   amrex::Real(-3.75),  amrex::Real(0.125)}}};
+}
+
+std::string trace_label (const AdvType adv_type,
+                         const int sigma,
+                         const int sample_index,
+                         const amrex::Real actual,
+                         const amrex::Real expected,
+                         const amrex::Real factor)
+{
+    return "scheme=" + scheme_name(adv_type) +
+           " sigma=" + std::to_string(sigma) +
+           " sample=" + std::to_string(sample_index) +
+           " actual=" + std::to_string(static_cast<double>(actual)) +
+           " expected=" + std::to_string(static_cast<double>(expected)) +
+           " normalized_error=" + std::to_string(static_cast<double>(normalized_error(actual, expected, factor)));
+}
+
+} // namespace
+
+// Motivation: The reference stencils must satisfy the independently derived
+// finite-volume exactness orders before they are used in device-path comparisons.
+TEST(InterpolationScalar, ReferencePolynomialExactnessFiniteVolume)
+{
+    const std::array<ReferenceCase, 7> cases = {{
+        {AdvType::Centered_2nd, 0},
+        {AdvType::Upwind_3rd, -1},
+        {AdvType::Upwind_3rd, 1},
+        {AdvType::Centered_4th, 0},
+        {AdvType::Upwind_5th, -1},
+        {AdvType::Upwind_5th, 1},
+        {AdvType::Centered_6th, 0}}};
+
+    for (const ReferenceCase& test_case : cases) {
+        for (int degree = 0; degree <= exactness_degree(test_case.adv_type); ++degree) {
+            const StencilValues stencil = make_monomial_stencil(degree);
+            const amrex::Real actual = reference_reconstruction(stencil, test_case.adv_type, test_case.sigma);
+            const amrex::Real expected = (degree == 0) ? amrex::Real(1.0) : amrex::Real(0.0);
+
+            SCOPED_TRACE(trace_label(test_case.adv_type, test_case.sigma, degree,
+                                     actual, expected, kPolynomialRelTol));
+            expect_near_relative(actual, expected, kPolynomialRelTol);
+        }
+    }
+}
+
+// Motivation: Leading-error constants lock stencil orientation and distinguish
+// 2nd/3rd/4th/5th/6th order behavior.
+TEST(InterpolationScalar, ReferenceLeadingErrorCoefficients)
+{
+    const std::array<ReferenceCase, 7> cases = {{
+        {AdvType::Centered_2nd, 0},
+        {AdvType::Upwind_3rd, -1},
+        {AdvType::Upwind_3rd, 1},
+        {AdvType::Centered_4th, 0},
+        {AdvType::Upwind_5th, -1},
+        {AdvType::Upwind_5th, 1},
+        {AdvType::Centered_6th, 0}}};
+
+    for (const ReferenceCase& test_case : cases) {
+        const int degree = leading_error_degree(test_case.adv_type);
+        const StencilValues stencil = make_monomial_stencil(degree);
+        const amrex::Real actual = reference_reconstruction(stencil, test_case.adv_type, test_case.sigma);
+        const amrex::Real expected = leading_error_expected(test_case.adv_type, test_case.sigma);
+
+        SCOPED_TRACE(trace_label(test_case.adv_type, test_case.sigma, degree,
+                                 actual, expected, kPolynomialRelTol));
+        expect_near_relative(actual, expected, kPolynomialRelTol);
+    }
+}
+
+// Motivation: A zero velocity removes the odd upwind correction, so upwind 3/5
+// reduce to centered 4/6.
+TEST(InterpolationScalar, ZeroUpwindReferenceReducesToCentered)
+{
+    const auto stencils = asymmetric_stencils();
+
+    for (int sample_index = 0; sample_index < static_cast<int>(stencils.size()); ++sample_index) {
+        const StencilValues& stencil = stencils[sample_index];
+
+        const amrex::Real upwind3_zero = reference_reconstruction(stencil, AdvType::Upwind_3rd, 0);
+        const amrex::Real centered4 = reference_reconstruction(stencil, AdvType::Centered_4th, 0);
+        SCOPED_TRACE(trace_label(AdvType::Upwind_3rd, 0, sample_index,
+                                 upwind3_zero, centered4, kValueRelTol));
+        expect_near_relative(upwind3_zero, centered4, kValueRelTol);
+
+        const amrex::Real upwind5_zero = reference_reconstruction(stencil, AdvType::Upwind_5th, 0);
+        const amrex::Real centered6 = reference_reconstruction(stencil, AdvType::Centered_6th, 0);
+        SCOPED_TRACE(trace_label(AdvType::Upwind_5th, 0, sample_index,
+                                 upwind5_zero, centered6, kValueRelTol));
+        expect_near_relative(upwind5_zero, centered6, kValueRelTol);
+    }
+}
+
+// Motivation: Flipping the upwind sign and mirroring the stencil must give the
+// same face value.
+TEST(InterpolationScalar, PositiveNegativeUpwindReferenceMirrorSymmetry)
+{
+    const auto stencils = asymmetric_stencils();
+    const std::array<AdvType, 2> upwind_schemes = {{AdvType::Upwind_3rd, AdvType::Upwind_5th}};
+
+    for (const AdvType adv_type : upwind_schemes) {
+        for (int sample_index = 0; sample_index < static_cast<int>(stencils.size()); ++sample_index) {
+            const StencilValues& stencil = stencils[sample_index];
+            const amrex::Real positive = reference_reconstruction(stencil, adv_type, 1);
+            const amrex::Real negative_mirror =
+                reference_reconstruction(mirrored_stencil(stencil), adv_type, -1);
+
+            SCOPED_TRACE(trace_label(adv_type, 1, sample_index,
+                                     positive, negative_mirror, kValueRelTol));
+            expect_near_relative(positive, negative_mirror, kValueRelTol);
+        }
+    }
+}
+
+// Motivation: interpolatedVal is a non-WENO centered/upwind helper; this
+// documents the invalid-domain guard without relying on brittle AMReX death tests.
+TEST(InterpolationScalar, SupportedAdvTypePredicateClassifiesOnlyNonWenoSchemes)
+{
+    for (const AdvType adv_type : kSupportedAdvTypes) {
+        EXPECT_TRUE(isSupportedInterpolationAdvType(adv_type)) << scheme_name(adv_type);
+    }
+
+    for (const AdvType adv_type : kUnsupportedAdvTypes) {
+        EXPECT_FALSE(isSupportedInterpolationAdvType(adv_type)) << scheme_name(adv_type);
+    }
+}


### PR DESCRIPTION
## Summary

This PR fixes two defects in the non-WENO interpolation helpers and adds contract-based unit tests for `ERF_Interpolation.H`.

The production changes:

- reject unsupported `AdvType` values instead of returning zero,
- form x/y perturbation differences from `qty - r0_arr`, matching the z branch.

The new tests cover:

- finite-volume polynomial exactness,
- leading error coefficients,
- zero-upwind limits,
- upwind sign symmetry,
- axis-specific wrapper behavior,
- far-stencil branch coverage,
- perturbation invariants, and
- density-wrapper consistency.

This PR does not change the existing upwind-sign normalization behavior. A follow-up can audit whether these legacy wrappers should preserve fractional blended-upwind weights or remain pure sign-based helpers.

## Testing

All unit tests pass.