### PR TITLE
BDY Interp Restart

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1130,6 +1130,19 @@ ERF::InitData_post ()
 
             int ntimes = std::min(n_time_old+3, static_cast<int>(bdy_data_xlo.size()));
 
+            // Need itime=0 for vertical interpolation
+            if (n_time_old>0) {
+                int itime = 0;
+                amrex::Print() << "READING IN BDY " << itime << std::endl;
+                read_from_wrfbdy(itime,nc_bdy_file,geom[0].Domain(),
+                                 bdy_data_xlo,bdy_data_xhi,bdy_data_ylo,bdy_data_yhi,
+                                 real_width);
+                convert_all_wrfbdy_data(itime, geom[0].Domain(), bdy_data_xlo, bdy_data_xhi, bdy_data_ylo, bdy_data_yhi,
+                                        *mf_MUB, *mf_C1H, *mf_C2H,
+                                        vars_new[lev][Vars::xvel], vars_new[lev][Vars::yvel], vars_new[lev][Vars::cons],
+                                        geom[lev], use_moist, wrf_PHB, z_phys_nd[0]);
+            }
+
             for (int itime = n_time_old; itime < ntimes; itime++)
             {
                 amrex::Print() << "READING IN BDY " << itime << std::endl;

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -387,7 +387,7 @@ ERF::WriteCheckpointFile () const
 
         if (solverChoice.use_real_bcs && solverChoice.init_type == InitType::WRFInput) {
             if (lev == 0) {
-                amrex::Print() << "Writing C1H/C2H/MUB variables at level " << lev << std::endl;
+                amrex::Print() << "Writing C1H/C2H/MUB/PHB variables at level " << lev << std::endl;
                 MultiFab tmp1d(ba1d[0],dmap[0],1,0);
 
                 MultiFab::Copy(tmp1d,*mf_C1H,0,0,1,0);
@@ -397,9 +397,12 @@ ERF::WriteCheckpointFile () const
                 VisMF::Write(tmp1d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "C2H"));
 
                 MultiFab tmp2d(ba2d[0],dmap[0],1,mf_MUB->nGrowVect());
-
                 MultiFab::Copy(tmp2d,*mf_MUB,0,0,1,mf_MUB->nGrowVect());
                 VisMF::Write(tmp2d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MUB"));
+
+                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
+                MultiFab::Copy(tmp3d,*wrf_PHB,0,0,1,0);
+                VisMF::Write(tmp3d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "PHB"));
             }
         }
 #endif
@@ -943,6 +946,7 @@ ERF::ReadCheckpointFile ()
 
         if (solverChoice.use_real_bcs && solverChoice.init_type == InitType::WRFInput) {
             if (lev == 0) {
+                amrex::Print() << "Reading C1H/C2H/MUB/PHB variables at level " << lev << std::endl;
                 MultiFab tmp1d(ba1d[0],dmap[0],1,0);
 
                 VisMF::Read(tmp1d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "C1H"));
@@ -955,6 +959,11 @@ ERF::ReadCheckpointFile ()
 
                 VisMF::Read(tmp2d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "MUB"));
                 MultiFab::Copy(*mf_MUB,tmp2d,0,0,1,mf_MUB->nGrowVect());
+
+                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
+                wrf_PHB = std::make_unique<MultiFab>(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
+                VisMF::Read(tmp3d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "PHB"));
+                MultiFab::Copy(*wrf_PHB,tmp3d,0,0,1,0);
             }
         }
 #endif


### PR DESCRIPTION
# Summary
We must always read the BDY data at `itime=0` when restarting since it provides the heights for interpolation. Additionally, the PHB variables must be written and read from the chk file.