### PR TITLE
Generalize vert_implicit_fac to be per level

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -464,7 +464,7 @@ List of Parameters
 |                                     | each RK stage?       | "None"         | compressible,       |
 |                                     |                      |                | "None" if anelastic |
 +-------------------------------------+----------------------+----------------+---------------------+
-| **erf.vert_implicit**               | Do vertical implicit | Boolean        | true if compresible |
+| **erf.vert_implicit**               | Do vertical implicit | Boolean        | true if compressible|
 |                                     | solve for diffusion  |                | false if anelastic  |
 |                                     | of u, v, theta, KE,  |                |                     |
 |                                     | and qv with default  |                |                     |

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -464,15 +464,15 @@ List of Parameters
 |                                     | each RK stage?       | "None"         | compressible,       |
 |                                     |                      |                | "None" if anelastic |
 +-------------------------------------+----------------------+----------------+---------------------+
-| **erf.vert_implicit**               | Do vertical implicit | Boolean        | true                |
-|                                     | solve for diffusion  |                |                     |
+| **erf.vert_implicit**               | Do vertical implicit | Boolean        | true if compresible |
+|                                     | solve for diffusion  |                | false if anelastic  |
 |                                     | of u, v, theta, KE,  |                |                     |
 |                                     | and qv with default  |                |                     |
 |                                     | time-centering in    |                |                     |
 |                                     | each stage           |                |                     |
 +-------------------------------------+----------------------+----------------+---------------------+
 | **erf.vert_implicit_fac**           | How much implicit    | Real >= 0      | 1.0, 1.0, 0.0       |
-|                                     | vertical diffusion   | (explicit) and | (fully explicit)    |
+|                                     | vertical diffusion   | (explicit) and |                     |
 |                                     | to include in each   | <= 1 (implicit)|                     |
 |                                     | RK stage?            |                |                     |
 |                                     |                      |                |                     |

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -612,6 +612,14 @@ struct SolverChoice {
             turbChoice[lev].init_params(lev,max_level,pp_prefix);
         }
 
