### PR TITLE
Implicit Diffusion BC Checks

### DIFF
--- a/Exec/CanonicalTests/EkmanSpiral/inputs_input_sounding
+++ b/Exec/CanonicalTests/EkmanSpiral/inputs_input_sounding
@@ -19,7 +19,7 @@ zhi.type = "SlipWall"
 
 # TIME STEP CONTROL
 erf.substepping_type = None
-erf.fixed_dt         = 0.5     # fixed time step
+erf.fixed_dt         = 0.03     # fixed time step
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval   = 1       # timesteps between computing mass

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -701,6 +701,12 @@ struct SolverChoice {
                 //      the acoustic substepping (if it happens, i.e. if any of the implicit_fac > zero)
                 // The default is true (i.e. that it happens before the acoustic substepping).
                 pp.query("implicit_before_substep", implicit_before_substep);
+                for (int lev = 0; lev <= max_level; lev++) {
+                    if ( (substepping_type[lev] == SubsteppingType::None) && !implicit_before_substep) {
+                        amrex::Print() << "implicit_before_substep cannot be false without substepping; setting to true." << "\n";
+                        implicit_before_substep = true;
+                    }
+                }
 
                 if (!implicit_thermal_diffusion  &&
                     !implicit_moisture_diffusion &&

--- a/Source/Diffusion/ERF_ImplicitDiff_N.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_N.cpp
@@ -81,9 +81,9 @@ ImplicitDiffForStateLU_N (const Box& bx,
     amrex::ignore_unused(foextrap_on_zlo, foextrap_on_zhi);
 
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || neumann_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+                              "Unexpected lower BC for scalars used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || neumann_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
+                              "Unexpected upper BC for scalars used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt * dz_inv;
 
@@ -262,16 +262,14 @@ ImplicitDiffForMomLU_N (const Box& bx,
                             bc_ptr[bc_comp].lo(2) == ERFBCType::ext_dir_prim);
     bool ext_dir_on_zhi  = (bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir ||
                             bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir_prim);
+    bool foextrap_on_zlo = (bc_ptr[bc_comp].lo(2) == ERFBCType::foextrap);
     bool foextrap_on_zhi = (bc_ptr[bc_comp].hi(2) == ERFBCType::foextrap);
     amrex::ignore_unused(foextrap_on_zhi);
 
-    AMREX_ASSERT_WITH_MESSAGE(ext_dir_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+    AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || ext_dir_on_zlo || use_SurfLayer,
+                              "Unexpected lower BC for momentum used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || ext_dir_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
-    if (stagdir < 2 && (ext_dir_on_zlo || ext_dir_on_zhi)) {
-        amrex::Warning("No-slip walls have not been fully tested");
-    }
+                              "Unexpected upper BC for momentum used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt * dz_inv;
 
@@ -337,6 +335,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
                       c_tmp = zero;
                       RHS_a(i,j,klo) = zero;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       a_tmp = -two * Fact * rhoAlpha_lo * dz_inv;
                       RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv;
                   }
@@ -344,6 +343,9 @@ ImplicitDiffForMomLU_N (const Box& bx,
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
                   RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau(i,j,klo));
                   RHS_a(i,j,klo) += Fact * tau(i,j,klo);
+              } else {
+                  // NOTE: FOEXTRAP has zero lower flux (nothing to add to RHS)
+                  RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau_corr(i,j,klo));
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
@@ -393,6 +395,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
                       a_tmp = zero;
                       RHS_a(i,j,khi) = zero;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       c_tmp = -two * Fact * rhoAlpha_hi * dz_inv;
                       RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv;
                   }

--- a/Source/Diffusion/ERF_ImplicitDiff_S.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_S.cpp
@@ -79,9 +79,9 @@ ImplicitDiffForStateLU_S (const Box& bx,
     amrex::ignore_unused(foextrap_on_zlo, foextrap_on_zhi);
 
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || neumann_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+                              "Unexpected lower BC for scalars used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || neumann_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
+                              "Unexpected upper BC for scalars used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt;
 
@@ -272,16 +272,14 @@ ImplicitDiffForMomLU_S (const Box& bx,
                             bc_ptr[bc_comp].lo(2) == ERFBCType::ext_dir_prim);
     bool ext_dir_on_zhi  = (bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir ||
                             bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir_prim);
+    bool foextrap_on_zlo = (bc_ptr[bc_comp].lo(2) == ERFBCType::foextrap);
     bool foextrap_on_zhi = (bc_ptr[bc_comp].hi(2) == ERFBCType::foextrap);
     amrex::ignore_unused(foextrap_on_zhi);
 
-    AMREX_ASSERT_WITH_MESSAGE(ext_dir_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+    AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || ext_dir_on_zlo || use_SurfLayer,
+                              "Unexpected lower BC for momentum used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || ext_dir_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
-    if (stagdir < 2 && (ext_dir_on_zlo || ext_dir_on_zhi)) {
-        amrex::Warning("No-slip walls have not been fully tested");
-    }
+                              "Unexpected upper BC for momentum used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt;
 
@@ -352,6 +350,7 @@ ImplicitDiffForMomLU_S (const Box& bx,
                       c_tmp = 0.;
                       RHS_a(i,j,klo) = 0.;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       a_tmp = -two * Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
                       RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv_lo * dz_inv;
                   }
@@ -359,6 +358,9 @@ ImplicitDiffForMomLU_S (const Box& bx,
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
                   RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau(i,j,klo)) * dz_inv;
                   RHS_a(i,j,klo) += Fact * dz_inv * tau(i,j,klo);
+              } else {
+                  // NOTE: FOEXTRAP has zero lower flux (nothing to add to RHS)
+                  RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau_corr(i,j,klo));
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
@@ -416,6 +418,7 @@ ImplicitDiffForMomLU_S (const Box& bx,
                       a_tmp = zero;
                       RHS_a(i,j,khi) = zero;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       c_tmp = -two * Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
                       RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv_hi * dz_inv;
                   }

--- a/Source/Diffusion/ERF_ImplicitDiff_T.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_T.cpp
@@ -83,9 +83,9 @@ ImplicitDiffForStateLU_T (const Box& bx,
     amrex::ignore_unused(foextrap_on_zlo, foextrap_on_zhi);
 
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || neumann_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+                              "Unexpected lower BC for scalars used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || neumann_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
+                              "Unexpected upper BC for scalars used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt * dz_inv;
 
@@ -282,16 +282,14 @@ ImplicitDiffForMomLU_T (const Box& bx,
                             bc_ptr[bc_comp].lo(2) == ERFBCType::ext_dir_prim);
     bool ext_dir_on_zhi  = (bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir ||
                             bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir_prim);
+    bool foextrap_on_zlo = (bc_ptr[bc_comp].lo(2) == ERFBCType::foextrap);
     bool foextrap_on_zhi = (bc_ptr[bc_comp].hi(2) == ERFBCType::foextrap);
     amrex::ignore_unused(foextrap_on_zhi);
 
-    AMREX_ASSERT_WITH_MESSAGE(ext_dir_on_zlo || use_SurfLayer,
-                              "Unexpected lower BC used with implicit vertical diffusion");
+    AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zlo || ext_dir_on_zlo || use_SurfLayer,
+                              "Unexpected lower BC for momentum used with implicit vertical diffusion");
     AMREX_ASSERT_WITH_MESSAGE(foextrap_on_zhi || ext_dir_on_zhi,
-                              "Unexpected upper BC used with implicit vertical diffusion");
-    if (stagdir < 2 && (ext_dir_on_zlo || ext_dir_on_zhi)) {
-        amrex::Warning("No-slip walls have not been fully tested");
-    }
+                              "Unexpected upper BC for momentum used with implicit vertical diffusion");
 
     Real Fact = implicit_fac * dt * dz_inv;
 
@@ -368,6 +366,7 @@ ImplicitDiffForMomLU_T (const Box& bx,
                       c_tmp = zero;
                       RHS_a(i,j,klo) = zero;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       a_tmp = -two * Fact * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
                       RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv / met_h_zeta_lo;
                   }
@@ -375,6 +374,9 @@ ImplicitDiffForMomLU_T (const Box& bx,
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
                   RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau(i,j,klo));
                   RHS_a(i,j,klo) += Fact * tau(i,j,klo);
+              } else {
+                  // NOTE: FOEXTRAP has zero lower flux (nothing to add to RHS)
+                  RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau_corr(i,j,klo));
               }
 
               b_tmp      = detJface * rhoface - a_tmp - c_tmp;
