### PR TITLE
Add MPI-backed parallel unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,9 +108,14 @@ jobs:
         grep -Eq '^[A-Za-z0-9_].*\.$' ${{runner.workspace}}/unit-test-list.txt
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
 
-    - name: Unit Tests
+    - name: Run Serial Unit Tests
       run: |
-        ctest -L unit -VV
+        ctest -L unit --output-on-failure --no-tests=error
+      working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
+
+    - name: Run Parallel Tests
+      run: |
+        ctest -L parallel --output-on-failure --no-tests=error
       working-directory: ${{runner.workspace}}/ERF/build-${{matrix.os}}
 
     - name: Regression Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          -DERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE:BOOL=ON \
           '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_ENABLE_TESTS:BOOL=ON \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_ENABLE_TESTS:BOOL=ON \
           -DERF_ENABLE_ALL_WARNINGS:BOOL=ON \

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -80,6 +80,7 @@ jobs:
             -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
             -DERF_PRECISION:STRING=${{matrix.mesh_precision}} \
             -DERF_PARTICLES_PRECISION:STRING=${{matrix.particles_precision}} \
+            -DERF_TEST_NRANKS:STRING=2 \
             -DERF_ENABLE_UNIT_TESTS:BOOL=ON .
           echo "Building with $(nproc) processes"
           cmake --build build-${{matrix.cuda_pkg}} --parallel $(nproc) \

--- a/.github/workflows/gcc-rrtmgp.yml
+++ b/.github/workflows/gcc-rrtmgp.yml
@@ -86,6 +86,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_ENABLE_NETCDF:BOOL=${{matrix.netcdf}} \
           -DERF_ENABLE_HDF5:BOOL=${{matrix.netcdf}} \

--- a/.github/workflows/gcc-rrtmgp.yml
+++ b/.github/workflows/gcc-rrtmgp.yml
@@ -127,9 +127,14 @@ jobs:
         grep -Eq '^[A-Za-z0-9_].*\.$' ${{ github.workspace }}/unit-test-list.txt
       working-directory: ${{ github.workspace }}/erf_clone/build
 
-    - name: CMake Unit Tests
+    - name: Run Serial Unit Tests
       run: |
-        ctest -L unit -VV
+        ctest -L unit --output-on-failure --no-tests=error
+      working-directory: ${{ github.workspace }}/erf_clone/build
+
+    - name: Run Parallel Tests
+      run: |
+        ctest -L parallel --output-on-failure --no-tests=error
       working-directory: ${{ github.workspace }}/erf_clone/build
 
     - name: CMake Regression Tests # see file ERF/Tests/CTestList.cmake

--- a/.github/workflows/gcc-rrtmgp.yml
+++ b/.github/workflows/gcc-rrtmgp.yml
@@ -86,6 +86,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          -DERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE:BOOL=ON \
           '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_ENABLE_NETCDF:BOOL=${{matrix.netcdf}} \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -88,10 +88,16 @@ jobs:
         grep -Eq '^[A-Za-z0-9_].*\.$' ${{runner.workspace}}/unit-test-list.txt
       working-directory: ${{runner.workspace}}/ERF/build
 
-    - name: CMake Unit Tests
+    - name: Run Serial Unit Tests
       if: matrix.particles_precision == 'DOUBLE' && matrix.mesh_precision == 'DOUBLE'
       run: |
-        ctest -L unit -VV
+        ctest -L unit --output-on-failure --no-tests=error
+      working-directory: ${{runner.workspace}}/ERF/build
+
+    - name: Run Parallel Tests
+      if: matrix.particles_precision == 'DOUBLE' && matrix.mesh_precision == 'DOUBLE'
+      run: |
+        ctest -L parallel --output-on-failure --no-tests=error
       working-directory: ${{runner.workspace}}/ERF/build
 
     - name: CMake Regression Tests # see file ERF/Tests/CTestList.cmake

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -51,6 +51,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          -DERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE:BOOL=ON \
           '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_PRECISION:STRING=${{matrix.mesh_precision}} \

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -51,6 +51,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=ON \
+          '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_PRECISION:STRING=${{matrix.mesh_precision}} \
           -DERF_PARTICLES_PRECISION:STRING=${{matrix.particles_precision}} \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,6 +49,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=TRUE \
+          '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_PRECISION:STRING=${{matrix.mesh_precision}} \
           -DERF_PARTICLES_PRECISION:STRING=${{matrix.particles_precision}} \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -49,6 +49,7 @@ jobs:
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DERF_DIM:STRING=3 \
           -DERF_ENABLE_MPI:BOOL=TRUE \
