### PR TITLE
Add W m-2 surface flux diagnostics

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -814,6 +814,22 @@ variables in this order.
 |                               | diagnostic path. ERF writes -999 when SurfaceLayer is |
 |                               | not active.                                           |
 +-------------------------------+-------------------------------------------------------+
+| **sensible_heat_flux**        | Surface sensible heat flux [W m^-2]. ERF writes     |
+|                               | -999 when the flux field is not available.          |
++-------------------------------+-------------------------------------------------------+
+| **latent_heat_flux**          | Surface latent heat flux [W m^-2]. ERF writes       |
+|                               | -999 when moisture is disabled or the flux field is |
+|                               | not available.                                       |
++-------------------------------+-------------------------------------------------------+
+
+sens_flux and laten_flux are legacy ERF internal conservative scalar flux
+outputs. sensible_heat_flux and latent_heat_flux convert those applied
+conservative fluxes to W m^-2 using Cp_d and L_v, respectively.
+
+The sign convention follows ERF's lower-boundary flux convention. No source-
+specific Noah-MP or MOST conversion is applied in the diagnostic layer. The
+Noah-MP LSM kinematic-to-conservative conversion happens upstream in
+SurfaceLayer.
 
 Surface Diagnostic Source Codes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Source/Diagnostics/ERF_SurfaceFluxDiagnostics.H
+++ b/Source/Diagnostics/ERF_SurfaceFluxDiagnostics.H
@@ -1,0 +1,43 @@
+#ifndef ERF_SURFACE_FLUX_DIAGNOSTICS_H_
+#define ERF_SURFACE_FLUX_DIAGNOSTICS_H_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+
+#include "ERF_Constants.H"
+
+namespace surface_flux_diagnostics
+{
+
+/**
+ * Convert applied conservative surface fluxes to W m^-2 for 2D plotfile output.
+ *
+ * `SFS_hfx3` and `SFS_q1fx3` are already conservative applied fluxes. Noah-MP
+ * LSM kinematic fluxes are converted to conservative fluxes in
+ * `SurfaceLayer::compute_SurfaceLayer_bcs`, so this layer must not multiply by
+ * density. The output sign convention follows ERF's lower-boundary flux
+ * convention. These helpers exist so the 2D writer does not duplicate unit
+ * semantics.
+ *
+ * Maintenance note:
+ * Do not add source-specific Noah-MP/MOST branches here. If this helper ever
+ * appears to need a density factor, the applied SurfaceLayer flux contract has
+ * likely been broken upstream.
+ */
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real
+sensible_heat_flux_wm2_from_rhotheta_flux (amrex::Real rhotheta_flux) noexcept
+{
+    return Cp_d * rhotheta_flux;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real
+latent_heat_flux_wm2_from_rhoqv_flux (amrex::Real rhoqv_flux) noexcept
+{
+    return L_v * rhoqv_flux;
+}
+
+} // namespace surface_flux_diagnostics
+
+#endif

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -2,6 +2,7 @@
 #include "ERF_Plotfile2DCatalog.H"
 #include "ERF_NCPlotFile.H"
 #include "ERF_Plotfile2DUtils.H"
+#include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
 #include "ERF_EpochTime.H"
 #include "ERF_SrcHeaders.H"
 #include "ERF_StormDiagnostics.H"
@@ -541,6 +542,52 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             }
             mf_comp++;
         } // surface_diagnostic_source
