### PR TITLE
Make 2D surface diagnostics native-SHOC aware

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -781,8 +781,9 @@ variables in this order.
 | **Olen**                      | Obukhov length from the surface layer [m]. ERF writes |
 |                               | -999 when the surface layer is not active.            |
 +-------------------------------+-------------------------------------------------------+
-| **pblh**                      | Diagnosed planetary boundary layer height [m]. ERF    |
-|                               | writes -999 when the surface layer is not active.     |
+| **pblh**                      | Diagnosed planetary boundary layer height from the    |
+|                               | active PBL diagnostic provider [m]. ERF writes -999   |
+|                               | when no PBL diagnostics are active.                   |
 +-------------------------------+-------------------------------------------------------+
 | **t_surf**                    | Surface temperature from the surface layer [K]. ERF   |
 |                               | writes -999 when the surface layer is not active.     |
@@ -821,6 +822,16 @@ variables in this order.
 |                               | -999 when moisture is disabled or the flux field is |
 |                               | not available.                                       |
 +-------------------------------+-------------------------------------------------------+
+| **shoc_u_star**               | Native SHOC friction velocity diagnostic [m/s]. ERF  |
+|                               | writes -999 when Native SHOC is not active.          |
++-------------------------------+-------------------------------------------------------+
+| **shoc_Olen**                 | Native SHOC Obukhov length diagnostic [m]. ERF      |
+|                               | writes -999 when Native SHOC is not active.          |
++-------------------------------+-------------------------------------------------------+
+| **shoc_wthv_sfc**             | Native SHOC surface virtual potential temperature    |
+|                               | flux [K m s^-1]. ERF writes -999 when Native SHOC is |
+|                               | not active.                                          |
++-------------------------------+-------------------------------------------------------+
 
 sens_flux and laten_flux are legacy ERF internal conservative scalar flux
 outputs. sensible_heat_flux and latent_heat_flux convert those applied
@@ -834,6 +845,10 @@ SurfaceLayer.
 Native SHOC continues to consume the host flux and stress arrays through its
 existing preprocessing path, which divides by near-surface density before the
 coupled column update.
+
+In native SHOC state_update mode, SHOC is the transport owner. The
+``surface_diagnostic_source`` field still describes the upstream surface-flux
+source path used before SHOC consumes it.
 
 Surface Diagnostic Source Codes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -781,9 +781,10 @@ variables in this order.
 | **Olen**                      | Obukhov length from the surface layer [m]. ERF writes |
 |                               | -999 when the surface layer is not active.            |
 +-------------------------------+-------------------------------------------------------+
-| **pblh**                      | Diagnosed planetary boundary layer height from the    |
-|                               | active PBL diagnostic provider [m]. ERF writes -999   |
-|                               | when no PBL diagnostics are active.                   |
+| **pblh**                      | Diagnosed planetary boundary layer height [m]. Native |
+|                               | SHOC diagnostics are used when available; otherwise   |
+|                               | ERF falls back to SurfaceLayer. ERF writes -999 when  |
+|                               | no PBL diagnostic provider is available.              |
 +-------------------------------+-------------------------------------------------------+
 | **t_surf**                    | Surface temperature from the surface layer [K]. ERF   |
 |                               | writes -999 when the surface layer is not active.     |
@@ -797,14 +798,20 @@ variables in this order.
 | **OLR**                       | Outgoing longwave radiation at the model top [W/m^2]. |
 |                               | ERF writes -999 when radiation is not active.         |
 +-------------------------------+-------------------------------------------------------+
-| **sens_flux**                 | Surface sensible heat flux from the vertical surface  |
-|                               | flux field [kg K m^-2 s^-1]. ERF writes -999 when the |
-|                               | flux field is not available.                          |
+| **sens_flux**                 | Conservative surface sensible heat flux [kg K m^-2    |
+|                               | s^-1]. In native SHOC ``state_update`` mode, this     |
+|                               | reports the preserved surface flux consumed by SHOC.  |
+|                               | Otherwise, it reports the host vertical surface flux  |
+|                               | field. ERF writes -999 when the corresponding flux    |
+|                               | source is unavailable.                                |
 +-------------------------------+-------------------------------------------------------+
-| **laten_flux**                | Surface moisture flux from the vertical water-vapor   |
-|                               | flux field [kg m^-2 s^-1]. This is a legacy output    |
-|                               | name. ERF writes -999 when the flux field is not      |
-|                               | available.                                            |
+| **laten_flux**                | Conservative surface moisture flux [kg m^-2 s^-1].    |
+|                               | This is a legacy output name. In native SHOC          |
+|                               | ``state_update`` mode, this reports the preserved     |
+|                               | surface moisture flux consumed by SHOC. Otherwise, it |
+|                               | reports the host vertical water-vapor surface flux    |
+|                               | field. ERF writes -999 when the corresponding flux    |
+|                               | source is unavailable.                                |
 +-------------------------------+-------------------------------------------------------+
 | **surf_pres**                 | Surface pressure [Pa].                                |
 +-------------------------------+-------------------------------------------------------+
@@ -812,41 +819,55 @@ variables in this order.
 |                               | zero when moisture is disabled.                       |
 +-------------------------------+-------------------------------------------------------+
 | **surface_diagnostic_source** | Source code for the cell-centered SurfaceLayer scalar |
-|                               | diagnostic path. ERF writes -999 when SurfaceLayer is |
-|                               | not active.                                           |
+|                               | diagnostic path [1]. ERF writes -999 when SurfaceLay  |
+|                               | er is not active.                                     |
 +-------------------------------+-------------------------------------------------------+
