### PR TITLE
Add 2D surface diagnostic source mask

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -753,62 +753,103 @@ Output Options for 2D Plotfiles
 The table below lists the built-in 2D diagnostic catalog. ERF writes selected
 variables in this order.
 
-+--------------------+---------------------------------------------------------------+
-| Parameter          | Definition                                                    |
-+====================+===============================================================+
-| **z_surf**         | Surface elevation [m].                                        |
-+--------------------+---------------------------------------------------------------+
-| **landmask**       | Land-sea mask. Land is 1 and sea is 0 [1].                    |
-+--------------------+---------------------------------------------------------------+
-| **mapfac**         | Map factor at mass points [1].                                |
-+--------------------+---------------------------------------------------------------+
-| **lat_m**          | Latitude at unstaggered mass points [deg].                    |
-+--------------------+---------------------------------------------------------------+
-| **lon_m**          | Longitude at unstaggered mass points [deg].                   |
-+--------------------+---------------------------------------------------------------+
-| **u_star**         | Friction velocity from the surface layer [m/s]. ERF writes    |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **w_star**         | Convective velocity scale from the surface layer [m/s]. ERF   |
-|                    | writes -999 when the surface layer is not active.             |
-+--------------------+---------------------------------------------------------------+
-| **t_star**         | Temperature scale from the surface layer [K]. ERF writes      |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **q_star**         | Humidity scale from the surface layer [kg/kg]. ERF writes     |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **Olen**           | Obukhov length from the surface layer [m]. ERF writes -999    |
-|                    | when the surface layer is not active.                         |
-+--------------------+---------------------------------------------------------------+
-| **pblh**           | Diagnosed planetary boundary layer height [m]. ERF writes     |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **t_surf**         | Surface temperature from the surface layer [K]. ERF writes    |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **q_surf**         | Surface humidity from the surface layer [kg/kg]. ERF writes   |
-|                    | -999 when the surface layer is not active.                    |
-+--------------------+---------------------------------------------------------------+
-| **z0**             | Roughness height from the surface layer [m]. ERF writes -999  |
-|                    | when the surface layer is not active.                         |
-+--------------------+---------------------------------------------------------------+
-| **OLR**            | Outgoing longwave radiation at the model top [W/m^2]. ERF     |
-|                    | writes -999 when radiation is not active.                     |
-+--------------------+---------------------------------------------------------------+
-| **sens_flux**      | Surface sensible heat flux from the vertical surface flux     |
-|                    | field [kg K m^-2 s^-1]. ERF writes -999 when the flux field   |
-|                    | is not available.                                             |
-+--------------------+---------------------------------------------------------------+
-| **laten_flux**     | Surface moisture flux from the vertical water-vapor flux      |
-|                    | field [kg m^-2 s^-1]. This is a legacy output name. ERF       |
-|                    | writes -999 when the flux field is not available.             |
-+--------------------+---------------------------------------------------------------+
-| **surf_pres**      | Surface pressure [Pa].                                        |
-+--------------------+---------------------------------------------------------------+
-| **integrated_qv**  | Column-integrated water vapor [kg/m^2]. ERF writes zero when  |
-|                    | moisture is disabled.                                         |
-+--------------------+---------------------------------------------------------------+
++-------------------------------+-------------------------------------------------------+
+| Parameter                     | Definition                                            |
++===============================+=======================================================+
+| **z_surf**                    | Surface elevation [m].                                |
++-------------------------------+-------------------------------------------------------+
+| **landmask**                  | Land-sea mask. Land is 1 and sea is 0 [1].            |
++-------------------------------+-------------------------------------------------------+
+| **mapfac**                    | Map factor at mass points [1].                        |
++-------------------------------+-------------------------------------------------------+
+| **lat_m**                     | Latitude at unstaggered mass points [deg].            |
++-------------------------------+-------------------------------------------------------+
+| **lon_m**                     | Longitude at unstaggered mass points [deg].           |
++-------------------------------+-------------------------------------------------------+
+| **u_star**                    | Friction velocity from the surface layer [m/s]. ERF   |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **w_star**                    | Convective velocity scale from the surface layer [m/s]|
+|                               | ERF writes -999 when the surface layer is not active. |
++-------------------------------+-------------------------------------------------------+
+| **t_star**                    | Temperature scale from the surface layer [K]. ERF     |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **q_star**                    | Humidity scale from the surface layer [kg/kg]. ERF    |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **Olen**                      | Obukhov length from the surface layer [m]. ERF writes |
+|                               | -999 when the surface layer is not active.            |
++-------------------------------+-------------------------------------------------------+
+| **pblh**                      | Diagnosed planetary boundary layer height [m]. ERF    |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **t_surf**                    | Surface temperature from the surface layer [K]. ERF   |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **q_surf**                    | Surface humidity from the surface layer [kg/kg]. ERF  |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **z0**                        | Roughness height from the surface layer [m]. ERF      |
+|                               | writes -999 when the surface layer is not active.     |
++-------------------------------+-------------------------------------------------------+
+| **OLR**                       | Outgoing longwave radiation at the model top [W/m^2]. |
+|                               | ERF writes -999 when radiation is not active.         |
++-------------------------------+-------------------------------------------------------+
+| **sens_flux**                 | Surface sensible heat flux from the vertical surface  |
+|                               | flux field [kg K m^-2 s^-1]. ERF writes -999 when the |
+|                               | flux field is not available.                          |
++-------------------------------+-------------------------------------------------------+
+| **laten_flux**                | Surface moisture flux from the vertical water-vapor   |
+|                               | flux field [kg m^-2 s^-1]. This is a legacy output    |
+|                               | name. ERF writes -999 when the flux field is not      |
+|                               | available.                                            |
++-------------------------------+-------------------------------------------------------+
+| **surf_pres**                 | Surface pressure [Pa].                                |
++-------------------------------+-------------------------------------------------------+
+| **integrated_qv**             | Column-integrated water vapor [kg/m^2]. ERF writes    |
+|                               | zero when moisture is disabled.                       |
++-------------------------------+-------------------------------------------------------+
+| **surface_diagnostic_source** | Source code for the cell-centered SurfaceLayer scalar |
+|                               | diagnostic path. ERF writes -999 when SurfaceLayer is |
+|                               | not active.                                           |
++-------------------------------+-------------------------------------------------------+
+
+Surface Diagnostic Source Codes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``surface_diagnostic_source`` is a cell-centered categorical diagnostic. It
+reports the source path used by the SurfaceLayer scalar diagnostic path. It
+does not report fractional land-cover contributions.
+
+If an input dataset contains fractional land information, this diagnostic still
+reports the categorical source used by ERF's active SurfaceLayer scalar flux
+path.
+
+The diagnostic does not fully describe staggered stress-face provenance. ERF
+may average adjacent LSM and non-LSM contributions when applying staggered
+surface stresses.
+
++------+---------------------------------------------------------------+
+| Code | Meaning                                                       |
++======+===============================================================+
+| -999 | SurfaceLayer is inactive or the field is unavailable.         |
++------+---------------------------------------------------------------+
+| 0    | Missing or unset.                                             |
++------+---------------------------------------------------------------+
+| 1    | Non-LSM SurfaceLayer over land.                               |
++------+---------------------------------------------------------------+
+| 2    | LSM over land.                                                |
++------+---------------------------------------------------------------+
+| 3    | Non-LSM SurfaceLayer fallback where an LSM flux was undefined |
+|      | or unavailable for a land cell.                               |
++------+---------------------------------------------------------------+
+| 4    | Non-LSM SurfaceLayer over sea.                                |
++------+---------------------------------------------------------------+
+| 5    | Custom prescribed surface-layer values.                       |
++------+---------------------------------------------------------------+
+| 6    | RICO prescribed surface-layer values.                         |
++------+---------------------------------------------------------------+
 
 Examples of Usage
 -----------------

