### PR TITLE
Use face density for Kessler rain sedimentation

### DIFF
--- a/Source/Microphysics/Kessler/ERF_InitKessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_InitKessler.cpp
@@ -79,7 +79,8 @@ void Kessler::Copy_State_to_Micro (const MultiFab& cons_in)
         auto tabs_array  = mic_fab_vars[MicVar_Kess::tabs]->array(mfi);
         auto pres_array  = mic_fab_vars[MicVar_Kess::pres]->array(mfi);
 
-        // Get pressure, theta, temperature, density, and qt, qp
+        // getPgivenRTh returns Pa. Kessler stores pressure in mbar / hPa for the
+        // qsat helper path, so convert here after forming temperature and density.
         ParallelFor( box3d, [=] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             rho_array(i,j,k)   = states_array(i,j,k,Rho_comp);

--- a/Source/Microphysics/Kessler/ERF_Kessler.H
+++ b/Source/Microphysics/Kessler/ERF_Kessler.H
@@ -54,6 +54,8 @@ public:
     void
     Define (SolverChoice& sc) override
     {
+        // Use one latent-over-cp factor for both the saturation solve and theta
+        // update. L_v comes from ERF_Constants.H; c_p comes from SolverChoice.
         m_fac_cond = L_v / sc.c_p;
         m_axis     = sc.ave_plane;
         m_do_cond  = (!sc.use_shoc);

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -164,11 +164,13 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                         kessler_face_state(k, k_hi, rho_km1, rho_k, qp_km1, qp_k);
 
                     const Real terminal_velocity = kessler_terminal_velocity(face_state.rho, face_state.qp);
+                    const Real donor_rho = rho_array(i,j,donor_k);
+                    const Real donor_qp = std::max(Real(0), qp_array(i,j,donor_k));
                     const Real donor_detJ = (dJ_array) ? dJ_array(i,j,donor_k) : Real(1);
                     // Limit the outgoing donor-face flux by the donor cell's available
                     // detJ-weighted precipitating water. This prevents over-removal for detJ < 1
                     // before the nonnegative qp clip.
-                    const Real max_flux = face_state.rho * face_state.qp * donor_detJ / coef;
+                    const Real max_flux = donor_rho * donor_qp * donor_detJ / coef;
                     fz_array(i,j,k) = amrex::min(
                         kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
 

--- a/Source/Microphysics/Kessler/ERF_Kessler.cpp
+++ b/Source/Microphysics/Kessler/ERF_Kessler.cpp
@@ -58,6 +58,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 
                 Real qsat_local, dtqsat_local;
                 Real pressure = pres_array(i,j,k);
+                // Kessler stores pressure in mbar / hPa for the qsat helpers.
                 erf_qsatw(tabs_array(i,j,k), pressure, qsat_local);
                 erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat_local);
 
@@ -116,8 +117,9 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
 
         auto const& ma_rho_arr = mic_fab_vars[MicVar_Kess::rho]->const_arrays();
         auto const& ma_qp_arr = mic_fab_vars[MicVar_Kess::qp]->const_arrays();
-        // The sedimentation CFL is based on terminal velocity, not precipitating
-        // mass flux. fz stores rho * Vt * qp for the flux update below.
+        // The sedimentation CFL uses fall speed, not precipitating mass flux.
+        // fz stores rho * Vt * qp for the flux divergence below, so the reduction
+        // recomputes Vt from the same face state used for the flux.
         GpuTuple<Real> max_terminal_velocity = ParReduce(TypeList<ReduceOpMax>{},
                                                          TypeList<Real>{},
                                                          fz, IntVect(0),
@@ -167,16 +169,19 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                     const Real donor_rho = rho_array(i,j,donor_k);
                     const Real donor_qp = std::max(Real(0), qp_array(i,j,donor_k));
                     const Real donor_detJ = (dJ_array) ? dJ_array(i,j,donor_k) : Real(1);
-                    // Limit the outgoing donor-face flux by the donor cell's available
-                    // detJ-weighted precipitating water. This prevents over-removal for detJ < 1
-                    // before the nonnegative qp clip.
+                    // The face flux uses face rho and donor qp. The limiter uses donor rho,
+                    // donor qp, and donor detJ because it caps how much rain can leave the donor
+                    // cell in this substep.
+                    // Cap outgoing flux by the donor cell's detJ-weighted available rain water:
+                    // F * dt / dz <= rho_donor * qp_donor * detJ_donor.
+                    // This keeps compressed cells from losing more rain than they contain.
                     const Real max_flux = donor_rho * donor_qp * donor_detJ / coef;
                     fz_array(i,j,k) = amrex::min(
                         kessler_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
 
                     if(k==k_lo){
-                        // Convert precipitation mass per unit area [kg m^-2] to water depth [mm]:
-                        // divide by liquid-water density [kg m^-3], then multiply by mm per m.
+                        // Surface accumulation stores the bottom-face precipitation mass per area
+                        // increment converted to liquid-water depth.
                         rain_accum_array(i,j,k) = rain_accum_array(i,j,k)
                                                 + kessler_rain_accumulation_increment(fz_array(i,j,k) * dtn);
                     }
@@ -236,6 +241,7 @@ void Kessler::AdvanceKessler (const SolverChoice &solverChoice)
                 Real qsat, dtqsat;
 
                 Real pressure = pres_array(i,j,k);
+                // Kessler stores pressure in mbar / hPa for the qsat helpers.
                 erf_qsatw(tabs_array(i,j,k), pressure, qsat);
                 erf_dtqsatw(tabs_array(i,j,k), pressure, dtqsat);
 

--- a/Source/Microphysics/Kessler/ERF_KesslerUtils.H
+++ b/Source/Microphysics/Kessler/ERF_KesslerUtils.H
@@ -117,13 +117,17 @@ KesslerFaceState kessler_face_state (const int k,
 {
     KesslerFaceState face_state{amrex::Real(0), amrex::Real(0)};
 
-    // Downward sedimentation uses the upper-cell donor state at interior faces.
-    // The top boundary face uses the top cell below the boundary.
+    // Downward sedimentation upwinds rain mixing ratio from the donor cell.
+    // Air density remains face-centered for the z-face flux. The donor-cell
+    // density is used separately only for the availability limiter.
     if (k == k_hi + 1) {
         face_state.rho = rho_km1;
         face_state.qp = qp_km1;
-    } else {
+    } else if (k == 0) {
         face_state.rho = rho_k;
+        face_state.qp = qp_k;
+    } else {
+        face_state.rho = amrex::Real(0.5) * (rho_km1 + rho_k);
         face_state.qp = qp_k;
     }
 

--- a/Source/Microphysics/Kessler/ERF_KesslerUtils.H
+++ b/Source/Microphysics/Kessler/ERF_KesslerUtils.H
@@ -70,6 +70,8 @@ int kessler_num_sedimentation_substeps (const amrex::Real current_reduced_value,
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real kessler_rain_accumulation_increment (const amrex::Real precip_mass_per_area) noexcept
 {
+    // Convert precipitation mass per unit area [kg m^-2] to liquid-water depth
+    // [mm]: divide by water density [kg m^-3], then multiply by mm per meter.
     return precip_mass_per_area
         * kessler_water_depth_m_per_kg_m2
         * kessler_millimeters_per_meter;
@@ -117,9 +119,11 @@ KesslerFaceState kessler_face_state (const int k,
 {
     KesslerFaceState face_state{amrex::Real(0), amrex::Real(0)};
 
-    // Downward sedimentation upwinds rain mixing ratio from the donor cell.
-    // Air density remains face-centered for the z-face flux. The donor-cell
-    // density is used separately only for the availability limiter.
+    // Sedimentation is one-way downward transport. Use a face-centered density
+    // for the z-face flux, but upwind the transported rain mixing ratio from the
+    // donor cell. A centered qp can create flux from downstream rain when the
+    // donor cell is dry. The top boundary face uses the top cell below the
+    // boundary.
     if (k == k_hi + 1) {
         face_state.rho = rho_km1;
         face_state.qp = qp_km1;
@@ -131,7 +135,7 @@ KesslerFaceState kessler_face_state (const int k,
         face_state.qp = qp_k;
     }
 
-    // MUST MATCH: current AdvanceKessler nonnegative face qp clipping.
+    // MUST MATCH: current AdvanceKessler nonnegative donor-qp clip before flux formation.
     face_state.qp = std::max(amrex::Real(0), face_state.qp);
     return face_state;
 }
@@ -161,7 +165,7 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
 {
     // Units must match current AdvanceKessler: q* are mass fractions, rho is in
     // the production density units currently carried by Kessler, pressure is in
-    // the current production mbar units, and dt is in seconds.
+    // Kessler's mbar / hPa path for qsat helpers, and dt is in seconds.
     const KesslerSaturationAdjustment saturation_adjustment =
         kessler_saturation_adjustment(qv, qc, qsat, dtqsat, do_cond, latent_over_cp);
     KesslerSourceTerms source_terms{
@@ -174,10 +178,8 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
         amrex::Real(0), (qsat - qv) / (amrex::Real(1) + latent_over_cp * dtqsat));
     const amrex::Real remaining_capacity = amrex::max(
         amrex::Real(0), capacity - saturation_adjustment.dq_cloud_to_vapor);
-    // Saturation adjustment returns at most one nonzero phase-change direction:
-    // condensation reduces vapor in supersaturation, while cloud evaporation
-    // increases vapor in subsaturation. Rain evaporation uses the vapor state
-    // after that cloud adjustment.
+    // Cloud evaporation gets first claim on the linearized subsaturation
+    // capacity. Rain evaporation can use only the remaining capacity.
     const amrex::Real qv_eff = qv
         - saturation_adjustment.dq_vapor_to_cloud
         + saturation_adjustment.dq_cloud_to_vapor;
@@ -199,6 +201,8 @@ KesslerSourceTerms kessler_warm_rain_sources (const amrex::Real qv,
 
     if (qc > amrex::Real(0)) {
         const amrex::Real qcc = qc;
+        // Cloud-to-rain conversion is capped by cloud water available after
+        // saturation adjustment, not by the original qc.
         const amrex::Real available_cloud = amrex::max(
             amrex::Real(0), qc + saturation_adjustment.dq_vapor_to_cloud - saturation_adjustment.dq_cloud_to_vapor);
         amrex::Real auto_r = amrex::Real(0);

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -88,6 +88,8 @@ inline KesslerFaceState reference_column_face_state (const std::array<PrimitiveS
                                                      const int face_k)
 {
     KesslerFaceState face_state{amrex::Real(0.0), amrex::Real(0.0)};
+    // Mirror the production sedimentation face split: face-centered rho for the
+    // z-face flux and donor/upwind qp for downward transport.
     if (face_k == 2) {
         face_state.rho = states[1].rho;
         face_state.qp = states[1].qp;
@@ -130,6 +132,8 @@ inline SedimentationColumnState advance_reference_sedimentation_column (
             const amrex::Real terminal_velocity = reference_terminal_velocity(face_state.rho, face_state.qp);
             const amrex::Real donor_rho = result.states[donor_k].rho;
             const amrex::Real donor_qp = std::max(amrex::Real(0.0), result.states[donor_k].qp);
+            // Mirror the production donor-cap limiter, which is separate from the
+            // face-centered flux state.
             const amrex::Real max_flux = donor_rho * donor_qp / coef;
             face_fluxes[face_k] = amrex::min(
                 reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
@@ -493,9 +497,10 @@ TEST(KesslerPhysicalProperties, KesslerPublicFlow_DetJWeightedColumnWaterBudgetI
                 property_accumulation_tol(4, before.total_water_sum));
 }
 
-// Motivation: Compressed cells with detJ < 1 tighten the donor-cell water
-// capacity that can leave through a sedimentation face in one substep. The
-// detJ-weighted column water budget should still balance against surface rain.
+// Motivation: Compressed cells with detJ < 1 tighten the donor-cell rho * qp *
+// detJ capacity that can leave through a sedimentation face in one substep.
+// The detJ-weighted column water budget should still balance against surface
+// rain.
 TEST(KesslerPhysicalProperties, KesslerPublicFlow_DetJWeightedColumnWaterBudgetIncludesSurfaceRainWithCompressedCells)
 {
     const amrex::Geometry geom = make_geometry(1, 1, 4);

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
@@ -88,9 +88,16 @@ inline KesslerFaceState reference_column_face_state (const std::array<PrimitiveS
                                                      const int face_k)
 {
     KesslerFaceState face_state{amrex::Real(0.0), amrex::Real(0.0)};
-    const int donor_k = kessler_face_donor_k(face_k, 1);
-    face_state.rho = states[donor_k].rho;
-    face_state.qp = states[donor_k].qp;
+    if (face_k == 2) {
+        face_state.rho = states[1].rho;
+        face_state.qp = states[1].qp;
+    } else if (face_k == 0) {
+        face_state.rho = states[0].rho;
+        face_state.qp = states[0].qp;
+    } else {
+        face_state.rho = amrex::Real(0.5) * (states[0].rho + states[1].rho);
+        face_state.qp = states[1].qp;
+    }
 
     face_state.qp = std::max(amrex::Real(0.0), face_state.qp);
     return face_state;
@@ -118,9 +125,12 @@ inline SedimentationColumnState advance_reference_sedimentation_column (
     for (int nsub = 0; nsub < n_substeps; ++nsub) {
         std::array<amrex::Real, 3> face_fluxes{};
         for (int face_k = 0; face_k < 3; ++face_k) {
+            const int donor_k = kessler_face_donor_k(face_k, 1);
             const KesslerFaceState face_state = reference_column_face_state(result.states, face_k);
             const amrex::Real terminal_velocity = reference_terminal_velocity(face_state.rho, face_state.qp);
-            const amrex::Real max_flux = face_state.rho * face_state.qp / coef;
+            const amrex::Real donor_rho = result.states[donor_k].rho;
+            const amrex::Real donor_qp = std::max(amrex::Real(0.0), result.states[donor_k].qp);
+            const amrex::Real max_flux = donor_rho * donor_qp / coef;
             face_fluxes[face_k] = amrex::min(
                 reference_precip_flux(face_state.rho, terminal_velocity, face_state.qp), max_flux);
         }

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -489,7 +489,7 @@ TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
     EXPECT_NEAR(bottom.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
     EXPECT_NEAR(top.rho, amrex::Real(1.0), formula_abs_tol(amrex::Real(1.0)));
     EXPECT_NEAR(top.qp, amrex::Real(0.2), formula_abs_tol(amrex::Real(0.2)));
-    EXPECT_NEAR(interior.rho, amrex::Real(1.1), formula_abs_tol(amrex::Real(1.1)));
+    EXPECT_NEAR(interior.rho, amrex::Real(1.05), formula_abs_tol(amrex::Real(1.05)));
     EXPECT_NEAR(interior.qp, amrex::Real(0.3), formula_abs_tol(amrex::Real(0.3)));
 }
 
@@ -520,6 +520,15 @@ TEST(KesslerScalar, FaceState_UsesUpperCellDonorThenClips)
         kessler_face_state(1, 2, amrex::Real(1.0), amrex::Real(1.0), -amrex::Real(0.2), amrex::Real(0.1));
 
     EXPECT_NEAR(actual.qp, amrex::Real(0.1), formula_abs_tol(amrex::Real(0.1)));
+}
+
+TEST(KesslerScalar, FaceState_UsesFaceCenteredDensityWithDonorRain)
+{
+    const KesslerFaceState actual =
+        kessler_face_state(1, 2, amrex::Real(1.0), amrex::Real(1.4), amrex::Real(0.0), amrex::Real(1.0e-3));
+
+    EXPECT_NEAR(actual.rho, amrex::Real(1.2), formula_abs_tol(amrex::Real(1.2)));
+    EXPECT_NEAR(actual.qp, amrex::Real(1.0e-3), formula_abs_tol(amrex::Real(1.0e-3)));
 }
 
 // Motivation: Equal face fluxes imply zero sedimentation tendency. This is the

--- a/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
+++ b/Tests/Unit/Microphysics/Kessler/ERF_GTestKesslerScalar.cpp
@@ -475,7 +475,8 @@ TEST(KesslerScalar, PrecipFlux_AnalyticDerivativeInPositiveDomain)
 }
 
 // Motivation: Face-state selection has three branches: bottom, top, and
-// interior. This protects the public sedimentation path's boundary logic.
+// interior. Interior faces keep rho centered on the z face while qp stays
+// donor/upwind for downward sedimentation.
 TEST(KesslerScalar, FaceState_BottomTopInteriorBranches)
 {
     const KesslerFaceState bottom =
@@ -510,9 +511,8 @@ TEST(KesslerScalar, FaceState_ClipsNegativeFaceRainWater)
     EXPECT_NEAR(actual.qp, amrex::Real(0.0), exact_zero_or_near_zero_tol());
 }
 
-// Motivation: Interior sedimentation faces use the upper-cell donor state for
-// downward precipitation transport, then clip the donor rain water
-// nonnegative.
+// Motivation: Downward sedimentation upwinds the donor rain mixing ratio and
+// clips it nonnegative before forming a face flux.
 TEST(KesslerScalar, FaceState_UsesUpperCellDonorThenClips)
 {
     // MUST MATCH: production interior donor-cell selection and clipping order.
@@ -522,6 +522,8 @@ TEST(KesslerScalar, FaceState_UsesUpperCellDonorThenClips)
     EXPECT_NEAR(actual.qp, amrex::Real(0.1), formula_abs_tol(amrex::Real(0.1)));
 }
 
+// Motivation: The z-face flux uses face-centered density even when the donor
+// rain mixing ratio comes from the upper cell.
 TEST(KesslerScalar, FaceState_UsesFaceCenteredDensityWithDonorRain)
 {
     const KesslerFaceState actual =
@@ -731,9 +733,8 @@ TEST(KesslerScalar, Characterization_SedimentationThresholdUsesAbsoluteOneEMinus
     EXPECT_FALSE(kessler_is_small_sedimentation_value(amrex::Real(1.0e-14)));
 }
 
-// Motivation: Rain accumulation converts precipitation mass per area to liquid
-// water depth in millimeters using ERF constants for water density and unit
-// conversion.
+// Motivation: Rain accumulation converts precipitation mass per area [kg m^-2]
+// to liquid-water depth [mm] using ERF water density and metric conversion.
 TEST(KesslerScalar, RainAccumulationConvertsMassPerAreaToMillimeters)
 {
     const amrex::Real rho = amrex::Real(1.2);


### PR DESCRIPTION
## Summary

This PR fixes the Kessler sedimentation face-state treatment.

The previous Kessler update correctly upwinded rain mixing ratio for downward sedimentation, but it also used donor-cell density in the z-face flux. That mixed a donor-state choice for `qp` with a face-location choice for `rho`.

This patch separates those roles:

- use face-centered density for the z-face flux and terminal velocity;
- use donor/upwind rain mixing ratio for downward sedimentation;
- use donor-cell `rho`, donor-cell `qp`, and donor-cell `detJ` only for the donor availability limiter.

## Why this matters

`fz` is a face-centered sedimentation flux. The rain mixing ratio should be upwinded for one-way downward sedimentation, but density in the flux should remain located at the face.

The donor limiter still needs donor-cell quantities because it caps outgoing rain by the water available in the donor cell.

This keeps the finite-volume water cap while making the face flux location consistent.

## Tests

This PR updates the Kessler face-state tests to check:

- bottom face: `rho_k`, `qp_k`;
- interior face: face-centered `rho`, donor `qp`;
- top boundary face: `rho_km1`, `qp_km1`.

It also keeps the existing Kessler sedimentation and detJ column-budget tests in place.

## Performance and portability

This change adds no new production kernels, reductions, or `MultiFab` allocations.

The helper path remains AMReX GPU-callable and uses `amrex::Real`.

## Expected answer changes

This may change Kessler results compared with the previous merged implementation. That change is intentional. The flux now uses face-centered density instead of donor-cell density, while preserving donor/upwind rain transport.