### PR TITLE
Refactor SAM microphysics under bit-for-bit guard

### DIFF
--- a/Source/Microphysics/SAM/ERF_CloudSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_CloudSAM.cpp
@@ -1,5 +1,6 @@
 #include "ERF_SAM.H"
 #include "ERF_IndexDefines.H"
+#include "ERF_SAMUtils.H"
 #include "ERF_TileNoZ.H"
 #include "ERF_EOS.H"
 
@@ -22,8 +23,7 @@ SAM::Cloud (const SolverChoice& sc)
     Real rdOcp    = m_rdOcp;
 
     int SAM_moisture_type = 1;
-    if (sc.moisture_type == MoistureType::SAM_NoIce ||
-        sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce) {
+    if (sam_is_no_ice(sc.moisture_type)) {
         SAM_moisture_type = 2;
     }
 
@@ -66,52 +66,27 @@ SAM::Cloud (const SolverChoice& sc)
             //       This ensures the omn splitting is enforced
             //       before the Newton iteration, which assumes it is.
 
-            omn = one;
-            if (SAM_moisture_type == 1){
-                // Cloud ice not permitted (melt to form water)
-                if (tabs_array(i,j,k) >= tbgmax) {
-                    omn = one;
-                    delta_qi = qci_array(i,j,k);
-                    qci_array(i,j,k)   = zero;
-                    qcl_array(i,j,k)  += delta_qi;
-                    tabs_array(i,j,k) -= fac_fus * delta_qi;
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), pres_array(i,j,k), rdOcp);
-                }
-                // Cloud water not permitted (freeze to form ice)
-                else if (tabs_array(i,j,k) <= tbgmin) {
-                    omn = zero;
-                    delta_qc = qcl_array(i,j,k);
-                    qcl_array(i,j,k)   = zero;
-                    qci_array(i,j,k)  += delta_qc;
-                    tabs_array(i,j,k) += fac_fus * delta_qc;
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), pres_array(i,j,k), rdOcp);
-                }
-                // Mixed cloud phase (split according to omn)
-                else {
-                    omn = an*tabs_array(i,j,k)-bn;
-                    delta_qc = qcl_array(i,j,k) - qn_array(i,j,k) * omn;
-                    delta_qi = qci_array(i,j,k) - qn_array(i,j,k) * (one - omn);
-                    qcl_array(i,j,k)   = qn_array(i,j,k) * omn;
-                    qci_array(i,j,k)   = qn_array(i,j,k) * (one - omn);
-                    tabs_array(i,j,k) += fac_fus * delta_qc;
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), pres_array(i,j,k), rdOcp);
-                }
-            }
-            else if (SAM_moisture_type == 2)
-            {
-                // No ice. ie omn = one
-                delta_qc = qcl_array(i,j,k) - qn_array(i,j,k);
-                delta_qi = zero;
-                qcl_array(i,j,k)   = qn_array(i,j,k);
-                qci_array(i,j,k)   = zero;
-                tabs_array(i,j,k) += fac_cond * delta_qc;
-                theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), pres_array(i,j,k), rdOcp);
-            }
+            const SAMCloudPhaseChange phase_change =
+                sam_partition_cloud_phase(SAM_moisture_type,
+                                          tabs_array(i,j,k),
+                                          qn_array(i,j,k),
+                                          qcl_array(i,j,k),
+                                          qci_array(i,j,k),
+                                          fac_cond, fac_fus,
+                                          an, bn);
+            omn = phase_change.omn;
+            delta_qc = phase_change.delta_qc;
+            delta_qi = phase_change.delta_qi;
+            qcl_array(i,j,k) = phase_change.qcl;
+            qci_array(i,j,k) = phase_change.qci;
+            tabs_array(i,j,k) = phase_change.tabs;
+            theta_array(i,j,k) = sam_theta_from_stored_pressure_as_pa(tabs_array(i,j,k),
+                                                                      pres_array(i,j,k), rdOcp);
 
             // Saturation moisture fractions
             erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsatw);
             erf_qsati(tabs_array(i,j,k), pres_array(i,j,k), qsati);
-            qsat = omn * qsatw  + (one-omn) * qsati;
+            qsat = sam_mixed_qsat(omn, qsatw, qsati);
 
             // We have enough total moisture to relax to equilibrium
             if (qt_array(i,j,k) > qsat) {
@@ -125,7 +100,8 @@ SAM::Cloud (const SolverChoice& sc)
                                                   qn_array  , qt_array);
 
                 // Update theta
-                theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
+                theta_array(i,j,k) = sam_theta_from_stored_mbar_converted_to_pa(tabs_array(i,j,k),
+                                                                                 pres_array(i,j,k), rdOcp);
 
             //
             // We cannot blindly relax to qsat, but we can convert qc/qi -> qv.
@@ -151,12 +127,13 @@ SAM::Cloud (const SolverChoice& sc)
                 tabs_array(i,j,k) -= fac_cond * delta_qc + fac_sub * delta_qi;
 
                 // Update theta
-                theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
+                theta_array(i,j,k) = sam_theta_from_stored_mbar_converted_to_pa(tabs_array(i,j,k),
+                                                                                 pres_array(i,j,k), rdOcp);
 
                 // Verify assumption that qv > qsat does not occur
                 erf_qsatw(tabs_array(i,j,k), pres_array(i,j,k), qsatw);
                 erf_qsati(tabs_array(i,j,k), pres_array(i,j,k), qsati);
-                qsat = omn * qsatw  + (one-omn) * qsati;
+                qsat = sam_mixed_qsat(omn, qsatw, qsati);
                 if (qt_array(i,j,k) > qsat) {
 
                     // Update temperature
@@ -168,7 +145,8 @@ SAM::Cloud (const SolverChoice& sc)
                                                       qn_array  , qt_array);
 
                     // Update theta
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
+                    theta_array(i,j,k) = sam_theta_from_stored_mbar_converted_to_pa(tabs_array(i,j,k),
+                                                                                     pres_array(i,j,k), rdOcp);
 
                 }
             }

--- a/Source/Microphysics/SAM/ERF_IceFall.cpp
+++ b/Source/Microphysics/SAM/ERF_IceFall.cpp
@@ -1,5 +1,6 @@
 #include <AMReX_ParReduce.H>
 #include "ERF_SAM.H"
+#include "ERF_SAMUtils.H"
 #include "ERF_TileNoZ.H"
 #include <cmath>
 
@@ -10,8 +11,7 @@ using namespace amrex;
  */
 void SAM::IceFall (const SolverChoice& sc) {
 
-    if(sc.moisture_type == MoistureType::SAM_NoIce ||
-       sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce)
+    if (sam_is_no_ice(sc.moisture_type))
       return;
 
     Real dtn  = dt;
@@ -44,19 +44,16 @@ void SAM::IceFall (const SolverChoice& sc) {
 
         ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            Real rho_avg, qci_avg;
-            if (k==k_lo) {
-                rho_avg = rho_array(i,j,k);
-                qci_avg = qci_array(i,j,k);
-            } else if (k==k_hi+1) {
-                rho_avg = rho_array(i,j,k-1);
-                qci_avg = qci_array(i,j,k-1);
-            } else {
-                rho_avg = myhalf*(rho_array(i,j,k-1) + rho_array(i,j,k));
-                qci_avg = myhalf*(qci_array(i,j,k-1) + qci_array(i,j,k));
-            }
-            Real vt_ice = min( Real(0.4),
-                               Real(8.66)*std::pow( (amrex::max(Real(0),qci_avg)+Real(1.e-10)) , Real(0.24)) );
+            const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
+            const Real rho_k = (k == k_hi + 1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
+            const Real qci_km1 = (k == k_lo) ? qci_array(i,j,k) : qci_array(i,j,k-1);
+            const Real qci_k = (k == k_hi + 1) ? qci_array(i,j,k-1) : qci_array(i,j,k);
+            const SAMFaceState face_state = sam_face_average_state(k, k_lo, k_hi,
+                                                                   rho_km1, rho_k,
+                                                                   zero, zero,
+                                                                   qci_km1, qci_k,
+                                                                   zero, zero);
+            const Real vt_ice = sam_cloud_ice_terminal_velocity(face_state.qci_avg);
 
             // NOTE: Fz is the sedimentation flux from the advective operator.
             //       In the terrain-following coordinate system, the z-deriv in
@@ -64,7 +61,7 @@ void SAM::IceFall (const SolverChoice& sc) {
             //       there are no u/v components to the sedimentation velocity.
             //       Therefore, we simply end up with a division by detJ when
             //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-            fz_array(i,j,k) = rho_avg*vt_ice*qci_avg;
+            fz_array(i,j,k) = face_state.rho_avg * vt_ice * face_state.qci_avg;
         });
     }
 
@@ -81,7 +78,7 @@ void SAM::IceFall (const SolverChoice& sc) {
                              return { ma_fz_arr[box_no](i,j,k) };
                          });
     wt_max = get<0>(max) + std::numeric_limits<Real>::epsilon();
-    n_substep = int( std::ceil(wt_max * coef / CFL_MAX) );
+    n_substep = sam_substep_count_from_reduced_flux(wt_max, dtn, m_dzmin);
     AMREX_ALWAYS_ASSERT(n_substep >= 1);
     coef /= Real(n_substep);
     dtn  /= Real(n_substep);