+          -DERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE:BOOL=ON \
           '-DERF_PARALLEL_TEST_NRANKS:STRING=1;2;4' \
           -DERF_ENABLE_PARTICLES:BOOL=${{matrix.particles}} \
           -DERF_PRECISION:STRING=${{matrix.mesh_precision}} \

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,10 +87,16 @@ jobs:
         grep -Eq '^[A-Za-z0-9_].*\.$' ${{runner.workspace}}/unit-test-list.txt
       working-directory: ${{runner.workspace}}/ERF/build
 
-    - name: CMake Unit Tests
+    - name: Run Serial Unit Tests
       if: matrix.particles_precision == 'DOUBLE' && matrix.mesh_precision == 'DOUBLE'
       run: |
-        ctest -L unit -VV
+        ctest -L unit --output-on-failure --no-tests=error
+      working-directory: ${{runner.workspace}}/ERF/build
+
+    - name: Run Parallel Tests
+      if: matrix.particles_precision == 'DOUBLE' && matrix.mesh_precision == 'DOUBLE'
+      run: |
+        ctest -L parallel --output-on-failure --no-tests=error
       working-directory: ${{runner.workspace}}/ERF/build
 
     - name: CMake Regression Tests # see file ERF/Tests/CTestList.cmake

--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -547,18 +547,21 @@ endfunction(build_erf_lib)
 
 function(build_erf_exe erf_exe_name)
 
+  set(options NO_ERF_MAIN)
+  cmake_parse_arguments(BUILD_ERF_EXE "${options}" "" "" ${ARGN})
+
   set(SRC_DIR ${PROJECT_SOURCE_DIR}/Source)
 
-  if(NOT "${erf_exe_name}" STREQUAL "erf_unit_tests")
-  target_sources(${erf_exe_name}
-     PRIVATE
-       ${SRC_DIR}/main.cpp
-  )
+  if(NOT BUILD_ERF_EXE_NO_ERF_MAIN)
+    target_sources(${erf_exe_name}
+       PRIVATE
+         ${SRC_DIR}/main.cpp
+    )
   endif()
 
-target_link_libraries(${erf_exe_name} PUBLIC ${erf_lib_name})
-include(${PROJECT_SOURCE_DIR}/CMake/SetERFCompileFlags.cmake)
-set_erf_compile_flags(${erf_exe_name})
+  target_link_libraries(${erf_exe_name} PUBLIC ${erf_lib_name})
+  include(${PROJECT_SOURCE_DIR}/CMake/SetERFCompileFlags.cmake)
+  set_erf_compile_flags(${erf_exe_name})
 
   if(ERF_ENABLE_EKAT)
     # Link privately to avoid duplicate link flags, but propagate includes

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -12,6 +12,13 @@ if(ERF_ENABLE_TESTS OR ERF_ENABLE_UNIT_TESTS)
     set(ERF_PARALLEL_TEST_NRANKS "${ERF_PARALLEL_TEST_NRANKS}" CACHE STRING
         "Semicolon-separated MPI rank counts for parallel GoogleTest unit tests")
   endif()
+
+  option(ERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE
+    "Allow oversubscribed MPI launches for parallel GoogleTest unit tests"
+    OFF)
+
+  set(ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS "" CACHE STRING
+      "Extra mpiexec preflags for parallel GoogleTest unit tests")
 endif()
 
 if(ERF_ENABLE_TESTS)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,6 +1,13 @@
