### PR TITLE
RRTMGP Memory Allocation

### DIFF
--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -87,6 +87,8 @@ public:
             m_col_offsets[mfi.index()] = m_ncol;
             m_ncol += nx * ny;
         }
+
+        m_ncol_chunk = amrex::min(m_ncol, m_ncol_chunk);
     };
 
     virtual
@@ -371,7 +373,7 @@ private:
     int m_rad_freq_in_steps = 1;
 
     // Number of columns to process per RRTMGP chunk (controls peak memory)
-    int m_ncol_chunk = 5000;
+    int m_ncol_chunk = 1024;
 
     // Whether or not to do subcolumn sampling of cloud state for MCICA
     bool m_do_subcol_sampling = true;


### PR DESCRIPTION
# Summary

This PR corrects a memory allocation issue with RRTMGP. The column chunking approach uses a default value of `5000`, which implies a grid with lateral sizes `~70`. This assumption can lead to massive over allocation and kill GPU simulations. To correct the issue, the default value is set to `1024`, which is the size of a warp and corresponds to a `32^2` grid. Then the min of the default value and the `m_ncol` is employed to keep from over allocating when many ranks are employed.