### PR TITLE
Add metadata sidecar for 2D plotfiles

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -386,6 +386,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/IO/ERF_Plotfile.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DCatalog.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2D.cpp
+       ${SRC_DIR}/IO/ERF_Plotfile2DMetadata.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DUtils.cpp
        ${SRC_DIR}/IO/ERF_WriteSubvolume.cpp
        ${SRC_DIR}/IO/ERF_WriteJobInfo.cpp

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -871,6 +871,55 @@ In native SHOC ``state_update`` mode, SHOC is the transport owner. The
 ``surface_diagnostic_source`` field still describes the upstream surface-flux
 source path used before SHOC consumes it.
 
+2D AMReX Metadata Sidecar
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Native AMReX 2D plotfiles include a JSON metadata sidecar named
+``2DMetadata.json`` in the plotfile directory. The sidecar lists the selected
+2D variables in output component order. For each variable it records the
+component index, name, long name, units, diagnostic category, missing-value
+policy, and documented missing value.
+
+The sidecar uses the same 2D diagnostic catalog that defines the plotfile
+variables. It does not change field values and does not record a separate
+runtime source-selection mask. For example, in native SHOC ``state_update``
+mode the flux fields may come from preserved SHOC-consumed flux snapshots, as
+described above, but the sidecar records the public diagnostic metadata for the
+selected variables.
+
+This sidecar is written for native AMReX 2D plotfiles. NetCDF metadata
+attributes are not changed by this feature.
+
+Example:
+
+.. code-block:: json
+
+   {
+     "format_version": 1,
+     "kind": "ERF 2D plotfile metadata",
+     "n_variables": 2,
+     "variables": [
+       {
+         "component_index": 0,
+         "name": "z_surf",
+         "long_name": "Surface elevation",
+         "units": "m",
+         "category": "Geometry",
+         "missing_policy": "AlwaysAvailable",
+         "missing_value": null
+       },
+       {
+         "component_index": 1,
+         "name": "latent_heat_flux",
+         "long_name": "Surface latent heat flux",
+         "units": "W m^-2",
+         "category": "SurfaceFlux",
+         "missing_policy": "FillMinus999WhenUnavailable",
+         "missing_value": -999
+       }
+     ]
+   }
+
 Surface Diagnostic Source Codes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -1,5 +1,6 @@
 #include "ERF.H"
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DMetadata.H"
 #include "ERF_NCPlotFile.H"
 #include "ERF_Plotfile2DUtils.H"
 #include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
@@ -707,6 +708,9 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         WriteMultiLevelPlotfile(plotfilename, finest_level+1,
                                 GetVecOfConstPtrs(mf),
                                 varnames, my_geom, t_new[0], istep, refRatio());
+        // Native AMReX 2D plotfiles write a JSON sidecar with catalog
+        // metadata for the selected output variables only.
+        plotfile2d::write_2d_metadata_json(plotfilename, varnames);
         writeJobInfo(plotfilename);
 
 #ifdef ERF_USE_NETCDF

--- a/Source/IO/ERF_Plotfile2DMetadata.H
+++ b/Source/IO/ERF_Plotfile2DMetadata.H
@@ -1,0 +1,33 @@
+#ifndef ERF_PLOTFILE2DMETADATA_H_
+#define ERF_PLOTFILE2DMETADATA_H_
+
+#include <string>
+
+#include <AMReX_Vector.H>
+
+#include "ERF_Plotfile2DCatalog.H"
+
+// Utilities for writing machine-readable metadata for native AMReX 2D
+// plotfiles. This layer formats the existing 2D diagnostic catalog. It must not
+// compute diagnostics or duplicate diagnostic metadata strings.
+
+namespace plotfile2d
+{
+
+const char* diagnostic_category_to_string (DiagnosticCategory category) noexcept;
+const char* missing_policy_to_string (MissingPolicy policy) noexcept;
+
+std::string missing_value_json (MissingPolicy policy);
+
+std::string escape_json_string (const std::string& value);
+
+std::string format_2d_metadata_json (const amrex::Vector<std::string>& varnames);
+
+std::string metadata_json_filename (const std::string& plotfilename);
+
+void write_2d_metadata_json (const std::string& plotfilename,
+                             const amrex::Vector<std::string>& varnames);
+
+} // namespace plotfile2d
+
+#endif

