### PR TITLE
Change the default tolerances to 1e-6 when using FLOAT

### DIFF
--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -1131,8 +1131,13 @@ struct SolverChoice {
     bool implicit_before_substep     = true;
 
     int         ncorr               = 1;
+#ifdef AMREX_USE_FLOAT
+    amrex::Real poisson_abstol      = amrex::Real(1e-6);
+    amrex::Real poisson_reltol      = amrex::Real(1e-6);
+#else
     amrex::Real poisson_abstol      = amrex::Real(1e-8);
     amrex::Real poisson_reltol      = amrex::Real(1e-8);
+#endif
 
     bool        test_mapfactor         = false;
 


### PR DESCRIPTION
When using floating point precision rather than double precision, a tolerance for the Poisson solve of 1e-8 may be too much.   In this PR we set the default to 1e-6 instead of 1=e6 when AMREX_USE_FLOAT is true.