### PR TITLE
Refactor 2D plotfile diagnostic assembly

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -387,6 +387,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/IO/ERF_Plotfile.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DCatalog.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2D.cpp
+       ${SRC_DIR}/IO/ERF_Plotfile2DFill.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DMetadata.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DUtils.cpp
        ${SRC_DIR}/IO/ERF_WriteSubvolume.cpp

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -920,6 +920,18 @@ Example:
      ]
    }
 
+2D Diagnostic Assembly
+~~~~~~~~~~~~~~~~~~~~~~
+
+ERF assembles built-in 2D diagnostics from several source patterns. Most
+current fields are surface or single-level diagnostics. ``integrated_qv`` is a
+column-reduction diagnostic. Future diagnostics may add more column
+reductions, such as liquid water path, or interpolated horizontal surfaces,
+such as fields on pressure levels.
+
+This organization does not change the public 2D variable names, component
+order, units, missing-value conventions, or ``2DMetadata.json`` schema.
+
 Surface Diagnostic Source Codes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -1,9 +1,9 @@
 #include "ERF.H"
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DFill.H"
 #include "ERF_Plotfile2DMetadata.H"
 #include "ERF_NCPlotFile.H"
 #include "ERF_Plotfile2DUtils.H"
-#include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
 #include "ERF_EpochTime.H"
 #include "ERF_SrcHeaders.H"
 #include "ERF_StormDiagnostics.H"
@@ -165,6 +165,9 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         const MultiFab* pblh_source = nullptr;
         const MultiFab* sens_flux_source = SFS_hfx3_lev[lev].get();
         const MultiFab* laten_flux_source = SFS_q1fx3_lev[lev].get();
+        const MultiFab* shoc_ustar_source = nullptr;
+        const MultiFab* shoc_olen_source = nullptr;
+        const MultiFab* shoc_wthv_source = nullptr;
 #ifdef ERF_USE_NATIVE_SHOC
         const ShocDriver* native_shoc = native_shoc_driver[lev].get();
         const bool native_shoc_owns_scalar_fluxes =
@@ -189,6 +192,11 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 native_shoc_has_consumed_flux_diagnostics,
                 SFS_q1fx3_lev[lev] != nullptr)) {
             laten_flux_source = &native_shoc->consumed_laten_flux_diagnostics();
+        }
+        if (native_shoc && native_shoc->has_native_diagnostics()) {
+            shoc_ustar_source = &native_shoc->shoc_ustar_diagnostics();
+            shoc_olen_source = &native_shoc->shoc_olen_diagnostics();
+            shoc_wthv_source = &native_shoc->wthv_sec_diagnostics();
         }
 #endif
         // pblh should follow the active PBL diagnostic provider. Native SHOC
@@ -287,246 +295,87 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         } // lon_m
 
         ///////////////////////////////////////////////////////////////////////