--- a/Source/IO/ERF_Plotfile2DMetadata.cpp
+++ b/Source/IO/ERF_Plotfile2DMetadata.cpp
@@ -66,6 +66,7 @@ diagnostic_category_to_string (DiagnosticCategory category) noexcept
     case DiagnosticCategory::SurfaceLayer:     return "SurfaceLayer";
     case DiagnosticCategory::Radiation:        return "Radiation";
     case DiagnosticCategory::SurfaceFlux:      return "SurfaceFlux";
+    case DiagnosticCategory::PBL:              return "PBL";
     case DiagnosticCategory::SurfaceState:     return "SurfaceState";
     case DiagnosticCategory::ColumnIntegral:   return "ColumnIntegral";
     }

--- a/Source/IO/ERF_Plotfile2DMetadata.cpp
+++ b/Source/IO/ERF_Plotfile2DMetadata.cpp
@@ -1,0 +1,184 @@
+#include "ERF_Plotfile2DMetadata.H"
+
+#include <fstream>
+#include <sstream>
+
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Utility.H>
+
+namespace plotfile2d
+{
+
+namespace
+{
+
+void append_escaped_codepoint (std::string& out, unsigned char c)
+{
+    static constexpr char hex_digits[] = "0123456789abcdef";
+
+    out += "\\u00";
+    out += hex_digits[(c >> 4) & 0x0f];
+    out += hex_digits[c & 0x0f];
+}
+
+void append_json_string (std::ostringstream& os, const std::string& value)
+{
+    os << '\"' << escape_json_string(value) << '\"';
+}
+
+void append_variable_record (std::ostringstream& os,
+                             const DiagnosticDescriptor& descriptor,
+                             int component_index,
+                             bool is_last)
+{
+    os << "    {\n";
+    os << "      \"component_index\": " << component_index << ",\n";
+    os << "      \"name\": ";
+    append_json_string(os, descriptor.name);
+    os << ",\n";
+    os << "      \"long_name\": ";
+    append_json_string(os, descriptor.long_name);
+    os << ",\n";
+    os << "      \"units\": ";
+    append_json_string(os, descriptor.units);
+    os << ",\n";
+    os << "      \"category\": ";
+    append_json_string(os, diagnostic_category_to_string(descriptor.category));
+    os << ",\n";
+    os << "      \"missing_policy\": ";
+    append_json_string(os, missing_policy_to_string(descriptor.missing_policy));
+    os << ",\n";
+    os << "      \"missing_value\": " << missing_value_json(descriptor.missing_policy) << "\n";
+    os << "    }";
+    if (!is_last) {
+        os << ",";
+    }
+    os << "\n";
+}
+
+} // namespace
+
+const char*
+diagnostic_category_to_string (DiagnosticCategory category) noexcept
+{
+    switch (category) {
+    case DiagnosticCategory::Geometry:        return "Geometry";
+    case DiagnosticCategory::SurfaceLayer:     return "SurfaceLayer";
+    case DiagnosticCategory::Radiation:        return "Radiation";
+    case DiagnosticCategory::SurfaceFlux:      return "SurfaceFlux";
+    case DiagnosticCategory::SurfaceState:     return "SurfaceState";
+    case DiagnosticCategory::ColumnIntegral:   return "ColumnIntegral";
+    }
+
+    amrex::Abort("Unhandled DiagnosticCategory in 2D metadata writer");
+    return "";
+}
+
+const char*
+missing_policy_to_string (MissingPolicy policy) noexcept
+{
+    switch (policy) {
+    case MissingPolicy::AlwaysAvailable:            return "AlwaysAvailable";
+    case MissingPolicy::FillZeroWhenUnavailable:     return "FillZeroWhenUnavailable";
+    case MissingPolicy::FillMinus999WhenUnavailable: return "FillMinus999WhenUnavailable";
+    }
+
+    amrex::Abort("Unhandled MissingPolicy in 2D metadata writer");
+    return "";
+}
+
+std::string
+missing_value_json (MissingPolicy policy)
+{
+    switch (policy) {
+    case MissingPolicy::AlwaysAvailable:            return "null";
+    case MissingPolicy::FillZeroWhenUnavailable:     return "0";
+    case MissingPolicy::FillMinus999WhenUnavailable: return "-999";
+    }
+
+    amrex::Abort("Unhandled MissingPolicy in 2D metadata writer");
+    return {};
+}
+
+std::string
+escape_json_string (const std::string& value)
+{
+    std::string escaped;
+    escaped.reserve(value.size() + 8);
+
+    for (unsigned char c : value) {
+        switch (c) {
+        case '\"': escaped += "\\\""; break;
+        case '\\': escaped += "\\\\"; break;
+        case '\n': escaped += "\\n"; break;
+        case '\t': escaped += "\\t"; break;
+        case '\r': escaped += "\\r"; break;
+        default:
+            if (c < 0x20) {
+                append_escaped_codepoint(escaped, c);
+            } else {
+                escaped.push_back(static_cast<char>(c));
+            }
+            break;
+        }
+    }
+
+    return escaped;
+}
+
+std::string
+metadata_json_filename (const std::string& plotfilename)
+{
+    return plotfilename + "/2DMetadata.json";
+}
+
+std::string
+format_2d_metadata_json (const amrex::Vector<std::string>& varnames)
+{
+    // Native AMReX 2D plotfiles get a metadata sidecar for the selected
+    // output variables only. The writer formats catalog metadata; it does not
+    // compute diagnostics or encode runtime source selection.
+    std::ostringstream os;
+    os << "{\n";
+    os << "  \"format_version\": 1,\n";
+    os << "  \"kind\": \"ERF 2D plotfile metadata\",\n";
+    os << "  \"n_variables\": " << static_cast<int>(varnames.size()) << ",\n";
+    os << "  \"variables\": [\n";
+
+    for (int i = 0; i < static_cast<int>(varnames.size()); ++i) {
+        const auto* descriptor = find_diagnostic(varnames[i]);
+        if (descriptor == nullptr) {
+            amrex::Abort("2D metadata requested for unknown diagnostic '" + varnames[i] + "'");
+        }
+
+        append_variable_record(os, *descriptor, i, i == static_cast<int>(varnames.size()) - 1);
+    }
+
+    os << "  ]\n";
+    os << "}\n";
+    return os.str();
+}
+
+void
+write_2d_metadata_json (const std::string& plotfilename,
+                        const amrex::Vector<std::string>& varnames)
+{
+    // Native AMReX 2D plotfiles write this sidecar next to the plotfile
+    // directory on the I/O processor only.
+    if (!amrex::ParallelDescriptor::IOProcessor()) {
+        return;
+    }
+
+    const std::string filename = metadata_json_filename(plotfilename);
+    std::ofstream outfile(filename, std::ios::out | std::ios::trunc);
+    if (!outfile.good()) {
+        amrex::FileOpenFailed(filename);
+    }
+
+    outfile << format_2d_metadata_json(varnames);
+    if (!outfile.good()) {
+        amrex::FileOpenFailed(filename);
+    }
+}
+
+} // namespace plotfile2d