-| **sensible_heat_flux**        | Surface sensible heat flux [W m^-2]. ERF writes     |
-|                               | -999 when the flux field is not available.          |
+| **sensible_heat_flux**        | Surface sensible heat flux [W m^-2], computed from    |
+|                               | the same conservative source as ``sens_flux``. In     |
+|                               | native SHOC ``state_update`` mode, this uses SHOC's   |
+|                               | preserved consumed-flux snapshot. ERF writes -999     |
+|                               | when the sensible flux source is unavailable.         |
 +-------------------------------+-------------------------------------------------------+
-| **latent_heat_flux**          | Surface latent heat flux [W m^-2]. ERF writes       |
-|                               | -999 when moisture is disabled or the flux field is |
-|                               | not available.                                       |
+| **latent_heat_flux**          | Surface latent heat flux [W m^-2], computed from the  |
+|                               | same conservative source as ``laten_flux``. In native |
+|                               | SHOC ``state_update`` mode, this uses SHOC's          |
+|                               | preserved consumed-flux snapshot. ERF writes -999     |
+|                               | when moisture or the latent flux source is            |
+|                               | unavailable.                                          |
 +-------------------------------+-------------------------------------------------------+
-| **shoc_u_star**               | Native SHOC friction velocity diagnostic [m/s]. ERF  |
-|                               | writes -999 when Native SHOC is not active.          |
+| **shoc_u_star**               | Native SHOC friction velocity diagnostic [m/s]. ERF   |
+|                               | writes -999 when native SHOC diagnostics are          |
+|                               | unavailable.                                          |
 +-------------------------------+-------------------------------------------------------+
-| **shoc_Olen**                 | Native SHOC Obukhov length diagnostic [m]. ERF      |
-|                               | writes -999 when Native SHOC is not active.          |
+| **shoc_Olen**                 | Native SHOC Obukhov length diagnostic [m]. ERF writes |
+|                               | -999 when native SHOC diagnostics are unavailable.    |
 +-------------------------------+-------------------------------------------------------+
-| **shoc_wthv_sfc**             | Native SHOC surface virtual potential temperature    |
-|                               | flux [K m s^-1]. ERF writes -999 when Native SHOC is |
-|                               | not active.                                          |
+| **shoc_wthv_sfc**             | Native SHOC surface virtual potential temperature     |
+|                               | flux [K m s^-1]. ERF writes -999 when native SHOC     |
+|                               | diagnostics are unavailable.                          |
 +-------------------------------+-------------------------------------------------------+
 
-sens_flux and laten_flux are legacy ERF internal conservative scalar flux
-outputs. sensible_heat_flux and latent_heat_flux convert those applied
-conservative fluxes to W m^-2 using Cp_d and L_v, respectively.
+``sens_flux`` and ``laten_flux`` are legacy ERF conservative scalar flux
+outputs. ``sensible_heat_flux`` and ``latent_heat_flux`` convert the same
+selected conservative flux sources to W m^-2 using ``Cp_d`` and ``L_v``,
+respectively.
 
-The sign convention follows ERF's lower-boundary flux convention. No source-
-specific Noah-MP or MOST conversion is applied in the diagnostic layer. The
-Noah-MP LSM kinematic-to-conservative conversion happens upstream in
-SurfaceLayer.
+For non-SHOC configurations and native SHOC host-diffusion mode, these outputs
+use the host vertical surface flux arrays. In native SHOC ``state_update`` mode,
+SHOC consumes those surface fluxes before the host diffusion path clears the
+overlapping arrays. In that mode, the 2D flux diagnostics use SHOC's preserved
+consumed-flux snapshots, component by component. If the corresponding host flux
+field was unavailable before SHOC consumed it, ERF writes -999 rather than a
+zero SHOC snapshot.
 
-Native SHOC continues to consume the host flux and stress arrays through its
-existing preprocessing path, which divides by near-surface density before the
-coupled column update.
+The sign convention follows ERF's lower-boundary flux convention. No
+source-specific Noah-MP, MOST, or SHOC conversion is applied in the 2D
+diagnostic layer. Noah-MP LSM kinematic-to-conservative conversion happens
+upstream in SurfaceLayer. Native SHOC converts the conservative host fluxes to
+kinematic column inputs internally, then the diagnostic snapshot preserves the
+consumed flux in conservative ERF output units.
 
-In native SHOC state_update mode, SHOC is the transport owner. The
+In native SHOC ``state_update`` mode, SHOC is the transport owner. The
 ``surface_diagnostic_source`` field still describes the upstream surface-flux
 source path used before SHOC consumes it.
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -166,18 +166,27 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         const MultiFab* laten_flux_source = SFS_q1fx3_lev[lev].get();
 #ifdef ERF_USE_NATIVE_SHOC
         const ShocDriver* native_shoc = native_shoc_driver[lev].get();
-        // Native SHOC state_update clears the host SFS arrays after consuming
-        // them, so 2D flux diagnostics must use SHOC's preserved snapshots
-        // when SHOC owns scalar surface transport.
-        const bool use_native_shoc_consumed_fluxes =
-            native_shoc &&
-            native_shoc->owns_scalar_surface_fluxes() &&
-            native_shoc->has_consumed_surface_flux_diagnostics();
+        const bool native_shoc_owns_scalar_fluxes =
+            native_shoc && native_shoc->owns_scalar_surface_fluxes();
+        const bool native_shoc_has_consumed_flux_diagnostics =
+            native_shoc && native_shoc->has_consumed_surface_flux_diagnostics();
         if (native_shoc && native_shoc->has_native_diagnostics()) {
             pblh_source = &native_shoc->pblh_diagnostics();
         }