-        // These quantities are diagnosed by the surface layer
+        // These quantities are diagnosed by the surface layer or the active
+        // PBL provider.
         if (containerHasElement(plot_var_names, "u_star")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_u_star(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_u_star(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // ustar
+        } // u_star
 
         if (containerHasElement(plot_var_names, "w_star")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_w_star(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_w_star(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // wstar
+        } // w_star
 
         if (containerHasElement(plot_var_names, "t_star")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_t_star(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_t_star(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // tstar
+        } // t_star
 
         if (containerHasElement(plot_var_names, "q_star")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_q_star(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_q_star(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // qstar
+        } // q_star
 
         if (containerHasElement(plot_var_names, "Olen")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_olen(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_olen(lev) : nullptr,
+                0, -999);
             mf_comp++;
         } // Olen
 
         if (containerHasElement(plot_var_names, "pblh")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (pblh_source) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = pblh_source->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, pblh_source, 0, -999);
             mf_comp++;
         } // pblh
 
         if (containerHasElement(plot_var_names, "t_surf")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& tsurf  = m_SurfaceLayer->get_t_surf(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = tsurf(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_t_surf(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // tsurf
+        } // t_surf
 
         if (containerHasElement(plot_var_names, "q_surf")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_q_surf(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_q_surf(lev) : nullptr,
+                0, -999);
             mf_comp++;
-        } // qsurf
+        } // q_surf
 
         if (containerHasElement(plot_var_names, "z0")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& ustar  = m_SurfaceLayer->get_z0(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                       derdat(i, j, k, mf_comp) = ustar(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_z0(lev) : nullptr,
+                0, -999);
             mf_comp++;
         } // z0
 
         if (containerHasElement(plot_var_names, "OLR")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (solverChoice.rad_type != RadiationType::None) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& olr    = rad_fluxes[lev]->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = olr(i, j, khi, 2);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, rad_fluxes[lev].get(), khi, -999, 2);
             mf_comp++;
         } // OLR
 
         if (containerHasElement(plot_var_names, "sens_flux")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (sens_flux_source) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& hfx_arr = sens_flux_source->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = hfx_arr(i, j, klo);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, sens_flux_source, klo, -999);
             mf_comp++;
         } // sens_flux
 
         // Keep the legacy output name "laten_flux"; it maps to the vertical
         // water-vapor surface flux field.
         if (containerHasElement(plot_var_names, "laten_flux")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (laten_flux_source) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& qfx_arr = laten_flux_source->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = qfx_arr(i, j, klo);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999,mf_comp,1,0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, laten_flux_source, klo, -999);
             mf_comp++;
         } // laten_flux
 
@@ -551,6 +400,7 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         } // surf_pres
 
         if (containerHasElement(plot_var_names, "integrated_qv")) {
+            // Column-reduction example for future column-integrated diagnostics.
             MultiFab mf_qv_int(mf[lev],make_alias,mf_comp,1);
             if (solverChoice.moisture_type != MoistureType::None) {
                 volWgtColumnSum(lev, vars_new[lev][Vars::cons], RhoQ1_comp, mf_qv_int, *detJ_cc[lev]);
@@ -561,137 +411,40 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         }
 
         if (containerHasElement(plot_var_names, "surface_diagnostic_source")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (m_SurfaceLayer) {
-                for (MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& source = m_SurfaceLayer->get_surface_diagnostic_source(lev)->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = source(i, j, 0);
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp,
+                m_SurfaceLayer ? m_SurfaceLayer->get_surface_diagnostic_source(lev) : nullptr,
+                0, -999);
             mf_comp++;
         } // surface_diagnostic_source
 
         if (containerHasElement(plot_var_names, "sensible_heat_flux")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (sens_flux_source) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& hfx_arr = sens_flux_source->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        // Delegate unit semantics to the surface flux diagnostics helper.
-                        derdat(i, j, k, mf_comp) =
-                            surface_flux_diagnostics::sensible_heat_flux_wm2_from_rhotheta_flux(
-                                hfx_arr(i, j, klo));
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_sensible_heat_flux_from_klevel_or_missing(
+                mf[lev], mf_comp, sens_flux_source, klo, -999);
             mf_comp++;
         } // sensible_heat_flux
 
         if (containerHasElement(plot_var_names, "latent_heat_flux")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-            if (laten_flux_source) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& qfx_arr = laten_flux_source->const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        // Delegate unit semantics to the surface flux diagnostics helper.
-                        derdat(i, j, k, mf_comp) =
-                            surface_flux_diagnostics::latent_heat_flux_wm2_from_rhoqv_flux(
-                                qfx_arr(i, j, klo));
-                    });
-                }
-            } else {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_latent_heat_flux_from_klevel_or_missing(
+                mf[lev], mf_comp, laten_flux_source, klo, -999);
             mf_comp++;
         } // latent_heat_flux
 
         if (containerHasElement(plot_var_names, "shoc_u_star")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-#ifdef ERF_USE_NATIVE_SHOC
-            if (native_shoc && native_shoc->has_native_diagnostics()) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& source = native_shoc->shoc_ustar_diagnostics().const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = source(i, j, klo);
-                    });
-                }
-            } else
-#endif
-            {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, shoc_ustar_source, klo, -999);
             mf_comp++;
         } // shoc_u_star
 
         if (containerHasElement(plot_var_names, "shoc_Olen")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-#ifdef ERF_USE_NATIVE_SHOC
-            if (native_shoc && native_shoc->has_native_diagnostics()) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& source = native_shoc->shoc_olen_diagnostics().const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = source(i, j, klo);
-                    });
-                }
-            } else
-#endif
-            {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, shoc_olen_source, klo, -999);
             mf_comp++;
         } // shoc_Olen
 
         if (containerHasElement(plot_var_names, "shoc_wthv_sfc")) {
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-#ifdef ERF_USE_NATIVE_SHOC
-            if (native_shoc && native_shoc->has_native_diagnostics()) {
-                for ( MFIter mfi(mf[lev],TilingIfNotGPU()); mfi.isValid(); ++mfi)
-                {
-                    const Box& bx = mfi.tilebox();
-                    const auto& derdat = mf[lev].array(mfi);
-                    const auto& source = native_shoc->wthv_sec_diagnostics().const_array(mfi);
-                    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                        derdat(i, j, k, mf_comp) = source(i, j, klo);
-                    });
-                }
-            } else
-#endif
-            {
-                mf[lev].setVal(-999, mf_comp, 1, 0);
-            }
+            plotfile2d::fill_component_from_klevel_or_value(
+                mf[lev], mf_comp, shoc_wthv_source, klo, -999);
             mf_comp++;
         } // shoc_wthv_sfc
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -19,6 +19,9 @@ namespace
 // validates the requested names, assembles the slab geometry, fills existing
 // diagnostics, and dispatches to AMReX or NetCDF output. Nontrivial science
 // diagnostics should live in dedicated modules and be called from here.