@@ -436,6 +438,7 @@ ImplicitDiffForMomLU_T (const Box& bx,
                       a_tmp = zero;
                       RHS_a(i,j,khi) = zero;
                   } else {
+                      // NOTE: wall is 1/2 dz away (2 dz_inv)
                       c_tmp = -two * Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
                       RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv / met_h_zeta_hi;
                   }

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -299,7 +299,8 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
 void ERF::init_bcs ()
 {
     bool rho_read = false;
-    bool read_prim_theta = true;
+    bool read_prim_theta  = true;
+    bool use_surfacelayer = false;
 
     init_phys_bcs(rho_read, read_prim_theta);
 
@@ -449,6 +450,7 @@ void ERF::init_bcs ()
             }
             else if ( bct == ERF_BC::surface_layer )
             {
+                use_surfacelayer = true;
                 AMREX_ALWAYS_ASSERT(dir == 2 && side == Orientation::low);
                 domain_bcs_type[BCVars::xvel_bc+0].setLo(dir, ERFBCType::hoextrap);
                 domain_bcs_type[BCVars::xvel_bc+1].setLo(dir, ERFBCType::hoextrap);
@@ -686,6 +688,43 @@ void ERF::init_bcs ()
                     domain_bcs_type[BCVars::RhoKE_bc_comp].setLo(dir, ERFBCType::ext_dir);
                 }
             }