-        if (use_native_shoc_consumed_fluxes) {
+        // Native SHOC state_update clears the host SFS arrays after consuming
+        // them. Use SHOC's preserved snapshots only for flux components whose
+        // corresponding host SFS field existed; otherwise keep the source null
+        // so the 2D writer emits the documented -999 missing value.
+        if (plotfile2d::use_native_shoc_consumed_flux_source(
+                native_shoc_owns_scalar_fluxes,
+                native_shoc_has_consumed_flux_diagnostics,
+                SFS_hfx3_lev[lev] != nullptr)) {
             sens_flux_source = &native_shoc->consumed_sens_flux_diagnostics();
+        }
+        if (plotfile2d::use_native_shoc_consumed_flux_source(
+                native_shoc_owns_scalar_fluxes,
+                native_shoc_has_consumed_flux_diagnostics,
+                SFS_q1fx3_lev[lev] != nullptr)) {
             laten_flux_source = &native_shoc->consumed_laten_flux_diagnostics();
         }
 #endif

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -161,6 +161,33 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         int klo = geom[lev].Domain().smallEnd(2);
         int khi = geom[lev].Domain().bigEnd(2);
 
+        const MultiFab* pblh_source = nullptr;
+        const MultiFab* sens_flux_source = SFS_hfx3_lev[lev].get();
+        const MultiFab* laten_flux_source = SFS_q1fx3_lev[lev].get();
+#ifdef ERF_USE_NATIVE_SHOC
+        const ShocDriver* native_shoc = native_shoc_driver[lev].get();
+        // Native SHOC state_update clears the host SFS arrays after consuming
+        // them, so 2D flux diagnostics must use SHOC's preserved snapshots
+        // when SHOC owns scalar surface transport.
+        const bool use_native_shoc_consumed_fluxes =
+            native_shoc &&
+            native_shoc->owns_scalar_surface_fluxes() &&
+            native_shoc->has_consumed_surface_flux_diagnostics();
+        if (native_shoc && native_shoc->has_native_diagnostics()) {
+            pblh_source = &native_shoc->pblh_diagnostics();
+        }
+        if (use_native_shoc_consumed_fluxes) {
+            sens_flux_source = &native_shoc->consumed_sens_flux_diagnostics();
+            laten_flux_source = &native_shoc->consumed_laten_flux_diagnostics();
+        }
+#endif
+        // pblh should follow the active PBL diagnostic provider. Native SHOC
+        // diagnoses its own PBL height in state_update mode; SurfaceLayer
+        // remains the fallback for non-SHOC configurations.
+        if (!pblh_source && m_SurfaceLayer) {
+            pblh_source = m_SurfaceLayer->get_pblh(lev);
+        }
+
         if (containerHasElement(plot_var_names, "z_surf")) {
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -355,12 +382,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            if (m_SurfaceLayer) {
+            if (pblh_source) {
                 for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_pblh(lev)->const_array(mfi);
+                    const auto& ustar  = pblh_source->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                        derdat(i, j, k, mf_comp) = ustar(i, j, 0);
                     });
@@ -455,12 +482,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            if (SFS_hfx3_lev[lev]) {
+            if (sens_flux_source) {
                 for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& hfx_arr = SFS_hfx3_lev[lev]->const_array(mfi);
+                    const auto& hfx_arr = sens_flux_source->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         derdat(i, j, k, mf_comp) = hfx_arr(i, j, klo);
                     });
@@ -477,12 +504,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            if (SFS_q1fx3_lev[lev]) {
+            if (laten_flux_source) {
                 for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& qfx_arr = SFS_q1fx3_lev[lev]->const_array(mfi);
+                    const auto& qfx_arr = laten_flux_source->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         derdat(i, j, k, mf_comp) = qfx_arr(i, j, klo);
                     });
@@ -547,12 +574,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            if (SFS_hfx3_lev[lev]) {
+            if (sens_flux_source) {
                 for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& hfx_arr = SFS_hfx3_lev[lev]->const_array(mfi);
+                    const auto& hfx_arr = sens_flux_source->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         // Delegate unit semantics to the surface flux diagnostics helper.
                         derdat(i, j, k, mf_comp) =
@@ -570,12 +597,12 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
-            if (SFS_q1fx3_lev[lev]) {
+            if (laten_flux_source) {
                 for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
                 {
                     const Box& bx = mfi.tilebox();
                     const auto& derdat = mf[lev].array(mfi);
-                    const auto& qfx_arr = SFS_q1fx3_lev[lev]->const_array(mfi);
+                    const auto& qfx_arr = laten_flux_source->const_array(mfi);
                     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         // Delegate unit semantics to the surface flux diagnostics helper.
                         derdat(i, j, k, mf_comp) =
@@ -588,6 +615,75 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             }
             mf_comp++;
         } // latent_heat_flux
+
+        if (containerHasElement(plot_var_names, "shoc_u_star")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+#ifdef ERF_USE_NATIVE_SHOC
+            if (native_shoc && native_shoc->has_native_diagnostics()) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& source = native_shoc->shoc_ustar_diagnostics().const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = source(i, j, klo);
+                    });
+                }
+            } else
+#endif
+            {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // shoc_u_star
+
+        if (containerHasElement(plot_var_names, "shoc_Olen")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+#ifdef ERF_USE_NATIVE_SHOC
+            if (native_shoc && native_shoc->has_native_diagnostics()) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& source = native_shoc->shoc_olen_diagnostics().const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = source(i, j, klo);
+                    });
+                }
+            } else
+#endif
+            {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // shoc_Olen
+
+        if (containerHasElement(plot_var_names, "shoc_wthv_sfc")) {
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+#ifdef ERF_USE_NATIVE_SHOC
+            if (native_shoc && native_shoc->has_native_diagnostics()) {
+                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
+                {
+                    const Box& bx = mfi.tilebox();
+                    const auto& derdat = mf[lev].array(mfi);
+                    const auto& source = native_shoc->wthv_sec_diagnostics().const_array(mfi);
+                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        derdat(i, j, k, mf_comp) = source(i, j, klo);
+                    });
+                }
+            } else
+#endif
+            {
+                mf[lev].setVal(-999, mf_comp, 1, 0);
+            }
+            mf_comp++;
+        } // shoc_wthv_sfc
 
         if (mf_comp != ncomp_mf) {
             Abort(plotfile2d::format_2d_component_count_error(lev, mf_comp, ncomp_mf));

--- a/Source/IO/ERF_Plotfile2DCatalog.H
+++ b/Source/IO/ERF_Plotfile2DCatalog.H
@@ -31,7 +31,10 @@ enum class DiagnosticID
     IntegratedQv,
     SurfaceDiagnosticSource,
     SensibleHeatFlux,
-    LatentHeatFlux
+    LatentHeatFlux,
+    ShocUStar,
+    ShocOlen,
+    ShocWthvSfc
 };
 
 enum class DiagnosticCategory
