### PR TITLE
BDY Interp Loop

### DIFF
--- a/Source/IO/ERF_ReadFromWRFBdy.cpp
+++ b/Source/IO/ERF_ReadFromWRFBdy.cpp
@@ -359,7 +359,7 @@ convert_wrfbdy_data (const int itime,
                 z_lo_src = bdy_c_z_src(i,j,kstart);
 
                 bool found = false;
-                for (int lk(kstart+1); lk<khi; ++lk) {
+                for (int lk(kstart+1); lk<=khi; ++lk) {
                     z_hi_src = bdy_c_z_src(i,j,lk);
                     if (z_dst >= z_lo_src && z_dst <= z_hi_src) {
                         found = true;
@@ -392,7 +392,7 @@ convert_wrfbdy_data (const int itime,
                 z_lo_src = bdy_u_z_src(i,j,kstart);
 
                 bool found = false;
-                for (int lk(kstart+1); lk<khi; ++lk) {
+                for (int lk(kstart+1); lk<=khi; ++lk) {
                     z_hi_src = bdy_u_z_src(i,j,lk);
                     if (z_dst >= z_lo_src && z_dst <= z_hi_src) {
                         found = true;
@@ -423,7 +423,7 @@ convert_wrfbdy_data (const int itime,
                 z_lo_src = bdy_v_z_src(i,j,kstart);
 
                 bool found = false;
-                for (int lk(kstart+1); lk<khi; ++lk) {
+                for (int lk(kstart+1); lk<=khi; ++lk) {
                     z_hi_src = bdy_v_z_src(i,j,lk);
                     if (z_dst >= z_lo_src && z_dst <= z_hi_src) {
                         found = true;


### PR DESCRIPTION
# Summary
The `Th, U, V` vars resize `1/2 dz` from a z-face. Since `khi` comes from the domain, which is CC, we should loop over `lk=khi` to try and interpolate the data.