### PR TITLE
Substep ERF with NOAH-MP

### DIFF
--- a/.codespell-ignore-words
+++ b/.codespell-ignore-words
@@ -22,3 +22,5 @@ ptd
 Yau
 pigen
 ist
+emiss
+BTYE

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -393,6 +393,7 @@ public:
                       amrex::MultiFab& cons_in,
                       amrex::MultiFab& xvel_in,
                       amrex::MultiFab& yvel_in,
+                      const amrex::Real& time,
                       const amrex::Real& dt_advance);
 
     void advance_radiation (int lev,

--- a/Source/LandSurfaceModel/ERF_LandSurface.H
+++ b/Source/LandSurfaceModel/ERF_LandSurface.H
@@ -56,10 +56,12 @@ public:
              amrex::MultiFab& yvel_in,
              amrex::MultiFab* hfx3_out,
              amrex::MultiFab* qfx3_out,
+             const amrex::Real& time,
              const amrex::Real& dt_advance,
              const int& nstep)
     {
-        m_lsm_model[lev]->Advance_With_State(lev, cons_in, xvel_in, yvel_in, hfx3_out, qfx3_out, dt_advance, nstep);
+        m_lsm_model[lev]->Advance_With_State(lev, cons_in, xvel_in, yvel_in,
+                                             hfx3_out, qfx3_out, time, dt_advance, nstep);
     }
 
     void

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
@@ -83,6 +83,7 @@ public:
                         amrex::MultiFab& yvel_in,
                         amrex::MultiFab* hfx3_out,
                         amrex::MultiFab* qfx3_out,
+                        const amrex::Real& elapsed_time,
                         const amrex::Real& dt,
                         const int& nstep) override;
 

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -205,9 +205,10 @@ NOAHMP::Init (const int& lev,
         // Write initial plotfile for land with the tag 0
         Print() << "Noah-MP writing lnd.nc file at lev: " << lev << std::endl;
         noahmpio->WriteLand(0);
-  }
+    }
+    AMREX_ALWAYS_ASSERT(m_dt <= noahmpio_vect[0].DTBL);
 
-  Print() << "Noah-MP initialization completed" << std::endl;
+    Print() << "Noah-MP initialization completed" << std::endl;
 
 };
 
@@ -226,9 +227,13 @@ NOAHMP::Advance_With_State (const int& lev,
                             MultiFab& yvel_in,
                             MultiFab* /*hfx3_out*/,
                             MultiFab* /*qfx3_out*/,
+                            const Real& elapsed_time,
                             const Real& dt,
                             const int& nstep)
 {
+    // Verify we need to take another LSM step
+    Real NOAH_time = static_cast<Real>(noahmpio_vect[0].itimestep-1) * static_cast<Real>(noahmpio_vect[0].DTBL);
+    if (elapsed_time < NOAH_time) { return; }
 
     Box domain = m_geom.Domain();
 
@@ -355,7 +360,7 @@ NOAHMP::Advance_With_State (const int& lev,
 
         // Call the noahmpio driver code. This runs the land model forcing for
         // each object in noahmpio_vect that represent a block in the domain.
-        noahmpio->itimestep = nstep+1;
+        noahmpio->itimestep += 1;
         noahmpio->DriverMain();
 
         // Copy results from NoahmpIO back to temporary arrays

--- a/Source/LandSurfaceModel/Null/ERF_NullSurf.H
+++ b/Source/LandSurfaceModel/Null/ERF_NullSurf.H
@@ -34,6 +34,7 @@ class NullSurf {
                         amrex::MultiFab& /*yvel_in*/,
                         amrex::MultiFab* /*hfx3_out*/,
                         amrex::MultiFab* /*qfx3_out*/,
+                        const amrex::Real& /*elapsed_time*/,
                         const amrex::Real& /*dt_advance*/,
                         const int& /*nstep*/) { }
 

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -283,13 +283,14 @@ ERF::Advance (int lev, Real time, Real dt_lev, int iteration, int /*ncycle*/)
     // **************************************************************************************
     // Update the land surface model
     // **************************************************************************************
-    advance_lsm(lev, S_new, U_new, V_new, dt_lev);
+    Real time_at_end_of_step = time+dt_lev;
+    advance_lsm(lev, S_new, U_new, V_new, time_at_end_of_step, dt_lev);
 
 #ifdef ERF_USE_PARTICLES
     // **************************************************************************************
     // Update the particle positions
     // **************************************************************************************
-   evolveTracers( lev, dt_lev, vars_new, z_phys_nd );
+   evolveTracers(lev, dt_lev, vars_new, z_phys_nd);
 #endif
 
     // ***********************************************************************************************

--- a/Source/TimeIntegration/ERF_AdvanceLSM.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceLSM.cpp
@@ -6,11 +6,14 @@ void ERF::advance_lsm (int lev,
                        MultiFab& cons_in,
                        MultiFab& xvel_in,
                        MultiFab& yvel_in,
+                       const Real& time,
                        const Real& dt_advance)
 {
     if (solverChoice.lsm_type != LandSurfaceType::None) {
         if (solverChoice.lsm_type == LandSurfaceType::NOAHMP) {
-            lsm.Advance(lev, cons_in, xvel_in, yvel_in, SFS_hfx3_lev[lev].get(), SFS_q1fx3_lev[lev].get(), dt_advance, istep[0]);
+            lsm.Advance(lev, cons_in, xvel_in, yvel_in,
+                        SFS_hfx3_lev[lev].get(), SFS_q1fx3_lev[lev].get(),
+                        time, dt_advance, istep[0]);
         } else {
             lsm.Advance(lev, dt_advance);
         }


### PR DESCRIPTION
# Summary
This PR bumps the noah-mp submodule to pick up [PR 7](https://github.com/erf-model/noahmp/pull/7). The aforementioned change to noah exposes the lsm time step `DTBL`. This PR does sanity checking and allows ERF to run at smaller timesteps than the LSM.

## Possible future improvement
1. Perfectly time sync the two codes (accumulate time and/or modify noah time step)
2. Time average the forcings going to noah
3. Store old and new fluxes from Noah and pass a time interpolated value to the surface layer