@@ -40,6 +43,7 @@ enum class DiagnosticCategory
     SurfaceLayer,
     Radiation,
     SurfaceFlux,
+    PBL,
     SurfaceState,
     ColumnIntegral
 };

--- a/Source/IO/ERF_Plotfile2DCatalog.cpp
+++ b/Source/IO/ERF_Plotfile2DCatalog.cpp
@@ -27,7 +27,7 @@ const amrex::Vector<DiagnosticDescriptor>& catalog_storage ()
         {DiagnosticID::TStar,          "t_star",       "Temperature scale from the surface layer",        "K",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::QStar,          "q_star",       "Humidity scale from the surface layer",           "kg/kg",     DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::Olen,           "Olen",         "Obukhov length from the surface layer",          "m",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
-        {DiagnosticID::Pblh,           "pblh",         "Planetary boundary layer height",                "m",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::Pblh,           "pblh",         "Planetary boundary layer height from the active PBL diagnostic provider", "m",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::TSurf,          "t_surf",       "Surface temperature from the surface layer",      "K",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::QSurf,          "q_surf",       "Surface humidity from the surface layer",         "kg/kg",     DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::Z0,             "z0",           "Roughness height from the surface layer",         "m",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
@@ -42,6 +42,9 @@ const amrex::Vector<DiagnosticDescriptor>& catalog_storage ()
                                                         "1",         DiagnosticCategory::SurfaceLayer,    MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::SensibleHeatFlux,"sensible_heat_flux","Surface sensible heat flux",                  "W m^-2",    DiagnosticCategory::SurfaceFlux,     MissingPolicy::FillMinus999WhenUnavailable},
         {DiagnosticID::LatentHeatFlux,  "latent_heat_flux","Surface latent heat flux",                    "W m^-2",    DiagnosticCategory::SurfaceFlux,     MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::ShocUStar,      "shoc_u_star",  "Native SHOC friction velocity diagnostic",        "m/s",       DiagnosticCategory::PBL,             MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::ShocOlen,       "shoc_Olen",    "Native SHOC Obukhov length diagnostic",            "m",         DiagnosticCategory::PBL,             MissingPolicy::FillMinus999WhenUnavailable},
+        {DiagnosticID::ShocWthvSfc,    "shoc_wthv_sfc","Native SHOC surface virtual potential temperature flux", "K m s^-1", DiagnosticCategory::PBL,             MissingPolicy::FillMinus999WhenUnavailable},
     };
 
     return catalog;

--- a/Source/IO/ERF_Plotfile2DUtils.H
+++ b/Source/IO/ERF_Plotfile2DUtils.H
@@ -3,6 +3,7 @@
 
 #include <string>
 
+#include <AMReX_GpuQualifiers.H>
 #include <AMReX_Vector.H>
 
 // Narrow helper utilities for 2D plotfile request handling and message
