### PR TITLE
Docs & RRTMGP nvar

### DIFF
--- a/Docs/sphinx_doc/BoundaryConditions.rst
+++ b/Docs/sphinx_doc/BoundaryConditions.rst
@@ -194,16 +194,12 @@ Real Domain BCs
 ----------------------
 
 When using real lateral boundary conditions, time-dependent observation data is read
-from a file. In ERF, the observation data is utilized to nudge the solution state towards
+from a file. In ERF, the observation (BDY) data is utilized to nudge the solution state towards
 the observation data in the interior of the domain. We explicitly note that the wall normal
-velocity on a domain boundary is **not** nudged toward the observation data but is computed
-from a zero normal gradient (outflow) condition that uses a one-sided difference on the domain
-interior. Therefore, a key difference between real domain BCs in ERF and WRF is that ERF allows
-the normal velocity at a domain wall to adjust, given the nudged adjacent velocities, while
-WRF imposes a Dirichlet condition; see the yellow region in Figure 8 below.
-The user may specify (in the inputs file) the total width of the interior boundary region with
-``erf.real_width = <Int>`` (yellow + blue). The real BCs are only imposed for
-:math:`\psi = \left\{ \theta; \; q_v; \; u; \; v \right\}`.
+velocity on a domain boundary are set to the observational data and the RHS for these points
+is assigned the BDY tendency. The user may specify (in the inputs file) the total
+width of the interior boundary region with ``erf.real_width = <Int>`` (yellow + blue).
+The real BCs are only imposed for :math:`\psi = \left\{ \theta; \; q_v; \; u; \; v \right\}`.
 
 .. |wrfbdy| image:: figures/wrfbdy_BCs.png
            :width: 600

--- a/Docs/sphinx_doc/CouplingToNoahMP.rst
+++ b/Docs/sphinx_doc/CouplingToNoahMP.rst
@@ -33,6 +33,11 @@ Currently, Noah-MP may only be utilized for simulations that are initialized fro
 for Noah-MP initialization: ``namelist.erf`` and ``NoahmpTable.TBL``. Sample files are provided for
 the :download:`namelist.erf <namelist.erf>` and :download:`NoahmpTable.TBL <NoahmpTable.TBL>`.
 
+To improve computational efficiency, the Noah-MP timestep, specified via ``NOAH_TIMESTEP``
+in the **namelist.erf** file, may be set larger than the ERF timestep to allow subcycling
+in time. For example, if an 4s timestep is utilized for ERF and a 40s timestep is utilized for
+Noah-MP, then Noah-MP will be updated every 10 steps.
+
 Files Overview
 --------------
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1956,13 +1956,15 @@ List of Parameters
 +=====================================+========================================+===================+===================================+
 | **erf.radiation_model**             | Enable radiation model                 | "None", "RRTMGP"  | "None"                            |
 +-------------------------------------+----------------------------------------+-------------------+-----------------------------------+
+| **erf.rad_nvar**                    | Size of block memory allocation        | Integer > 0       | 12                                |
++-------------------------------------+----------------------------------------+-------------------+-----------------------------------+
 | **erf.rad_t_sfc**                   | Surface temperature if no LSM          | Real              | Must be set without LSM           |
 +-------------------------------------+----------------------------------------+-------------------+-----------------------------------+
 | **erf.rad_freq_in_steps**           | Radiation update frequency (steps)     | Integer >= 1      | 1                                 |
 +-------------------------------------+----------------------------------------+-------------------+-----------------------------------+
 | **erf.rad_ncol_chunk**              | Columns per RRTMGP kernel launch.      | Integer >= 1      | 5000. Lower values reduce peak    |
 |                                     | Controls peak GPU memory by processing |                   | GPU memory; higher values reduce  |
