### PR TITLE
base state pressure gradient check for flat terrain only

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1711,9 +1711,10 @@ ERF::InitData_post ()
 #endif
 
     // Print max values of lateral gradients of base state pressure at level 0
+    // Only for flat terrain where horizontal gradients should be zero
     if (verbose > 0) {
         for (int lev = 0; lev <= finest_level; ++lev) {
-            if ( (lev == 0) && (solverChoice.terrain_type != TerrainType::EB) ) {
+            if ( (lev == 0) && (solverChoice.terrain_type == TerrainType::None) ) {
                 compute_max_pressure_gradient_diagnostic(lev);
             }
         }


### PR DESCRIPTION
The verification of zero horizontal pressure gradients in the base state should only be done for flat terrain since a terrain-following grid with non-flat terrain should have non-zero gradients.

Tested by running Askervein. Was aborting, but runs with this change.