### PR TITLE
Correcting minor error in hurricane tracker output

### DIFF
--- a/Source/IO/ERF_TrackerOutput.cpp
+++ b/Source/IO/ERF_TrackerOutput.cpp
@@ -123,7 +123,7 @@ ERF::WriteVTKPolyline(const std::string& filename,
     // Write points (Z=0 assumed)
     vtkfile << "POINTS " << num_points << " float\n";
     for (const auto& pt : points_xy) {
-        vtkfile << pt[0] << " " << pt[1] << " Real(10000.0)\n";
+        vtkfile << pt[0] << " " << pt[1] << 10000.0 << std::endl;
     }
 
     // Write polyline connectivity


### PR DESCRIPTION
This PR corrects a minor error in the vtk file writing for hurricane diagnostics.