--- a/Source/IO/Make.package
+++ b/Source/IO/Make.package
@@ -2,6 +2,7 @@
 CEXE_sources += ERF_Plotfile.cpp
 CEXE_sources += ERF_Plotfile2DCatalog.cpp
 CEXE_sources += ERF_Plotfile2D.cpp
+CEXE_sources += ERF_Plotfile2DMetadata.cpp
 CEXE_sources += ERF_Plotfile2DUtils.cpp
 CEXE_sources += ERF_Checkpoint.cpp
 CEXE_sources += ERF_WriteJobInfo.cpp

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DMetadata.H"
 #include "ERF_Plotfile2DUtils.H"
 
 using namespace plotfile2d;
@@ -368,4 +369,118 @@ TEST(Plotfile2D, InvalidStreamMessageReportsAllowedValues)
 
     EXPECT_TRUE(contains(message, "invalid stream index 0"));
     EXPECT_TRUE(contains(message, "expected 1 or 2"));
+}
+
+// Motivation: The JSON sidecar is a public metadata contract, so diagnostic
+// categories must serialize to stable, readable strings.
+TEST(Plotfile2DMetadata, CategoryStringsMatchPublicMetadataSchema)
+{
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::Geometry), "Geometry");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceLayer), "SurfaceLayer");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::Radiation), "Radiation");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceFlux), "SurfaceFlux");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceState), "SurfaceState");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::ColumnIntegral), "ColumnIntegral");
+}
+
+// Motivation: Downstream readers need to distinguish always-available fields
+// from fields that use zero or -999 as their documented unavailable value.
+TEST(Plotfile2DMetadata, MissingPolicyStringsAndValuesMatchPublicMetadataSchema)
+{
+    EXPECT_STREQ(missing_policy_to_string(MissingPolicy::AlwaysAvailable), "AlwaysAvailable");
+    EXPECT_EQ(missing_value_json(MissingPolicy::AlwaysAvailable), "null");
+
+    EXPECT_STREQ(missing_policy_to_string(MissingPolicy::FillZeroWhenUnavailable), "FillZeroWhenUnavailable");
+    EXPECT_EQ(missing_value_json(MissingPolicy::FillZeroWhenUnavailable), "0");
+
+    EXPECT_STREQ(missing_policy_to_string(MissingPolicy::FillMinus999WhenUnavailable),
+                 "FillMinus999WhenUnavailable");
+    EXPECT_EQ(missing_value_json(MissingPolicy::FillMinus999WhenUnavailable), "-999");
+}
+
+// Motivation: Metadata strings come from catalog descriptors. The sidecar must
+// remain valid JSON if future descriptors contain quotes or control characters.
+TEST(Plotfile2DMetadata, EscapesJsonStrings)
+{
+    const std::string input = "\"quoted\" slash\\ line\n tab\t return\r";
+    const std::string expected = "\\\"quoted\\\" slash\\\\ line\\n tab\\t return\\r";
+
+    EXPECT_EQ(escape_json_string(input), expected);
+}
+
+// Motivation: The sidecar must describe plotfile components by output index,
+// so its variable order must match the selected plotfile component order.
+TEST(Plotfile2DMetadata, FormatsSelectedVariablesInOutputOrder)
+{
+    const amrex::Vector<std::string> selected{
+        "z_surf", "pblh", "latent_heat_flux", "surface_diagnostic_source"
+    };
+
+    const std::string json = format_2d_metadata_json(selected);
+
+    EXPECT_TRUE(contains(json, "\"format_version\": 1"));
+    EXPECT_TRUE(contains(json, "\"kind\": \"ERF 2D plotfile metadata\""));
+    EXPECT_TRUE(contains(json, "\"n_variables\": 4"));
+    EXPECT_TRUE(contains(json, "\"component_index\": 0"));
+    EXPECT_TRUE(contains(json, "\"component_index\": 1"));
+    EXPECT_TRUE(contains(json, "\"component_index\": 2"));
+    EXPECT_TRUE(contains(json, "\"component_index\": 3"));
+    EXPECT_TRUE(contains(json, "\"name\": \"z_surf\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"pblh\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"latent_heat_flux\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"surface_diagnostic_source\""));
+    EXPECT_TRUE(contains(json, "\"long_name\": \"Surface elevation\""));
+    EXPECT_TRUE(contains(json, "\"units\": \"m\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"Geometry\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"SurfaceLayer\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"SurfaceFlux\""));
+    EXPECT_TRUE(contains(json, "\"missing_policy\": \"AlwaysAvailable\""));
+    EXPECT_TRUE(contains(json, "\"missing_policy\": \"FillMinus999WhenUnavailable\""));
+    EXPECT_TRUE(contains(json, "\"missing_value\": null"));
+    EXPECT_TRUE(contains(json, "\"missing_value\": -999"));
+
+    const auto z_pos = json.find("\"name\": \"z_surf\"");
+    const auto pblh_pos = json.find("\"name\": \"pblh\"");
+    const auto latent_pos = json.find("\"name\": \"latent_heat_flux\"");
+    const auto source_pos = json.find("\"name\": \"surface_diagnostic_source\"");
+    ASSERT_NE(z_pos, std::string::npos);
+    ASSERT_NE(pblh_pos, std::string::npos);
+    ASSERT_NE(latent_pos, std::string::npos);
+    ASSERT_NE(source_pos, std::string::npos);
+    EXPECT_LT(z_pos, pblh_pos);
+    EXPECT_LT(pblh_pos, latent_pos);
+    EXPECT_LT(latent_pos, source_pos);
+}
+
+// Motivation: The sidecar must describe the components written to this
+// plotfile, not every possible catalog entry.
+TEST(Plotfile2DMetadata, FormatsOnlySelectedVariables)
+{
+    const amrex::Vector<std::string> selected{"surf_pres"};
+    const std::string json = format_2d_metadata_json(selected);
+
+    EXPECT_TRUE(contains(json, "\"n_variables\": 1"));
+    EXPECT_TRUE(contains(json, "\"name\": \"surf_pres\""));
+    EXPECT_FALSE(contains(json, "\"name\": \"z_surf\""));
+}
+
+// Motivation: Adding new catalog entries should fail fast if the metadata
+// sidecar cannot serialize their category, missing policy, or descriptor
+// fields.
+TEST(Plotfile2DMetadata, FormatsEveryCatalogDiagnostic)
+{
+    const auto names = plotfile2d::diagnostic_names();
+    const std::string json = format_2d_metadata_json(names);
+
+    EXPECT_TRUE(contains(json, std::string("\"n_variables\": ") + std::to_string(names.size())));
+    for (const auto& name : names) {
+        EXPECT_TRUE(contains(json, "\"name\": \"" + name + "\""));
+    }
+}
+
+// Motivation: The metadata file should travel with the native AMReX 2D
+// plotfile directory and not collide with other output streams.
+TEST(Plotfile2DMetadata, MetadataFilenameLivesInsidePlotfileDirectory)
+{
+    EXPECT_EQ(metadata_json_filename("plt2d_00010"), "plt2d_00010/2DMetadata.json");
 }

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -379,6 +379,7 @@ TEST(Plotfile2DMetadata, CategoryStringsMatchPublicMetadataSchema)
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceLayer), "SurfaceLayer");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::Radiation), "Radiation");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceFlux), "SurfaceFlux");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::PBL), "PBL");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceState), "SurfaceState");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::ColumnIntegral), "ColumnIntegral");
 }