@@ -11,6 +12,19 @@
 
 namespace plotfile2d
 {
+
+// Native SHOC state_update preserves consumed surface fluxes for diagnostics,
+// but each flux component remains available only if the corresponding host SFS
+// field existed before SHOC consumed and cleared it.
+AMREX_FORCE_INLINE
+bool use_native_shoc_consumed_flux_source (bool native_shoc_owns_scalar_fluxes,
+                                           bool native_shoc_has_consumed_flux_diagnostics,
+                                           bool host_flux_field_available) noexcept
+{
+    return native_shoc_owns_scalar_fluxes &&
+           native_shoc_has_consumed_flux_diagnostics &&
+           host_flux_field_available;
+}
 
 struct PlotVariableSelection
 {

--- a/Source/PBL/Shoc/ERF_ShocDriver.H
+++ b/Source/PBL/Shoc/ERF_ShocDriver.H
@@ -86,9 +86,24 @@ public:
     bool owns_surface_fluxes () const;
     bool debug_summary_enabled () const { return m_opts.debug_summary; }
     bool has_native_diagnostics () const { return m_eddy_coeffs_cc.isDefined(); }
+    bool has_consumed_surface_flux_diagnostics () const
+    {
+        return m_consumed_sens_flux_cc.isDefined() && m_consumed_laten_flux_cc.isDefined();
+    }
     const amrex::MultiFab& native_diagnostics () const { return m_eddy_coeffs_cc; }
     // Native SHOC pblh is diagnosed in meters above local ground (AGL).
     const amrex::MultiFab& pblh_diagnostics () const { return m_pblh_cc; }
+    // Diagnostic-only provenance of the scalar fluxes consumed by native SHOC.
+    const amrex::MultiFab& consumed_sens_flux_diagnostics () const
+    {
+        return m_consumed_sens_flux_cc;
+    }
+    const amrex::MultiFab& consumed_laten_flux_diagnostics () const
+    {
+        return m_consumed_laten_flux_cc;
+    }
+    const amrex::MultiFab& shoc_ustar_diagnostics () const { return m_shoc_ustar_cc; }
+    const amrex::MultiFab& shoc_olen_diagnostics () const { return m_shoc_olen_cc; }
     const amrex::MultiFab& shoc_cldfrac_diagnostics () const { return m_shoc_cldfrac_cc; }
     const amrex::MultiFab& shoc_ql_diagnostics () const { return m_shoc_ql_cc; }
     const amrex::MultiFab& shoc_ql2_diagnostics () const { return m_shoc_ql2_cc; }
@@ -126,7 +141,11 @@ private:
     amrex::MultiFab m_eddy_coeffs_cc;
     amrex::MultiFab m_prev_turb_cc;
     amrex::MultiFab m_prev_wthv_sec_cc;
+    amrex::MultiFab m_consumed_sens_flux_cc;
+    amrex::MultiFab m_consumed_laten_flux_cc;
     amrex::MultiFab m_pblh_cc;
+    amrex::MultiFab m_shoc_ustar_cc;
+    amrex::MultiFab m_shoc_olen_cc;
     amrex::MultiFab m_shoc_cldfrac_cc;
     amrex::MultiFab m_shoc_ql_cc;
     amrex::MultiFab m_shoc_ql2_cc;

--- a/Source/PBL/Shoc/ERF_ShocDriver.cpp
+++ b/Source/PBL/Shoc/ERF_ShocDriver.cpp
@@ -336,7 +336,11 @@ ShocDriver::ensure_storage (const MultiFab& cons,
                                 EddyDiff::NumDiffs, 0);
         m_prev_turb_cc.define(cons.boxArray(), cons.DistributionMap(), 2, 0);
         m_prev_wthv_sec_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
+        m_consumed_sens_flux_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
+        m_consumed_laten_flux_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
         m_pblh_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
+        m_shoc_ustar_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
+        m_shoc_olen_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
         m_shoc_cldfrac_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
         m_shoc_ql_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
         m_shoc_ql2_cc.define(cons.boxArray(), cons.DistributionMap(), 1, 0);
@@ -368,7 +372,11 @@ ShocDriver::ensure_storage (const MultiFab& cons,
     m_u_tend_fc.setVal(0.0);
     m_v_tend_fc.setVal(0.0);
     m_eddy_coeffs_cc.setVal(0.0);
+    m_consumed_sens_flux_cc.setVal(0.0);
+    m_consumed_laten_flux_cc.setVal(0.0);
     m_pblh_cc.setVal(0.0);
+    m_shoc_ustar_cc.setVal(0.0);
+    m_shoc_olen_cc.setVal(0.0);
     m_shoc_cldfrac_cc.setVal(0.0);
     m_shoc_ql_cc.setVal(0.0);
     m_shoc_ql2_cc.setVal(0.0);
@@ -571,6 +579,10 @@ ShocDriver::advance (MultiFab& cons,
         auto u_tend_cc = m_u_tend_cc.array(mfi);
         auto v_tend_cc = m_v_tend_cc.array(mfi);
         auto pblh_arr = m_pblh_cc.array(mfi);
+        auto consumed_sens_flux_arr = m_consumed_sens_flux_cc.array(mfi);
+        auto consumed_laten_flux_arr = m_consumed_laten_flux_cc.array(mfi);
+        auto shoc_ustar_arr = m_shoc_ustar_cc.array(mfi);
+        auto shoc_olen_arr = m_shoc_olen_cc.array(mfi);
         auto shoc_cldfrac_arr = m_shoc_cldfrac_cc.array(mfi);
         auto shoc_ql_arr = m_shoc_ql_cc.array(mfi);
         auto shoc_ql2_arr = m_shoc_ql2_cc.array(mfi);
@@ -592,6 +604,10 @@ ShocDriver::advance (MultiFab& cons,
 
         const auto shoc_mix = col.shoc_mix.const_array();
         const auto pblh = col.pblh.const_array();
+        const auto surf_sens_flux = col.surf_sens_flux.const_array();
+        const auto surf_lat_flux = col.surf_lat_flux.const_array();
+        const auto ustar = col.ustar.const_array();
+        const auto obklen = col.obklen.const_array();
         const auto shoc_cldfrac = col.shoc_cldfrac.const_array();
         const auto shoc_ql = col.shoc_ql.const_array();
         const auto shoc_ql2 = col.shoc_ql2.const_array();
@@ -629,6 +645,8 @@ ShocDriver::advance (MultiFab& cons,
             ParallelFor(xy_box, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
             {
                 const int ic = shoc_column_index(layout, i, j);
+                const int k0 = layout.kmin;
+                const Real rho_sfc = rho(ic,0,0);
                 for (int kk = 0; kk < layout.nlev; ++kk) {
                     const int k = layout.kmin + kk;
                     const Real l = shoc_mix(ic,kk,0);
@@ -683,6 +701,15 @@ ShocDriver::advance (MultiFab& cons,
                     buoy_prod_arr(i,j,k) = buoy_prod(ic,kk,0);
                     diss_tke_arr(i,j,k) = diss_tke(ic,kk,0);
                 }
+                // Motivation: Native SHOC state_update consumes SurfaceLayer
+                // fluxes before the host diffusion path clears the overlapping
+                // SFS arrays. Preserve the consumed conservative fluxes here
+                // so 2D diagnostics report the surface forcing SHOC actually
+                // used, not the cleared host arrays.
+                consumed_sens_flux_arr(i,j,k0) = rho_sfc * surf_sens_flux(ic,0,0);
+                consumed_laten_flux_arr(i,j,k0) = rho_sfc * surf_lat_flux(ic,0,0);
+                shoc_ustar_arr(i,j,k0) = ustar(ic,0,0);
+                shoc_olen_arr(i,j,k0) = obklen(ic,0,0);
                 });
         }
 

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -230,6 +230,44 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceFluxComposition)
     EXPECT_EQ(latent->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }
 
+// Motivation: Native SHOC state_update preserves consumed flux snapshots, but
+// the 2D writer must not turn an absent host latent-flux field into a zero
+// SHOC snapshot. Missing flux components should still fill -999.
+TEST(Plotfile2D, NativeShocConsumedFluxSelectionRequiresHostFluxField)
+{
+    EXPECT_TRUE(plotfile2d::use_native_shoc_consumed_flux_source(true, true, true));
+    EXPECT_FALSE(plotfile2d::use_native_shoc_consumed_flux_source(true, true, false));
+    EXPECT_FALSE(plotfile2d::use_native_shoc_consumed_flux_source(true, false, true));
+    EXPECT_FALSE(plotfile2d::use_native_shoc_consumed_flux_source(false, true, true));
+    EXPECT_FALSE(plotfile2d::use_native_shoc_consumed_flux_source(false, false, false));
+}
+
+// Motivation: Sensible and latent fluxes are selected independently, so one
+// missing host field must not force the other component to use the wrong
+// source.
+TEST(Plotfile2D, NativeShocConsumedFluxSelectionIsComponentSpecific)
+{
+    const bool native_shoc_owns_scalar_fluxes = true;
+    const bool native_shoc_has_consumed_flux_diagnostics = true;
+    const bool host_sensible_flux_available = true;
+    const bool host_latent_flux_available = false;
+
+    const bool use_sensible =
+        plotfile2d::use_native_shoc_consumed_flux_source(
+            native_shoc_owns_scalar_fluxes,
+            native_shoc_has_consumed_flux_diagnostics,
+            host_sensible_flux_available);
+
+    const bool use_latent =
+        plotfile2d::use_native_shoc_consumed_flux_source(
+            native_shoc_owns_scalar_fluxes,
+            native_shoc_has_consumed_flux_diagnostics,
+            host_latent_flux_available);
+
+    EXPECT_TRUE(use_sensible);
+    EXPECT_FALSE(use_latent);
+}
+
 // Motivation: Native SHOC diagnostics are public 2D outputs, so their catalog
 // entries must expose the intended category and missing-value policy.
 TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForNativeShocSurfaceDiagnostics)

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -99,7 +99,8 @@ TEST(Plotfile2D, CatalogNamesMatchCanonicalOrder)
         "u_star", "w_star", "t_star", "q_star", "Olen", "pblh",
         "t_surf", "q_surf", "z0", "OLR", "sens_flux", "laten_flux",
         "surf_pres", "integrated_qv", "surface_diagnostic_source",
-        "sensible_heat_flux", "latent_heat_flux"
+        "sensible_heat_flux", "latent_heat_flux",
+        "shoc_u_star", "shoc_Olen", "shoc_wthv_sfc"
     };
 
     EXPECT_EQ(plotfile2d::diagnostic_names(), expected);
@@ -145,6 +146,7 @@ TEST(Plotfile2D, CatalogDescriptorsHaveRequiredMetadata)
         case plotfile2d::DiagnosticCategory::SurfaceLayer:
         case plotfile2d::DiagnosticCategory::Radiation:
         case plotfile2d::DiagnosticCategory::SurfaceFlux:
+        case plotfile2d::DiagnosticCategory::PBL:
         case plotfile2d::DiagnosticCategory::SurfaceState:
         case plotfile2d::DiagnosticCategory::ColumnIntegral:
             valid_category = true;
@@ -174,6 +176,21 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForKnownName)
     EXPECT_STREQ(descriptor->name, "sens_flux");
     EXPECT_EQ(descriptor->id, plotfile2d::DiagnosticID::SensFlux);
     EXPECT_EQ(descriptor->category, plotfile2d::DiagnosticCategory::SurfaceFlux);
+    EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+}
+
+// Motivation: pblh now follows the active PBL diagnostic provider, so the
+// catalog metadata must describe the provider rather than only SurfaceLayer.
+TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForPblh)
+{
+    const auto* descriptor = plotfile2d::find_diagnostic("pblh");
+
+    ASSERT_NE(descriptor, nullptr);
+    EXPECT_STREQ(descriptor->name, "pblh");
+    EXPECT_EQ(descriptor->id, plotfile2d::DiagnosticID::Pblh);
+    EXPECT_EQ(descriptor->category, plotfile2d::DiagnosticCategory::SurfaceLayer);
+    EXPECT_STREQ(descriptor->units, "m");
+    EXPECT_TRUE(contains(descriptor->long_name, "active PBL diagnostic provider"));
     EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }
 
