### PR TITLE
Fix gtest discovery and GPU math portability

### DIFF
--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -87,8 +87,10 @@ if(ERF_ENABLE_MPI)
 
   if(DEFINED ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS AND
      NOT "${ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS}" STREQUAL "")
+    separate_arguments(erf_parallel_test_user_mpiexec_preflags
+      UNIX_COMMAND "${ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS}")
     list(APPEND erf_parallel_test_mpiexec_preflags
-      ${ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS})
+      ${erf_parallel_test_user_mpiexec_preflags})
   endif()
 
   if(ERF_PARALLEL_TEST_ALLOW_OVERSUBSCRIBE)

--- a/Tests/Unit/ERF_GTestMain.cpp
+++ b/Tests/Unit/ERF_GTestMain.cpp
@@ -1,4 +1,7 @@
 #include <AMReX.H>
+
+#include <cstdio>
+#include <cstdlib>
 #include <gtest/gtest.h>
 
 int
@@ -7,12 +10,15 @@ main (int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
 
     // When invoked with --gtest_list_tests (gtest_discover_tests prints the
-    // test list this way), skip amrex::Initialize so we don't hang the MPI/GPU
-    // runtime, and use std::_Exit to skip static destructors that can block on
-    // Cray MPICH atexit handlers.
+    // test list this way and CMake consumes it from stdout), skip
+    // amrex::Initialize so we don't hang the MPI/GPU runtime, and use
+    // std::_Exit to skip static destructors that can block on Cray MPICH
+    // atexit handlers. Flush stdio first because _Exit bypasses normal stream
+    // cleanup.
     if (::testing::GTEST_FLAG(list_tests))
     {
         const int list_result = RUN_ALL_TESTS();
+        std::fflush(nullptr);
         std::_Exit(list_result);
     }
 

--- a/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationCommon.H
+++ b/Tests/Unit/Utils/Interpolation/ERF_GTestInterpolationCommon.H
@@ -582,8 +582,8 @@ amrex::Real upwind3sl_reference_flux (const amrex::Real sp1,
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real smooth_periodic_function (const amrex::Real x)
 {
-    const amrex::Real two_pi = amrex::Real(2.0) * std::acos(amrex::Real(-1.0));
-    return std::sin(two_pi * x) + amrex::Real(0.25) * std::cos(amrex::Real(3.0) * two_pi * x);
+    return amrex::Math::sinpi(amrex::Real(2.0) * x) +
+           amrex::Real(0.25) * amrex::Math::cospi(amrex::Real(6.0) * x);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -593,13 +593,16 @@ amrex::Real smooth_periodic_cell_average (const int cell,
     const amrex::Real dx = amrex::Real(1.0) / amrex::Real(num_cells);
     const amrex::Real x_lo = dx * amrex::Real(cell);
     const amrex::Real x_hi = x_lo + dx;
-    const amrex::Real two_pi = amrex::Real(2.0) * std::acos(amrex::Real(-1.0));
-    const amrex::Real six_pi = amrex::Real(3.0) * two_pi;
+    const amrex::Real pi = amrex::Math::pi<amrex::Real>();
 
-    const amrex::Real avg_sin = (std::cos(two_pi * x_lo) - std::cos(two_pi * x_hi)) /
-                                (two_pi * dx);
-    const amrex::Real avg_cos = (std::sin(six_pi * x_hi) - std::sin(six_pi * x_lo)) /
-                                (six_pi * dx);
+    const amrex::Real avg_sin =
+        (amrex::Math::cospi(amrex::Real(2.0) * x_lo) -
+         amrex::Math::cospi(amrex::Real(2.0) * x_hi)) /
+        (amrex::Real(2.0) * pi * dx);
+    const amrex::Real avg_cos =
+        (amrex::Math::sinpi(amrex::Real(6.0) * x_hi) -
+         amrex::Math::sinpi(amrex::Real(6.0) * x_lo)) /
+        (amrex::Real(6.0) * pi * dx);
     return avg_sin + amrex::Real(0.25) * avg_cos;
 }
 


### PR DESCRIPTION
## Summary

This PR fixes follow-up portability issues from the recent GitLab CI/gtest updates.

It makes three focused changes:

- flushes stdio before using `std::_Exit` in the `--gtest_list_tests` path, so CMake/GoogleTest discovery can reliably consume the test list while still avoiding AMReX/MPI/GPU teardown hangs on affected systems;
- replaces host `std` trigonometric calls in GPU-qualified interpolation test helpers with AMReX device-aware math helpers;
- splits `ERF_PARALLEL_TEST_MPIEXEC_PREFLAGS` before appending it to the CTest MPI launch command, matching the handling of the standard MPI launcher variables.

## Motivation

The prior CI/gtest change (PR #3228) intentionally skipped `amrex::Initialize` during GoogleTest discovery and used `_Exit` to avoid runtime teardown hangs. Since `_Exit` bypasses normal stream cleanup, the test-listing path should explicitly flush stdout/stderr first.

The interpolation smooth-periodic helpers are marked `AMREX_GPU_HOST_DEVICE`, so their trigonometric calls should use AMReX math utilities rather than host-only `std` calls.

The MPI launcher handling already split standard MPI variables for CTest, but user-provided MPI preflags still needed the same treatment.