@@ -413,7 +414,7 @@ TEST(Plotfile2DMetadata, EscapesJsonStrings)
 TEST(Plotfile2DMetadata, FormatsSelectedVariablesInOutputOrder)
 {
     const amrex::Vector<std::string> selected{
-        "z_surf", "pblh", "latent_heat_flux", "surface_diagnostic_source"
+        "z_surf", "pblh", "latent_heat_flux", "shoc_wthv_sfc"
     };
 
     const std::string json = format_2d_metadata_json(selected);
@@ -428,12 +429,13 @@ TEST(Plotfile2DMetadata, FormatsSelectedVariablesInOutputOrder)
     EXPECT_TRUE(contains(json, "\"name\": \"z_surf\""));
     EXPECT_TRUE(contains(json, "\"name\": \"pblh\""));
     EXPECT_TRUE(contains(json, "\"name\": \"latent_heat_flux\""));
-    EXPECT_TRUE(contains(json, "\"name\": \"surface_diagnostic_source\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"shoc_wthv_sfc\""));
     EXPECT_TRUE(contains(json, "\"long_name\": \"Surface elevation\""));
     EXPECT_TRUE(contains(json, "\"units\": \"m\""));
     EXPECT_TRUE(contains(json, "\"category\": \"Geometry\""));
     EXPECT_TRUE(contains(json, "\"category\": \"SurfaceLayer\""));
     EXPECT_TRUE(contains(json, "\"category\": \"SurfaceFlux\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"PBL\""));
     EXPECT_TRUE(contains(json, "\"missing_policy\": \"AlwaysAvailable\""));
     EXPECT_TRUE(contains(json, "\"missing_policy\": \"FillMinus999WhenUnavailable\""));
     EXPECT_TRUE(contains(json, "\"missing_value\": null"));
@@ -442,14 +444,14 @@ TEST(Plotfile2DMetadata, FormatsSelectedVariablesInOutputOrder)
     const auto z_pos = json.find("\"name\": \"z_surf\"");
     const auto pblh_pos = json.find("\"name\": \"pblh\"");
     const auto latent_pos = json.find("\"name\": \"latent_heat_flux\"");
-    const auto source_pos = json.find("\"name\": \"surface_diagnostic_source\"");
+    const auto shoc_wthv_pos = json.find("\"name\": \"shoc_wthv_sfc\"");
     ASSERT_NE(z_pos, std::string::npos);
     ASSERT_NE(pblh_pos, std::string::npos);
     ASSERT_NE(latent_pos, std::string::npos);
-    ASSERT_NE(source_pos, std::string::npos);
+    ASSERT_NE(shoc_wthv_pos, std::string::npos);
     EXPECT_LT(z_pos, pblh_pos);
     EXPECT_LT(pblh_pos, latent_pos);
-    EXPECT_LT(latent_pos, source_pos);
+    EXPECT_LT(latent_pos, shoc_wthv_pos);
 }
 
 // Motivation: The sidecar must describe the components written to this