@@ -211,6 +228,35 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceFluxComposition)
     EXPECT_EQ(latent->category, plotfile2d::DiagnosticCategory::SurfaceFlux);
     EXPECT_STREQ(latent->units, "W m^-2");
     EXPECT_EQ(latent->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+}
+
+// Motivation: Native SHOC diagnostics are public 2D outputs, so their catalog
+// entries must expose the intended category and missing-value policy.
+TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForNativeShocSurfaceDiagnostics)
+{
+    const auto* ustar = plotfile2d::find_diagnostic("shoc_u_star");
+    ASSERT_NE(ustar, nullptr);
+    EXPECT_STREQ(ustar->name, "shoc_u_star");
+    EXPECT_EQ(ustar->id, plotfile2d::DiagnosticID::ShocUStar);
+    EXPECT_EQ(ustar->category, plotfile2d::DiagnosticCategory::PBL);
+    EXPECT_STREQ(ustar->units, "m/s");
+    EXPECT_EQ(ustar->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+
+    const auto* olen = plotfile2d::find_diagnostic("shoc_Olen");
+    ASSERT_NE(olen, nullptr);
+    EXPECT_STREQ(olen->name, "shoc_Olen");
+    EXPECT_EQ(olen->id, plotfile2d::DiagnosticID::ShocOlen);
+    EXPECT_EQ(olen->category, plotfile2d::DiagnosticCategory::PBL);
+    EXPECT_STREQ(olen->units, "m");
+    EXPECT_EQ(olen->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+
+    const auto* wthv = plotfile2d::find_diagnostic("shoc_wthv_sfc");
+    ASSERT_NE(wthv, nullptr);
+    EXPECT_STREQ(wthv->name, "shoc_wthv_sfc");
+    EXPECT_EQ(wthv->id, plotfile2d::DiagnosticID::ShocWthvSfc);
+    EXPECT_EQ(wthv->category, plotfile2d::DiagnosticCategory::PBL);
+    EXPECT_STREQ(wthv->units, "K m s^-1");
+    EXPECT_EQ(wthv->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
 }
 
 // Motivation: Unknown catalog lookups should fail cleanly so callers can

--- a/Tests/Unit/Shoc/ERF_ShocDriverTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocDriverTests.cpp
@@ -992,6 +992,7 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     });
     EXPECT_TRUE(driver.has_native_diagnostics());
     EXPECT_TRUE(driver.uses_state_update());
+    EXPECT_TRUE(driver.has_consumed_surface_flux_diagnostics());
 
     expect_multifab_finite(driver.native_diagnostics(), 0, EddyDiff::NumDiffs, "native_diagnostics");
     expect_component_nonnegative(driver.native_diagnostics(), EddyDiff::Mom_v, "native Kmv");
@@ -1005,6 +1006,10 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
 
     expect_multifab_finite(driver.pblh_diagnostics(), 0, 1, "pblh");
     expect_component_nonnegative(driver.pblh_diagnostics(), 0, "pblh");
+    expect_multifab_finite(driver.consumed_sens_flux_diagnostics(), 0, 1, "consumed_sens_flux");
+    expect_multifab_finite(driver.consumed_laten_flux_diagnostics(), 0, 1, "consumed_laten_flux");
+    expect_multifab_finite(driver.shoc_ustar_diagnostics(), 0, 1, "shoc_ustar");
+    expect_multifab_finite(driver.shoc_olen_diagnostics(), 0, 1, "shoc_olen");
 
     expect_multifab_finite(driver.shoc_cldfrac_diagnostics(), 0, 1, "cloud fraction");
     expect_component_between(driver.shoc_cldfrac_diagnostics(), 0, 0.0_rt, 1.0_rt, "cloud fraction");
@@ -1050,6 +1055,10 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     expect_component_between(qfx3, 0, 0.0_rt, 0.0_rt, "qfx3 cleared");
     expect_component_minmax_match(tau13, tau13_before, 0, "tau13 preserved for host momentum diffusion");
     expect_component_minmax_match(tau23, tau23_before, 0, "tau23 preserved for host momentum diffusion");
+    expect_component_minmax_match(driver.consumed_sens_flux_diagnostics(), hfx3_before, 0,
+                                  "consumed sensible flux preserved");
+    expect_component_minmax_match(driver.consumed_laten_flux_diagnostics(), qfx3_before, 0,
+                                  "consumed latent flux preserved");
 
     amrex::Vector<MultiFab> rhs(IntVars::NumTypes);
     rhs[IntVars::cons].define(ba, dm, NVAR_max, 0);
@@ -1311,6 +1320,80 @@ TEST(ShocDriver, PassiveScalarIsNotModifiedByNativeShoc)
     });
 
     EXPECT_EQ(component_max_abs(rhs[IntVars::cons], RhoScalar_comp), 0.0_rt);