+        vert_implicit_fac.resize(max_level+1);
+        for (int lev = 0; lev <= max_level; lev++) {
+            vert_implicit_fac[lev].resize(3);
+            vert_implicit_fac[lev][0] = one;
+            vert_implicit_fac[lev][1] = one;
+            vert_implicit_fac[lev][2] = zero;
+        }
+
         // YSU PBL: use consistent coriolis frequency
         for (int lev = 0; lev <= max_level; lev++) {
             if (turbChoice[lev].pbl_ysu_use_consistent_coriolis) {
@@ -650,21 +658,34 @@ struct SolverChoice {
 
         // Implicit vertical diffusion (not available with Shoc)
         if (use_shoc) {
-            amrex::Print() << "Turning off native vertical implicit solve with SHOC PBL scheme." << std::endl;
-            vert_implicit_fac[0] = zero;
-            vert_implicit_fac[1] = zero;
-            vert_implicit_fac[2] = zero;
+            amrex::Print() << "Turning off native vertical implicit solve at all levels with SHOC PBL scheme." << std::endl;
+            for (int lev = 0; lev <= max_level; lev++) {
+               vert_implicit_fac[lev][0] = zero;
+               vert_implicit_fac[lev][1] = zero;
+               vert_implicit_fac[lev][2] = zero;
+            }
         } else {
             // This controls the time-centering of the vertical differences in the diffusive term
             bool do_vert_implicit = true;
             pp.query("vert_implicit", do_vert_implicit);
 
             if (!do_vert_implicit) {
-                amrex::Print() << "Turning off native vertical implicit solve from vert_implicit flag." << std::endl;
-                vert_implicit_fac[0] = zero;
-                vert_implicit_fac[1] = zero;
-                vert_implicit_fac[2] = zero;
+                for (int lev = 0; lev <= max_level; lev++) {
+                   amrex::Print() << "Turning off native vertical implicit solve from vert_implicit flag at level " << lev << std::endl;
+                   vert_implicit_fac[lev][0] = zero;
+                   vert_implicit_fac[lev][1] = zero;
+                   vert_implicit_fac[lev][2] = zero;
+                }
             } else {
+
+                for (int lev = 0; lev <= max_level; lev++) {
+                   if (anelastic[lev]) {
+                       amrex::Print() << "Turning off native vertical implicit solve flag because anelastic at level " << lev << std::endl;
+                       vert_implicit_fac[lev][0] = zero;
+                       vert_implicit_fac[lev][1] = zero;
+                       vert_implicit_fac[lev][2] = zero;
+                    }
+                }
 
                 // This may be one value for all RK stages or a different value in each stage
                 int n_impfac = pp.countval("vert_implicit_fac");
@@ -676,9 +697,15 @@ struct SolverChoice {
                 if (n_impfac == 1) {
                     amrex::Real fac_in;
                     pp.get("vert_implicit_fac", fac_in);
-                    for (int i=0; i<3; ++i) { vert_implicit_fac[i] = fac_in; }
+                    for (int lev = 0; lev <= max_level; lev++) {
+                        for (int i=0; i<3; ++i) {
+                            vert_implicit_fac[lev][i] = fac_in;
+                        }
+                    }
                 } else if (n_impfac == 3) {
-                    pp.getarr("vert_implicit_fac", vert_implicit_fac);
+                    for (int lev = 0; lev <= max_level; lev++) {
+                        pp.getarr("vert_implicit_fac", vert_implicit_fac[lev]);
+                    }
                 }
 
                 // If true (default), include implicit contributions to vertical
@@ -709,11 +736,16 @@ struct SolverChoice {
                 }
 
                 // Do not allow implicit vertical diff with EB
-                if (terrain_type == TerrainType::EB && do_vert_implicit) {
-                    amrex::Print() << "Implicit diffusion is not supported with EB; turning off." << "\n";
-                    vert_implicit_fac[0] = zero;
-                    vert_implicit_fac[1] = zero;
-                    vert_implicit_fac[2] = zero;
+
+                if (terrain_type == TerrainType::EB) {
+                    for (int lev = 0; lev <= max_level; lev++) {
+                        if (do_vert_implicit) {
+                            amrex::Print() << "Implicit diffusion is not supported with EB; turning off at level " << lev << "\n";
+                            vert_implicit_fac[lev][0] = zero;
+                            vert_implicit_fac[lev][1] = zero;
+                            vert_implicit_fac[lev][2] = zero;
+                        }
+                    }
                 }
 
                 if (!implicit_thermal_diffusion  &&
@@ -721,9 +753,11 @@ struct SolverChoice {
                     !implicit_ke_diffusion       &&
                     !implicit_momentum_diffusion) {
                     amrex::Print() << "Thermal, moisture, KE, and momentum diffusion are all turned off; turning off vertical implicit solve." << std::endl;
-                    vert_implicit_fac[0] = zero;
-                    vert_implicit_fac[1] = zero;
-                    vert_implicit_fac[2] = zero;
+                    for (int lev = 0; lev <= max_level; lev++) {
+                        vert_implicit_fac[lev][0] = zero;
+                        vert_implicit_fac[lev][1] = zero;
+                        vert_implicit_fac[lev][2] = zero;
+                    }
                 }
             } // do_vert_implicit
         } // use_shoc
@@ -930,14 +964,17 @@ struct SolverChoice {
             l_use_kturb = (l_use_kturb || turbChoice[lev].use_kturb);
         }
         bool l_use_diff    = ( (diffChoice.molec_diff_type != MolecDiffType::None) || l_use_kturb );
-        bool l_implicit_diff = (vert_implicit_fac[0] > zero ||
-                                vert_implicit_fac[1] > zero ||
-                                vert_implicit_fac[2] > zero);
-        if (l_implicit_diff && !l_use_diff) {
-            amrex:: Print() << "No molecular or turbulent diffusion, turning off implicit solve" << std::endl;
-            vert_implicit_fac[0] = zero;
-            vert_implicit_fac[1] = zero;
-            vert_implicit_fac[2] = zero;
+
+        for (int lev = 0; lev <= max_level; lev++) {
+            bool l_implicit_diff = (vert_implicit_fac[lev][0] > zero ||
+                                    vert_implicit_fac[lev][1] > zero ||
+                                    vert_implicit_fac[lev][2] > zero);
+            if (l_implicit_diff && !l_use_diff) {
+                amrex:: Print() << "No molecular or turbulent diffusion, turning off implicit solve at level " << lev << std::endl;
+                vert_implicit_fac[lev][0] = zero;
+                vert_implicit_fac[lev][1] = zero;
+                vert_implicit_fac[lev][2] = zero;
+            }
         }
 
         for (int lev = 0; lev <= max_level; lev++) {
@@ -964,21 +1001,23 @@ struct SolverChoice {
            }
         }
 
-        amrex::Print() << "vert_implicit_fac           : " << vert_implicit_fac[0] << " "
-                                                           << vert_implicit_fac[1] << " "
-                                                           << vert_implicit_fac[2];
-        if (vert_implicit_fac[0] > zero ||
-            vert_implicit_fac[1] > zero ||
-            vert_implicit_fac[2] > zero)
-        {
-            amrex::Print() << " (theta = " << implicit_thermal_diffusion
-                           << ", moisture = " << implicit_moisture_diffusion
-                           << ", tke = " << implicit_ke_diffusion
-                           << ", momenta = " << implicit_momentum_diffusion;
+        for (int lev = 0; lev <= max_level; lev++) {
+            amrex::Print() << "vert_implicit_fac at level  : " << lev << " " << vert_implicit_fac[lev][0] << " "
+                                                                             << vert_implicit_fac[lev][1] << " "
+                                                                             << vert_implicit_fac[lev][2];
+            if (vert_implicit_fac[lev][0] > zero ||
+                vert_implicit_fac[lev][1] > zero ||
+                vert_implicit_fac[lev][2] > zero)
+            {
+                amrex::Print() << " (theta = " << implicit_thermal_diffusion
+                               << ", moisture = " << implicit_moisture_diffusion
+                               << ", tke = " << implicit_ke_diffusion
+                               << ", momenta = " << implicit_momentum_diffusion;
 #ifdef ERF_IMPLICIT_W
-            amrex::Print() << ", including w";
+                amrex::Print() << ", including w";
 #endif
-            amrex::Print() << ")";
+                amrex::Print() << ")";
+            }
         }
         amrex::Print() << std::endl;
         amrex::Print() << "use_coriolis                : " << use_coriolis << std::endl;
@@ -1194,7 +1233,8 @@ struct SolverChoice {
     // theta, u, v (and w if ERF_IMPLICIT_W is set)
     // 0: fully explicit
     // 1: fully implicit
-    amrex::Vector<amrex::Real> vert_implicit_fac = {one, one, zero}; // one value per RK stage
+    amrex::Vector<amrex::Vector<amrex::Real>> vert_implicit_fac; // one value per RK stage
+
     // if any vert_implicit_fac > 0, then the following apply:
     bool implicit_thermal_diffusion  = true;
     bool implicit_moisture_diffusion = true;

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1047,13 +1047,16 @@ ERF::InitData_post ()
     }
 
 #ifdef ERF_IMPLICIT_W
-    if (SolverChoice::mesh_type == MeshType::VariableDz &&
-        (solverChoice.vert_implicit_fac[0] > 0 ||
-         solverChoice.vert_implicit_fac[1] > 0 ||
-         solverChoice.vert_implicit_fac[2] > 0  )       &&
-        solverChoice.implicit_momentum_diffusion)
-    {
-        Warning("Doing implicit solve for u, v, and w with terrain -- this has not been tested");
+    if ( (SolverChoice::mesh_type == MeshType::VariableDz) &&
+         (solverChoice.implicit_momentum_diffusion) ) {
+        for (int lev = 0; lev <= finest_level; lev++) {
+            if ( (solverChoice.vert_implicit_fac[lev][0] > 0) ||
+                 (solverChoice.vert_implicit_fac[lev][1] > 0) ||
+                 (solverChoice.vert_implicit_fac[lev][2] > 0) )
+            {
+                Warning("Doing implicit solve for u, v, and w with terrain at level " << lev << " -- this has not been tested");
+            }
+        }
     }
 #endif
 

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -538,9 +538,9 @@ ERF::update_diffusive_arrays (int lev, const BoxArray& ba, const DistributionMap
     bool l_use_moist   = (  solverChoice.moisture_type != MoistureType::None  );
     bool l_rotate      = (  solverChoice.use_rotate_surface_flux  );
 
-    bool l_implicit_diff = (solverChoice.vert_implicit_fac[0] > 0 ||
-                            solverChoice.vert_implicit_fac[1] > 0 ||
-                            solverChoice.vert_implicit_fac[2] > 0);
+    bool l_implicit_diff = (solverChoice.vert_implicit_fac[lev][0] > 0 ||
+                            solverChoice.vert_implicit_fac[lev][1] > 0 ||
+                            solverChoice.vert_implicit_fac[lev][2] > 0);
 
     bool l_eb_surface_layer = (l_use_eb && solverChoice.ebChoice.eb_boundary_type == EBBoundaryType::SurfaceLayer);
 

--- a/Source/TimeIntegration/ERF_ImplicitPost.H
+++ b/Source/TimeIntegration/ERF_ImplicitPost.H
@@ -3,7 +3,7 @@
         // *****************************************************************************
         const bool l_do_implicit_ke    = solverChoice.implicit_ke_diffusion;
         const bool l_do_implicit_moist = solverChoice.implicit_moisture_diffusion;
-        const Real l_vert_implicit_fac = solverChoice.vert_implicit_fac[nrk];
+        const Real l_vert_implicit_fac = solverChoice.vert_implicit_fac[level][nrk];
         if ( l_vert_implicit_fac > zero ) {
 
             const bool l_use_turb         = solverChoice.turbChoice[level].use_kturb;

--- a/Source/TimeIntegration/ERF_ImplicitPre.H
+++ b/Source/TimeIntegration/ERF_ImplicitPre.H
@@ -2,7 +2,7 @@
         // Do semi-implicit solve for diffusion: theta, u, and v
         // *****************************************************************************
         {
-            const Real l_vert_implicit_fac = solverChoice.vert_implicit_fac[nrk];
+            const Real l_vert_implicit_fac = solverChoice.vert_implicit_fac[level][nrk];
 
             if (l_vert_implicit_fac > zero) {
 

--- a/Source/TimeIntegration/ERF_MakeTauTerms.cpp
+++ b/Source/TimeIntegration/ERF_MakeTauTerms.cpp
@@ -55,7 +55,7 @@ void erf_make_tau_terms (int level, int nrk,
     const bool need_SmnSmn      = (tc.les_type  == LESType::Deardorff ||
                                    tc.rans_type == RANSType::kEqn);
 
-    const bool do_implicit = (solverChoice.vert_implicit_fac[nrk] > 0) && solverChoice.implicit_momentum_diffusion;
+    const bool do_implicit = (solverChoice.vert_implicit_fac[level][nrk] > 0) && solverChoice.implicit_momentum_diffusion;
 
     const Box& domain = geom.Domain();
     const int domlo_z = domain.smallEnd(2);

--- a/Source/TimeIntegration/ERF_SlowRhsPost.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPost.cpp
@@ -425,7 +425,7 @@ void erf_slow_rhs_post (int level, int finest_level,
                     Real l_vert_implicit_fac = zero;
                     if ( (ivar == RhoKE_comp && solverChoice.implicit_ke_diffusion      ) ||
                          (ivar == RhoQ1_comp && solverChoice.implicit_moisture_diffusion) ) {
-                        l_vert_implicit_fac = solverChoice.vert_implicit_fac[nrk];
+                        l_vert_implicit_fac = solverChoice.vert_implicit_fac[level][nrk];
                     }
 
                     const Array4<const Real> tm_arr = t_mean_mf ? t_mean_mf->const_array(mfi) : Array4<const Real>{};

--- a/Source/TimeIntegration/ERF_SlowRhsPre.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPre.cpp
@@ -144,7 +144,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
     const bool l_need_SmnSmn    = tc.use_keqn;
 
     const Real l_vert_implicit_fac = (solverChoice.implicit_thermal_diffusion) ?
-                                     solverChoice.vert_implicit_fac[nrk] : zero;
+                                     solverChoice.vert_implicit_fac[level][nrk] : zero;
 
     const bool l_use_moisture  = (solverChoice.moisture_type != MoistureType::None);
     const bool l_use_SurfLayer = (SurfLayer != nullptr);

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
@@ -188,7 +188,7 @@
 #endif
                          fr_as_crse, fr_as_fine);
 
-        if ((solverChoice.vert_implicit_fac[nrk] > zero) && solverChoice.implicit_before_substep) {
+        if ((solverChoice.vert_implicit_fac[level][nrk] > zero) && solverChoice.implicit_before_substep) {
             MultiFab scratch(S_data[IntVars::cons].boxArray(),S_data[IntVars::cons].DistributionMap(), 2,
                              S_data[IntVars::cons].nGrowVect());
             MultiFab::Copy(scratch, S_old[IntVars::cons], 0, 0, 2, S_data[IntVars::cons].nGrowVect()); // scratch := S_old               (for rho, rhotheta)

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -170,7 +170,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
         // Even if we update all the conserved variables we don't need
         // to fillpatch the slow ones every acoustic substep
 
-        if ( (solverChoice.vert_implicit_fac[nrk] > zero) && !solverChoice.implicit_before_substep &&
+        if ( (solverChoice.vert_implicit_fac[level][nrk] > zero) && !solverChoice.implicit_before_substep &&
              (fast_step == n_sub-1) )
         {
             MultiFab scratch(S_data[IntVars::cons], make_alias, 0, 2);

--- a/Tests/test_files/ParticleAdvect/ParticleAdvect.i
+++ b/Tests/test_files/ParticleAdvect/ParticleAdvect.i
@@ -3,7 +3,6 @@ erf.prob_name = "Particles Over Flat Ground"
 
 erf.init_type = Isentropic
 
-
 max_step =  10
 
 amrex.fpe_trap_invalid = 1
@@ -59,10 +58,6 @@ erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta pr
 # SOLVER CHOICE
 erf.use_gravity = true
 erf.les_type = "None"
-
-# MULTILEVEL
-amr.max_level = 0
-
 
 erf.dycore_horiz_adv_type  = Centered_2nd
 erf.dycore_vert_adv_type   = Centered_2nd

--- a/Tests/test_files/ParticleWoA/ParticleWoA.i
+++ b/Tests/test_files/ParticleWoA/ParticleWoA.i
@@ -60,10 +60,6 @@ erf.plot_vars_1     = density x_velocity y_velocity z_velocity pressure theta pr
 erf.use_gravity = true
 erf.les_type = "None"
 
-# MULTILEVEL
-amr.max_level = 0
-
-
 # TERRRAIN GRID TYPE
 erf.terrain_type = StaticFittedMesh
 erf.terrain_smoothing = 0

--- a/Tests/test_files/SDM_Bubble2D_Adv_AMR1/SDM_Bubble2D_Adv_AMR1.i
+++ b/Tests/test_files/SDM_Bubble2D_Adv_AMR1/SDM_Bubble2D_Adv_AMR1.i
@@ -27,9 +27,6 @@ erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-
 # CHECKPOINT FILES
 erf.check_file      = chk       # root name of checkpoint file
 erf.check_int       = -1        # number of timesteps between checkpoints

--- a/Tests/test_files/SDM_Bubble2D_Adv_AMR2/SDM_Bubble2D_Adv_AMR2.i
+++ b/Tests/test_files/SDM_Bubble2D_Adv_AMR2/SDM_Bubble2D_Adv_AMR2.i
@@ -27,9 +27,6 @@ erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-
 # CHECKPOINT FILES
 erf.check_file      = chk       # root name of checkpoint file
 erf.check_int       = -1        # number of timesteps between checkpoints

--- a/Tests/test_files/SDM_Bubble3D_Adv/SDM_Bubble3D_Adv.i
+++ b/Tests/test_files/SDM_Bubble3D_Adv/SDM_Bubble3D_Adv.i
@@ -29,9 +29,6 @@ erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-
 # CHECKPOINT FILES
 erf.check_file      = chk       # root name of checkpoint file
 erf.check_int       = -1        # number of timesteps between checkpoints

--- a/Tests/test_files/SDM_Bubble3D_Adv_AMR1/SDM_Bubble3D_Adv_AMR1.i
+++ b/Tests/test_files/SDM_Bubble3D_Adv_AMR1/SDM_Bubble3D_Adv_AMR1.i
@@ -29,9 +29,6 @@ erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-
 # CHECKPOINT FILES
 erf.check_file      = chk       # root name of checkpoint file
 erf.check_int       = -1        # number of timesteps between checkpoints

--- a/Tests/test_files/SDM_Bubble3D_Adv_AMR2/SDM_Bubble3D_Adv_AMR2.i
+++ b/Tests/test_files/SDM_Bubble3D_Adv_AMR2/SDM_Bubble3D_Adv_AMR2.i
@@ -29,9 +29,6 @@ erf.sum_interval   = 1       # timesteps between computing mass
 erf.v              = 1       # verbosity in ERF.cpp
 amr.v              = 1       # verbosity in Amr.cpp
 
-# REFINEMENT / REGRIDDING
-amr.max_level       = 0       # maximum level number allowed
-
 # CHECKPOINT FILES
 erf.check_file      = chk       # root name of checkpoint file
 erf.check_int       = -1        # number of timesteps between checkpoints


### PR DESCRIPTION
This PR has two effects:

1) Make vert_implicit_fac an array of arrays - over levels then over RK stages.  This allows us to set different flags at different levels. 

2) Turns off vert_implicit if anelastic.    Note we needed (1) in order to allow hybrid algorithms, i.e. compressible at level 0 and anelastic at level 1.