### PR TITLE
Change from hoextrap to foextrap for scalars at bottom boundary when …

### DIFF
--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -675,7 +675,7 @@ void ERF::init_bcs ()
             {
                 AMREX_ALWAYS_ASSERT(dir == 2 && side == Orientation::low);
                 for (int i = 0; i < NBCVAR_max; i++) {
-                    domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::hoextrap);
+                    domain_bcs_type[BCVars::cons_bc+i].setLo(dir, ERFBCType::foextrap);
                 }
                 if (keqn_dir) {
                     Print() << "Setting surface layer logical BC to dirichlet for RANS with k model" << std::endl;


### PR DESCRIPTION
…using surface layer