### PR TITLE
Add virtual destructor to SDInitProperties (fix -Wnon-virtual-dtor)

### DIFF
--- a/Source/Particles/ERF_SDInitialization.H
+++ b/Source/Particles/ERF_SDInitialization.H
@@ -150,6 +150,8 @@ class SDInitProperties
 {
     public:
 
+        virtual ~SDInitProperties() = default;
+
         using MatVec = std::vector<std::unique_ptr<MaterialProperties>>;
 
         /*!< Initial number of super-droplets per cell */


### PR DESCRIPTION
Add a virtual destructor to `SDInitProperties` (a polymorphic base) to silence `-Wnon-virtual-dtor`.