### PR TITLE
This PR reverts two recent changes: 1) for now we don't use erfbdy fo…

### DIFF
--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -752,10 +752,14 @@ ERF::init_zphys (int lev, Real elapsed_time)
                 AMREX_ALWAYS_ASSERT_WITH_MESSAGE(rel_diff < Real(1.e-8), "Terrain is taller than domain top!");
             }
 
+#if 0
+            // This remains commented out until we verify that the stretched and variable dz pathways
+            //   in fact give the same answer when appropriate
             if (SolverChoice::mesh_type == MeshType::VariableDz)
             {
                 check_mesh_type(lev);
             }
+#endif
         } // lev == 0
 
     } else {

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -732,14 +732,16 @@ ERF::ReadCheckpointFile ()
             VisMF::Read(z_height, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "Z_Phys_nd"));
             MultiFab::Copy(*z_phys_nd[lev],z_height,0,0,1,ng);
             update_terrain_arrays(lev);
- 
+
             // Compute the min dz and pass to the micro model
             Real dzmin = get_dzmin_terrain(*z_phys_nd[lev]);
             micro->Set_dzmin(lev, dzmin);
- 
+
+#if 0
             if ( (solverChoice.init_type != InitType::WRFInput) && (solverChoice.init_type != InitType::Metgrid) ) {
                 check_mesh_type(lev);
             }
+#endif
         }
 
         // Read in the moisture model restart variables
@@ -1132,7 +1134,9 @@ ERF::ReadCheckpointFile ()
 
         // Check for erfbdy file.
         std::string erfbdy_header = erfbdy_file + "/Header";
-        use_erfbdy = FileSystem::Exists(erfbdy_header);
+
+        // For now we disable this for InitType::WRFInput because it failed the WPS_Test_restart regression test
+        use_erfbdy = ( (solverChoice.init_type == InitType::Metgrid) && FileSystem::Exists(erfbdy_header) );
 
         if (solverChoice.init_type == InitType::Metgrid) {
             if (!use_erfbdy) {


### PR DESCRIPTION
…r InitType::WRFInput, and 2) we don't check for whether VariableDz can be changed to StretchedDz at start or restart