### PR TITLE
Bubble prob error

### DIFF
--- a/Exec/ERF_Prob.cpp
+++ b/Exec/ERF_Prob.cpp
@@ -222,7 +222,7 @@ Problem::init_custom_pert_vels (
     else if (my_prob_name_ci == "moving terrain") {
 #include "Prob/ERF_InitCustomPertVels_MovingTerrain.H"
     }
-    if (my_prob_name_ci == "bubble") {
+    else if (my_prob_name_ci == "bubble") {
 #include "Prob/ERF_InitCustomPertVels_ConstantU.H"
     }
     else if  (my_prob_name_ci == "bomex") {


### PR DESCRIPTION
# Summary
This PR fixes a copy paste error where an `if` should have been an `else if`.