-|                                     | radiation in batches of this size.      |                   | kernel launch overhead.           |
+|                                     | radiation in batches of this size.     |                   | kernel launch overhead.           |
 +-------------------------------------+----------------------------------------+-------------------+-----------------------------------+
 | **erf.rad_write_fluxes**            | Write radiation fluxes to plotfiles    | true / false      | false                             |
 +-------------------------------------+----------------------------------------+-------------------+-----------------------------------+

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
@@ -91,7 +91,7 @@ void
 rrtmgp_initialize (gas_concs_t& gas_concs,
                    const std::string& coefficients_file_sw, const std::string& coefficients_file_lw,
                    const std::string& cloud_optics_file_sw, const std::string& cloud_optics_file_lw,
-                   size_t& nvar);
+                   const int& nvar);
 
 
 void

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
@@ -90,7 +90,8 @@ get_subsampled_clouds (const int ncol,
 void
 rrtmgp_initialize (gas_concs_t& gas_concs,
                    const std::string& coefficients_file_sw, const std::string& coefficients_file_lw,
-                   const std::string& cloud_optics_file_sw, const std::string& cloud_optics_file_lw);
+                   const std::string& cloud_optics_file_sw, const std::string& cloud_optics_file_lw,
+                   size_t& nvar);
 
 
 void

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -230,7 +230,8 @@ rrtmgp_initialize (gas_concs_t& gas_concs_k,
                    const std::string& coefficients_file_sw,
                    const std::string& coefficients_file_lw,
                    const std::string& cloud_optics_file_sw,
-                   const std::string& cloud_optics_file_lw)
+                   const std::string& cloud_optics_file_lw,
+                   const size_t& nvar)
 {
     // Initialize Kokkos
     if (!Kokkos::is_initialized()) {  Kokkos::initialize(); }
@@ -250,11 +251,10 @@ rrtmgp_initialize (gas_concs_t& gas_concs_k,
     load_cld_lutcoeff(*cloud_optics_lw_k, cloud_optics_file_lw);
 
     // Initialize kokkos rrtmgp pool allocator
-    const size_t nvar = 12;
     const size_t ngpt = std::max(k_dist_sw_k->get_ngpt(),k_dist_lw_k->get_ngpt());
     const size_t ncol = gas_concs_k.ncol;
     const size_t nlay = gas_concs_k.nlay;
-    auto my_size_ref = static_cast<unsigned long>(nvar * ncol * nlay * ngpt);
+    auto my_size_ref  = static_cast<unsigned long>(nvar * ncol * nlay * ngpt);
     pool_t::init(my_size_ref);
 
     // We are now initialized!

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -231,7 +231,7 @@ rrtmgp_initialize (gas_concs_t& gas_concs_k,
                    const std::string& coefficients_file_lw,
                    const std::string& cloud_optics_file_sw,
                    const std::string& cloud_optics_file_lw,
-                   const size_t& nvar)
+                   const int& nvar)
 {
     // Initialize Kokkos
     if (!Kokkos::is_initialized()) {  Kokkos::initialize(); }

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -376,7 +376,7 @@ private:
     int m_ncol_chunk = 1024;
 
     // Number of vars for s_mem allocation
-    size_t m_rad_nvar = 12;
+    int m_rad_nvar = 12;
 
     // Whether or not to do subcolumn sampling of cloud state for MCICA
     bool m_do_subcol_sampling = true;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -375,6 +375,9 @@ private:
     // Number of columns to process per RRTMGP chunk (controls peak memory)
     int m_ncol_chunk = 1024;
 
+    // Number of vars for s_mem allocation
+    size_t m_rad_nvar = 12;
+
     // Whether or not to do subcolumn sampling of cloud state for MCICA
     bool m_do_subcol_sampling = true;
 

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -35,10 +35,17 @@ Radiation::Radiation (const int& lev,
     ParmParse pp("erf");
 
     // Must specify a surface temp (LSM can overwrite)
-    pp.get("rad_t_sfc",m_rad_t_sfc);
+    pp.get("rad_t_sfc", m_rad_t_sfc);
 
     // Radiation timestep, as a number of atm steps
     pp.query("rad_freq_in_steps", m_rad_freq_in_steps);
+
+    // Get nvar if specified
+    pp.query("rad_nvar", m_rad_nvar);
+    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rad_nvar >= 0,
+        "erf.rad_nvar must be greater than 0. "
+        "It controls the amount of memory allocated for temporaries with RRTMGP; "
+        "a value of 0 would allocate no memory.");
 
     // Number of columns per RRTMGP chunk (controls peak GPU memory)
     pp.query("rad_ncol_chunk", m_ncol_chunk);
@@ -1037,7 +1044,8 @@ Radiation::initialize_impl ()
         gas_concs_pool.init(gas_names_offset, m_ncol_chunk, m_nlay);
         rrtmgp::rrtmgp_initialize(gas_concs_pool,
                                   rrtmgp_coeffs_file_sw      , rrtmgp_coeffs_file_lw      ,
-                                  rrtmgp_cloud_optics_file_sw, rrtmgp_cloud_optics_file_lw);
+                                  rrtmgp_cloud_optics_file_sw, rrtmgp_cloud_optics_file_lw,
+                                  m_rad_nvar);
         gas_concs_pool.reset();
     }
 }


### PR DESCRIPTION
# Summary
This PR updates the docs regarding the Noah-MP timestep and ERF sub-cycling, as well as the real boundary condition algorithm and new `rad_nvar` input. Additionally, this PR makes the RRTMGP `nvar` a parsed quantity that defaults to `12`. 

## Notes
It has been observed that `nvar=12` is well optimized for the RRTMGP mempoolsingleton allocation of `s_mem` on Perlmutter and Kestrel. However, on different architectures, this value has been observed to be insufficient (likely due to different byte counts for doubles and ints). Making this value parsed will allow users on different architectures to keep running without rebuilding the code.