+        }
+    }
+
+    // Sanity check that implicit diffusion is consistent with the BC types.
+    // Turn off implicit diffusion for a component if its BCs don't match
+    // those allowed by the tridiagonal solver.
+    const BCRec* bc_ptr = domain_bcs_type.data();
+    Vector<int> cc_comp_map = {BCVars::RhoTheta_bc_comp, BCVars::RhoKE_bc_comp, BCVars::RhoQ1_bc_comp};
+    Vector<std::string> cc_comp_name = {"Theta", "KE", "Qv"};
+    for (int icomp(0); icomp < cc_comp_map.size(); ++icomp) {
+        int bc_comp = cc_comp_map[icomp];
+        bool foextrap_on_zlo = (bc_ptr[bc_comp].lo(2) == ERFBCType::foextrap);
+        bool foextrap_on_zhi = (bc_ptr[bc_comp].hi(2) == ERFBCType::foextrap);
+        bool neumann_on_zlo  = (bc_ptr[bc_comp].lo(2) == ERFBCType::neumann);
+        bool neumann_on_zhi  = (bc_ptr[bc_comp].hi(2) == ERFBCType::neumann);
+        if ( (!foextrap_on_zlo && !neumann_on_zlo && !use_surfacelayer) ||
+             (!foextrap_on_zhi && !neumann_on_zhi) ) {
+            Print() << "WARNING: Selected BCs for " << cc_comp_name[icomp] << " are not supported with implicit diffusion. Turning off implicit diffusion for this component." << "\n";
+            if (bc_comp == BCVars::RhoTheta_bc_comp) { solverChoice.implicit_thermal_diffusion  = false; }
+            if (bc_comp == BCVars::RhoKE_bc_comp)    { solverChoice.implicit_ke_diffusion       = false; }
+            if (bc_comp == BCVars::RhoQ1_bc_comp)    { solverChoice.implicit_moisture_diffusion = false; }
+        }
+    }
+    Vector<int> vel_comp_map = {BCVars::xvel_bc, BCVars::yvel_bc};
+    Vector<std::string> vel_comp_name = {"xvel", "yvel"};
+    for (int icomp(0); icomp < vel_comp_map.size(); ++icomp) {
+        int bc_comp = vel_comp_map[icomp];
+        bool ext_dir_on_zlo  = (bc_ptr[bc_comp].lo(2) == ERFBCType::ext_dir ||
+                                bc_ptr[bc_comp].lo(2) == ERFBCType::ext_dir_prim);
+        bool ext_dir_on_zhi  = (bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir ||
+                                bc_ptr[bc_comp].hi(2) == ERFBCType::ext_dir_prim);
+        bool foextrap_on_zlo = (bc_ptr[bc_comp].lo(2) == ERFBCType::foextrap);
+        bool foextrap_on_zhi = (bc_ptr[bc_comp].hi(2) == ERFBCType::foextrap);
+        if ( (!foextrap_on_zlo && !ext_dir_on_zlo && !use_surfacelayer) ||
+             (!foextrap_on_zhi && !ext_dir_on_zhi) ) {
+            Print() << "WARNING: Selected BCs for " << vel_comp_name[icomp] << " are not supported with implicit diffusion. Turning off implicit diffusion for this component." << "\n";
+            solverChoice.implicit_momentum_diffusion  = false;
         }
     }
 


### PR DESCRIPTION
# Summary
With implicit diffusion on by default, we need to check that the BCs are consistent with those supported by the tridiagonal solve. If they are not, we deactivate the implicit solve for the component and print a warning.

## Notes
The failure with Ekman and implicit diffusion was  due to too large of a `dt` that violated the CFL condition combined with the implicit solve yielding precision level fluctuations in `theta` that yielding significant `w` velocities. Reducing dt in that inputs to respect the CFL constraint allowed it to run stably.