+
+        if (containerHasElement(plot_var_names, "sensible_heat_flux")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (SFS_hfx3_lev[lev]) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& hfx_arr = SFS_hfx3_lev[lev]->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        // Delegate unit semantics to the surface flux diagnostics helper.
+                        derdat(i, j, k, mf_comp) =
+                            surface_flux_diagnostics::sensible_heat_flux_wm2_from_rhotheta_flux(
+                                hfx_arr(i, j, klo));
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // sensible_heat_flux
+
+        if (containerHasElement(plot_var_names, "latent_heat_flux")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+            if (SFS_q1fx3_lev[lev]) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& qfx_arr = SFS_q1fx3_lev[lev]->const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        // Delegate unit semantics to the surface flux diagnostics helper.
+                        derdat(i, j, k, mf_comp) =
+                            surface_flux_diagnostics::latent_heat_flux_wm2_from_rhoqv_flux(
+                                qfx_arr(i, j, klo));
+                    });
+                }
+            } else {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // latent_heat_flux
 
         if (mf_comp != ncomp_mf) {
             Abort(plotfile2d::format_2d_component_count_error(lev, mf_comp, ncomp_mf));

--- a/Source/IO/ERF_Plotfile2DCatalog.H
+++ b/Source/IO/ERF_Plotfile2DCatalog.H
@@ -29,7 +29,9 @@ enum class DiagnosticID
     LatenFlux,
     SurfPres,
     IntegratedQv,
-    SurfaceDiagnosticSource
+    SurfaceDiagnosticSource,
+    SensibleHeatFlux,
+    LatentHeatFlux
 };
 
 enum class DiagnosticCategory

--- a/Source/IO/ERF_Plotfile2DCatalog.cpp
+++ b/Source/IO/ERF_Plotfile2DCatalog.cpp
@@ -40,8 +40,8 @@ const amrex::Vector<DiagnosticDescriptor>& catalog_storage ()
                                          "surface_diagnostic_source",
                                                         "Surface diagnostic source code",
                                                         "1",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
-        {DiagnosticID::SensibleHeatFlux,"sensible_heat_flux","Surface sensible heat flux",                  "W m^-2",    DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
-        {DiagnosticID::LatentHeatFlux,  "latent_heat_flux","Surface latent heat flux",                    "W m^-2",    DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::SensibleHeatFlux,"sensible_heat_flux","Surface sensible heat flux",                  "W m^-2",    DiagnosticCategory::SurfaceFlux,     MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::LatentHeatFlux,  "latent_heat_flux","Surface latent heat flux",                    "W m^-2",    DiagnosticCategory::SurfaceFlux,     MissingPolicy::FillMinus999WhenUnavailable},
     };
 
     return catalog;

--- a/Source/IO/ERF_Plotfile2DCatalog.cpp
+++ b/Source/IO/ERF_Plotfile2DCatalog.cpp
@@ -40,6 +40,8 @@ const amrex::Vector<DiagnosticDescriptor>& catalog_storage ()
                                          "surface_diagnostic_source",
                                                         "Surface diagnostic source code",
                                                         "1",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::SensibleHeatFlux,"sensible_heat_flux","Surface sensible heat flux",                  "W m^-2",    DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::LatentHeatFlux,  "latent_heat_flux","Surface latent heat flux",                    "W m^-2",    DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
     };
 
     return catalog;

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -34,6 +34,7 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestHelloWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Diagnostics/ERF_GTestSurfaceFluxDiagnostics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestPlotfile2D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSKernel.cpp

--- a/Tests/Unit/Diagnostics/ERF_GTestSurfaceFluxDiagnostics.cpp
+++ b/Tests/Unit/Diagnostics/ERF_GTestSurfaceFluxDiagnostics.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
+
+using namespace surface_flux_diagnostics;
+
+// Motivation: The diagnostic layer must convert already-conservative surface
+// fluxes directly to W m^-2 and must not introduce a density factor.
+TEST(SurfaceFluxDiagnostics, SensibleHeatFluxConversionUsesCpD)
+{
+    const amrex::Real positive = amrex::Real(1.75);
+    const amrex::Real negative = amrex::Real(-0.5);
+
+    EXPECT_DOUBLE_EQ(sensible_heat_flux_wm2_from_rhotheta_flux(positive), Cp_d * positive);
+    EXPECT_DOUBLE_EQ(sensible_heat_flux_wm2_from_rhotheta_flux(negative), Cp_d * negative);
+}
+
+// Motivation: The diagnostic layer must convert already-conservative surface
+// fluxes directly to W m^-2 and must not introduce a density factor.
+TEST(SurfaceFluxDiagnostics, LatentHeatFluxConversionUsesLv)
+{
+    const amrex::Real positive = amrex::Real(1.75);
+    const amrex::Real negative = amrex::Real(-0.5);
+
+    EXPECT_DOUBLE_EQ(latent_heat_flux_wm2_from_rhoqv_flux(positive), L_v * positive);
+    EXPECT_DOUBLE_EQ(latent_heat_flux_wm2_from_rhoqv_flux(negative), L_v * negative);
+}

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -98,7 +98,8 @@ TEST(Plotfile2D, CatalogNamesMatchCanonicalOrder)
         "z_surf", "landmask", "mapfac", "lat_m", "lon_m",
         "u_star", "w_star", "t_star", "q_star", "Olen", "pblh",
         "t_surf", "q_surf", "z0", "OLR", "sens_flux", "laten_flux",
-        "surf_pres", "integrated_qv", "surface_diagnostic_source"
+        "surf_pres", "integrated_qv", "surface_diagnostic_source",
+        "sensible_heat_flux", "latent_heat_flux"
     };
 
     EXPECT_EQ(plotfile2d::diagnostic_names(), expected);