@@ -473,6 +475,10 @@ TEST(Plotfile2DMetadata, FormatsEveryCatalogDiagnostic)
     const std::string json = format_2d_metadata_json(names);
 
     EXPECT_TRUE(contains(json, std::string("\"n_variables\": ") + std::to_string(names.size())));
+    EXPECT_TRUE(contains(json, "\"name\": \"shoc_u_star\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"shoc_Olen\""));
+    EXPECT_TRUE(contains(json, "\"name\": \"shoc_wthv_sfc\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"PBL\""));
     for (const auto& name : names) {
         EXPECT_TRUE(contains(json, "\"name\": \"" + name + "\""));
     }


### PR DESCRIPTION
## Summary

This PR adds a JSON metadata sidecar for native AMReX 2D plotfiles.

Each 2D plotfile directory now includes `2DMetadata.json`. The file lists the selected 2D variables in output component order. For each variable, it records the component index, name, long name, units, diagnostic category, missing-value policy, and documented missing value.

The sidecar uses the existing 2D diagnostic catalog as its source of truth. It does not duplicate metadata strings in the writer.

## Motivation

The native AMReX 2D plotfile stores component names, but downstream tools need more context. Users and scripts need stable metadata for units, long names, categories, and missing-value conventions.

This PR makes that metadata machine-readable without changing any field values.

## Changes

* Add `Source/IO/ERF_Plotfile2DMetadata.H`.
* Add `Source/IO/ERF_Plotfile2DMetadata.cpp`.
* Write `<plotfile>/2DMetadata.json` for native AMReX 2D plotfiles.
* Serialize selected variables in output component order.
* Serialize diagnostic categories and missing-value policies as stable strings.
* Preserve the existing NetCDF path.
* Register the new source file in CMake and GNU make builds.
* Document the sidecar in the Sphinx plotfile docs.
* Add unit tests for:

  * category string serialization,
  * missing-policy serialization,
  * missing-value serialization,
  * JSON string escaping,
  * selected-variable ordering,
  * selected-only metadata output,
  * full-catalog metadata serialization,
  * sidecar filename placement.

## Scope

This PR changes metadata output only.

It does not change diagnostic values, SHOC behavior, SurfaceLayer behavior, Noah-MP coupling, MOST formulas, diffusion, radiation, plotfile variable selection, or NetCDF output.

The sidecar records public diagnostic metadata. It does not record a runtime source-selection mask. For example, in native SHOC `state_update` mode, flux diagnostics may come from preserved SHOC-consumed snapshots, but the sidecar records the metadata for the selected diagnostic variables.