@@ -103,19 +100,16 @@ void SAM::IceFall (const SolverChoice& sc) {
             // Update vertical flux every substep
             ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                Real rho_avg, qci_avg;
-                if (k==k_lo) {
-                    rho_avg = rho_array(i,j,k);
-                    qci_avg = qci_array(i,j,k);
-                } else if (k==k_hi+1) {
-                    rho_avg = rho_array(i,j,k-1);
-                    qci_avg = qci_array(i,j,k-1);
-                } else {
-                    rho_avg = myhalf*(rho_array(i,j,k-1) + rho_array(i,j,k));
-                    qci_avg = myhalf*(qci_array(i,j,k-1) + qci_array(i,j,k));
-                }
-                Real vt_ice = min( Real(0.4),
-                                   Real(8.66)*std::pow( (amrex::max(Real(0),qci_avg)+Real(1.e-10)) , Real(0.24)) );
+                const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
+                const Real rho_k = (k == k_hi + 1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
+                const Real qci_km1 = (k == k_lo) ? qci_array(i,j,k) : qci_array(i,j,k-1);
+                const Real qci_k = (k == k_hi + 1) ? qci_array(i,j,k-1) : qci_array(i,j,k);
+                const SAMFaceState face_state = sam_face_average_state(k, k_lo, k_hi,
+                                                                       rho_km1, rho_k,
+                                                                       zero, zero,
+                                                                       qci_km1, qci_k,
+                                                                       zero, zero);
+                const Real vt_ice = sam_cloud_ice_terminal_velocity(face_state.qci_avg);
 
                 // NOTE: Fz is the sedimentation flux from the advective operator.
                 //       In the terrain-following coordinate system, the z-deriv in
@@ -123,7 +117,7 @@ void SAM::IceFall (const SolverChoice& sc) {
                 //       there are no u/v components to the sedimentation velocity.
                 //       Therefore, we simply end up with a division by detJ when
                 //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-                fz_array(i,j,k) = rho_avg*vt_ice*qci_avg;
+                fz_array(i,j,k) = face_state.rho_avg * vt_ice * face_state.qci_avg;
             });
 
             // Update precip every substep
@@ -135,7 +129,8 @@ void SAM::IceFall (const SolverChoice& sc) {
                 //==================================================
                 // Cloud ice sedimentation (A32)
                 //==================================================
-                Real dqi  = dJinv * (one/rho_array(i,j,k)) * ( fz_array(i,j,k+1) - fz_array(i,j,k) ) * coef;
+                Real dqi  = sam_sedimentation_tendency(fz_array(i,j,k+1), fz_array(i,j,k),
+                                                       rho_array(i,j,k), dJinv, coef);
                 dqi = std::max(-qci_array(i,j,k), dqi);
 
                 // Add this increment to both non-precipitating and total water.

--- a/Source/Microphysics/SAM/ERF_InitSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_InitSAM.cpp
@@ -105,24 +105,28 @@ SAM::Copy_State_to_Micro (const MultiFab& cons_in)
         // Get pressure, theta, temperature, density, and qt, qp
         ParallelFor(box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            rho_array(i,j,k)   = states_array(i,j,k,Rho_comp);
-            theta_array(i,j,k) = states_array(i,j,k,RhoTheta_comp)/states_array(i,j,k,Rho_comp);
-
-            qv_array(i,j,k)    = std::max(Real(0),states_array(i,j,k,RhoQ1_comp)/states_array(i,j,k,Rho_comp));
-            qc_array(i,j,k)    = std::max(Real(0),states_array(i,j,k,RhoQ2_comp)/states_array(i,j,k,Rho_comp));
-            qi_array(i,j,k)    = std::max(Real(0),states_array(i,j,k,RhoQ3_comp)/states_array(i,j,k,Rho_comp));
-            qn_array(i,j,k)    = qc_array(i,j,k) + qi_array(i,j,k);
-            qt_array(i,j,k)    = qv_array(i,j,k) + qn_array(i,j,k);
-
-            qpr_array(i,j,k)   = std::max(Real(0),states_array(i,j,k,RhoQ4_comp)/states_array(i,j,k,Rho_comp));
-            qps_array(i,j,k)   = std::max(Real(0),states_array(i,j,k,RhoQ5_comp)/states_array(i,j,k,Rho_comp));
-            qpg_array(i,j,k)   = std::max(Real(0),states_array(i,j,k,RhoQ6_comp)/states_array(i,j,k,Rho_comp));
-             qp_array(i,j,k)   = qpr_array(i,j,k) + qps_array(i,j,k) + qpg_array(i,j,k);
-
-            tabs_array(i,j,k)  = getTgivenRandRTh(states_array(i,j,k,Rho_comp),
-                                                  states_array(i,j,k,RhoTheta_comp),
-                                                  qv_array(i,j,k));
-            pres_array(i,j,k)  = getPgivenRTh(states_array(i,j,k,RhoTheta_comp), qv_array(i,j,k)) * Real(0.01);
+            const SAMPrimitiveCell primitive =
+                sam_cons_to_primitive(states_array(i,j,k,Rho_comp),
+                                      states_array(i,j,k,RhoTheta_comp),
+                                      states_array(i,j,k,RhoQ1_comp),
+                                      states_array(i,j,k,RhoQ2_comp),
+                                      states_array(i,j,k,RhoQ3_comp),
+                                      states_array(i,j,k,RhoQ4_comp),
+                                      states_array(i,j,k,RhoQ5_comp),
+                                      states_array(i,j,k,RhoQ6_comp));
+            rho_array(i,j,k) = primitive.rho;
+            theta_array(i,j,k) = primitive.theta;
+            qv_array(i,j,k) = primitive.qv;
+            qc_array(i,j,k) = primitive.qcl;
+            qi_array(i,j,k) = primitive.qci;
+            qn_array(i,j,k) = primitive.qn;
+            qt_array(i,j,k) = primitive.qt;
+            qpr_array(i,j,k) = primitive.qpr;
+            qps_array(i,j,k) = primitive.qps;
+            qpg_array(i,j,k) = primitive.qpg;
+            qp_array(i,j,k) = primitive.qp;
+            tabs_array(i,j,k) = primitive.tabs;
+            pres_array(i,j,k) = primitive.pres_mbar;
         });
     }
 }
@@ -187,7 +191,7 @@ void SAM::Compute_Coefficients ()
         Real RhoTheta = rho_dptr[k]*theta_dptr[k];
         Real pressure = getPgivenRTh(RhoTheta, qv_dptr[k]);
         rho1d_t(k)    = rho_dptr[k];
-        pres1d_t(k)   = pressure*Real(0.01);
+        pres1d_t(k)   = sam_pa_to_mbar(pressure);
         // NOTE: Limit the temperature to the melting point of ice to avoid a divide by
         //       0 condition when computing the cold evaporation coefficients. This should
         //       not affect results since evaporation requires snow/graupel to be present
@@ -203,52 +207,20 @@ void SAM::Compute_Coefficients ()
     // Populate all the coefficients
     ParallelFor(nlev, [=] AMREX_GPU_DEVICE (int k) noexcept
     {
-        Real Prefactor;
-        Real pratio = std::sqrt(Real(1.29) / rho1d_t(k));
-        //Real rrr1   = Real(393.0)/(tabs1d_t(k)+Real(120.0))*std::pow((tabs1d_t(k)/Real(273.0)),Real(1.5));
-        //Real rrr2   = std::pow((tabs1d_t(k)/Real(273.0)),Real(1.94))*(Real(1000.0)/pres1d_t(k));
-        Real estw   = Real(100.0)*erf_esatw(tabs1d_t(k));
-        Real esti   = Real(100.0)*erf_esati(tabs1d_t(k));
-
-        // accretion by snow:
-        Real coef1   = fourth * PI * nzeros * a_snow * gams1 * pratio/std::pow((PI * rhos * nzeros/rho1d_t(k) ) , ((three+b_snow)/Real(4.0)));
-        Real coef2   = std::exp(Real(0.025)*(tabs1d_t(k) - Real(273.15)));
-        accrsi_t(k)  =  coef1 * coef2 * esicoef;
-        accrsc_t(k)  =  coef1 * esccoef;
-        coefice_t(k) =  coef2;
-
-        // evaporation of snow:
-        coef1 = (lsub/(tabs1d_t(k)*R_v)-one)*lsub/(therco*tabs1d_t(k));
-        coef2 = R_v * R_d / (diffelq * esti);
-        Prefactor = two * PI * nzeros / (rho1d_t(k) * (coef1 + coef2));
-        Prefactor *= (two/PI); // Shape factor snow
-        evaps1_t(k) = Prefactor * Real(0.65) * std::sqrt(rho1d_t(k) / (PI * rhos * nzeros));
-        evaps2_t(k) = Prefactor * Real(0.44) * std::sqrt(a_snow * rho1d_t(k) / muelq) * gams2
-                    * std::sqrt(pratio) * std::pow(rho1d_t(k) / (PI * rhos * nzeros) , ((Real(5.0)+b_snow)/Real(8.0)));
-
-        // accretion by graupel:
-        coef1 = fourth*PI*nzerog*a_grau*gamg1*pratio/std::pow((PI*rhog*nzerog/rho1d_t(k)) , ((three+b_grau)/Real(4.0)));
-        coef2 = std::exp(Real(0.025)*(tabs1d_t(k) - Real(273.15)));
-        accrgi_t(k) = coef1 * coef2 * egicoef;
-        accrgc_t(k) = coef1 * egccoef;
-
-        // evaporation of graupel:
-        coef1 = (lsub/(tabs1d_t(k)*R_v)-one)*lsub/(therco*tabs1d_t(k));
-        coef2 = R_v * R_d / (diffelq * esti);
-        Prefactor = two * PI * nzerog / (rho1d_t(k) * (coef1 + coef2)); // Shape factor for graupel is 1
-        evapg1_t(k) = Prefactor * Real(0.78) * std::sqrt(rho1d_t(k) / (PI * rhog * nzerog));
-        evapg2_t(k) = Prefactor * Real(0.31) * std::sqrt(a_grau * rho1d_t(k) / muelq) * gamg2
-                    * std::sqrt(pratio) * std::pow(rho1d_t(k) / (PI * rhog * nzerog) , ((Real(5.0)+b_grau)/Real(8.0)));
-
-        // accretion by rain:
-        accrrc_t(k) = fourth * PI * nzeror * a_rain * gamr1 * pratio/std::pow((PI * rhor * nzeror / rho1d_t(k)) , ((three+b_rain)/Real(4.)))* erccoef;
-
-        // evaporation of rain:
-        coef1 = (lcond/(tabs1d_t(k)*R_v)-one)*lcond/(therco*tabs1d_t(k));
-        coef2 = R_v * R_d / (diffelq * estw);
-        Prefactor = two * PI * nzeror / (rho1d_t(k) * (coef1 + coef2)); // Shape factor for rain is 1
-        evapr1_t(k) = Prefactor * Real(0.78) * std::sqrt(rho1d_t(k) / (PI * rhor * nzeror));
-        evapr2_t(k) = Prefactor * Real(0.31) * std::sqrt(a_rain * rho1d_t(k) / muelq) * gamr2
-                    * std::sqrt(pratio) * std::pow(rho1d_t(k) / (PI * rhor * nzeror) , ((Real(5.0)+b_rain)/Real(8.0)));
+        const SAMCoefficientRow row =
+            sam_compute_coefficient_row(rho1d_t(k), tabs1d_t(k),
+                                        gamr1, gamr2, gams1, gams2, gamg1, gamg2);
+        accrrc_t(k) = row.accrrc;
+        accrsi_t(k) = row.accrsi;
+        accrsc_t(k) = row.accrsc;
+        coefice_t(k) = row.coefice;
+        evaps1_t(k) = row.evaps1;
+        evaps2_t(k) = row.evaps2;
+        accrgi_t(k) = row.accrgi;
+        accrgc_t(k) = row.accrgc;
+        evapg1_t(k) = row.evapg1;
+        evapg2_t(k) = row.evapg2;
+        evapr1_t(k) = row.evapr1;
+        evapr2_t(k) = row.evapr2;
     });
 }