+if(ERF_ENABLE_TESTS OR ERF_ENABLE_UNIT_TESTS)
+  if(NOT DEFINED ERF_TEST_NRANKS OR "${ERF_TEST_NRANKS}" STREQUAL "")
+    set(ERF_TEST_NRANKS 2 CACHE STRING "Number of MPI ranks to use for each test" FORCE)
+  else()
+    set(ERF_TEST_NRANKS "${ERF_TEST_NRANKS}" CACHE STRING "Number of MPI ranks to use for each test")
+  endif()
+endif()
+
 if(ERF_ENABLE_TESTS)
   # Additional testing options
-  set(ERF_TEST_NRANKS 2 CACHE STRING  "Number of MPI ranks to use for each test")
   set(ERF_TEST_FCOMPARE_RTOL "2.0e-10" CACHE STRING "fcompare relative tolerance")
   set(ERF_TEST_FCOMPARE_ATOL "2.0e-10" CACHE STRING "fcompare absolute tolerance")
   set(ERF_TEST_GOLD_FILES_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ERFGoldFiles" CACHE PATH "Path to ERF gold files")

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,8 +1,16 @@
 if(ERF_ENABLE_TESTS OR ERF_ENABLE_UNIT_TESTS)
   if(NOT DEFINED ERF_TEST_NRANKS OR "${ERF_TEST_NRANKS}" STREQUAL "")
-    set(ERF_TEST_NRANKS 2 CACHE STRING "Number of MPI ranks to use for each test" FORCE)
+    set(ERF_TEST_NRANKS 2 CACHE STRING "Number of MPI ranks to use for each regression test" FORCE)
   else()
-    set(ERF_TEST_NRANKS "${ERF_TEST_NRANKS}" CACHE STRING "Number of MPI ranks to use for each test")
+    set(ERF_TEST_NRANKS "${ERF_TEST_NRANKS}" CACHE STRING "Number of MPI ranks to use for each regression test")
+  endif()
+
+  if(NOT DEFINED ERF_PARALLEL_TEST_NRANKS OR "${ERF_PARALLEL_TEST_NRANKS}" STREQUAL "")
+    set(ERF_PARALLEL_TEST_NRANKS "2" CACHE STRING
+        "Semicolon-separated MPI rank counts for parallel GoogleTest unit tests" FORCE)
+  else()
+    set(ERF_PARALLEL_TEST_NRANKS "${ERF_PARALLEL_TEST_NRANKS}" CACHE STRING
+        "Semicolon-separated MPI rank counts for parallel GoogleTest unit tests")
   endif()
 endif()
 

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -57,26 +57,18 @@ gtest_discover_tests(${erf_exe_name}
 )
 
 if(ERF_ENABLE_MPI)
-  find_package(MPI REQUIRED COMPONENTS CXX)
-
-  if(DEFINED ERF_TEST_NRANKS AND NOT "${ERF_TEST_NRANKS}" STREQUAL "")
-    set(erf_parallel_nprocs "${ERF_TEST_NRANKS}")
-  else()
-    set(erf_parallel_nprocs "2")
+  if(NOT TARGET MPI::MPI_CXX)
+    find_package(MPI REQUIRED COMPONENTS CXX)
   endif()
 
-  if(NOT "${erf_parallel_nprocs}" MATCHES "^[1-9][0-9]*$")
+  if(NOT MPIEXEC_EXECUTABLE)
     message(FATAL_ERROR
-      "ERF_TEST_NRANKS must be a positive integer; got '${erf_parallel_nprocs}'")
+      "MPIEXEC_EXECUTABLE is required to register parallel unit tests")
   endif()
 
-  if(erf_parallel_nprocs LESS 2)
-    message(FATAL_ERROR
-      "Parallel unit tests require at least 2 MPI ranks; got '${erf_parallel_nprocs}'")
+  if(NOT DEFINED ERF_PARALLEL_TEST_NRANKS OR "${ERF_PARALLEL_TEST_NRANKS}" STREQUAL "")
+    set(ERF_PARALLEL_TEST_NRANKS "2")
   endif()