+// The assembly path should stay explicit about three diagnostic shapes:
+// surface/single-level fields, column reductions, and future interpolated
+// horizontal surfaces.
 // Keep the fill order below synchronized with plotfile2d::diagnostic_catalog()
 // until the fill blocks move into dedicated diagnostic modules.
 
@@ -295,8 +298,10 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         } // lon_m
 
         ///////////////////////////////////////////////////////////////////////
-        // These quantities are diagnosed by the surface layer or the active
-        // PBL provider.
+        // Surface and single-level diagnostics use the fill helpers below.
+        // Column reductions and future interpolated surfaces keep explicit
+        // assembly paths until their contracts are isolated in dedicated
+        // helpers.
         if (containerHasElement(plot_var_names, "u_star")) {
             plotfile2d::fill_component_from_klevel_or_value(
                 mf[lev], mf_comp, m_SurfaceLayer ? m_SurfaceLayer->get_u_star(lev) : nullptr,
@@ -400,7 +405,9 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         } // surf_pres
 
         if (containerHasElement(plot_var_names, "integrated_qv")) {
-            // Column-reduction example for future column-integrated diagnostics.
+            // Current column-reduction example. Future LWP/IWP diagnostics
+            // should follow a separate column-reduction helper path rather
+            // than the single-k copy helpers.
             MultiFab mf_qv_int(mf[lev],make_alias,mf_comp,1);
             if (solverChoice.moisture_type != MoistureType::None) {
                 volWgtColumnSum(lev, vars_new[lev][Vars::cons], RhoQ1_comp, mf_qv_int, *detJ_cc[lev]);

--- a/Source/IO/ERF_Plotfile2DFill.H
+++ b/Source/IO/ERF_Plotfile2DFill.H
@@ -1,0 +1,46 @@
+#ifndef ERF_PLOTFILE2DFILL_H_
+#define ERF_PLOTFILE2DFILL_H_
+
+#include <AMReX_MultiFab.H>
+#include <AMReX_REAL.H>
+
+// Mechanical fill helpers for ERF 2D plotfile assembly. These helpers copy,
+// fill, and convert existing diagnostic sources into output components. They
+// must not own science formulas beyond simple unit conversions delegated to
+// existing diagnostic helpers.
+
+namespace plotfile2d
+{
+
+void fill_component_with_value (amrex::MultiFab& dst,
+                                int dst_comp,
+                                amrex::Real value);
+
+void fill_component_from_klevel (amrex::MultiFab& dst,
+                                 int dst_comp,
+                                 const amrex::MultiFab& src,
+                                 int src_k,
+                                 int src_comp = 0);
+
+void fill_component_from_klevel_or_value (amrex::MultiFab& dst,
+                                          int dst_comp,
+                                          const amrex::MultiFab* src,
+                                          int src_k,
+                                          amrex::Real missing_value,
+                                          int src_comp = 0);
+
+void fill_sensible_heat_flux_from_klevel_or_missing (amrex::MultiFab& dst,
+                                                     int dst_comp,
+                                                     const amrex::MultiFab* src,
+                                                     int src_k,
+                                                     amrex::Real missing_value);
+
+void fill_latent_heat_flux_from_klevel_or_missing (amrex::MultiFab& dst,
+                                                   int dst_comp,
+                                                   const amrex::MultiFab* src,
+                                                   int src_k,
+                                                   amrex::Real missing_value);
+
+} // namespace plotfile2d
+
+#endif

--- a/Source/IO/ERF_Plotfile2DFill.H
+++ b/Source/IO/ERF_Plotfile2DFill.H
@@ -5,23 +5,42 @@
 #include <AMReX_REAL.H>
 
 // Mechanical fill helpers for ERF 2D plotfile assembly. These helpers copy,
-// fill, and convert existing diagnostic sources into output components. They
-// must not own science formulas beyond simple unit conversions delegated to
-// existing diagnostic helpers.
+// fill, and convert existing diagnostic sources into output components.
+//
+// Preconditions:
+//   - dst is the already-allocated 2D plotfile MultiFab for one AMR level.
+//   - source MultiFabs use a compatible BoxArray/DistributionMapping layout.
+//   - src_k is interpreted in the source MultiFab's vertical index space.
+//
+// Non-goals:
+//   - Do not add diagnostic science here.
+//   - Do not encode runtime source selection here.
+//   - Do not use this layer as a registry for all future diagnostics.
+//
+// Column reductions, such as integrated_qv and future LWP/IWP diagnostics, need
+// separate helpers because they reduce over k rather than copying one k level.
+// Future pressure-surface diagnostics need interpolation-specific helpers.
 
 namespace plotfile2d
 {
 
+// Fill one destination component with a scalar value. Used for documented
+// missing values and zero fills.
 void fill_component_with_value (amrex::MultiFab& dst,
                                 int dst_comp,
                                 amrex::Real value);
 
+// Copy one source component at one source k level into one 2D destination
+// component. The caller owns source selection and chooses src_k.
 void fill_component_from_klevel (amrex::MultiFab& dst,
                                  int dst_comp,
                                  const amrex::MultiFab& src,
                                  int src_k,
                                  int src_comp = 0);
 
+// Copy from src when present; otherwise fill the destination component with the
+// documented missing value. This keeps optional diagnostics branch-local in the
+// writer.
 void fill_component_from_klevel_or_value (amrex::MultiFab& dst,
                                           int dst_comp,
                                           const amrex::MultiFab* src,
@@ -29,12 +48,18 @@ void fill_component_from_klevel_or_value (amrex::MultiFab& dst,
                                           amrex::Real missing_value,
                                           int src_comp = 0);
 
+// Convert the selected conservative sensible-flux source to W m^-2 for the
+// public sensible_heat_flux diagnostic. Unit semantics remain in
+// surface_flux_diagnostics.
 void fill_sensible_heat_flux_from_klevel_or_missing (amrex::MultiFab& dst,
                                                      int dst_comp,
                                                      const amrex::MultiFab* src,
                                                      int src_k,
                                                      amrex::Real missing_value);
 
+// Convert the selected conservative moisture-flux source to W m^-2 for the
+// public latent_heat_flux diagnostic. Unit semantics remain in
+// surface_flux_diagnostics.
 void fill_latent_heat_flux_from_klevel_or_missing (amrex::MultiFab& dst,
                                                    int dst_comp,
                                                    const amrex::MultiFab* src,

--- a/Source/IO/ERF_Plotfile2DFill.cpp
+++ b/Source/IO/ERF_Plotfile2DFill.cpp
@@ -1,0 +1,113 @@
+#include "ERF_Plotfile2DFill.H"
+
+#include <AMReX_Gpu.H>
+
+#include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
+
+using namespace amrex;
+
+namespace plotfile2d
+{
+
+void
+fill_component_with_value (MultiFab& dst, int dst_comp, Real value)
+{
+    dst.setVal(value, dst_comp, 1, 0);
+}
+
+void
+fill_component_from_klevel (MultiFab& dst,
+                            int dst_comp,
+                            const MultiFab& src,
+                            int src_k,
+                            int src_comp)
+{
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& dst_arr = dst.array(mfi);
+        const auto& src_arr = src.const_array(mfi);
+
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            dst_arr(i, j, k, dst_comp) = src_arr(i, j, src_k, src_comp);
+        });
+    }
+}
+
+void
+fill_component_from_klevel_or_value (MultiFab& dst,
+                                     int dst_comp,
+                                     const MultiFab* src,
+                                     int src_k,
+                                     Real missing_value,
+                                     int src_comp)
+{
+    if (src) {
+        fill_component_from_klevel(dst, dst_comp, *src, src_k, src_comp);
+    } else {
+        fill_component_with_value(dst, dst_comp, missing_value);
+    }
+}
+
+void
+fill_sensible_heat_flux_from_klevel_or_missing (MultiFab& dst,
+                                                int dst_comp,
+                                                const MultiFab* src,
+                                                int src_k,
+                                                Real missing_value)
+{
+    if (!src) {
+        fill_component_with_value(dst, dst_comp, missing_value);
+        return;
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& dst_arr = dst.array(mfi);
+        const auto& src_arr = src->const_array(mfi);
+
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            dst_arr(i, j, k, dst_comp) =
+                surface_flux_diagnostics::sensible_heat_flux_wm2_from_rhotheta_flux(
+                    src_arr(i, j, src_k, 0));
+        });
+    }
+}
+
+void
+fill_latent_heat_flux_from_klevel_or_missing (MultiFab& dst,
+                                              int dst_comp,
+                                              const MultiFab* src,
+                                              int src_k,
+                                              Real missing_value)
+{
+    if (!src) {
+        fill_component_with_value(dst, dst_comp, missing_value);
+        return;
+    }
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& dst_arr = dst.array(mfi);
+        const auto& src_arr = src->const_array(mfi);
+
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            dst_arr(i, j, k, dst_comp) =
+                surface_flux_diagnostics::latent_heat_flux_wm2_from_rhoqv_flux(
+                    src_arr(i, j, src_k, 0));
+        });
+    }
+}
+
+} // namespace plotfile2d