--- a/Source/Microphysics/SAM/ERF_Precip.cpp
+++ b/Source/Microphysics/SAM/ERF_Precip.cpp
@@ -1,5 +1,6 @@
 #include "ERF_SAM.H"
 #include "ERF_EOS.H"
+#include "ERF_SAMUtils.H"
 
 using namespace amrex;
 
@@ -9,8 +10,7 @@ using namespace amrex;
 void
 SAM::Precip (const SolverChoice& sc)
 {
-
-    if (sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce) return;
+    if (sam_is_no_precip(sc.moisture_type)) return;
 
     Real powr1 = (three + b_rain) / Real(4.0);
     Real powr2 = (Real(5.0) + b_rain) / Real(8.0);
@@ -84,14 +84,8 @@ SAM::Precip (const SolverChoice& sc)
             Real qsat, qsatw, qsati;
 
             Real qcc, qii, qpr, qps, qpg;
-            Real dprc, dpsc, dpgc;
-            Real dpsi, dpgi;
-
             Real dqc, dqca, dqi, dqia, dqp;
             Real dqpr, dqps, dqpg;
-
-            Real auto_r, autos;
-            Real accrcr, accrcs, accris, accrcg, accrig;
 
             // Work to be done for autoc/accr or evap
             if (qn_array(i,j,k)+qp_array(i,j,k) > zero) {
@@ -100,9 +94,12 @@ SAM::Precip (const SolverChoice& sc)
                     omp = Real(1);
                     omg = Real(0);
                 } else {
-                    omn = std::max(Real(0),std::min(Real(1),(tabs_array(i,j,k)-tbgmin)*a_bg));
-                    omp = std::max(Real(0),std::min(Real(1),(tabs_array(i,j,k)-tprmin)*a_pr));
-                    omg = std::max(Real(0),std::min(Real(1),(tabs_array(i,j,k)-tgrmin)*a_gr));
+                    omn = sam_cloud_liquid_fraction(SAM_moisture_type,
+                                                    tabs_array(i,j,k), a_bg, tbgmin * a_bg);
+                    omp = sam_precip_rain_fraction(SAM_moisture_type,
+                                                   tabs_array(i,j,k));
+                    omg = sam_graupel_fraction(SAM_moisture_type,
+                                               tabs_array(i,j,k));
                 }
 
                 qcc = qcl_array(i,j,k);
@@ -116,57 +113,21 @@ SAM::Precip (const SolverChoice& sc)
                 // Autoconversion (A30/A31) and accretion (A27)
                 //==================================================
                 if (qn_array(i,j,k) > zero) {
-                    accrcr = zero;
-                    accrcs = zero;
-                    accris = zero;
-                    accrcg = zero;
-                    accrig = zero;
-
-                    if (qcc > qcw0) {
-                        auto_r = alphaelq;
-                    } else {
-                        auto_r = zero;
-                    }
-
-                    if (qii > qci0) {
-                        autos = betaelq*coefice_t(k);
-                    } else {
-                        autos = zero;
-                    }
-
-                    if (omp > Real(0.001)) {
-                        accrcr = accrrc_t(k);
-                    }
-
-                    if (omp < Real(0.999) && omg < Real(0.999)) {
-                        accrcs = accrsc_t(k);
-                        accris = accrsi_t(k);
-                    }
-
-                    if (omp < Real(0.999) && omg > Real(0.001)) {
-                        accrcg = accrgc_t(k);
-                        accrig = accrgi_t(k);
-                    }
-
-                    // Autoconversion & accretion (sink for cloud comps)
-                    dqca = dtn * auto_r  * (qcc-qcw0);
-                    dprc = dtn * accrcr * qcc * std::pow(qpr, powr1);
-                    dpsc = dtn * accrcs * qcc * std::pow(qps, pows1);
-                    dpgc = dtn * accrcg * qcc * std::pow(qpg, powg1);
-
-                    dqia = dtn * autos  * (qii-qci0);
-                    dpsi = dtn * accris * qii * std::pow(qps, pows1);
-                    dpgi = dtn * accrig * qii * std::pow(qpg, powg1);
-
-                    // Rescale sinks to avoid negative cloud fractions
-                    dqc  = dqca + dprc + dpsc + dpgc;
-                    dqi  = dqia + dpsi + dpgi;
-                    Real scalec = std::min(qcl_array(i,j,k),dqc) / (dqc + eps);
-                    Real scalei = std::min(qci_array(i,j,k),dqi) / (dqi + eps);
-                    dqca *= scalec; dprc *= scalec; dpsc *= scalec; dpgc *= scalec;
-                    dqia *= scalei; dpsi *= scalei; dpgi *= scalei;
-                    dqc   = dqca + dprc + dpsc + dpgc;
-                    dqi   = dqia + dpsi + dpgi;
+                    SAMPrecipSources source_terms =
+                        sam_autoconversion_rates(dtn, qcc, qii, coefice_t(k));
+                    const SAMPrecipSources accretion_terms =
+                        sam_accretion_rates(dtn, qcc, qii, qpr, qps, qpg,
+                                            powr1, pows1, powg1,
+                                            omp, omg,
+                                            accrrc_t(k), accrsc_t(k), accrsi_t(k),
+                                            accrgc_t(k), accrgi_t(k));
+                    source_terms.dprc = accretion_terms.dprc;
+                    source_terms.dpsc = accretion_terms.dpsc;
+                    source_terms.dpgc = accretion_terms.dpgc;
+                    source_terms.dpsi = accretion_terms.dpsi;
+                    source_terms.dpgi = accretion_terms.dpgi;
+                    source_terms = sam_rescale_cloud_sinks(qcl_array(i,j,k), qci_array(i,j,k),
+                                                           eps, source_terms);
 
                     // NOTE: Autoconversion of cloud water and ice are sources
                     //       to qp, while accretion is a source to an individual
@@ -175,9 +136,14 @@ SAM::Precip (const SolverChoice& sc)
                     //       splitting does imply a latent heat source.
 
                     // Partition formed precip componentss
-                    dqpr = (dqca + dqia) * omp + dprc;
-                    dqps = (dqca + dqia) * (one - omp) * (one - omg) + dpsc + dpsi;
-                    dqpg = (dqca + dqia) * (one - omp) * omg         + dpgc + dpgi;
+                    source_terms = sam_partition_autoconverted_precip(source_terms, omp, omg);
+                    dqca = source_terms.dqca;
+                    dqia = source_terms.dqia;
+                    dqc = source_terms.dqc;
+                    dqi = source_terms.dqi;
+                    dqpr = source_terms.dqpr;
+                    dqps = source_terms.dqps;
+                    dqpg = source_terms.dqpg;
 
                     // Update the primitive state variables
                     qcl_array(i,j,k) -= dqc;
@@ -195,7 +161,8 @@ SAM::Precip (const SolverChoice& sc)
                     tabs_array(i,j,k) += fac_fus * ( dqca * (one - omp) - dqia * omp );
 
                     // Update theta
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
+                    theta_array(i,j,k) = sam_theta_from_stored_mbar_converted_to_pa(tabs_array(i,j,k),
+                                                                                     pres_array(i,j,k), rdOcp);
                 }
 
                 //==================================================
@@ -203,26 +170,33 @@ SAM::Precip (const SolverChoice& sc)
                 //==================================================
                 erf_qsatw(tabs_array(i,j,k),pres_array(i,j,k),qsatw);
                 erf_qsati(tabs_array(i,j,k),pres_array(i,j,k),qsati);
-                qsat = qsatw * omn + qsati * (one-omn);
+                qsat = sam_mixed_qsat(omn, qsatw, qsati);
                 if((qp_array(i,j,k) > zero) && (qv_array(i,j,k) < qsat)) {
 
-                    dqpr = evapr1_t(k)*std::sqrt(qpr) + evapr2_t(k)*std::pow(qpr,powr2);
-                    dqps = evaps1_t(k)*std::sqrt(qps) + evaps2_t(k)*std::pow(qps,pows2);
-                    dqpg = evapg1_t(k)*std::sqrt(qpg) + evapg2_t(k)*std::pow(qpg,powg2);
+                    SAMPrecipSources evaporation_terms =
+                        sam_precip_evaporation_rates(qpr, qps, qpg,
+                                                     powr2, pows2, powg2,
+                                                     evapr1_t(k), evapr2_t(k),
+                                                     evaps1_t(k), evaps2_t(k),
+                                                     evapg1_t(k), evapg2_t(k));
 
                     // NOTE: This is always a sink for precipitating comps
                     //       since qv<qsat and thus (1 - qv/qsat)>zero If we are
                     //       in a super-saturated state (qv>qsat) the Newton
                     //       iterations in Cloud() will have handled condensation.
-                    dqpr *= dtn * (one - qv_array(i,j,k)/qsat);
-                    dqps *= dtn * (one - qv_array(i,j,k)/qsat);
-                    dqpg *= dtn * (one - qv_array(i,j,k)/qsat);
+                    evaporation_terms.dqpr *= dtn * (one - qv_array(i,j,k)/qsat);
+                    evaporation_terms.dqps *= dtn * (one - qv_array(i,j,k)/qsat);
+                    evaporation_terms.dqpg *= dtn * (one - qv_array(i,j,k)/qsat);
 
                     // Limit to avoid negative moisture fractions
-                    dqpr = std::min(qpr_array(i,j,k),dqpr);
-                    dqps = std::min(qps_array(i,j,k),dqps);
-                    dqpg = std::min(qpg_array(i,j,k),dqpg);
-                    dqp  = dqpr + dqps + dqpg;
+                    evaporation_terms = sam_apply_precip_evaporation_limiter(qpr_array(i,j,k),
+                                                                             qps_array(i,j,k),
+                                                                             qpg_array(i,j,k),
+                                                                             evaporation_terms);
+                    dqpr = evaporation_terms.dqpr;
+                    dqps = evaporation_terms.dqps;
+                    dqpg = evaporation_terms.dqpg;
+                    dqp  = evaporation_terms.dqp;
 
                     // Update the primitive state variables
                      qv_array(i,j,k) += dqp;
@@ -238,7 +212,8 @@ SAM::Precip (const SolverChoice& sc)
                     tabs_array(i,j,k) -= fac_cond * dqpr + fac_sub * (dqps + dqpg);
 
                     // Update theta
-                    theta_array(i,j,k) = getThgivenTandP(tabs_array(i,j,k), Real(100.0)*pres_array(i,j,k), rdOcp);
+                    theta_array(i,j,k) = sam_theta_from_stored_mbar_converted_to_pa(tabs_array(i,j,k),
+                                                                                     pres_array(i,j,k), rdOcp);
                 }
             }
         });