-
-  set(erf_parallel_test_name
-      "${erf_parallel_exe_name}_np${erf_parallel_nprocs}")
 
   add_executable(${erf_parallel_exe_name})
   target_sources(${erf_parallel_exe_name}
@@ -92,24 +84,36 @@ if(ERF_ENABLE_MPI)
       GTest::gtest
       MPI::MPI_CXX
   )
-  target_compile_definitions(${erf_parallel_exe_name}
-    PRIVATE
-      ERF_PARALLEL_TEST_NPROCS=${erf_parallel_nprocs}
-  )
 
-  add_test(NAME ${erf_parallel_test_name}
-    COMMAND
-      ${MPIEXEC_EXECUTABLE}
-      ${MPIEXEC_NUMPROC_FLAG} ${erf_parallel_nprocs}
-      ${MPIEXEC_PREFLAGS}
-      $<TARGET_FILE:${erf_parallel_exe_name}>
-      ${MPIEXEC_POSTFLAGS}
-    COMMAND_EXPAND_LISTS
-  )
+  foreach(erf_parallel_nprocs IN LISTS ERF_PARALLEL_TEST_NRANKS)
+    if("${erf_parallel_nprocs}" STREQUAL "")
+      message(FATAL_ERROR
+        "ERF_PARALLEL_TEST_NRANKS contains an empty rank count")
+    endif()
 