+}
+
+// Motivation: Native SHOC state_update intentionally clears host SFS arrays
+// after consuming them. 2D diagnostics need a preserved snapshot of the
+// consumed fluxes so output reports the surface forcing SHOC used.
+TEST(ShocDriver, PreservesConsumedSurfaceFluxDiagnosticsAfterHostArraysAreCleared)
+{
+    Box domain(IntVect(0,0,0), IntVect(nx-1, ny-1, nz-1));
+    amrex::RealBox real_box(0.0_rt, 0.0_rt, 0.0_rt,
+                            500.0_rt, 100.0_rt, 900.0_rt);
+    int is_periodic[AMREX_SPACEDIM] = {1, 1, 0};
+    Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic);
+    const FixtureMap fixture = load_driver_fixture();
+
+    amrex::BoxArray ba(domain);
+    ba.maxSize(IntVect(3, ny, nz));
+    DistributionMapping dm(ba);
+
+    MultiFab cons(ba, dm, NVAR_max, 0);
+    amrex::BoxArray xba = amrex::convert(ba, IntVect(1,0,0));
+    amrex::BoxArray yba = amrex::convert(ba, IntVect(0,1,0));
+    amrex::BoxArray zba = amrex::convert(ba, IntVect(0,0,1));
+    amrex::BoxArray xzba = amrex::convert(ba, IntVect(1,0,1));
+    amrex::BoxArray yzba = amrex::convert(ba, IntVect(0,1,1));
+
+    MultiFab xvel(xba, dm, 1, 0);
+    MultiFab yvel(yba, dm, 1, 0);
+    MultiFab zvel(zba, dm, 1, 0);
+    MultiFab z_phys_nd(make_nodal_zphys_boxarray(ba), dm, 1, 0);
+    MultiFab hfx3(ba, dm, 1, 0);
+    MultiFab qfx3(ba, dm, 1, 0);
+    MultiFab tau13(xzba, dm, 1, 0);
+    MultiFab tau23(yzba, dm, 1, 0);
+    MultiFab eddy_diffs(ba, dm, EddyDiff::NumDiffs, 0);
+
+    initialize_state(cons, fixture);
+    initialize_velocity(xvel, yvel, zvel, fixture);
+    initialize_geometry(z_phys_nd, fixture);
+    initialize_surface_fluxes(hfx3, qfx3, tau13, tau23, fixture);
+    initialize_eddy_diffs(eddy_diffs, fixture);
+    shoc_test::sync();
+
+    MultiFab hfx3_before(ba, dm, 1, 0);
+    MultiFab qfx3_before(ba, dm, 1, 0);
+    MultiFab::Copy(hfx3_before, hfx3, 0, 0, 1, 0);
+    MultiFab::Copy(qfx3_before, qfx3, 0, 0, 1, 0);
+
+    SolverChoice solver_choice;
+    solver_choice.moisture_type = MoistureType::None;
+
+    ShocDriver driver(0, solver_choice);
+
+    shoc_test::run_and_sync([&] {
+        driver.advance(cons, xvel, yvel, zvel,
+                       &tau13, &tau23, &hfx3, &qfx3, &eddy_diffs,
+                       z_phys_nd, geom, 10.0_rt);
+    });
+
+    EXPECT_TRUE(driver.has_consumed_surface_flux_diagnostics());
+    expect_component_minmax_match(driver.consumed_sens_flux_diagnostics(), hfx3_before, 0,
+                                  "consumed sensible flux snapshot");
+    expect_component_minmax_match(driver.consumed_laten_flux_diagnostics(), qfx3_before, 0,
+                                  "consumed latent flux snapshot");
+
+    shoc_test::run_and_sync([&] {
+        driver.set_diff_stresses();
+    });
+
+    expect_component_between(hfx3, 0, 0.0_rt, 0.0_rt, "host hfx3 cleared");
+    expect_component_between(qfx3, 0, 0.0_rt, 0.0_rt, "host qfx3 cleared");
+    expect_component_minmax_match(driver.consumed_sens_flux_diagnostics(), hfx3_before, 0,
+                                  "preserved sensible flux snapshot");
+    expect_component_minmax_match(driver.consumed_laten_flux_diagnostics(), qfx3_before, 0,
+                                  "preserved latent flux snapshot");
 }
 
 TEST(ShocDriver, SecondAdvanceIgnoresHostDiffSeedsAfterCarryStateIsEstablished)