--- a/Source/Microphysics/SAM/ERF_PrecipFall.cpp
+++ b/Source/Microphysics/SAM/ERF_PrecipFall.cpp
@@ -1,5 +1,6 @@
 #include "ERF_Constants.H"
 #include "ERF_SAM.H"
+#include "ERF_SAMUtils.H"
 #include "ERF_TileNoZ.H"
 #include <cmath>
 
@@ -15,7 +16,7 @@ using namespace amrex;
 void
 SAM::PrecipFall (const SolverChoice& sc)
 {
-    if(sc.moisture_type == MoistureType::SAM_NoPrecip_NoIce) return;
+    if (sam_is_no_precip(sc.moisture_type)) return;
 
     Real rho_0 = Real(1.29);
 
@@ -40,7 +41,6 @@ SAM::PrecipFall (const SolverChoice& sc)
     auto qp    = mic_fab_vars[MicVar::qp];
     auto rho   = mic_fab_vars[MicVar::rho];
     auto tabs  = mic_fab_vars[MicVar::tabs];
-    auto theta = mic_fab_vars[MicVar::theta];
     auto rain_accum = mic_fab_vars[MicVar::rain_accum];
     auto snow_accum = mic_fab_vars[MicVar::snow_accum];
     auto graup_accum = mic_fab_vars[MicVar::graup_accum];
@@ -59,47 +59,21 @@ SAM::PrecipFall (const SolverChoice& sc)
 
     //  Precompute the vertical fluxes for CFL constraint
     for (MFIter mfi(fz, TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        auto qp_array   = qp->array(mfi);
-        auto rho_array  = rho->array(mfi);
-        auto tabs_array = tabs->array(mfi);
+        auto qp_array   = qp->const_array(mfi);
+        auto rho_array  = rho->const_array(mfi);
+        auto tabs_array = tabs->const_array(mfi);
         auto fz_array   = fz.array(mfi);
 
         const auto& box3d = mfi.tilebox();
 
         ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            Real rho_avg, tab_avg, qp_avg;
-            if (k==k_lo) {
-                rho_avg =  rho_array(i,j,k);
-                tab_avg = tabs_array(i,j,k);
-                 qp_avg =   qp_array(i,j,k);
-            } else if (k==k_hi+1) {
-                rho_avg =  rho_array(i,j,k-1);
-                tab_avg = tabs_array(i,j,k-1);
-                 qp_avg =   qp_array(i,j,k-1);
-            } else {
-                rho_avg = myhalf*( rho_array(i,j,k-1) +  rho_array(i,j,k));
-                tab_avg = myhalf*(tabs_array(i,j,k-1) + tabs_array(i,j,k));
-                 qp_avg = myhalf*(  qp_array(i,j,k-1) +   qp_array(i,j,k));
-            }
-
-            Real Pprecip = zero;
-            if(qp_avg > qp_threshold) {
-                Real omp, omg;
-                if (SAM_moisture_type == 2) {
-                    omp = one;
-                    omg = zero;
-                } else {
-                    omp = std::max(Real(0),std::min(Real(1),(tab_avg-tprmin)*a_pr));
-                    omg = std::max(Real(0),std::min(Real(1),(tab_avg-tgrmin)*a_gr));
-                }
-                Real qrr = omp*qp_avg;
-                Real qss = (one-omp)*(one-omg)*qp_avg;
-                Real qgg = (one-omp)*(omg)*qp_avg;
-                Pprecip = omp*vrain*std::pow(rho_avg*qrr,one+crain)
-                        + (one-omp)*( (one-omg)*vsnow*std::pow(rho_avg*qss,one+csnow)
-                                    +      omg *vgrau*std::pow(rho_avg*qgg,one+cgrau) );
-            }
+            const SAMPrecipFaceState face_state =
+                sam_precip_face_state(SAM_moisture_type,
+                                      rho_array, tabs_array, qp_array,
+                                      i, j, k, k_lo, k_hi);
+            const Real Pprecip = sam_precip_flux_from_face_state(face_state,
+                                                                 vrain, vsnow, vgrau);
 
             // NOTE: Fz is the sedimentation flux from the advective operator.
             //       In the terrain-following coordinate system, the z-deriv in
@@ -107,7 +81,9 @@ SAM::PrecipFall (const SolverChoice& sc)
             //       there are no u/v components to the sedimentation velocity.
             //       Therefore, we simply end up with a division by detJ when
             //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-            fz_array(i,j,k) = Pprecip * std::sqrt(rho_0/rho_avg);
+            fz_array(i,j,k) = sam_precip_flux_density_corrected(Pprecip,
+                                                                rho_0,
+                                                                face_state.rho_avg);
         });
     }
 
@@ -124,7 +100,7 @@ SAM::PrecipFall (const SolverChoice& sc)
                              return { ma_fz_arr[box_no](i,j,k) };
                          });
     wt_max = get<0>(max) + std::numeric_limits<Real>::epsilon();
-    n_substep = int( std::ceil(wt_max * coef / CFL_MAX) );
+    n_substep = sam_substep_count_from_reduced_flux(wt_max, dtn, m_dzmin);
     AMREX_ALWAYS_ASSERT(n_substep >= 1);
     coef /= Real(n_substep);
     dtn  /= Real(n_substep);
@@ -136,8 +112,8 @@ SAM::PrecipFall (const SolverChoice& sc)
             auto qps_array    = qps->array(mfi);
             auto qpg_array    = qpg->array(mfi);
             auto qp_array     = qp->array(mfi);
-            auto rho_array    = rho->array(mfi);
-            auto tabs_array   = tabs->array(mfi);
+            auto rho_array    = rho->const_array(mfi);
+            auto tabs_array   = tabs->const_array(mfi);
             auto fz_array     = fz.array(mfi);
 
             auto rain_accum_array = rain_accum->array(mfi);
@@ -152,38 +128,12 @@ SAM::PrecipFall (const SolverChoice& sc)
             // Update vertical flux every substep
             ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                Real rho_avg, tab_avg, qp_avg;
-                if (k==k_lo) {
-                    rho_avg =  rho_array(i,j,k);
-                    tab_avg = tabs_array(i,j,k);
-                     qp_avg =   qp_array(i,j,k);
-                } else if (k==k_hi+1) {
-                    rho_avg =  rho_array(i,j,k-1);
-                    tab_avg = tabs_array(i,j,k-1);
-                     qp_avg =   qp_array(i,j,k-1);
-                } else {
-                    rho_avg = myhalf*( rho_array(i,j,k-1) +  rho_array(i,j,k));
-                    tab_avg = myhalf*(tabs_array(i,j,k-1) + tabs_array(i,j,k));
-                     qp_avg = myhalf*(  qp_array(i,j,k-1) +   qp_array(i,j,k));
-                }
-
-                Real Pprecip = zero;
-                if(qp_avg > qp_threshold) {
-                    Real omp, omg;
-                    if (SAM_moisture_type == 2) {
-                        omp = one;
-                        omg = zero;
-                    } else {
-                        omp = std::max(Real(0),std::min(Real(1),(tab_avg-tprmin)*a_pr));
-                        omg = std::max(Real(0),std::min(Real(1),(tab_avg-tgrmin)*a_gr));
-                    }
-                    Real qrr = omp*qp_avg;
-                    Real qss = (one-omp)*(one-omg)*qp_avg;
-                    Real qgg = (one-omp)*(omg)*qp_avg;
-                    Pprecip = omp*vrain*std::pow(rho_avg*qrr,one+crain)
-                            + (one-omp)*( (one-omg)*vsnow*std::pow(rho_avg*qss,one+csnow)
-                                        +      omg *vgrau*std::pow(rho_avg*qgg,one+cgrau) );
-                }
+                const SAMPrecipFaceState face_state =
+                    sam_precip_face_state(SAM_moisture_type,
+                                          rho_array, tabs_array, qp_array,
+                                          i, j, k, k_lo, k_hi);
+                const Real Pprecip = sam_precip_flux_from_face_state(face_state,
+                                                                     vrain, vsnow, vgrau);
 
                 // NOTE: Fz is the sedimentation flux from the advective operator.
                 //       In the terrain-following coordinate system, the z-deriv in