-  set_tests_properties(${erf_parallel_test_name}
-    PROPERTIES
-      LABELS "parallel"
-      PROCESSORS ${erf_parallel_nprocs}
-  )
+    if(NOT "${erf_parallel_nprocs}" MATCHES "^[1-9][0-9]*$")
+      message(FATAL_ERROR
+        "ERF_PARALLEL_TEST_NRANKS entries must be positive integers; got '${erf_parallel_nprocs}'")
+    endif()
+
+    set(erf_parallel_test_name
+        "${erf_parallel_exe_name}_np${erf_parallel_nprocs}")
+
+    add_test(NAME ${erf_parallel_test_name}
+      COMMAND
+        ${MPIEXEC_EXECUTABLE}
+        ${MPIEXEC_NUMPROC_FLAG} ${erf_parallel_nprocs}
+        ${MPIEXEC_PREFLAGS}
+        $<TARGET_FILE:${erf_parallel_exe_name}>
+        ${MPIEXEC_POSTFLAGS}
+      COMMAND_EXPAND_LISTS
+    )
+
+    set_tests_properties(${erf_parallel_test_name}
+      PROPERTIES
+        LABELS "parallel"
+        PROCESSORS ${erf_parallel_nprocs}
+        ENVIRONMENT "ERF_PARALLEL_TEST_NPROCS=${erf_parallel_nprocs}"
+    )
+  endforeach()
 endif()

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -59,7 +59,24 @@ gtest_discover_tests(${erf_exe_name}
 if(ERF_ENABLE_MPI)
   find_package(MPI REQUIRED COMPONENTS CXX)
 
-  set(erf_parallel_nprocs ${ERF_TEST_NRANKS})
+  if(DEFINED ERF_TEST_NRANKS AND NOT "${ERF_TEST_NRANKS}" STREQUAL "")
+    set(erf_parallel_nprocs "${ERF_TEST_NRANKS}")
+  else()
+    set(erf_parallel_nprocs "2")
+  endif()
+
+  if(NOT "${erf_parallel_nprocs}" MATCHES "^[1-9][0-9]*$")
+    message(FATAL_ERROR
+      "ERF_TEST_NRANKS must be a positive integer; got '${erf_parallel_nprocs}'")
+  endif()
+
+  if(erf_parallel_nprocs LESS 2)
+    message(FATAL_ERROR
+      "Parallel unit tests require at least 2 MPI ranks; got '${erf_parallel_nprocs}'")
+  endif()
+
+  set(erf_parallel_test_name
+      "${erf_parallel_exe_name}_np${erf_parallel_nprocs}")
 
   add_executable(${erf_parallel_exe_name})
   target_sources(${erf_parallel_exe_name}
@@ -80,7 +97,7 @@ if(ERF_ENABLE_MPI)
       ERF_PARALLEL_TEST_NPROCS=${erf_parallel_nprocs}
   )
 
-  add_test(NAME ${erf_parallel_exe_name}_np${erf_parallel_nprocs}
+  add_test(NAME ${erf_parallel_test_name}
     COMMAND
       ${MPIEXEC_EXECUTABLE}
       ${MPIEXEC_NUMPROC_FLAG} ${erf_parallel_nprocs}
@@ -90,7 +107,7 @@ if(ERF_ENABLE_MPI)
     COMMAND_EXPAND_LISTS
   )
 
-  set_tests_properties(${erf_parallel_exe_name}_np${erf_parallel_nprocs}
+  set_tests_properties(${erf_parallel_test_name}
     PROPERTIES
       LABELS "parallel"
       PROCESSORS ${erf_parallel_nprocs}

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -70,6 +70,40 @@ if(ERF_ENABLE_MPI)
     set(ERF_PARALLEL_TEST_NRANKS "2")
   endif()
 
+  set(erf_parallel_test_mpiexec_preflags)
+
+  if(DEFINED ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS AND
+     NOT "${ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS}" STREQUAL "")
+    list(APPEND erf_parallel_test_mpiexec_preflags
+      ${ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS})
+  endif()
+
+  if(ERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE)
+    execute_process(
+      COMMAND ${MPIEXEC_EXECUTABLE} --version
+      OUTPUT_VARIABLE erf_mpiexec_version_out
+      ERROR_VARIABLE erf_mpiexec_version_err
+      RESULT_VARIABLE erf_mpiexec_version_result
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      ERROR_STRIP_TRAILING_WHITESPACE
+    )
+
+    string(TOLOWER
+      "${erf_mpiexec_version_out} ${erf_mpiexec_version_err}"
+      erf_mpiexec_version_text)
+
+    if(erf_mpiexec_version_result EQUAL 0 AND
+       erf_mpiexec_version_text MATCHES "open mpi|openrte|prrte")
+      list(APPEND erf_parallel_test_mpiexec_preflags
+        "--map-by" ":OVERSUBSCRIBE")
+      message(STATUS
+        "Parallel GoogleTest MPI oversubscription enabled for Open MPI/PRRTE")
+    else()
+      message(STATUS
+        "ERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE is ON, but mpiexec does not look like Open MPI/PRRTE; no oversubscribe flag was added.")
+    endif()
+  endif()
+
   add_executable(${erf_parallel_exe_name})
   target_sources(${erf_parallel_exe_name}
     PRIVATE
@@ -104,6 +138,7 @@ if(ERF_ENABLE_MPI)
         ${MPIEXEC_EXECUTABLE}
         ${MPIEXEC_NUMPROC_FLAG} ${erf_parallel_nprocs}
         ${MPIEXEC_PREFLAGS}
+        ${erf_parallel_test_mpiexec_preflags}
         $<TARGET_FILE:${erf_parallel_exe_name}>
         ${MPIEXEC_POSTFLAGS}
       COMMAND_EXPAND_LISTS

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -24,6 +24,7 @@ endif()
 
 set(erf_lib_name erf_srclib)
 set(erf_exe_name erf_unit_tests)
+set(erf_parallel_exe_name erf_parallel_tests)
 
 add_executable(${erf_exe_name})
 target_sources(${erf_exe_name}
@@ -45,7 +46,7 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/Kessler/ERF_GTestKesslerKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/Kessler/ERF_GTestKesslerPhysicalProperties.cpp
 )
-build_erf_exe(${erf_exe_name})
+build_erf_exe(${erf_exe_name} NO_ERF_MAIN)
 target_link_libraries(${erf_exe_name} PRIVATE GTest::gtest)
 
 include(GoogleTest)
@@ -54,3 +55,44 @@ gtest_discover_tests(${erf_exe_name}
   PROPERTIES
     LABELS "unit"
 )
+
+if(ERF_ENABLE_MPI)
+  find_package(MPI REQUIRED COMPONENTS CXX)
+
+  set(erf_parallel_nprocs ${ERF_TEST_NRANKS})
+
+  add_executable(${erf_parallel_exe_name})
+  target_sources(${erf_parallel_exe_name}
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/Exec/ERF_Prob.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestParallelMain.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestParallelHelloWorld.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
+  )
+  build_erf_exe(${erf_parallel_exe_name} NO_ERF_MAIN)
+  target_link_libraries(${erf_parallel_exe_name}
+    PRIVATE
+      GTest::gtest
+      MPI::MPI_CXX
+  )
+  target_compile_definitions(${erf_parallel_exe_name}
+    PRIVATE
+      ERF_PARALLEL_TEST_NPROCS=${erf_parallel_nprocs}
+  )
+
+  add_test(NAME ${erf_parallel_exe_name}_np${erf_parallel_nprocs}
+    COMMAND
+      ${MPIEXEC_EXECUTABLE}
+      ${MPIEXEC_NUMPROC_FLAG} ${erf_parallel_nprocs}
+      ${MPIEXEC_PREFLAGS}
+      $<TARGET_FILE:${erf_parallel_exe_name}>
+      ${MPIEXEC_POSTFLAGS}
+    COMMAND_EXPAND_LISTS
+  )
+
+  set_tests_properties(${erf_parallel_exe_name}_np${erf_parallel_nprocs}
+    PROPERTIES
+      LABELS "parallel"
+      PROCESSORS ${erf_parallel_nprocs}
+  )
+endif()

--- a/Tests/Unit/ERF_GTestParallelHelloWorld.cpp
+++ b/Tests/Unit/ERF_GTestParallelHelloWorld.cpp
@@ -3,9 +3,7 @@
 
 #include <gtest/gtest.h>
 
-#ifndef ERF_PARALLEL_TEST_NPROCS
-#define ERF_PARALLEL_TEST_NPROCS 2
-#endif
+#include <cstdlib>
 
 TEST(ParallelEnvironment, HelloWorld)
 {
@@ -14,8 +12,16 @@ TEST(ParallelEnvironment, HelloWorld)
 
     EXPECT_GE(my_rank, 0);
     EXPECT_LT(my_rank, n_ranks);
+    EXPECT_GE(n_ranks, 1);
 
-    EXPECT_EQ(n_ranks, ERF_PARALLEL_TEST_NPROCS);
+    if (const char* expected = std::getenv("ERF_PARALLEL_TEST_NPROCS")) {
+        char* end = nullptr;
+        const long expected_nprocs = std::strtol(expected, &end, 10);
+        ASSERT_NE(end, expected);
+        ASSERT_EQ(*end, '\0');
+        EXPECT_GT(expected_nprocs, 0);
+        EXPECT_EQ(n_ranks, expected_nprocs);
+    }
 
     int local_val = 1;
     amrex::ParallelDescriptor::ReduceIntSum(local_val);

--- a/Tests/Unit/ERF_GTestParallelHelloWorld.cpp
+++ b/Tests/Unit/ERF_GTestParallelHelloWorld.cpp
@@ -1,0 +1,24 @@
+#include <AMReX.H>
+#include <AMReX_ParallelDescriptor.H>
+
+#include <gtest/gtest.h>
+
+#ifndef ERF_PARALLEL_TEST_NPROCS
+#define ERF_PARALLEL_TEST_NPROCS 2
+#endif
+
+TEST(ParallelEnvironment, HelloWorld)
+{
+    const int my_rank = amrex::ParallelDescriptor::MyProc();
+    const int n_ranks = amrex::ParallelDescriptor::NProcs();
+
+    EXPECT_GE(my_rank, 0);
+    EXPECT_LT(my_rank, n_ranks);
+
+    EXPECT_EQ(n_ranks, ERF_PARALLEL_TEST_NPROCS);
+
+    int local_val = 1;
+    amrex::ParallelDescriptor::ReduceIntSum(local_val);
+
+    EXPECT_EQ(local_val, n_ranks);
+}

--- a/Tests/Unit/ERF_GTestParallelMain.cpp
+++ b/Tests/Unit/ERF_GTestParallelMain.cpp
@@ -1,0 +1,38 @@
+#include <AMReX.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_ccse-mpi.H>
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+int
+main (int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+
+    int provided = MPI_THREAD_SINGLE;
+    MPI_Init_thread(&argc, &argv, MPI_THREAD_FUNNELED, &provided);
+
+    int rank = 0;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    amrex::Initialize(argc, argv, true, MPI_COMM_WORLD);
+
+    auto& listeners = ::testing::UnitTest::GetInstance()->listeners();
+
+    if (rank != 0 && std::getenv("ERF_GTEST_VERBOSE_RANKS") == nullptr) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+
+    const int local_result = RUN_ALL_TESTS();
+
+    int global_result = local_result;
+    MPI_Allreduce(MPI_IN_PLACE, &global_result, 1, MPI_INT, MPI_MAX,
+                  MPI_COMM_WORLD);
+
+    amrex::Finalize();
+    MPI_Finalize();
+
+    return global_result;
+}


### PR DESCRIPTION
## Summary

This PR adds the first layer of an MPI-aware unit-test framework for ERF.

It introduces a separate `erf_parallel_tests` executable that initializes MPI and AMReX once, runs GoogleTest tests on all ranks, and reports a failure if any rank fails. The new executable is registered with CTest and runs in CPU CI on 1, 2, and 4 MPI ranks.

The first test is deliberately small. It checks that AMReX sees the expected number of ranks and that a simple parallel reduction returns the expected result. Its main purpose is to prove that the framework works: we can now add focused tests for distributed AMReX objects and communication paths without changing the serial unit-test executable.

This is a test-only change. It does not change model code, numerical methods, inputs, outputs, or runtime behavior. Results should remain bit-for-bit unchanged.

## Motivation

Many ERF components rely on MPI and AMReX for correct parallel behavior. Serial unit tests can check scalar formulas and single-process kernels, but they cannot test communication, distributed ownership, rank-dependent behavior, or ghost-cell exchange.

This PR creates the harness we need for those tests.

The new framework gives future tests a safe place to exercise parallel contracts such as:

- `MultiFab` construction and ownership,
- ghost-cell fill behavior,
- boundary exchange,
- parallel reductions,
- decomposition-sensitive operations,
- host/device behavior inside MPI-launched tests.

The first smoke test is intentionally simple. It keeps this PR low risk while establishing the pattern for future parallel tests.

Running the framework on 1, 2, and 4 ranks is useful because each case checks a different path:

- 1 rank checks the MPI-initialized path without inter-rank communication.
- 2 ranks checks the smallest real communication case.
- 4 ranks gives broader coverage of decomposition and neighbor patterns.

Some GitHub runners expose fewer MPI slots than the requested rank count. CPU CI therefore allows oversubscription for this small parallel unit-test executable only. Regression tests keep their existing MPI launch settings.

## Details

- Add `erf_parallel_tests` as a separate MPI-backed GoogleTest executable.
- Add a custom test `main` that initializes MPI and AMReX once.
- Run tests on all ranks and reduce the test status across ranks.
- Suppress normal non-root GoogleTest output by default to keep CI logs readable.
- Register one CTest entry per configured rank count.
- Add `ERF_PARALLEL_TEST_NRANKS` for parallel unit-test rank sweeps.
- Keep `ERF_TEST_NRANKS` for regression tests.
- Run the parallel unit-test framework on 1, 2, and 4 ranks in CPU CI.
- Add a parallel-test-only oversubscription option for GitHub-hosted CPU runners.
- Leave CUDA, HIP, and SYCL rank behavior unchanged unless those workflows opt in later.

## BFB

Expected BFB: yes.

This PR changes only test infrastructure and CI configuration. It does not change production source code, algorithms, constants, inputs, or output routines.