### PR DESCRIPTION
## Summary

This PR fixes 2D surface diagnostics for native SHOC `state_update` mode.

Native SHOC consumes SurfaceLayer lower-boundary fluxes and stresses before the host diffusion path runs. It then clears overlapping host flux arrays so the host path does not apply the same transport a second time.

The 2D writer previously read those host arrays directly. In native SHOC `state_update` mode, that could make surface flux diagnostics report cleared values rather than the fluxes SHOC actually used.

This PR preserves the scalar surface fluxes consumed by native SHOC and uses those snapshots for 2D output when SHOC owns scalar surface transport.

## Changes

* Add native SHOC diagnostic snapshots for consumed sensible and latent surface fluxes.
* Keep those snapshots in ERF conservative output units.
* Use SHOC consumed-flux snapshots for:

  * `sens_flux`
  * `laten_flux`
  * `sensible_heat_flux`
  * `latent_heat_flux`
* Select sensible and latent flux sources independently, so a missing latent-flux field still writes `-999`.
* Make 2D `pblh` use native SHOC diagnostics when available, with SurfaceLayer fallback.
* Add native SHOC 2D diagnostics:

  * `shoc_u_star`
  * `shoc_Olen`
  * `shoc_wthv_sfc`
* Update the 2D diagnostic catalog, docs, and unit tests.

## Scope

This PR changes diagnostic output only.

It does not change SHOC numerics, SurfaceLayer flux generation, Noah-MP coupling, MOST formulas, host diffusion behavior, or the SHOC clearing step that prevents double application.

The `surface_diagnostic_source` field remains the provenance mask for the upstream SurfaceLayer, LSM, MOST, custom, and RICO source paths. It is not a SHOC ownership mask.