@@ -191,20 +141,18 @@ SAM::PrecipFall (const SolverChoice& sc)
                 //       there are no u/v components to the sedimentation velocity.
                 //       Therefore, we simply end up with a division by detJ when
                 //       evaluating the source term: dJinv * (flux_hi - flux_lo) * dzinv.
-                fz_array(i,j,k) = Pprecip * std::sqrt(rho_0/rho_avg);
+                fz_array(i,j,k) = sam_precip_flux_density_corrected(Pprecip,
+                                                                    rho_0,
+                                                                    face_state.rho_avg);
 
                 if(k==k_lo){
-                    Real omp, omg;
-                    if (SAM_moisture_type == 2) {
-                        omp = one;
-                        omg = zero;
-                    } else {
-                        omp = std::max(Real(0),std::min(Real(1),(tab_avg-tprmin)*a_pr));
-                        omg = std::max(Real(0),std::min(Real(1),(tab_avg-tgrmin)*a_gr));
-                    }
-                    rain_accum_array(i,j,k)  = rain_accum_array(i,j,k)  + rho_avg*(omp*qp_avg)*vrain*dtn/rhor*Real(1000.0); // Divide by rho_water and convert to mm
-                    snow_accum_array(i,j,k)  = snow_accum_array(i,j,k)  + rho_avg*(one-omp)*(one-omg)*qp_avg*vsnow*dtn/rhos*Real(1000.0); // Divide by rho_snow and convert to mm
-                    graup_accum_array(i,j,k) = graup_accum_array(i,j,k) + rho_avg*(one-omp)*(omg)*qp_avg*vgrau*dtn/rhog*Real(1000.0); // Divide by rho_graupel and convert to mm
+                    const SAMSurfaceAccumulation surface_accum =
+                        sam_surface_accumulation(face_state.rho_avg, face_state.qp_avg,
+                                                 face_state.omp, face_state.omg,
+                                                 vrain, vsnow, vgrau, dtn);
+                    rain_accum_array(i,j,k)  = rain_accum_array(i,j,k)  + surface_accum.rain;
+                    snow_accum_array(i,j,k)  = snow_accum_array(i,j,k)  + surface_accum.snow;
+                    graup_accum_array(i,j,k) = graup_accum_array(i,j,k) + surface_accum.graupel;
                 }
             });
 
@@ -217,15 +165,12 @@ SAM::PrecipFall (const SolverChoice& sc)
                 //==================================================
                 // Precipitating sedimentation (A19)
                 //==================================================
-                Real dqp = dJinv * (one/rho_array(i,j,k)) * ( fz_array(i,j,k+1) - fz_array(i,j,k) ) * coef;
-                Real omp, omg;
-                if (SAM_moisture_type == 2) {
-                    omp = one;
-                    omg = zero;
-                } else {
-                    omp = std::max(Real(0),std::min(Real(1),(tabs_array(i,j,k)-tprmin)*a_pr));
-                    omg = std::max(Real(0),std::min(Real(1),(tabs_array(i,j,k)-tgrmin)*a_gr));
-                }
+                Real dqp = sam_sedimentation_tendency(fz_array(i,j,k+1), fz_array(i,j,k),
+                                                      rho_array(i,j,k), dJinv, coef);
+                const Real omp = sam_precip_rain_fraction(SAM_moisture_type,
+                                                          tabs_array(i,j,k));
+                const Real omg = sam_graupel_fraction(SAM_moisture_type,
+                                                      tabs_array(i,j,k));
 
                 qpr_array(i,j,k) = std::max(Real(0), qpr_array(i,j,k) + dqp*omp);
                 qps_array(i,j,k) = std::max(Real(0), qps_array(i,j,k) + dqp*(one-omp)*(one-omg));

--- a/Source/Microphysics/SAM/ERF_SAM.H
+++ b/Source/Microphysics/SAM/ERF_SAM.H
@@ -23,6 +23,7 @@
 #include "ERF_IndexDefines.H"
 #include "ERF_DataStruct.H"
 #include "ERF_NullMoist.H"