--- a/Source/BoundaryConditions/ERF_SurfaceDiagnosticSource.H
+++ b/Source/BoundaryConditions/ERF_SurfaceDiagnosticSource.H
@@ -1,0 +1,83 @@
+#ifndef ERF_SURFACE_DIAGNOSTIC_SOURCE_H_
+#define ERF_SURFACE_DIAGNOSTIC_SOURCE_H_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+
+namespace surface_diagnostics
+{
+
+// Diagnostic-only provenance codes written to 2D plotfiles.
+// These numeric values are a user-visible plotfile convention. Renumbering
+// them is a breaking output change. The mask is cell-centered and must not
+// affect flux calculations, boundary conditions, state updates, or staggered
+// stress-face source mixing.
+enum class SurfaceDiagnosticSource : int
+{
+    Missing              = 0,
+    SurfaceLayerLand     = 1,
+    LSMLand              = 2,
+    SurfaceLayerFallback = 3,
+    SurfaceLayerSea      = 4,
+    Custom               = 5,
+    RICO                 = 6
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+int
+to_int (SurfaceDiagnosticSource source) noexcept
+{
+    return static_cast<int>(source);
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real
+to_plot_value (SurfaceDiagnosticSource source) noexcept
+{
+    return static_cast<amrex::Real>(to_int(source));
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SurfaceDiagnosticSource
+classify_scalar_source (bool is_custom,
+                        bool is_rico,
+                        bool is_land,
+                        bool has_lsm_flux,
+                        bool lsm_flux_is_valid) noexcept
+{
+    if (is_custom) {
+        return SurfaceDiagnosticSource::Custom;
+    }
+    if (is_rico) {
+        return SurfaceDiagnosticSource::RICO;
+    }
+    if (is_land && has_lsm_flux && lsm_flux_is_valid) {
+        return SurfaceDiagnosticSource::LSMLand;
+    }
+    if (is_land && has_lsm_flux && !lsm_flux_is_valid) {
+        return SurfaceDiagnosticSource::SurfaceLayerFallback;
+    }
+    if (is_land) {
+        return SurfaceDiagnosticSource::SurfaceLayerLand;
+    }
+    return SurfaceDiagnosticSource::SurfaceLayerSea;
+}
+
+inline const char*
+source_name (SurfaceDiagnosticSource source) noexcept
+{
+    switch (source) {
+    case SurfaceDiagnosticSource::Missing:              return "missing";
+    case SurfaceDiagnosticSource::SurfaceLayerLand:     return "surface_layer_land";
+    case SurfaceDiagnosticSource::LSMLand:              return "lsm_land";
+    case SurfaceDiagnosticSource::SurfaceLayerFallback: return "surface_layer_fallback";
+    case SurfaceDiagnosticSource::SurfaceLayerSea:      return "surface_layer_sea";
+    case SurfaceDiagnosticSource::Custom:               return "custom";
+    case SurfaceDiagnosticSource::RICO:                 return "rico";
+    }
+    return "unknown";
+}
+
+} // namespace surface_diagnostics
+
+#endif

--- a/Source/BoundaryConditions/ERF_SurfaceDiagnosticSource.H
+++ b/Source/BoundaryConditions/ERF_SurfaceDiagnosticSource.H
@@ -45,14 +45,14 @@ classify_scalar_source (bool is_custom,
                         bool has_lsm_flux,
                         bool lsm_flux_is_valid) noexcept
 {
+    if (is_land && has_lsm_flux && lsm_flux_is_valid) {
+        return SurfaceDiagnosticSource::LSMLand;
+    }
     if (is_custom) {
         return SurfaceDiagnosticSource::Custom;
     }
     if (is_rico) {
         return SurfaceDiagnosticSource::RICO;
-    }
-    if (is_land && has_lsm_flux && lsm_flux_is_valid) {
-        return SurfaceDiagnosticSource::LSMLand;
     }
     if (is_land && has_lsm_flux && !lsm_flux_is_valid) {
         return SurfaceDiagnosticSource::SurfaceLayerFallback;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -13,6 +13,7 @@
 #include "ERF_MOSTAverage.H"
 #include "ERF_MOSTStress.H"
 #include "ERF_EBMOSTStress.H"
+#include "ERF_SurfaceDiagnosticSource.H"
 #include "ERF_TerrainMetrics.H"
 #include "ERF_PBLHeight.H"
 #include "ERF_MicrophysicsUtils.H"
@@ -463,6 +464,10 @@ public:
       q_surf[lev] = std::make_unique<amrex::MultiFab>(ba_flux, dm, ncomp, ng);
       q_surf[lev]->setVal(default_land_surf_moist);
 
+      surface_diagnostic_source[lev] = std::make_unique<amrex::MultiFab>(ba_flux, dm, ncomp, ng);
+      surface_diagnostic_source[lev]->setVal(
+          surface_diagnostics::to_plot_value(surface_diagnostics::SurfaceDiagnosticSource::Missing));
+
       // TODO: Do we want an enum struct for indexing?
 
       bool use_sst = (!m_sst_lev[lev].empty() && m_sst_lev[lev][0]);
@@ -639,6 +644,8 @@ public:
   amrex::MultiFab* get_q_surf (const int& lev) { return q_surf[lev].get(); }
   void set_q_surf(const int& lev, const amrex::Real qsurf) { q_surf[lev]->setVal(qsurf); }
 
+  amrex::MultiFab* get_surface_diagnostic_source (const int& lev) { return surface_diagnostic_source[lev].get(); }
+
   amrex::Real get_zref (const int& lev) { return (m_ma.get_zref(lev))->min(0); }
 
   amrex::MultiFab* get_z0 (const int& lev) { return &z_0[lev]; }
@@ -767,6 +774,10 @@ private:
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> pblh;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> t_surf;
   amrex::Vector<std::unique_ptr<amrex::MultiFab>> q_surf;
+  // Diagnostic-only provenance mask. This records the cell-centered source
+  // path used by the SurfaceLayer scalar diagnostic path. It must not feed
+  // back into flux calculations, boundary conditions, or model state.
+  amrex::Vector<std::unique_ptr<amrex::MultiFab>> surface_diagnostic_source;
 
   amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_sst_lev;
   amrex::Vector<amrex::Vector<amrex::MultiFab*>>  m_tsk_lev;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -335,6 +335,7 @@ public:
           q_star.resize(nlevs);
           t_surf.resize(nlevs);
           q_surf.resize(nlevs);
+          surface_diagnostic_source.resize(nlevs);
           olen.resize(nlevs);
           pblh.resize(nlevs);
       }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -542,6 +542,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         const auto q_star_arr = q_star[lev]->array(mfi);
         const auto t_surf_arr = t_surf[lev]->array(mfi);
         const auto q_surf_arr = q_surf[lev]->array(mfi);
+        auto surface_source_arr = surface_diagnostic_source[lev]->array(mfi);
 
         // Get LSM fluxes
         auto lmask_arr      = (m_lmask_lev[lev][0]) ? m_lmask_lev[lev][0]->array(mfi) :
@@ -557,6 +558,10 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             if (toLower(m_lsm_flux_name[n]) == "tau23")  { lsm_tau23_arr  = m_lsm_flux_lev[lev][n]->array(mfi); }
         }
 
+        const bool has_lsm_t_flux = static_cast<bool>(lsm_t_flux_arr);
+        const bool is_custom = (flux_type == FluxCalcType::CUSTOM);
+        const bool is_rico   = (flux_type == FluxCalcType::RICO);
+
 
         // Rho*Theta flux
         //============================================================================
@@ -570,15 +575,20 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             // open water); fall back to MOST there instead of applying garbage.
             Real Tflux;
             int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
-            if (lsm_t_flux_arr && is_land && lsm_t_flux_arr(i,j,0) < lsm_flux_undefined) {
+            const bool lsm_flux_is_valid = has_lsm_t_flux &&
+                                           lsm_t_flux_arr(i,j,0) < lsm_flux_undefined;
+            if (has_lsm_t_flux && is_land && lsm_flux_is_valid) {
                 Tflux = lsm_t_flux_arr(i,j,0);
             } else {
                 Tflux = flux_comp.compute_t_flux(i, j, k,
                                                  cons_arr, velx_arr, vely_arr,
                                                  umm_arr, tm_arr, u_star_arr,
                                                  t_star_arr, t_surf_arr);
-
             }
+
+            surface_source_arr(i,j,0) = surface_diagnostics::to_plot_value(
+                surface_diagnostics::classify_scalar_source(
+                    is_custom, is_rico, is_land, has_lsm_t_flux, lsm_flux_is_valid));
 
             // Do scalar flux rotations?
             if (rotate) {
@@ -615,6 +625,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 }
             });
         } // custom
+
+        surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 
         if (!rotate) {
             // Rho*u flux
@@ -741,6 +753,12 @@ SurfaceLayer::compute_SurfaceLayer_bcs_EB (const int& lev,
     const auto& u_bnorm = m_eb_vec[lev]->get_u_const_factory()->getBndryNorm();
     const auto& v_bnorm = m_eb_vec[lev]->get_v_const_factory()->getBndryNorm();
     const auto& w_bnorm = m_eb_vec[lev]->get_w_const_factory()->getBndryNorm();
+
+    // EB does not currently have a cell-centered scalar-source classification.
+    // Keep the provenance mask missing rather than inventing face-aware
+    // semantics for the staggered stress path.
+    surface_diagnostic_source[lev]->setVal(
+        surface_diagnostics::to_plot_value(surface_diagnostics::SurfaceDiagnosticSource::Missing));
 
     for (MFIter mfi(*mfs[0]); mfi.isValid(); ++mfi)
     {
@@ -901,6 +919,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs_EB (const int& lev,
             }
         });
     } // mfiter
+
+    surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 }
 
 void

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -626,8 +626,6 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             });
         } // custom
 