@@ -189,6 +190,27 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceDiagnosticSource)
     EXPECT_FALSE(std::string(descriptor->long_name).empty());
     EXPECT_FALSE(std::string(descriptor->units).empty());
     EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+}
+
+// Motivation: The W m^-2 diagnostics are public 2D outputs, so their catalog
+// entries must expose the intended units, category, and missing-value policy.
+TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceFluxComposition)
+{
+    const auto* sensible = plotfile2d::find_diagnostic("sensible_heat_flux");
+    ASSERT_NE(sensible, nullptr);
+    EXPECT_STREQ(sensible->name, "sensible_heat_flux");
+    EXPECT_EQ(sensible->id, plotfile2d::DiagnosticID::SensibleHeatFlux);
+    EXPECT_EQ(sensible->category, plotfile2d::DiagnosticCategory::SurfaceLayer);
+    EXPECT_STREQ(sensible->units, "W m^-2");
+    EXPECT_EQ(sensible->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+
+    const auto* latent = plotfile2d::find_diagnostic("latent_heat_flux");
+    ASSERT_NE(latent, nullptr);
+    EXPECT_STREQ(latent->name, "latent_heat_flux");
+    EXPECT_EQ(latent->id, plotfile2d::DiagnosticID::LatentHeatFlux);
+    EXPECT_EQ(latent->category, plotfile2d::DiagnosticCategory::SurfaceLayer);
+    EXPECT_STREQ(latent->units, "W m^-2");
+    EXPECT_EQ(latent->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }
 
 // Motivation: Unknown catalog lookups should fail cleanly so callers can

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -200,7 +200,7 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceFluxComposition)
     ASSERT_NE(sensible, nullptr);
     EXPECT_STREQ(sensible->name, "sensible_heat_flux");
     EXPECT_EQ(sensible->id, plotfile2d::DiagnosticID::SensibleHeatFlux);
-    EXPECT_EQ(sensible->category, plotfile2d::DiagnosticCategory::SurfaceLayer);
+    EXPECT_EQ(sensible->category, plotfile2d::DiagnosticCategory::SurfaceFlux);
     EXPECT_STREQ(sensible->units, "W m^-2");
     EXPECT_EQ(sensible->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 
@@ -208,7 +208,7 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceFluxComposition)
     ASSERT_NE(latent, nullptr);
     EXPECT_STREQ(latent->name, "latent_heat_flux");
     EXPECT_EQ(latent->id, plotfile2d::DiagnosticID::LatentHeatFlux);
-    EXPECT_EQ(latent->category, plotfile2d::DiagnosticCategory::SurfaceLayer);
+    EXPECT_EQ(latent->category, plotfile2d::DiagnosticCategory::SurfaceFlux);
     EXPECT_STREQ(latent->units, "W m^-2");
     EXPECT_EQ(latent->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }


### PR DESCRIPTION
## Summary

This PR adds a small surface flux diagnostic composition helper and two new optional 2D plotfile diagnostics:

```text
sensible_heat_flux
latent_heat_flux
```

These diagnostics report surface fluxes in `W m^-2`.

The new helper converts already-applied conservative SurfaceLayer fluxes to energy flux units:

```text
sensible_heat_flux = Cp_d * SFS_hfx3
latent_heat_flux   = L_v  * SFS_q1fx3
```

The helper explicitly documents the unit contract: the SurfaceLayer handoff already converts Noah-MP LSM kinematic fluxes to conservative applied fluxes, so the diagnostic layer must not apply an additional density factor.

## Changes

* Added `Source/Diagnostics/ERF_SurfaceFluxDiagnostics.H`.
* Added `sensible_heat_flux` and `latent_heat_flux` to the 2D diagnostic catalog.
* Appended the new diagnostics after `surface_diagnostic_source`, preserving existing 2D output order as a prefix.
* Added 2D writer support for the new diagnostics.
* Preserved legacy `sens_flux` and `laten_flux` behavior.
* Documented the new outputs in the Sphinx plotfile documentation.
* Added unit tests for the helper conversions and catalog metadata.

## Scope

This PR does not change model physics, SurfaceLayer flux selection, Noah-MP flux conversion, MOST flux formulas, or existing 2D diagnostic behavior.

The legacy diagnostics remain unchanged:

```text
sens_flux   -> conservative RhoTheta surface flux
laten_flux  -> conservative RhoQ1 / water-vapor surface flux
```

The new diagnostics provide user-facing `W m^-2` conversions of those applied conservative fluxes.