--- a/Source/IO/ERF_Plotfile2DFill.cpp
+++ b/Source/IO/ERF_Plotfile2DFill.cpp
@@ -22,6 +22,9 @@ fill_component_from_klevel (MultiFab& dst,
                             int src_k,
                             int src_comp)
 {
+    // Iterate over dst because it defines the 2D output component layout. The
+    // source must be box-compatible with dst on the horizontal tile covered by
+    // each MFIter.
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
 #endif
@@ -69,6 +72,8 @@ fill_sensible_heat_flux_from_klevel_or_missing (MultiFab& dst,
 #endif
     for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
+        // Keep unit conversion in the surface-flux diagnostic helper so this
+        // mechanical layer does not duplicate physical constants or units.
         const Box& bx = mfi.tilebox();
         const auto& dst_arr = dst.array(mfi);
         const auto& src_arr = src->const_array(mfi);
@@ -98,6 +103,8 @@ fill_latent_heat_flux_from_klevel_or_missing (MultiFab& dst,
 #endif
     for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
     {
+        // Keep unit conversion in the surface-flux diagnostic helper so this
+        // mechanical layer does not duplicate physical constants or units.
         const Box& bx = mfi.tilebox();
         const auto& dst_arr = dst.array(mfi);
         const auto& src_arr = src->const_array(mfi);

--- a/Source/IO/Make.package
+++ b/Source/IO/Make.package
@@ -2,6 +2,7 @@
 CEXE_sources += ERF_Plotfile.cpp
 CEXE_sources += ERF_Plotfile2DCatalog.cpp
 CEXE_sources += ERF_Plotfile2D.cpp
+CEXE_sources += ERF_Plotfile2DFill.cpp
 CEXE_sources += ERF_Plotfile2DMetadata.cpp
 CEXE_sources += ERF_Plotfile2DUtils.cpp
 CEXE_sources += ERF_Checkpoint.cpp

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -1,11 +1,18 @@
 #include <string>
 #include <unordered_set>
 
+#include <AMReX_Box.H>
+#include <AMReX_BoxArray.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Gpu.H>
+#include <AMReX_MultiFab.H>
 #include <gtest/gtest.h>
 
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DFill.H"
 #include "ERF_Plotfile2DMetadata.H"
 #include "ERF_Plotfile2DUtils.H"
+#include "Diagnostics/ERF_SurfaceFluxDiagnostics.H"
 
 using namespace plotfile2d;
 
@@ -15,6 +22,32 @@ namespace
 bool contains (const std::string& haystack, const std::string& needle)
 {
     return haystack.find(needle) != std::string::npos;
+}
+
+amrex::Box make_test_domain ()
+{
+    return amrex::Box(amrex::IntVect(0, 0, 0), amrex::IntVect(1, 1, 2));
+}
+
+amrex::BoxArray make_test_boxarray ()
+{
+    amrex::BoxArray ba(make_test_domain());
+    ba.maxSize(8);
+    return ba;
+}
+
+void set_component_value_at_k (amrex::MultiFab& mf, int comp, int k_level, amrex::Real value)
+{
+    for (amrex::MFIter mfi(mf, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const amrex::Box& bx = mfi.tilebox();
+        const auto& arr = mf.array(mfi);
+        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (k == k_level) {
+                arr(i, j, k, comp) = value;
+            }
+        });
+    }
+    amrex::Gpu::streamSynchronize();
 }
 
 } // namespace
@@ -369,6 +402,125 @@ TEST(Plotfile2D, InvalidStreamMessageReportsAllowedValues)
 
     EXPECT_TRUE(contains(message, "invalid stream index 0"));
     EXPECT_TRUE(contains(message, "expected 1 or 2"));
+}
+
+// Motivation: Missing-value fills should not corrupt neighboring output
+// components in the 2D plotfile MultiFab.
+TEST(Plotfile2DFill, FillComponentWithValueTouchesOnlyRequestedComponent)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab dst(ba, dm, 2, 0);
+
+    dst.setVal(amrex::Real(1.5), 0, 1, 0);
+    dst.setVal(amrex::Real(2.5), 1, 1, 0);
+
+    plotfile2d::fill_component_with_value(dst, 1, amrex::Real(-999.0));
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(1.5));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(1.5));
+    EXPECT_DOUBLE_EQ(dst.min(1), amrex::Real(-999.0));
+    EXPECT_DOUBLE_EQ(dst.max(1), amrex::Real(-999.0));
+}
+
+// Motivation: Surface, top-of-column, and future interpolated diagnostics rely
+// on copying the intended source level into the 2D output component.
+TEST(Plotfile2DFill, FillComponentFromKLevelUsesRequestedSourceLevelAndComponent)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab src(ba, dm, 2, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    src.setVal(amrex::Real(-1.0));
+    set_component_value_at_k(src, 1, 2, amrex::Real(23.5));
+
+    plotfile2d::fill_component_from_klevel(dst, 0, src, 2, 1);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(23.5));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(23.5));
+}
+
+// Motivation: Optional diagnostics such as SurfaceLayer, radiation, and SHOC
+// fields must write documented missing values when their source is unavailable.
+TEST(Plotfile2DFill, FillComponentFromKLevelOrValueUsesMissingValueWhenSourceIsNull)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    dst.setVal(amrex::Real(4.0));
+
+    plotfile2d::fill_component_from_klevel_or_value(dst, 0, nullptr, 0, amrex::Real(-999.0));
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(-999.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(-999.0));
+}
+
+// Motivation: The same helper must handle available and unavailable diagnostic
+// sources without changing the component order logic in the writer.
+TEST(Plotfile2DFill, FillComponentFromKLevelOrValueCopiesWhenSourceExists)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab src(ba, dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    src.setVal(amrex::Real(-2.0));
+    set_component_value_at_k(src, 0, 1, amrex::Real(17.25));
+
+    plotfile2d::fill_component_from_klevel_or_value(dst, 0, &src, 1, amrex::Real(-999.0));
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(17.25));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(17.25));
+}
+
+// Motivation: The 2D assembly refactor must preserve the W m^-2 conversion
+// used by the public sensible_heat_flux diagnostic.
+TEST(Plotfile2DFill, SensibleHeatFluxFillUsesSurfaceFluxConversion)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab src(ba, dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    src.setVal(amrex::Real(-7.0));
+    set_component_value_at_k(src, 0, 1, amrex::Real(1.75));
+
+    plotfile2d::fill_sensible_heat_flux_from_klevel_or_missing(
+        dst, 0, &src, 1, amrex::Real(-999.0));
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::Real expected =
+        surface_flux_diagnostics::sensible_heat_flux_wm2_from_rhotheta_flux(amrex::Real(1.75));
+    EXPECT_DOUBLE_EQ(dst.min(0), expected);
+    EXPECT_DOUBLE_EQ(dst.max(0), expected);
+}
+
+// Motivation: The 2D assembly refactor must preserve the W m^-2 conversion
+// used by the public latent_heat_flux diagnostic.
+TEST(Plotfile2DFill, LatentHeatFluxFillUsesSurfaceFluxConversion)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab src(ba, dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    src.setVal(amrex::Real(-7.0));
+    set_component_value_at_k(src, 0, 2, amrex::Real(-0.5));
+
+    plotfile2d::fill_latent_heat_flux_from_klevel_or_missing(
+        dst, 0, &src, 2, amrex::Real(-999.0));
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::Real expected =
+        surface_flux_diagnostics::latent_heat_flux_wm2_from_rhoqv_flux(amrex::Real(-0.5));
+    EXPECT_DOUBLE_EQ(dst.min(0), expected);
+    EXPECT_DOUBLE_EQ(dst.max(0), expected);
 }
 
 // Motivation: The JSON sidecar is a public metadata contract, so diagnostic


