### PR TITLE
WPS Restart Fix

### DIFF
--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -401,8 +401,9 @@ ERF::WriteCheckpointFile () const
                 MultiFab::Copy(tmp2d,*wrf_MUB,0,0,1,wrf_MUB->nGrowVect());
                 VisMF::Write(tmp2d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "MUB"));
 
-                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
-                MultiFab::Copy(tmp3d,*wrf_PHB,0,0,1,0);
+                ng = IntVect(1,1,0);
+                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,ng);
+                MultiFab::Copy(tmp3d,*wrf_PHB,0,0,1,ng);
                 VisMF::Write(tmp3d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "PHB"));
             }
         }
@@ -961,10 +962,11 @@ ERF::ReadCheckpointFile ()
                 VisMF::Read(tmp2d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "MUB"));
                 MultiFab::Copy(*wrf_MUB,tmp2d,0,0,1,wrf_MUB->nGrowVect());
 
-                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
-                wrf_PHB = std::make_unique<MultiFab>(convert(grids[0],IntVect(0,0,1)),dmap[0],1,0);
+                ng = IntVect(1,1,0);
+                MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,ng);
+                wrf_PHB = std::make_unique<MultiFab>(convert(grids[0],IntVect(0,0,1)),dmap[0],1,ng);
                 VisMF::Read(tmp3d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "PHB"));
-                MultiFab::Copy(*wrf_PHB,tmp3d,0,0,1,0);
+                MultiFab::Copy(*wrf_PHB,tmp3d,0,0,1,ng);
             }
         }
 #endif

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -555,6 +555,10 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
                 var_fab.clear();
             } // valid var (not rho)
 
+          bool lat_periodic = (geom[lev].isPeriodic(0) && geom[lev].isPeriodic(1));
+          int i_lo = boxes_at_level[lev][0].smallEnd(0); int i_hi = boxes_at_level[lev][0].bigEnd(0);
+          int j_lo = boxes_at_level[lev][0].smallEnd(1); int j_hi = boxes_at_level[lev][0].bigEnd(1);
+
           if ( var_name == "PH" ) {
               if (success) {
                   auto& ba_w = lev_new[Vars::zvel].boxArray();
@@ -574,15 +578,23 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
               }
           } else if ( var_name == "PHB" ) {
               if (success) {
+                  // NOTE: We call FillBoundary on wrf_PHB below
                   auto& ba_w = lev_new[Vars::zvel].boxArray();
-                  wrf_PHB = std::make_unique<MultiFab>(ba_w, dm, 1, ngz);
+                  wrf_PHB = std::make_unique<MultiFab>(ba_w, dm, 1, IntVect(1,1,0));
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
                   for ( MFIter mfi(*wrf_PHB, false); mfi.isValid(); ++mfi )
                   {
-                      FArrayBox &cur_fab = (*wrf_PHB)[mfi];
-                      cur_fab.template copy<RunOn::Device>(var_fab, 0, 0, 1);
+                      Box gtbx = mfi.growntilebox();
+                      const Array4<      Real>& dst_arr = wrf_PHB->array(mfi);
+                      const Array4<const Real>& src_arr = var_fab.const_array();
+                      ParallelFor(gtbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                      {
+                          int li = amrex::min(amrex::max(i, i_lo), i_hi);
+                          int lj = amrex::min(amrex::max(j, j_lo), j_hi);
+                          dst_arr(i,j,k) = src_arr(li,lj,k);
+                      });
                   }
                   var_fab.clear();
               } else {
@@ -652,10 +664,6 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
               }
               var_fab.clear();
           }
-
-          bool lat_periodic = (geom[lev].isPeriodic(0) && geom[lev].isPeriodic(1));
-          int i_lo = boxes_at_level[lev][0].smallEnd(0); int i_hi = boxes_at_level[lev][0].bigEnd(0);
-          int j_lo = boxes_at_level[lev][0].smallEnd(1); int j_hi = boxes_at_level[lev][0].bigEnd(1);
 
           // Initialize Latitude & Coriolis factors
           if ( var_name == "XLAT_V" ) {


### PR DESCRIPTION
# Summary
The BDY interpolation required ERF to store the base geopotential (PHB). However, due to the staggering of variables being interpolated, we need one ghost cell in PHB and we need to read/write those from the checkpoint file.