### PR TITLE
fix rebalancing to use qt not just qv

### DIFF
--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -1035,6 +1035,11 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
         Real tol  = Real(1.0e-10);
 #endif
         Real grav = CONST_GRAV;
+
+        MultiFab qt(lev_new[Vars::cons].boxArray(), lev_new[Vars::cons].DistributionMap(), 1, 0);
+        int n_qstate_into_total = micro->Get_Qstate_Moist_Size() - micro->Get_Qstate_Moist_NumConc_Size();
+        make_qt(lev_new[Vars::cons], qt, n_qstate_into_total);
+
         for ( MFIter mfi(lev_new[Vars::cons],TileNoZ()); mfi.isValid(); ++mfi ) {
             Box bx  = mfi.tilebox();
             int klo = bx.smallEnd(2);
@@ -1043,6 +1048,7 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
             bx.makeSlab(2,klo);
 
             const Array4<      Real>& con_arr = lev_new[Vars::cons].array(mfi);
+            const Array4<const Real>&  qt_arr = qt.const_array(mfi);
             const Array4<const Real>& z_arr = z_phys_nd[lev]->const_array(mfi);
 
             ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
@@ -1054,6 +1060,7 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
                 Real z_lo, z_hi;
                 Real R_lo, R_hi;
                 Real qv_lo, qv_hi;
+                Real qt_lo, qt_hi;
                 Real Th_lo, Th_hi;
                 Real P_lo, P_hi;
 
@@ -1062,29 +1069,31 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
                     // Vertical grid spacing
                     z_lo = zero; // corresponding to p_0
                     z_hi = Real(0.125) * (z_arr(i,j,klo  ) + z_arr(i+1,j,klo  ) + z_arr(i,j+1,klo  ) + z_arr(i+1,j+1,klo  )
-                                   +z_arr(i,j,klo+1) + z_arr(i+1,j,klo+1) + z_arr(i,j+1,klo+1) + z_arr(i+1,j+1,klo+1));
+                                         +z_arr(i,j,klo+1) + z_arr(i+1,j,klo+1) + z_arr(i,j+1,klo+1) + z_arr(i+1,j+1,klo+1));
                     dz = z_hi - z_lo;
 
                     // Establish known constant
+                    qt_lo =  qt_arr(i,j,klo);
                     qv_lo = con_arr(i,j,klo,RhoQ1_comp)    / con_arr(i,j,klo,Rho_comp);
                     Th_lo = con_arr(i,j,klo,RhoTheta_comp) / con_arr(i,j,klo,Rho_comp);
                     P_lo  = p_0;
                     R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-                    rho_tot_lo = R_lo * (one + qv_lo);
+                    rho_tot_lo = R_lo * (one + qt_lo);
                     C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
 
                     // Initial guess and residual
+                    qt_hi = qt_arr(i,j,klo);
                     qv_hi = con_arr(i,j,klo,RhoQ1_comp)    / con_arr(i,j,klo,Rho_comp);
                     Th_hi = con_arr(i,j,klo,RhoTheta_comp) / con_arr(i,j,klo,Rho_comp);
                     P_hi  = p_0;
                     R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-                    rho_tot_hi = R_hi * (one + qv_hi);
+                    rho_tot_hi = R_hi * (one + qt_hi);
                     F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
 
                     // Do iterations
                     HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
                                                  grav, C, Th_hi,
-                                                 qv_hi, qv_hi,
+                                                 qt_hi, qv_hi,
                                                  P_hi, R_hi, F);
 
                     // Assign data
@@ -1098,27 +1107,29 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
                 for (int k(klo+1); k<=khi; ++k) {
                     // Vertical grid spacing
                   z_hi = Real(0.125) * (z_arr(i,j,k  ) + z_arr(i+1,j,k  ) + z_arr(i,j+1,k  ) + z_arr(i+1,j+1,k  )
-                                 +z_arr(i,j,k+1) + z_arr(i+1,j,k+1) + z_arr(i,j+1,k+1) + z_arr(i+1,j+1,k+1));
+                                       +z_arr(i,j,k+1) + z_arr(i+1,j,k+1) + z_arr(i,j+1,k+1) + z_arr(i+1,j+1,k+1));
                   dz   = z_hi - z_lo;
 
                   // Establish known constant
+                  qt_lo = qt_arr(i,j,k-1);
                   qv_lo = con_arr(i,j,k-1,RhoQ1_comp)    / con_arr(i,j,k-1,Rho_comp);
                   Th_lo = con_arr(i,j,k-1,RhoTheta_comp) / con_arr(i,j,k-1,Rho_comp);
                   R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-                  rho_tot_lo = R_lo * (one + qv_lo);
+                  rho_tot_lo = R_lo * (one + qt_lo);
                   C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
 
                   // Initial guess and residual
+                  qt_hi = qt_arr(i,j,k);
                   qv_hi = con_arr(i,j,k,RhoQ1_comp)    / con_arr(i,j,k,Rho_comp);
                   Th_hi = con_arr(i,j,k,RhoTheta_comp) / con_arr(i,j,k,Rho_comp);
                   R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-                  rho_tot_hi = R_hi * (one + qv_hi);
+                  rho_tot_hi = R_hi * (one + qt_hi);
                   F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
 
                   // Do iterations
                   HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
                                                grav, C, Th_hi,
-                                               qv_hi, qv_hi,
+                                               qt_hi, qv_hi,
                                                P_hi, R_hi, F);
 
                   // Assign data


### PR DESCRIPTION
Rebalancing of wrfinput was previously using only qv not qt -- this fixes that so that the new diagnostic shows the initial state from wrfinput in HSE