### PR DESCRIPTION
## Summary

This PR refactors the 2D plotfile writer without changing output behavior.

It moves repeated 2D fill mechanics out of `ERF::Write2DPlotFile()` and into a small helper module. The writer still owns diagnostic source selection, SHOC-aware source handling, column reductions, output dispatch, and metadata sidecar writing.

No diagnostics are added.

## Motivation

`ERF::Write2DPlotFile()` had grown into a long sequence of source selection, fill loops, unit conversions, column reductions, and output calls. That made each new 2D diagnostic harder to review.

This refactor separates common fill mechanics from diagnostic-specific logic. It sets up cleaner future PRs for column reductions such as LWP/IWP and for pressure-surface interpolation.

## Changes

* Add `ERF_Plotfile2DFill.H`.
* Add `ERF_Plotfile2DFill.cpp`.
* Add helpers for:

  * scalar missing-value fills,
  * copying one source `k` level into a 2D output component,
  * optional-source fills with documented missing values,
  * sensible heat flux conversion to W m^-2,
  * latent heat flux conversion to W m^-2.
* Use the helper layer for repeated SurfaceLayer, PBL, radiation, surface-flux, and native-SHOC 2D fill blocks.
* Leave one-off diagnostics explicit, including:

  * `z_surf`,
  * `landmask`,
  * `mapfac`,
  * `lat_m`,
  * `lon_m`,
  * `surf_pres`,
  * `integrated_qv`.
* Keep `integrated_qv` as the current column-reduction example.
* Add focused unit tests for the new fill helpers.
* Add a short Sphinx note about 2D diagnostic assembly.
* Register the new source file in CMake and GNU make builds.

## Scope

This PR is an infrastructure refactor only.

It does not change diagnostic names, order, units, metadata, missing-value policy, or field values.

It does not change SHOC, SurfaceLayer, Noah-MP, MOST, diffusion, radiation, microphysics, NetCDF output, or the AMReX metadata sidecar schema.

