### PR TITLE
Fixes GPU portability bugs in the SatAdj unit tests.

### DIFF
--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjBoxCoverage.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjBoxCoverage.cpp
@@ -91,27 +91,6 @@ void run_kessler_norain_public_flow (Kessler& kessler,
     });
 }
 
-void poison_ghost_cells (amrex::MultiFab& mf,
-                         const std::initializer_list<int>& components,
-                         const amrex::Real sentinel)
-{
-    for (amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& fab_box = mfi.fabbox();
-        const amrex::Box& valid_box = mfi.validbox();
-        auto arr = mf.array(mfi);
-
-        run_and_sync([=] {
-            amrex::ParallelFor(fab_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                if (!valid_box.contains(amrex::IntVect(AMREX_D_DECL(i, j, k)))) {
-                    for (const int comp : components) {
-                        arr(i,j,k,comp) = sentinel;
-                    }
-                }
-            });
-        });
-    }
-}
-
 int wrap_index (int idx,
                 const int lo,
                 const int hi)
@@ -406,7 +385,7 @@ TEST(SatAdjBoxCoverage, PeriodicGhostFillAfterFullPublicFlow)
     });
 
     poison_ghost_cells(cons,
-                       {Rho_comp, RhoTheta_comp, RhoQ1_comp, RhoQ2_comp},
+                       amrex::GpuArray<int, 4>{Rho_comp, RhoTheta_comp, RhoQ1_comp, RhoQ2_comp},
                        amrex::Real(-999.0));
 
     run_and_sync([&]() { satadj.Copy_Micro_to_State(cons); });

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjCommon.H
@@ -350,6 +350,30 @@ inline void run_and_sync (F&& f)
     sync();
 }
 
+template <unsigned int N>
+inline void poison_ghost_cells (amrex::MultiFab& mf,
+                                const amrex::GpuArray<int, N>& components,
+                                const amrex::Real sentinel)
+{
+    const amrex::GpuArray<int, N> comps = components;
+
+    for (amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box fab_box = mfi.fabbox();
+        const amrex::Box valid_box = mfi.validbox();
+        auto arr = mf.array(mfi);
+
+        run_and_sync([=] {
+            amrex::ParallelFor(fab_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                if (!valid_box.contains(amrex::IntVect(AMREX_D_DECL(i, j, k)))) {
+                    for (unsigned int n = 0; n < N; ++n) {
+                        arr(i,j,k,comps[n]) = sentinel;
+                    }
+                }
+            });
+        });
+    }
+}
+
 inline amrex::BoxArray make_boxarray (const amrex::Box& domain)
 {
     return amrex::BoxArray(domain);

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjParallel.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjParallel.cpp
@@ -52,27 +52,6 @@ int wrap_index (int idx,
     return idx;
 }
 
-void poison_ghost_cells (amrex::MultiFab& mf,
-                         const std::initializer_list<int>& components,
-                         const amrex::Real sentinel)
-{
-    for (amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const amrex::Box& fab_box = mfi.fabbox();
-        const amrex::Box& valid_box = mfi.validbox();
-        auto arr = mf.array(mfi);
-
-        run_and_sync([=] {
-            amrex::ParallelFor(fab_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                if (!valid_box.contains(amrex::IntVect(AMREX_D_DECL(i, j, k)))) {
-                    for (const int comp : components) {
-                        arr(i,j,k,comp) = sentinel;
-                    }
-                }
-            });
-        });
-    }
-}
-
 amrex::Real expected_full_flow_component (const int component,
                                      const int i,
                                      const int j,
@@ -197,7 +176,7 @@ TEST(SatAdjParallel, FullPublicFlowFillBoundaryParallel)
     });
 
     poison_ghost_cells(cons,
-                       {Rho_comp, RhoTheta_comp, RhoQ1_comp, RhoQ2_comp},
+                       amrex::GpuArray<int, 4>{Rho_comp, RhoTheta_comp, RhoQ1_comp, RhoQ2_comp},
                        amrex::Real(-999.0));
 
     run_and_sync([&]() { satadj.Copy_Micro_to_State(cons); });