+#include "ERF_SAMUtils.H"
 
 namespace MicVar {
    enum {
@@ -187,7 +188,7 @@ public:
         amrex::Real fff, dfff, dtabs;
         amrex::Real lstar, dlstar;
         amrex::Real lstarw, lstari;
-        amrex::Real delta_qv, delta_qc, delta_qi;
+        amrex::Real delta_qc, delta_qi;
 
         // Initial guess for temperature & pressure
         amrex::Real tabs = tabs_array(i,j,k);
@@ -210,39 +211,36 @@ public:
             erf_dtqsatw(tabs, pres, dqsatw);
             erf_dtqsati(tabs, pres, dqsati);
 
+            omn = sam_cloud_liquid_fraction(SAM_moisture_type, tabs, an, bn);
+
             if (SAM_moisture_type == 1) {
                 // Cloud ice not permitted (condensation)
                 if(tabs >= tbgmax) {
-                    omn   = one;
                 }
                 // Cloud water not permitted (sublimation)
                 else if(tabs <= tbgmin) {
-                    omn    = zero;
                 }
                 // Mixed cloud phase (condensation & fusion)
                 else {
                     lstari = fac_fus;
-                    omn    = an*tabs-bn;
                     domn   = an;
                 }
             } else if (SAM_moisture_type == 2) {
-                omn  = one;
                 domn = zero;
             }
 
             // Linear combination of each component
-            qsat   =  omn * qsatw  + (one-omn) * qsati;
-            dqsat  =  omn * dqsatw + (one-omn) * dqsati
-                   + domn *  qsatw -     domn  *  qsati;
+            qsat   = sam_mixed_qsat(omn, qsatw, qsati);
+            dqsat  = sam_mixed_dqsat_dT(omn, domn, qsatw, qsati, dqsatw, dqsati);
             lstar  =  omn * lstarw + (one-omn) * lstari;
             dlstar = domn * lstarw -     domn  * lstari;
 
             // Function for root finding:
             // 0 = -T_new + T_old + L_eff/C_p * (qv - qsat)
-            fff   = -tabs + tabs_array(i,j,k) +  lstar*(qv_array(i,j,k) - qsat);
+            fff   = sam_newton_residual(tabs, tabs_array(i,j,k), lstar, qv_array(i,j,k), qsat);
 
             // Derivative of function (T_new iterated on)
-            dfff  = -one + dlstar*(qv_array(i,j,k) - qsat) - lstar*dqsat;
+            dfff  = sam_newton_residual_derivative(lstar, dlstar, qv_array(i,j,k), qsat, dqsat);
 
             // Update the temperature
             dtabs = -fff/dfff;
@@ -256,12 +254,14 @@ public:
         qsat += dqsat*dtabs;
 
         // Changes in each component
-        delta_qv = qv_array(i,j,k) - qsat;
-        delta_qc = std::max(-qc_array(i,j,k), delta_qv * omn);
-        delta_qi = std::max(-qi_array(i,j,k), delta_qv * (one-omn));
+        const SAMCloudPhaseChange phase_change =
+            sam_apply_condensate_limiter(qv_array(i,j,k), qsat,
+                                         qc_array(i,j,k), qi_array(i,j,k), omn);
+        delta_qc = phase_change.delta_qc;
+        delta_qi = phase_change.delta_qi;
 
         // Partition the change in non-precipitating q
-        qv_array(i,j,k)  = qsat;
+        qv_array(i,j,k)  = phase_change.qv;
         qc_array(i,j,k) += delta_qc;
         qi_array(i,j,k) += delta_qi;
         qn_array(i,j,k)  = qc_array(i,j,k) + qi_array(i,j,k);

--- a/Source/Microphysics/SAM/ERF_SAMUtils.H
+++ b/Source/Microphysics/SAM/ERF_SAMUtils.H
@@ -1,0 +1,665 @@
+#ifndef ERF_SAM_UTILS_H_
+#define ERF_SAM_UTILS_H_
+
+#include <cmath>
+#include <limits>
+
+#include <AMReX_Array4.H>
+#include <AMReX_GpuQualifiers.H>
+
+#include "ERF_Constants.H"
+#include "ERF_DataStruct.H"
+#include "ERF_EOS.H"
+#include "ERF_IndexDefines.H"
+#include "ERF_MicrophysicsUtils.H"
+
+struct SAMPhaseFractions {
+    amrex::Real omn{one};
+    amrex::Real omp{one};
+    amrex::Real omg{zero};
+};
+
+struct SAMCloudPhaseChange {
+    amrex::Real omn{one};
+    amrex::Real delta_qv{zero};
+    amrex::Real delta_qc{zero};
+    amrex::Real delta_qi{zero};
+    amrex::Real qv{zero};
+    amrex::Real qcl{zero};
+    amrex::Real qci{zero};
+    amrex::Real qn{zero};
+    amrex::Real qt{zero};
+    amrex::Real tabs{zero};
+};
+
+struct SAMPrecipSources {
+    amrex::Real dqca{zero};
+    amrex::Real dprc{zero};
+    amrex::Real dpsc{zero};
+    amrex::Real dpgc{zero};
+    amrex::Real dqia{zero};
+    amrex::Real dpsi{zero};
+    amrex::Real dpgi{zero};
+    amrex::Real dqc{zero};
+    amrex::Real dqi{zero};
+    amrex::Real dqpr{zero};
+    amrex::Real dqps{zero};
+    amrex::Real dqpg{zero};
+    amrex::Real dqp{zero};
+};
+
+struct SAMPrimitiveCell {
+    amrex::Real rho{zero};
+    amrex::Real theta{zero};
+    amrex::Real tabs{zero};
+    amrex::Real pres_mbar{zero};
+    amrex::Real qv{zero};
+    amrex::Real qcl{zero};
+    amrex::Real qci{zero};
+    amrex::Real qn{zero};
+    amrex::Real qt{zero};
+    amrex::Real qpr{zero};
+    amrex::Real qps{zero};
+    amrex::Real qpg{zero};
+    amrex::Real qp{zero};
+};
+
+struct SAMCoefficientRow {
+    amrex::Real accrrc{zero};
+    amrex::Real accrsi{zero};
+    amrex::Real accrsc{zero};
+    amrex::Real coefice{zero};
+    amrex::Real evaps1{zero};
+    amrex::Real evaps2{zero};
+    amrex::Real accrgi{zero};
+    amrex::Real accrgc{zero};
+    amrex::Real evapg1{zero};
+    amrex::Real evapg2{zero};
+    amrex::Real evapr1{zero};
+    amrex::Real evapr2{zero};
+};
+
+struct SAMPrecipFaceState {
+    amrex::Real rho_avg{zero};
+    amrex::Real tabs_avg{zero};
+    amrex::Real qp_avg{zero};
+    amrex::Real omp{one};
+    amrex::Real omg{zero};
+    amrex::Real qrr{zero};
+    amrex::Real qss{zero};
+    amrex::Real qgg{zero};
+};
+
+struct SAMFaceState {
+    amrex::Real rho_avg{zero};
+    amrex::Real tabs_avg{zero};
+    amrex::Real qci_avg{zero};
+    amrex::Real qp_avg{zero};
+};
+
+struct SAMSurfaceAccumulation {
+    amrex::Real rain{zero};
+    amrex::Real snow{zero};
+    amrex::Real graupel{zero};
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_mbar_to_pa (const amrex::Real pres_mbar) noexcept
+{
+    // SAM stores pressure in mbar. EOS and theta helpers expect Pa.
+    return amrex::Real(100.0) * pres_mbar;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_pa_to_mbar (const amrex::Real pres_pa) noexcept
+{
+    return amrex::Real(0.01) * pres_pa;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_theta_from_stored_mbar_converted_to_pa (const amrex::Real tabs,
+                                                        const amrex::Real pres_mbar,
+                                                        const amrex::Real rdOcp) noexcept
+{
+    // SAM stores pressure in mbar on this path. EOS helpers expect Pa.
+    return getThgivenTandP(tabs, sam_mbar_to_pa(pres_mbar), rdOcp);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_theta_from_stored_pressure_as_pa (const amrex::Real tabs,
+                                                  const amrex::Real stored_pres,
+                                                  const amrex::Real rdOcp) noexcept
+{
+    // This SAM path passes the stored pressure value as though it were already Pa.
+    return getThgivenTandP(tabs, stored_pres, rdOcp);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrimitiveCell sam_cons_to_primitive (const amrex::Real rho,
+                                        const amrex::Real rho_theta,
+                                        const amrex::Real rho_qv,
+                                        const amrex::Real rho_qcl,
+                                        const amrex::Real rho_qci,
+                                        const amrex::Real rho_qpr,
+                                        const amrex::Real rho_qps,
+                                        const amrex::Real rho_qpg) noexcept
+{
+    // Copy-in clips moisture and stores pressure in mbar.
+    SAMPrimitiveCell result{};
+    result.rho = rho;
+    result.theta = rho_theta / rho;
+    result.qv = amrex::max(amrex::Real(0.0), rho_qv / rho);
+    result.qcl = amrex::max(amrex::Real(0.0), rho_qcl / rho);
+    result.qci = amrex::max(amrex::Real(0.0), rho_qci / rho);
+    result.qn = result.qcl + result.qci;
+    result.qt = result.qv + result.qn;
+    result.qpr = amrex::max(amrex::Real(0.0), rho_qpr / rho);
+    result.qps = amrex::max(amrex::Real(0.0), rho_qps / rho);
+    result.qpg = amrex::max(amrex::Real(0.0), rho_qpg / rho);
+    result.qp = result.qpr + result.qps + result.qpg;
+    result.tabs = getTgivenRandRTh(rho, rho_theta, result.qv);
+    result.pres_mbar = sam_pa_to_mbar(getPgivenRTh(rho_theta, result.qv));
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+void sam_primitive_to_cons (const SAMPrimitiveCell& primitive,
+                            const amrex::Array4<amrex::Real>& states_arr,
+                            const int i,
+                            const int j,
+                            const int k) noexcept
+{
+    // Copy-out clips moisture before writing conserved state.
+    states_arr(i,j,k,RhoTheta_comp) = primitive.rho * primitive.theta;
+    states_arr(i,j,k,RhoQ1_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qv);
+    states_arr(i,j,k,RhoQ2_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qcl);
+    states_arr(i,j,k,RhoQ3_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qci);
+    states_arr(i,j,k,RhoQ4_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qpr);
+    states_arr(i,j,k,RhoQ5_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qps);
+    states_arr(i,j,k,RhoQ6_comp) = primitive.rho * amrex::max(amrex::Real(0.0), primitive.qpg);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool sam_is_no_ice (const MoistureType moisture_type) noexcept
+{
+    return moisture_type == MoistureType::SAM_NoIce ||
+           moisture_type == MoistureType::SAM_NoPrecip_NoIce;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool sam_is_no_precip (const MoistureType moisture_type) noexcept
+{
+    return moisture_type == MoistureType::SAM_NoPrecip_NoIce;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_cloud_liquid_fraction (const int SAM_moisture_type,
+                                       const amrex::Real tabs,
+                                       const amrex::Real an,
+                                       const amrex::Real bn) noexcept
+{
+    if (SAM_moisture_type == 2) {
+        return one;
+    }
+    if (tabs >= tbgmax) {
+        return one;
+    }
+    if (tabs <= tbgmin) {
+        return zero;
+    }
+    return an * tabs - bn;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_precip_rain_fraction (const int SAM_moisture_type,
+                                      const amrex::Real tabs) noexcept
+{
+    if (SAM_moisture_type == 2) {
+        return one;
+    }
+    return amrex::max(amrex::Real(0.0), amrex::min(amrex::Real(1.0), (tabs - tprmin) * a_pr));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_graupel_fraction (const int SAM_moisture_type,
+                                  const amrex::Real tabs) noexcept
+{
+    if (SAM_moisture_type == 2) {
+        return zero;
+    }
+    return amrex::max(amrex::Real(0.0), amrex::min(amrex::Real(1.0), (tabs - tgrmin) * a_gr));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMCloudPhaseChange sam_partition_cloud_phase (const int SAM_moisture_type,
+                                               const amrex::Real tabs,
+                                               const amrex::Real qn,
+                                               const amrex::Real qcl,
+                                               const amrex::Real qci,
+                                               const amrex::Real fac_cond,
+                                               const amrex::Real fac_fus,
+                                               const amrex::Real an,
+                                               const amrex::Real bn) noexcept
+{
+    SAMCloudPhaseChange result{};
+    result.qcl = qcl;
+    result.qci = qci;
+    result.tabs = tabs;
+    result.omn = sam_cloud_liquid_fraction(SAM_moisture_type, tabs, an, bn);
+
+    if (SAM_moisture_type == 1) {
+        if (tabs >= tbgmax) {
+            result.omn = one;
+            result.delta_qi = qci;
+            result.qci = zero;
+            result.qcl += result.delta_qi;
+            result.tabs -= fac_fus * result.delta_qi;
+        } else if (tabs <= tbgmin) {
+            result.omn = zero;
+            result.delta_qc = qcl;
+            result.qcl = zero;
+            result.qci += result.delta_qc;
+            result.tabs += fac_fus * result.delta_qc;
+        } else {
+            result.delta_qc = qcl - qn * result.omn;
+            result.delta_qi = qci - qn * (one - result.omn);
+            result.qcl = qn * result.omn;
+            result.qci = qn * (one - result.omn);
+            result.tabs += fac_fus * result.delta_qc;
+        }
+    } else {
+        result.omn = one;
+        result.delta_qc = qcl - qn;
+        result.qcl = qn;
+        result.qci = zero;
+        result.tabs += fac_cond * result.delta_qc;
+    }
+
+    result.qn = result.qcl + result.qci;
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_mixed_qsat (const amrex::Real omn,
+                            const amrex::Real qsatw,
+                            const amrex::Real qsati) noexcept
+{
+    return omn * qsatw + (one - omn) * qsati;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_mixed_dqsat_dT (const amrex::Real omn,
+                                const amrex::Real domn,
+                                const amrex::Real qsatw,
+                                const amrex::Real qsati,
+                                const amrex::Real dqsatw,
+                                const amrex::Real dqsati) noexcept
+{
+    return omn * dqsatw + (one - omn) * dqsati + domn * qsatw - domn * qsati;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_newton_residual (const amrex::Real tabs_new,
+                                 const amrex::Real tabs_old,
+                                 const amrex::Real lstar,
+                                 const amrex::Real qv,
+                                 const amrex::Real qsat) noexcept
+{
+    return -tabs_new + tabs_old + lstar * (qv - qsat);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_newton_residual_derivative (const amrex::Real lstar,
+                                            const amrex::Real dlstar,
+                                            const amrex::Real qv,
+                                            const amrex::Real qsat,
+                                            const amrex::Real dqsat) noexcept
+{
+    return -one + dlstar * (qv - qsat) - lstar * dqsat;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMCloudPhaseChange sam_apply_condensate_limiter (const amrex::Real qv,
+                                                  const amrex::Real qsat,
+                                                  const amrex::Real qc,
+                                                  const amrex::Real qi,
+                                                  const amrex::Real omn) noexcept
+{
+    SAMCloudPhaseChange result{};
+    result.delta_qv = qv - qsat;
+    result.delta_qc = amrex::max(-qc, result.delta_qv * omn);
+    result.delta_qi = amrex::max(-qi, result.delta_qv * (one - omn));
+    result.qv = qsat;
+    result.qcl = qc + result.delta_qc;
+    result.qci = qi + result.delta_qi;
+    result.qn = result.qcl + result.qci;
+    result.qt = result.qv + result.qn;
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_autoconversion_rates (const amrex::Real dtn,
+                                           const amrex::Real qcc,
+                                           const amrex::Real qii,
+                                           const amrex::Real coefice_k) noexcept
+{
+    SAMPrecipSources result{};
+    // MUST MATCH: SAM rain autoconversion threshold.
+    const amrex::Real auto_r = (qcc > qcw0) ? alphaelq : zero;
+    const amrex::Real autos = (qii > qci0) ? betaelq * coefice_k : zero;
+    result.dqca = dtn * auto_r * (qcc - qcw0);
+    result.dqia = dtn * autos * (qii - qci0);
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_accretion_rates (const amrex::Real dtn,
+                                      const amrex::Real qcc,
+                                      const amrex::Real qii,
+                                      const amrex::Real qpr,
+                                      const amrex::Real qps,
+                                      const amrex::Real qpg,
+                                      const amrex::Real powr1,
+                                      const amrex::Real pows1,
+                                      const amrex::Real powg1,
+                                      const amrex::Real omp,
+                                      const amrex::Real omg,
+                                      const amrex::Real accrrc_k,
+                                      const amrex::Real accrsc_k,
+                                      const amrex::Real accrsi_k,
+                                      const amrex::Real accrgc_k,
+                                      const amrex::Real accrgi_k) noexcept
+{
+    SAMPrecipSources result{};
+    amrex::Real accrcr = zero;
+    amrex::Real accrcs = zero;
+    amrex::Real accris = zero;
+    amrex::Real accrcg = zero;
+    amrex::Real accrig = zero;
+
+    // MUST MATCH: SAM precipitation phase-fraction activation thresholds.
+    if (omp > amrex::Real(0.001)) {
+        accrcr = accrrc_k;
+    }
+    if (omp < amrex::Real(0.999) && omg < amrex::Real(0.999)) {
+        accrcs = accrsc_k;
+        accris = accrsi_k;
+    }
+    if (omp < amrex::Real(0.999) && omg > amrex::Real(0.001)) {
+        accrcg = accrgc_k;
+        accrig = accrgi_k;
+    }
+
+    result.dprc = dtn * accrcr * qcc * std::pow(qpr, powr1);
+    result.dpsc = dtn * accrcs * qcc * std::pow(qps, pows1);
+    result.dpgc = dtn * accrcg * qcc * std::pow(qpg, powg1);
+    result.dpsi = dtn * accris * qii * std::pow(qps, pows1);
+    result.dpgi = dtn * accrig * qii * std::pow(qpg, powg1);
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_rescale_cloud_sinks (const amrex::Real qcl,
+                                          const amrex::Real qci,
+                                          const amrex::Real eps,
+                                          SAMPrecipSources result) noexcept
+{
+    result.dqc = result.dqca + result.dprc + result.dpsc + result.dpgc;
+    result.dqi = result.dqia + result.dpsi + result.dpgi;
+
+    const amrex::Real scalec = amrex::min(qcl, result.dqc) / (result.dqc + eps);
+    const amrex::Real scalei = amrex::min(qci, result.dqi) / (result.dqi + eps);
+
+    result.dqca *= scalec;
+    result.dprc *= scalec;
+    result.dpsc *= scalec;
+    result.dpgc *= scalec;
+    result.dqia *= scalei;
+    result.dpsi *= scalei;
+    result.dpgi *= scalei;
+    result.dqc = result.dqca + result.dprc + result.dpsc + result.dpgc;
+    result.dqi = result.dqia + result.dpsi + result.dpgi;
+
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_partition_autoconverted_precip (SAMPrecipSources result,
+                                                     const amrex::Real omp,
+                                                     const amrex::Real omg) noexcept
+{
+    result.dqpr = (result.dqca + result.dqia) * omp + result.dprc;
+    result.dqps = (result.dqca + result.dqia) * (one - omp) * (one - omg) + result.dpsc + result.dpsi;
+    result.dqpg = (result.dqca + result.dqia) * (one - omp) * omg + result.dpgc + result.dpgi;
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_precip_evaporation_rates (const amrex::Real qpr,
+                                               const amrex::Real qps,
+                                               const amrex::Real qpg,
+                                               const amrex::Real powr2,
+                                               const amrex::Real pows2,
+                                               const amrex::Real powg2,
+                                               const amrex::Real evapr1_k,
+                                               const amrex::Real evapr2_k,
+                                               const amrex::Real evaps1_k,
+                                               const amrex::Real evaps2_k,
+                                               const amrex::Real evapg1_k,
+                                               const amrex::Real evapg2_k) noexcept
+{
+    SAMPrecipSources result{};
+    result.dqpr = evapr1_k * std::sqrt(qpr) + evapr2_k * std::pow(qpr, powr2);
+    result.dqps = evaps1_k * std::sqrt(qps) + evaps2_k * std::pow(qps, pows2);
+    result.dqpg = evapg1_k * std::sqrt(qpg) + evapg2_k * std::pow(qpg, powg2);
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipSources sam_apply_precip_evaporation_limiter (const amrex::Real qpr,
+                                                       const amrex::Real qps,
+                                                       const amrex::Real qpg,
+                                                       SAMPrecipSources result) noexcept
+{
+    result.dqpr = amrex::min(qpr, result.dqpr);
+    result.dqps = amrex::min(qps, result.dqps);
+    result.dqpg = amrex::min(qpg, result.dqpg);
+    result.dqp = result.dqpr + result.dqps + result.dqpg;
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMCoefficientRow sam_compute_coefficient_row (const amrex::Real rho,
+                                               const amrex::Real tabs,
+                                               const amrex::Real gamr1,
+                                               const amrex::Real gamr2,
+                                               const amrex::Real gams1,
+                                               const amrex::Real gams2,
+                                               const amrex::Real gamg1,
+                                               const amrex::Real gamg2) noexcept
+{
+    // Preserve the SAM baseline formula ordering in these closure rows.
+    SAMCoefficientRow row{};
+    amrex::Real prefactor;
+    amrex::Real pratio = std::sqrt(amrex::Real(1.29) / rho);
+    amrex::Real estw = amrex::Real(100.0) * erf_esatw(tabs);
+    amrex::Real esti = amrex::Real(100.0) * erf_esati(tabs);
+
+    amrex::Real coef1 = fourth * PI * nzeros * a_snow * gams1 * pratio
+        / std::pow((PI * rhos * nzeros / rho), ((three + b_snow) / amrex::Real(4.0)));
+    amrex::Real coef2 = std::exp(amrex::Real(0.025) * (tabs - amrex::Real(273.15)));
+    row.accrsi = coef1 * coef2 * esicoef;
+    row.accrsc = coef1 * esccoef;
+    row.coefice = coef2;
+
+    coef1 = (lsub / (tabs * R_v) - one) * lsub / (therco * tabs);
+    coef2 = R_v * R_d / (diffelq * esti);
+    prefactor = two * PI * nzeros / (rho * (coef1 + coef2));
+    prefactor *= (two / PI);
+    row.evaps1 = prefactor * amrex::Real(0.65) * std::sqrt(rho / (PI * rhos * nzeros));
+    row.evaps2 = prefactor * amrex::Real(0.44) * std::sqrt(a_snow * rho / muelq) * gams2
+        * std::sqrt(pratio) * std::pow(rho / (PI * rhos * nzeros), ((amrex::Real(5.0) + b_snow) / amrex::Real(8.0)));
+
+    coef1 = fourth * PI * nzerog * a_grau * gamg1 * pratio
+        / std::pow((PI * rhog * nzerog / rho), ((three + b_grau) / amrex::Real(4.0)));
+    coef2 = std::exp(amrex::Real(0.025) * (tabs - amrex::Real(273.15)));
+    row.accrgi = coef1 * coef2 * egicoef;
+    row.accrgc = coef1 * egccoef;
+
+    coef1 = (lsub / (tabs * R_v) - one) * lsub / (therco * tabs);
+    coef2 = R_v * R_d / (diffelq * esti);
+    prefactor = two * PI * nzerog / (rho * (coef1 + coef2));
+    row.evapg1 = prefactor * amrex::Real(0.78) * std::sqrt(rho / (PI * rhog * nzerog));
+    row.evapg2 = prefactor * amrex::Real(0.31) * std::sqrt(a_grau * rho / muelq) * gamg2
+        * std::sqrt(pratio) * std::pow(rho / (PI * rhog * nzerog), ((amrex::Real(5.0) + b_grau) / amrex::Real(8.0)));
+
+    row.accrrc = fourth * PI * nzeror * a_rain * gamr1 * pratio
+        / std::pow((PI * rhor * nzeror / rho), ((three + b_rain) / amrex::Real(4.0))) * erccoef;
+
+    coef1 = (lcond / (tabs * R_v) - one) * lcond / (therco * tabs);
+    coef2 = R_v * R_d / (diffelq * estw);
+    prefactor = two * PI * nzeror / (rho * (coef1 + coef2));
+    row.evapr1 = prefactor * amrex::Real(0.78) * std::sqrt(rho / (PI * rhor * nzeror));
+    row.evapr2 = prefactor * amrex::Real(0.31) * std::sqrt(a_rain * rho / muelq) * gamr2
+        * std::sqrt(pratio) * std::pow(rho / (PI * rhor * nzeror), ((amrex::Real(5.0) + b_rain) / amrex::Real(8.0)));
+    return row;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_cloud_ice_terminal_velocity (const amrex::Real qci_avg) noexcept
+{
+    // MUST MATCH: SAM cloud-ice terminal-velocity coefficient and exponent.
+    return amrex::min(amrex::Real(0.4),
+                      amrex::Real(8.66) * std::pow((amrex::max(amrex::Real(0.0), qci_avg) + amrex::Real(1.e-10)), amrex::Real(0.24)));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMFaceState sam_face_average_state (const int k,
+                                     const int k_lo,
+                                     const int k_hi,
+                                     const amrex::Real rho_km1,
+                                     const amrex::Real rho_k,
+                                     const amrex::Real tabs_km1,
+                                     const amrex::Real tabs_k,
+                                     const amrex::Real qci_km1,
+                                     const amrex::Real qci_k,
+                                     const amrex::Real qp_km1,
+                                     const amrex::Real qp_k) noexcept
+{
+    SAMFaceState result{};
+    if (k == k_lo) {
+        result.rho_avg = rho_k;
+        result.tabs_avg = tabs_k;
+        result.qci_avg = qci_k;
+        result.qp_avg = qp_k;
+    } else if (k == k_hi + 1) {
+        result.rho_avg = rho_km1;
+        result.tabs_avg = tabs_km1;
+        result.qci_avg = qci_km1;
+        result.qp_avg = qp_km1;
+    } else {
+        result.rho_avg = myhalf * (rho_km1 + rho_k);
+        result.tabs_avg = myhalf * (tabs_km1 + tabs_k);
+        result.qci_avg = myhalf * (qci_km1 + qci_k);
+        result.qp_avg = myhalf * (qp_km1 + qp_k);
+    }
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int sam_substep_count_from_reduced_flux (const amrex::Real reduced_flux,
+                                         const amrex::Real dt,
+                                         const amrex::Real dz) noexcept
+{
+    // Substeps follow the legacy reduced-flux rule. Property tests will audit it.
+    // MUST MATCH: SAM::CFL_MAX.
+    return static_cast<int>(std::ceil(reduced_flux * (dt / dz) / myhalf));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMPrecipFaceState sam_precip_face_state (
+    const int SAM_moisture_type,
+    const amrex::Array4<const amrex::Real>& rho_array,
+    const amrex::Array4<const amrex::Real>& tabs_array,
+    const amrex::Array4<const amrex::Real>& qp_array,
+    const int i,
+    const int j,
+    const int k,
+    const int k_lo,
+    const int k_hi) noexcept
+{
+    // MUST MATCH: SAM PrecipFall bottom/interior/top face rules.
+    SAMPrecipFaceState result{};
+    if (k == k_lo) {
+        result.rho_avg = rho_array(i,j,k);
+        result.tabs_avg = tabs_array(i,j,k);
+        result.qp_avg = qp_array(i,j,k);
+    } else if (k == k_hi + 1) {
+        result.rho_avg = rho_array(i,j,k-1);
+        result.tabs_avg = tabs_array(i,j,k-1);
+        result.qp_avg = qp_array(i,j,k-1);
+    } else {
+        result.rho_avg = myhalf * (rho_array(i,j,k-1) + rho_array(i,j,k));
+        result.tabs_avg = myhalf * (tabs_array(i,j,k-1) + tabs_array(i,j,k));
+        result.qp_avg = myhalf * (qp_array(i,j,k-1) + qp_array(i,j,k));
+    }
+    result.omp = sam_precip_rain_fraction(SAM_moisture_type, result.tabs_avg);
+    result.omg = sam_graupel_fraction(SAM_moisture_type, result.tabs_avg);
+    result.qrr = result.omp * result.qp_avg;
+    result.qss = (one - result.omp) * (one - result.omg) * result.qp_avg;
+    result.qgg = (one - result.omp) * result.omg * result.qp_avg;
+    return result;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_precip_flux_from_face_state (const SAMPrecipFaceState& face_state,
+                                             const amrex::Real vrain,
+                                             const amrex::Real vsnow,
+                                             const amrex::Real vgrau) noexcept
+{
+    if (face_state.qp_avg <= qp_threshold) {
+        return zero;
+    }
+    return face_state.omp * vrain * std::pow(face_state.rho_avg * face_state.qrr, one + crain)
+        + (one - face_state.omp)
+            * ((one - face_state.omg) * vsnow * std::pow(face_state.rho_avg * face_state.qss, one + csnow)
+               + face_state.omg * vgrau * std::pow(face_state.rho_avg * face_state.qgg, one + cgrau));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_precip_flux_density_corrected (const amrex::Real precip_flux,
+                                               const amrex::Real rho_0,
+                                               const amrex::Real rho_avg) noexcept
+{
+    return precip_flux * std::sqrt(rho_0 / rho_avg);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sam_sedimentation_tendency (const amrex::Real fz_hi,
+                                        const amrex::Real fz_lo,
+                                        const amrex::Real rho,
+                                        const amrex::Real dJinv,
+                                        const amrex::Real coef) noexcept
+{
+    return dJinv * (one / rho) * (fz_hi - fz_lo) * coef;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SAMSurfaceAccumulation sam_surface_accumulation (const amrex::Real rho_avg,
+                                                 const amrex::Real qp_avg,
+                                                 const amrex::Real omp,
+                                                 const amrex::Real omg,
+                                                 const amrex::Real vrain,
+                                                 const amrex::Real vsnow,
+                                                 const amrex::Real vgrau,
+                                                 const amrex::Real dtn) noexcept
+{
+    SAMSurfaceAccumulation result{};
+    // Surface accumulation preserves the SAM baseline formula. Property tests will audit it.
+    result.rain = rho_avg * (omp * qp_avg) * vrain * dtn / rhor * amrex::Real(1000.0);
+    result.snow = rho_avg * (one - omp) * (one - omg) * qp_avg * vsnow * dtn / rhos * amrex::Real(1000.0);
+    result.graupel = rho_avg * (one - omp) * omg * qp_avg * vgrau * dtn / rhog * amrex::Real(1000.0);
+    return result;
+}
+
+#endif

--- a/Source/Microphysics/SAM/ERF_UpdateSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_UpdateSAM.cpp
@@ -34,15 +34,16 @@ SAM::Copy_Micro_to_State (MultiFab& cons)
         // get potential total density, temperature, qt, qp
         ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            states_arr(i,j,k,RhoTheta_comp) = rho_arr(i,j,k)*theta_arr(i,j,k);
-
-            states_arr(i,j,k,RhoQ1_comp)    = rho_arr(i,j,k)*std::max(Real(0),qv_arr(i,j,k));
-            states_arr(i,j,k,RhoQ2_comp)    = rho_arr(i,j,k)*std::max(Real(0),qc_arr(i,j,k));
-            states_arr(i,j,k,RhoQ3_comp)    = rho_arr(i,j,k)*std::max(Real(0),qi_arr(i,j,k));
-
-            states_arr(i,j,k,RhoQ4_comp)    = rho_arr(i,j,k)*std::max(Real(0),qpr_arr(i,j,k));
-            states_arr(i,j,k,RhoQ5_comp)    = rho_arr(i,j,k)*std::max(Real(0),qps_arr(i,j,k));
-            states_arr(i,j,k,RhoQ6_comp)    = rho_arr(i,j,k)*std::max(Real(0),qpg_arr(i,j,k));
+            SAMPrimitiveCell primitive{};
+            primitive.rho = rho_arr(i,j,k);
+            primitive.theta = theta_arr(i,j,k);
+            primitive.qv = qv_arr(i,j,k);
+            primitive.qcl = qc_arr(i,j,k);
+            primitive.qci = qi_arr(i,j,k);
+            primitive.qpr = qpr_arr(i,j,k);
+            primitive.qps = qps_arr(i,j,k);
+            primitive.qpg = qpg_arr(i,j,k);
+            sam_primitive_to_cons(primitive, states_arr, i, j, k);
         });
     }
 


### PR DESCRIPTION
## Summary

This PR refactors the SAM microphysics implementation into small, named helper functions. It keeps the production algorithm unchanged.

The refactor covers the SAM public advance path:

- `Cloud`
- `IceFall`
- `Precip`
- `PrecipFall`
- copy-in and copy-out state conversion
- coefficient setup
- sedimentation face and flux helpers

The new helper surface lives in `ERF_SAMUtils.H`.

## Why

The old SAM implementation mixed physics formulas, unit conversions, branch predicates, limiters, and state updates inside large kernels. That made the code hard to audit and hard to test.

This refactor separates those concerns. It gives future tests stable targets for:

- phase fractions
- saturation adjustment pieces
- precipitation source terms
- sedimentation fluxes
- surface accumulation
- copy-in and copy-out conversions
- coefficient rows

The goal is to make the next phase safer: add physical and mathematical contract tests, then fix bugs one proven contract at a time.

## Bit-for-bit proof

This refactor was first developed on a temporary BFB proof branch. That branch kept a frozen legacy SAM reference path and compared it against the refactored production path.

The BFB harness exercised:

- `SAM_NoPrecip_NoIce`
- `SAM_NoIce`
- full `SAM`
- SHOC-disabled and SHOC-enabled cloud behavior
- warm, cold, and mixed cloud regimes
- precipitation source branches
- evaporation limiter branches
- cloud and precipitation sedimentation
- bottom, interior, and top face handling
- `detJ` and non-`detJ` paths
- surface rain, snow, and graupel accumulation

The proof branch passed CI. This clean branch removes the temporary BFB harness and keeps only the BFB-proven production refactor.

## What changed

- Added `Source/Microphysics/SAM/ERF_SAMUtils.H`.
- Extracted scalar helpers and small POD structs.
- Named pressure-unit conversion helpers.
- Named source-term, limiter, phase-fraction, flux, and tendency helpers.
- Refactored SAM production files to use those helpers.
- Removed the temporary BFB scaffold from this clean branch.

## What did not change

This PR does not fix physics.

It does not change:

- pressure-unit behavior
- latent-heating behavior
- sedimentation CFL behavior
- surface accumulation behavior
- sedimentation boundary behavior
- process splitting
- production kernel structure
- production reductions
- production MultiFab allocations

Any future physics change should come with a failing contract test first.

## Review notes

This PR should be reviewed as a behavior-preserving refactor. The main question is whether the helper names and boundaries make the SAM code easier to audit, test, and maintain.

An additional PR should add property and contract tests for the refactored helpers and public SAM flow.