### PR TITLE
SDM: fix -Wshadow (ctx) and -Wunused-parameter warnings

### DIFF
--- a/Source/Particles/ERF_SuperDropletPCAdvection.cpp
+++ b/Source/Particles/ERF_SuperDropletPCAdvection.cpp
@@ -50,7 +50,7 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
                  AMREX_ASSERT(!a_flow_vel[1].contains_nan());,
                  AMREX_ASSERT(!a_flow_vel[2].contains_nan()););
 
-    const auto ctx = buildProcessContext(a_lev);
+    const auto proc_ctx = buildProcessContext(a_lev);
     const Geometry& geom = m_gdb->Geom(a_lev);
     const Box& dom = geom.Domain();
     const int  k_max = dom.bigEnd(AMREX_SPACEDIM-1) - dom.smallEnd(AMREX_SPACEDIM-1);
@@ -62,9 +62,9 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
     const auto vterm_type_w = m_term_vel_type_w;
 
     // Terminal velocity calculator (shared across tiles)
-    TerminalVelocity<ParticleReal> term_vel { ctx.rho_water };
+    TerminalVelocity<ParticleReal> term_vel { proc_ctx.rho_water };
 
-    forEachParticleTile(a_lev, ctx,
+    forEachParticleTile(a_lev, proc_ctx,
         [&](ParIterType& /*pti*/, int grid, ParticleType* p_pbox,
             const SDProcess::ParticlePointers& ptrs,
             const SDProcess::ProcessContext& ctx)

--- a/Source/Particles/ERF_SuperDropletPCBoundaries.cpp
+++ b/Source/Particles/ERF_SuperDropletPCBoundaries.cpp
@@ -18,7 +18,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
     BL_PROFILE("SuperDropletPC::applyBoundaryTreatment()");
     const MFPtr& z_height = a_z_phys_nd[a_lev];
 
-    const auto ctx = buildProcessContext(a_lev);
+    const auto proc_ctx = buildProcessContext(a_lev);
     const auto save_inac = m_save_inactive;
 
     // number of super-droplets per cell
@@ -26,13 +26,13 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
     // number of physical particles per cell
     Real num_par_per_cell = zero;
     for (int i = 0; i < m_num_initializations; i++) {
-        num_par_per_cell += m_initializations[i]->numParticlesPerCell(ctx.cell_volume);
+        num_par_per_cell += m_initializations[i]->numParticlesPerCell(proc_ctx.cell_volume);
     }
     auto multiplicity = (num_sd_per_cell > 0 ? num_par_per_cell / num_sd_per_cell : zero);
 
     Long num_deactivated_particles = 0;
 
-    forEachParticleTile(a_lev, ctx,
+    forEachParticleTile(a_lev, proc_ctx,
         [&](ParIterType& /*pti*/, int grid, ParticleType* p_pbox,
             const SDProcess::ParticlePointers& ptrs,
             const SDProcess::ProcessContext& ctx)

--- a/Source/Particles/ERF_SuperDropletPCMassChange.cpp
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.cpp
@@ -29,7 +29,7 @@ void SuperDropletPC::MassChange ( int                                         a_
 
     BL_PROFILE("SuperDropletPC::MassChange()");
 
-    const auto ctx = buildProcessContext(a_lev);
+    const auto proc_ctx = buildProcessContext(a_lev);
 
     const std::unique_ptr<MultiFab>& z_height = a_z_phys_nd[a_lev];
 
@@ -72,7 +72,7 @@ void SuperDropletPC::MassChange ( int                                         a_
     constexpr int rtoff_r = SuperDropletsRealIdx::ncomps;
 #endif
 
-    forEachParticleTile(a_lev, ctx,
+    forEachParticleTile(a_lev, proc_ctx,
         [&](ParIterType& pti, int grid, ParticleType* p_pbox,
             const SDProcess::ParticlePointers& ptrs,
             const SDProcess::ProcessContext& ctx)

--- a/Source/Particles/ERF_SuperDropletPCRecycle.cpp
+++ b/Source/Particles/ERF_SuperDropletPCRecycle.cpp
@@ -20,6 +20,8 @@ void SuperDropletPC::Recycle ( const int             a_lev,
 {
     BL_PROFILE("SuperDropletPC::Recycle()");
 
+    amrex::ignore_unused(a_iter, a_dt);
+
     const auto num_sd_deactivated = NumSDDeactivated();
     const auto num_sd = NumSuperDroplets();
     const auto deac_frac = (num_sd > 0 ? static_cast<Real>(num_sd_deactivated)/static_cast<Real>(num_sd) : 0.0);
@@ -100,7 +102,7 @@ void SuperDropletPC::Recycle ( const int             a_lev,
         const auto init_r = *(m_initializations[init_idx]);
         const auto sampled_multiplicity = init_r.sampledMultiplicity();
 
-        const auto ctx = buildProcessContext(a_lev);
+        const auto proc_ctx = buildProcessContext(a_lev);
         const auto dx_h = Geom(a_lev).CellSize();
         const Real cell_volume = dx_h[0]*dx_h[1]*dx_h[2];
 
@@ -127,7 +129,7 @@ void SuperDropletPC::Recycle ( const int             a_lev,
         const auto z_min = m_recyc_zmin;
         const auto z_max = m_recyc_zmax;
 
-        forEachParticleTile(a_lev, ctx,
+        forEachParticleTile(a_lev, proc_ctx,
             [&](ParIterType& /*pti*/, int grid, ParticleType* p_pbox,
                 const SDProcess::ParticlePointers& ptrs,
                 const SDProcess::ProcessContext& ctx)
@@ -251,9 +253,9 @@ void SuperDropletPC::Recycle ( const int             a_lev,
 
         amrex::Print() << "Removing inactive particles.\n";
 
-        const auto ctx = buildProcessContext(a_lev);
+        const auto proc_ctx = buildProcessContext(a_lev);
 
-        forEachParticleTile(a_lev, ctx,
+        forEachParticleTile(a_lev, proc_ctx,
             [&](ParIterType& /*pti*/, int /*grid*/, ParticleType* p_pbox,
                 const SDProcess::ParticlePointers& ptrs,
                 const SDProcess::ProcessContext& /*ctx*/)


### PR DESCRIPTION
Fix `-Wshadow` (the `ctx` from `buildProcessContext` shadowed by the `forEachParticleTile` lambda parameter, in `MassChange`/`Recycle`/`Boundaries`/`Advection`) and `-Wunused-parameter` (`a_iter`, `a_dt` in `Recycle`) warnings in the SDM particle code.