--- a/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjTemperatureDiagnostics.cpp
+++ b/Tests/Unit/Microphysics/SatAdj/ERF_GTestSatAdjTemperatureDiagnostics.cpp
@@ -197,18 +197,25 @@ TEST(SatAdjTemperatureDiagnostics, ProductionMoistDerivedTemperatureMatchesEOSPr
     const amrex::BoxArray ba = make_boxarray(geom.Domain(), amrex::IntVect(AMREX_D_DECL(4, 4, 2)));
     const amrex::DistributionMapping dm(ba);
     amrex::MultiFab cons(ba, dm, RhoQ2_comp + 1, 0);
+    amrex::MultiFab der(ba, dm, 1, 0);
+    amrex::MultiFab zcc(ba, dm, 1, 0);
     fill_conserved_state_portable(cons);
+    zcc.setVal(amrex::Real(0.0));
 
     for (amrex::MFIter mfi(cons); mfi.isValid(); ++mfi) {
-        const amrex::Box bx = mfi.validbox();
-        amrex::FArrayBox derfab(bx, 1);
-        amrex::FArrayBox zfab(bx, 1);  // unused by erf_dermoisttemp
-        derived::erf_dermoisttemp(bx, derfab, 0, 1, cons[mfi], zfab, geom,
+        const amrex::Box& bx = mfi.validbox();
+        derived::erf_dermoisttemp(bx, der[mfi], 0, 1, cons[mfi], zcc[mfi], geom,
                                   amrex::Real(0.0), nullptr, 0);
-        amrex::Gpu::streamSynchronize();
+    }
+    satadj_test::sync();
 
-        const auto der = derfab.const_array();
-        const auto dat = cons[mfi].const_array();
+    const amrex::MultiFab der_host = make_host_mirror(der);
+    const amrex::MultiFab cons_host = make_host_mirror(cons);
+
+    for (amrex::MFIter mfi(cons_host); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.validbox();
+        const auto der_arr = der_host.const_array(mfi);
+        const auto dat = cons_host.const_array(mfi);
         for (int k = bx.smallEnd(2); k <= bx.bigEnd(2); ++k) {
             for (int j = bx.smallEnd(1); j <= bx.bigEnd(1); ++j) {
                 for (int i = bx.smallEnd(0); i <= bx.bigEnd(0); ++i) {
@@ -216,7 +223,7 @@ TEST(SatAdjTemperatureDiagnostics, ProductionMoistDerivedTemperatureMatchesEOSPr
                     const amrex::Real rhotheta = dat(i, j, k, RhoTheta_comp);
                     const amrex::Real qv = dat(i, j, k, RhoQ1_comp) / rho;
                     const amrex::Real expected = getTgivenRandRTh(rho, rhotheta, qv);
-                    const amrex::Real actual = der(i, j, k);
+                    const amrex::Real actual = der_arr(i, j, k);
                     EXPECT_NEAR(actual, expected,
                                 derived_temperature_tol(expected))
                         << "i=" << i << " j=" << j << " k=" << k


### PR DESCRIPTION
## Summary

This PR fixes GPU portability bugs in the SatAdj unit tests. See comments to #3232. 

It makes three focused changes:

- replaces duplicated `std::initializer_list` ghost-cell poisoning helpers with one shared `amrex::GpuArray` helper;
- updates the serial and parallel SatAdj ghost-fill tests to use that device-safe helper;
- rewrites the moist-temperature diagnostic test so host-side checks read host mirrors, not device-resident data.

## Motivation

CUDA and HIP CI reported illegal GPU memory accesses in the SatAdj ghost-fill tests. CUDA also exposed a segfault in the moist-temperature diagnostic test.

These were test portability bugs. The ghost-fill tests captured host-only initializer-list state in GPU lambdas. The diagnostic test read data on the host after a GPU kernel wrote it.

## Impact

This PR changes test code only. It does not change production model code, numerical algorithms, or physics. It should not affect BFB results or model solutions.

The tests keep the same coverage and assertions. They only change how test data moves across host and device.