-        surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
-
         if (!rotate) {
             // Rho*u flux
             //============================================================================
@@ -919,6 +917,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs_EB (const int& lev,
             }
         });
     } // mfiter
+
+    surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 
 }
 

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -626,8 +626,6 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             });
         } // custom
 
-        surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
-
         if (!rotate) {
             // Rho*u flux
             //============================================================================

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -626,6 +626,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             });
         } // custom
 
+        surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
+
         if (!rotate) {
             // Rho*u flux
             //============================================================================
@@ -918,7 +920,6 @@ SurfaceLayer::compute_SurfaceLayer_bcs_EB (const int& lev,
         });
     } // mfiter
 
-    surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 }
 
 void

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -711,9 +711,11 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                                      t12_arr, t21_arr,
                                      t13_arr, t31_arr,
                                      t23_arr, t32_arr);
-            });
+                });
         }
     } // mfiter
+
+    surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 }
 
 /**
@@ -917,8 +919,6 @@ SurfaceLayer::compute_SurfaceLayer_bcs_EB (const int& lev,
             }
         });
     } // mfiter
-
-    surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());
 
 }
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -522,6 +522,26 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             mf_comp++;
         }
 
+        if (containerHasElement(plot_var_names, "surface_diagnostic_source")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (m_SurfaceLayer) {
+                for (MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& source = m_SurfaceLayer->get_surface_diagnostic_source(lev)->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = source(i, j, 0);
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // surface_diagnostic_source
+
         if (mf_comp != ncomp_mf) {
             Abort(plotfile2d::format_2d_component_count_error(lev, mf_comp, ncomp_mf));
         }

--- a/Source/IO/ERF_Plotfile2DCatalog.H
+++ b/Source/IO/ERF_Plotfile2DCatalog.H
@@ -28,7 +28,8 @@ enum class DiagnosticID
     SensFlux,
     LatenFlux,
     SurfPres,
-    IntegratedQv
+    IntegratedQv,
+    SurfaceDiagnosticSource
 };
 
 enum class DiagnosticCategory

--- a/Source/IO/ERF_Plotfile2DCatalog.cpp
+++ b/Source/IO/ERF_Plotfile2DCatalog.cpp
@@ -36,6 +36,10 @@ const amrex::Vector<DiagnosticDescriptor>& catalog_storage ()
         {DiagnosticID::LatenFlux,      "laten_flux",   "Surface moisture flux (legacy output name)",      "kg m^-2 s^-1", DiagnosticCategory::SurfaceFlux,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::SurfPres,       "surf_pres",    "Surface pressure",                                "Pa",        DiagnosticCategory::SurfaceState,   MissingPolicy::AlwaysAvailable},
         {DiagnosticID::IntegratedQv,   "integrated_qv","Column-integrated water vapor",                   "kg/m^2",    DiagnosticCategory::ColumnIntegral, MissingPolicy::FillZeroWhenUnavailable},
+        {DiagnosticID::SurfaceDiagnosticSource,
+                                         "surface_diagnostic_source",
+                                                        "Surface diagnostic source code",
+                                                        "1",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
     };
 
     return catalog;

--- a/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
+++ b/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
@@ -62,10 +62,4 @@ TEST(SurfaceDiagnosticSource, ClassifiesLsmAndFallbackPaths)
 
     EXPECT_EQ(classify_scalar_source(false, false, false, false, false),
               SurfaceDiagnosticSource::SurfaceLayerSea);
-
-    EXPECT_EQ(classify_scalar_source(true, false, true, true, true),
-              SurfaceDiagnosticSource::Custom);
-
-    EXPECT_EQ(classify_scalar_source(false, true, true, true, true),
-              SurfaceDiagnosticSource::RICO);
 }

--- a/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
+++ b/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
@@ -45,9 +45,17 @@ TEST(SurfaceDiagnosticSource, ClassifiesLsmAndFallbackPaths)
 {
     EXPECT_EQ(classify_scalar_source(false, false, true,  true,  true),
               SurfaceDiagnosticSource::LSMLand);
+    EXPECT_EQ(classify_scalar_source(true, false, true,  true,  true),
+              SurfaceDiagnosticSource::LSMLand);
+    EXPECT_EQ(classify_scalar_source(false, true, true,  true,  true),
+              SurfaceDiagnosticSource::LSMLand);
 
     EXPECT_EQ(classify_scalar_source(false, false, true,  true,  false),
               SurfaceDiagnosticSource::SurfaceLayerFallback);
+    EXPECT_EQ(classify_scalar_source(true, false, true,  true,  false),
+              SurfaceDiagnosticSource::Custom);
+    EXPECT_EQ(classify_scalar_source(false, true, true,  true,  false),
+              SurfaceDiagnosticSource::RICO);
 
     EXPECT_EQ(classify_scalar_source(false, false, true,  false, false),
               SurfaceDiagnosticSource::SurfaceLayerLand);

--- a/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
+++ b/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
@@ -1,0 +1,63 @@
+#include <array>
+#include <string>
+
+#include <gtest/gtest.h>
+
+#include "ERF_SurfaceDiagnosticSource.H"
+
+using namespace surface_diagnostics;
+
+// Motivation: surface_diagnostic_source writes numeric codes to plotfiles, so
+// the code values must stay stable across releases.
+TEST(SurfaceDiagnosticSource, PlotCodesAreStable)
+{
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::Missing), 0);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::SurfaceLayerLand), 1);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::LSMLand), 2);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::SurfaceLayerFallback), 3);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::SurfaceLayerSea), 4);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::Custom), 5);
+    EXPECT_EQ(to_int(SurfaceDiagnosticSource::RICO), 6);
+}
+
+// Motivation: source names make docs and debugging messages easier to keep in
+// sync with the numeric plotfile convention.
+TEST(SurfaceDiagnosticSource, SourceNamesAreNonEmpty)
+{
+    const std::array<SurfaceDiagnosticSource, 7> values{
+        SurfaceDiagnosticSource::Missing,
+        SurfaceDiagnosticSource::SurfaceLayerLand,
+        SurfaceDiagnosticSource::LSMLand,
+        SurfaceDiagnosticSource::SurfaceLayerFallback,
+        SurfaceDiagnosticSource::SurfaceLayerSea,
+        SurfaceDiagnosticSource::Custom,
+        SurfaceDiagnosticSource::RICO
+    };
+
+    for (const auto value : values) {
+        EXPECT_FALSE(std::string(source_name(value)).empty());
+    }
+}
+
+// Motivation: scalar source classification must distinguish valid LSM values
+// from fallback values without changing the underlying flux calculation.
+TEST(SurfaceDiagnosticSource, ClassifiesLsmAndFallbackPaths)
+{
+    EXPECT_EQ(classify_scalar_source(false, false, true,  true,  true),
+              SurfaceDiagnosticSource::LSMLand);
+
+    EXPECT_EQ(classify_scalar_source(false, false, true,  true,  false),
+              SurfaceDiagnosticSource::SurfaceLayerFallback);
+
+    EXPECT_EQ(classify_scalar_source(false, false, true,  false, false),
+              SurfaceDiagnosticSource::SurfaceLayerLand);
+
+    EXPECT_EQ(classify_scalar_source(false, false, false, false, false),
+              SurfaceDiagnosticSource::SurfaceLayerSea);
+
+    EXPECT_EQ(classify_scalar_source(true, false, true, true, true),
+              SurfaceDiagnosticSource::Custom);
+
+    EXPECT_EQ(classify_scalar_source(false, true, true, true, true),
+              SurfaceDiagnosticSource::RICO);
+}

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -33,6 +33,7 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestMain.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestHelloWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestPlotfile2D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSKernel.cpp

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -98,7 +98,7 @@ TEST(Plotfile2D, CatalogNamesMatchCanonicalOrder)
         "z_surf", "landmask", "mapfac", "lat_m", "lon_m",
         "u_star", "w_star", "t_star", "q_star", "Olen", "pblh",
         "t_surf", "q_surf", "z0", "OLR", "sens_flux", "laten_flux",
-        "surf_pres", "integrated_qv"
+        "surf_pres", "integrated_qv", "surface_diagnostic_source"
     };
 
     EXPECT_EQ(plotfile2d::diagnostic_names(), expected);
@@ -173,6 +173,21 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForKnownName)
     EXPECT_STREQ(descriptor->name, "sens_flux");
     EXPECT_EQ(descriptor->id, plotfile2d::DiagnosticID::SensFlux);
     EXPECT_EQ(descriptor->category, plotfile2d::DiagnosticCategory::SurfaceFlux);
+    EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+}
+
+// Motivation: The new provenance mask is a public 2D output, so its catalog
+// entry must be findable and carry the metadata that documents its output
+// convention.
+TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceDiagnosticSource)
+{
+    const auto* descriptor = plotfile2d::find_diagnostic("surface_diagnostic_source");
+
+    ASSERT_NE(descriptor, nullptr);
+    EXPECT_STREQ(descriptor->name, "surface_diagnostic_source");
+    EXPECT_EQ(descriptor->id, plotfile2d::DiagnosticID::SurfaceDiagnosticSource);
+    EXPECT_FALSE(std::string(descriptor->long_name).empty());
+    EXPECT_FALSE(std::string(descriptor->units).empty());
     EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }
 


### PR DESCRIPTION
## Summary

This PR adds a new optional 2D plotfile diagnostic:

```text
surface_diagnostic_source
```

The diagnostic reports the cell-centered source path used by the SurfaceLayer scalar diagnostic and heat-flux path. It is diagnostic-only and does not feed back into flux calculations, boundary conditions, tendencies, time stepping, or model state.

Changes include:

* Add a header-only `SurfaceDiagnosticSource` helper with stable plotfile codes.
* Add SurfaceLayer-owned `surface_diagnostic_source` storage and a getter.
* Fill the mask from the same scalar heat-flux source decision used in `compute_SurfaceLayer_bcs`.
* Copy the SurfaceLayer-owned mask in `ERF_Plotfile2D.cpp` without inferring provenance in the I/O layer.
* Append `surface_diagnostic_source` to the 2D plotfile catalog.
* Document the new 2D output variable and its source-code table.
* Add unit tests for stable code values, source names, classifier behavior, catalog order, and metadata.

## Source-code convention

The new diagnostic uses these plotfile codes:

```text
-999  SurfaceLayer is inactive or the field is unavailable
0     Missing or unset
1     Non-LSM SurfaceLayer over land
2     LSM over land
3     Non-LSM SurfaceLayer fallback where an LSM flux was undefined or unavailable for a land cell
4     Non-LSM SurfaceLayer over sea
5     Custom prescribed surface-layer values
6     RICO prescribed surface-layer values
```

## Scope and limitations

`surface_diagnostic_source` is cell-centered and categorical.

It does not report fractional land-cover contributions. If input data include fractional land information, this field still reports the categorical source used by ERF’s active SurfaceLayer scalar flux path.

It also does not describe staggered stress-face provenance. ERF may average adjacent LSM and non-LSM contributions when applying staggered `tau13` and `tau23` stresses. Face-aware stress provenance is left for a future diagnostic.

For EB terrain, the mask remains `Missing` because this PR does not define a clean cell-centered EB provenance convention.

## Expected behavior change

Existing model solutions and existing 2D output variables are unchanged.

The only new user-visible behavior is the optional 2D plotfile variable:

```text
surface_diagnostic_source
```
