### PR TITLE
Add sampled-level 2D diagnostics for height, pressure, model index, and winds

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -390,6 +390,9 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/IO/ERF_Plotfile2DFill.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DMetadata.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DWaterPath.cpp
+       ${SRC_DIR}/IO/ERF_Plotfile2DSampledField.cpp
+       ${SRC_DIR}/IO/ERF_Plotfile2DSampledLevel.cpp
+       ${SRC_DIR}/IO/ERF_Plotfile2DInterpolator.cpp
        ${SRC_DIR}/IO/ERF_Plotfile2DUtils.cpp
        ${SRC_DIR}/IO/ERF_WriteSubvolume.cpp
        ${SRC_DIR}/IO/ERF_WriteJobInfo.cpp

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -998,36 +998,139 @@ Example sampled-level metadata:
 2D Sampled-Level Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-ERF can write sampled-level 2D diagnostics from a vertical coordinate and a
-field registry. A sampled level set is defined under
-``erf.plot2d.level_set.<name>.`` and is selected for each 2D output stream by
-``erf.plot2d_level_sets_1`` or ``erf.plot2d_level_sets_2``.
+ERF can write 2D fields sampled on model-index, height, or pressure levels. This
+mode lets one 2D output stream combine built-in diagnostics with fields on
+user-defined vertical targets.
 
-The supported coordinates are:
+Select sampled level sets for each 2D output stream with:
 
-+--------------+-------------------------------------------+
-| Coordinate   | Meaning                                   |
-+==============+===========================================+
-| model_index  | Copy the requested model level exactly.   |
-+--------------+-------------------------------------------+
-| height_msl   | Sample at cell-centered height above mean |
-|              | sea level.                                |
-+--------------+-------------------------------------------+
-| height_agl   | Sample at cell-centered height above      |
-|              | local terrain.                            |
-+--------------+-------------------------------------------+
-| pressure     | Sample at cell-centered pressure.         |
-+--------------+-------------------------------------------+
+.. code-block:: text
 
-The supported fields are ``rho``, ``theta``, ``temp``, ``pressure``,
-``height_msl``, ``height_agl``, ``qv``, ``qc``, ``qi``, ``qr``, ``qs``, and
-``qg``. Density, potential temperature, temperature, pressure, and height use
-the existing ERF thermodynamic and terrain helpers. Microphysical mass species
-are sampled as mixing ratios.
+   erf.plot2d_level_sets_1 = upper_air bl_heights
+   erf.plot2d_level_sets_2 = native_k
 
-Example inputs:
+Define each level set under ``erf.plot2d.level_set.<name>.``.
 
-Pressure levels:
+Required keys:
+
+.. code-block:: text
+
+   erf.plot2d.level_set.<name>.coordinate = ...
+   erf.plot2d.level_set.<name>.values = ...
+   erf.plot2d.level_set.<name>.fields = ...
+
+Optional keys:
+
+.. code-block:: text
+
+   erf.plot2d.level_set.<name>.units = ...
+   erf.plot2d.level_set.<name>.interpolation = ...
+   erf.plot2d.level_set.<name>.missing_value = ...
+
+The default missing value is ``-999``. ERF does not extrapolate sampled-level
+diagnostics. If a target lies outside the column, ERF writes the level set's
+missing value.
+
+Supported coordinates:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 48 16 16
+
+   * - Coordinate
+     - Meaning
+     - Units
+     - Interpolation
+   * - ``model_index``
+     - Cell-centered model level index.
+     - ``1``
+     - ``none``
+   * - ``height_msl``
+     - Cell-centered height above mean sea level.
+     - ``m``
+     - ``linear``
+   * - ``height_agl``
+     - Cell-centered height above local terrain.
+     - ``m``
+     - ``linear``
+   * - ``pressure``
+     - Cell-centered pressure.
+     - ``Pa`` or ``hPa``
+     - ``linear``
+
+ERF converts pressure targets in ``hPa`` to canonical ``Pa`` values in metadata.
+Model-index values must be integers. ERF rejects unsupported coordinates and
+units during input parsing. Isentropic output is not enabled because it needs a
+crossing policy for non-monotonic potential-temperature columns.
+
+Supported fields:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 52 14 26
+
+   * - Field
+     - Meaning
+     - Units
+     - Availability
+   * - ``rho``
+     - Density.
+     - ``kg m^-3``
+     - Always available.
+   * - ``theta``
+     - Potential temperature.
+     - ``K``
+     - Always available.
+   * - ``temp``
+     - Temperature.
+     - ``K``
+     - Always available.
+   * - ``pressure``
+     - Pressure.
+     - ``Pa``
+     - Always available.
+   * - ``height_msl``
+     - Height above mean sea level.
+     - ``m``
+     - Always available.
+   * - ``height_agl``
+     - Height above local terrain.
+     - ``m``
+     - Always available.
+   * - ``qv``
+     - Water vapor mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qv``.
+   * - ``qc``
+     - Cloud liquid water mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qc``.
+   * - ``qi``
+     - Cloud ice mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qi``.
+   * - ``qr``
+     - Rain mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qr``.
+   * - ``qs``
+     - Snow mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qs``.
+   * - ``qg``
+     - Graupel mixing ratio.
+     - ``kg kg^-1``
+     - Available when the active moisture model has ``qg``.
+
+Use the canonical sampled species names ``qv``, ``qc``, ``qi``, ``qr``, ``qs``,
+and ``qg``. Do not use 3D derived-variable aliases such as ``qrain``, ``qsnow``,
+or ``qgraup`` in sampled-level output.
+
+If a requested moisture field is unavailable for the active moisture model, ERF
+warns and skips that field. If all requested fields in a level set are
+unavailable, ERF aborts with an input error.
+
+Pressure-level example:
 
 .. code-block:: text
 
@@ -1038,7 +1141,7 @@ Pressure levels:
    erf.plot2d.level_set.upper_air.values = 850 700 500
    erf.plot2d.level_set.upper_air.fields = theta temp qv qc
 
-Height-agl levels:
+Height-above-ground example:
 
 .. code-block:: text
 
@@ -1048,7 +1151,7 @@ Height-agl levels:
    erf.plot2d.level_set.bl_heights.values = 100 500 1000
    erf.plot2d.level_set.bl_heights.fields = theta qv qc
 
-Model-index levels:
+Model-index example:
 
 .. code-block:: text
 
@@ -1058,38 +1161,62 @@ Model-index levels:
    erf.plot2d.level_set.native_k.values = 0 10 20
    erf.plot2d.level_set.native_k.fields = theta qv qc
 
-Output names use this pattern:
+Sampled-level output names follow this pattern:
+
+.. code-block:: text
+
+   <field>_<coordinate_tag>_<value_tag>
+
+Examples:
 
 .. code-block:: text
 
    theta_p_850hPa
    qv_p_700hPa
    qc_z_agl_500m
+   theta_z_msl_1000m
    theta_k_10
 
-For linear sampling, ERF uses adjacent levels :math:`k_0` and :math:`k_1`
-that bracket the requested target coordinate :math:`C_t`.
+ERF writes sampled-level variables after built-in variables in the same 2D
+stream. Within sampled-level output, ERF writes variables in level-set order,
+target-value order, and field order.
+
+For linear sampling, ERF finds adjacent cell centers :math:`k_0` and
+:math:`k_1` that bracket the target coordinate :math:`C_t`.
 
 .. math::
 
    F_t = (1 - w) F_{k_0} + w F_{k_1}
 
-.. math::
-
-   w = \frac{C_t - C_{k_0}}{C_{k_1} - C_{k_0}}
-
-Model-index sampling copies the requested level exactly. If the target lies
-outside the column, ERF writes the configured missing value.
+with
 
 .. math::
 
-   q_x = \frac{\rho q_x}{\rho}
+   w = \frac{C_t - C_{k_0}}{C_{k_1} - C_{k_0}}.
 
-The sampled-level metadata records the source field and the vertical
-coordinate. The metadata uses ``format_version = 2``. Future extensions can
-add isentropic coordinates, derived field providers, vorticity, potential
-vorticity, and staggered velocity fields after their sampling rules are
-defined.
+The bracket test works for increasing coordinates, such as height, and
+decreasing coordinates, such as pressure. Model-index sampling copies the
+requested level exactly.
+
+Microphysical mass species are sampled as mixing ratios. ERF stores each
+species as a conserved density :math:`\rho q_x`, so sampled output uses
+
+.. math::
+
+   q_x = \frac{\rho q_x}{\rho}.
+
+ERF uses ``qv = 0`` for dry-run pressure and temperature calculations, but it
+does not expose sampled ``qv`` unless the active moisture model has a water-vapor
+state component.
+
+Sampled-level metadata records ``source_field`` and ``vertical_coordinate`` in
+the native AMReX ``2DMetadata.json`` sidecar. NetCDF 2D output uses the same
+sampled-level variable names, but it does not write sampled-level metadata
+attributes.
+
+Isentropic levels, vorticity, potential vorticity, and staggered velocity fields
+need additional sampling rules. They are not part of this sampled-level output
+mode.
 
 2D Water-Path Diagnostics
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1138,8 +1265,8 @@ conserved mass component. Two-moment number concentrations are not water mass
 paths and are not included.
 
 The metadata sidecar records these fields as ``ColumnIntegral`` diagnostics
-with ``FillZeroWhenUnavailable`` missing-value policy. The sidecar schema is
-unchanged.
+with ``FillZeroWhenUnavailable`` missing-value policy. Water-path diagnostics
+use the built-in metadata fields and add no water-path-specific metadata keys.
 
 Surface Diagnostic Source Codes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -888,8 +888,9 @@ sidecar does not change field values. For example, in native SHOC
 flux snapshots, as described above, but the sidecar records the public
 diagnostic metadata for the selected variables.
 
-This sidecar is written for native AMReX 2D plotfiles. NetCDF metadata
-attributes are not changed by this feature. The sidecar format version is 2.
+Native AMReX 2D plotfiles write sampled-level metadata in ``2DMetadata.json``.
+NetCDF 2D output uses the same sampled-level variable names, but this PR does
+not add NetCDF-specific metadata attributes. The sidecar format version is 2.
 
 Example:
 
@@ -921,6 +922,36 @@ Example:
      ]
    }
 
+Sampled-level example:
+
+.. code-block:: json
+
+   {
+     "format_version": 2,
+     "kind": "ERF 2D plotfile metadata",
+     "n_variables": 1,
+     "variables": [
+       {
+         "component_index": 0,
+         "name": "theta_p_850hPa",
+         "long_name": "Potential temperature sampled on pressure levels",
+         "units": "K",
+         "category": "SampledLevel",
+         "missing_policy": "FillMinus999WhenUnavailable",
+         "missing_value": -999,
+         "source_field": "theta",
+         "vertical_coordinate": {
+           "type": "pressure",
+           "value": 850,
+           "units": "hPa",
+           "canonical_value": 85000,
+           "canonical_units": "Pa",
+           "interpolation": "linear"
+         }
+       }
+     ]
+   }
+
 2D Diagnostic Assembly
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -930,8 +961,10 @@ the scheme-aware water-path diagnostics are column reductions. Future
 diagnostics may add interpolated horizontal surfaces, such as fields on
 pressure levels.
 
-This organization does not change the public 2D variable names, component
-order, units, missing-value conventions, or ``2DMetadata.json`` schema.
+This organization does not change the public names, component order, units, or
+missing-value conventions for built-in 2D diagnostics. Sampled-level
+diagnostics extend the native AMReX metadata sidecar in ``format_version = 2``
+with optional ``source_field`` and ``vertical_coordinate`` records.
 
 2D Sampled-Level Diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -962,6 +995,48 @@ The supported fields are ``rho``, ``theta``, ``temp``, ``pressure``,
 ``qg``. Density, potential temperature, temperature, pressure, and height use
 the existing ERF thermodynamic and terrain helpers. Microphysical mass species
 are sampled as mixing ratios.
+
+Example inputs:
+
+Pressure levels:
+
+.. code-block:: text
+
+   erf.plot2d_level_sets_1 = upper_air
+
+   erf.plot2d.level_set.upper_air.coordinate = pressure
+   erf.plot2d.level_set.upper_air.units = hPa
+   erf.plot2d.level_set.upper_air.values = 850 700 500
+   erf.plot2d.level_set.upper_air.fields = theta temp qv qc
+
+Height-agl levels:
+
+.. code-block:: text
+
+   erf.plot2d_level_sets_1 = bl_heights
+
+   erf.plot2d.level_set.bl_heights.coordinate = height_agl
+   erf.plot2d.level_set.bl_heights.values = 100 500 1000
+   erf.plot2d.level_set.bl_heights.fields = theta qv qc
+
+Model-index levels:
+
+.. code-block:: text
+
+   erf.plot2d_level_sets_1 = native_k
+
+   erf.plot2d.level_set.native_k.coordinate = model_index
+   erf.plot2d.level_set.native_k.values = 0 10 20
+   erf.plot2d.level_set.native_k.fields = theta qv qc
+
+Output names use this pattern:
+
+.. code-block:: text
+
+   theta_p_850hPa
+   qv_p_700hPa
+   qc_z_agl_500m
+   theta_k_10
 
 For linear sampling, ERF uses adjacent levels :math:`k_0` and :math:`k_1`
 that bracket the requested target coordinate :math:`C_t`.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -750,106 +750,160 @@ concentration.
 Output Options for 2D Plotfiles
 -------------------------------
 
-The table below lists the built-in 2D diagnostic catalog. ERF writes selected
-variables in this order.
+ERF supports two 2D plotfile streams. Use ``erf.plot2d_vars_1`` and
+``erf.plot2d_vars_2`` to request built-in 2D diagnostics. Use
+``erf.plot2d_level_sets_1`` and ``erf.plot2d_level_sets_2`` to request
+sampled-level diagnostics.
 
-+-------------------------------+-------------------------------------------------------+
-| Parameter                     | Definition                                            |
-+===============================+=======================================================+
-| **z_surf**                    | Surface elevation [m].                                |
-+-------------------------------+-------------------------------------------------------+
-| **landmask**                  | Land-sea mask. Land is 1 and sea is 0 [1].            |
-+-------------------------------+-------------------------------------------------------+
-| **mapfac**                    | Map factor at mass points [1].                        |
-+-------------------------------+-------------------------------------------------------+
-| **lat_m**                     | Latitude at unstaggered mass points [deg].            |
-+-------------------------------+-------------------------------------------------------+
-| **lon_m**                     | Longitude at unstaggered mass points [deg].           |
-+-------------------------------+-------------------------------------------------------+
-| **u_star**                    | Friction velocity from the surface layer [m/s]. ERF   |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **w_star**                    | Convective velocity scale from the surface layer [m/s]|
-|                               | ERF writes -999 when the surface layer is not active. |
-+-------------------------------+-------------------------------------------------------+
-| **t_star**                    | Temperature scale from the surface layer [K]. ERF     |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **q_star**                    | Humidity scale from the surface layer [kg/kg]. ERF    |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **Olen**                      | Obukhov length from the surface layer [m]. ERF writes |
-|                               | -999 when the surface layer is not active.            |
-+-------------------------------+-------------------------------------------------------+
-| **pblh**                      | Diagnosed planetary boundary layer height [m]. Native |
-|                               | SHOC diagnostics are used when available; otherwise   |
-|                               | ERF falls back to SurfaceLayer. ERF writes -999 when  |
-|                               | no PBL diagnostic provider is available.              |
-+-------------------------------+-------------------------------------------------------+
-| **t_surf**                    | Surface temperature from the surface layer [K]. ERF   |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **q_surf**                    | Surface humidity from the surface layer [kg/kg]. ERF  |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **z0**                        | Roughness height from the surface layer [m]. ERF      |
-|                               | writes -999 when the surface layer is not active.     |
-+-------------------------------+-------------------------------------------------------+
-| **OLR**                       | Outgoing longwave radiation at the model top [W/m^2]. |
-|                               | ERF writes -999 when radiation is not active.         |
-+-------------------------------+-------------------------------------------------------+
-| **sens_flux**                 | Conservative surface sensible heat flux [kg K m^-2    |
-|                               | s^-1]. In native SHOC ``state_update`` mode, this     |
-|                               | reports the preserved surface flux consumed by SHOC.  |
-|                               | Otherwise, it reports the host vertical surface flux  |
-|                               | field. ERF writes -999 when the corresponding flux    |
-|                               | source is unavailable.                                |
-+-------------------------------+-------------------------------------------------------+
-| **laten_flux**                | Conservative surface moisture flux [kg m^-2 s^-1].    |
-|                               | This is a legacy output name. In native SHOC          |
-|                               | ``state_update`` mode, this reports the preserved     |
-|                               | surface moisture flux consumed by SHOC. Otherwise, it |
-|                               | reports the host vertical water-vapor surface flux    |
-|                               | field. ERF writes -999 when the corresponding flux    |
-|                               | source is unavailable.                                |
-+-------------------------------+-------------------------------------------------------+
-| **surf_pres**                 | Surface pressure [Pa].                                |
-+-------------------------------+-------------------------------------------------------+
-| **integrated_qv**             | Column-integrated water vapor [kg/m^2]. ERF writes    |
-|                               | zero when moisture is disabled.                       |
-+-------------------------------+-------------------------------------------------------+
-| **surface_diagnostic_source** | Source code for the cell-centered SurfaceLayer scalar |
-|                               | diagnostic path [1]. ERF writes -999 when SurfaceLay  |
-|                               | er is not active.                                     |
-+-------------------------------+-------------------------------------------------------+
-| **sensible_heat_flux**        | Surface sensible heat flux [W m^-2], computed from    |
-|                               | the same conservative source as ``sens_flux``. In     |
-|                               | native SHOC ``state_update`` mode, this uses SHOC's   |
-|                               | preserved consumed-flux snapshot. ERF writes -999     |
-|                               | when the sensible flux source is unavailable.         |
-+-------------------------------+-------------------------------------------------------+
-| **latent_heat_flux**          | Surface latent heat flux [W m^-2], computed from the  |
-|                               | same conservative source as ``laten_flux``. In native |
-|                               | SHOC ``state_update`` mode, this uses SHOC's          |
-|                               | preserved consumed-flux snapshot. ERF writes -999     |
-|                               | when moisture or the latent flux source is            |
-|                               | unavailable.                                          |
-+-------------------------------+-------------------------------------------------------+
-| **shoc_u_star**               | Native SHOC friction velocity diagnostic [m/s]. ERF   |
-|                               | writes -999 when native SHOC diagnostics are          |
-|                               | unavailable.                                          |
-+-------------------------------+-------------------------------------------------------+
-| **shoc_Olen**                 | Native SHOC Obukhov length diagnostic [m]. ERF writes |
-|                               | -999 when native SHOC diagnostics are unavailable.    |
-+-------------------------------+-------------------------------------------------------+
-| **shoc_wthv_sfc**             | Native SHOC surface virtual potential temperature     |
-|                               | flux [K m s^-1]. ERF writes -999 when native SHOC     |
-|                               | diagnostics are unavailable.                          |
-+-------------------------------+-------------------------------------------------------+
+Built-in variables and sampled-level variables can appear in the same 2D output
+stream. ERF writes built-in variables first. It writes selected built-in
+variables in the catalog order shown below, not in input order. ERF then appends
+sampled-level variables in level-set order, target-value order, and field order.
+
+Built-In 2D Diagnostic Catalog
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 16 24 56
+
+   * - Variable
+     - Units
+     - Availability
+     - Description
+   * - ``z_surf``
+     - ``m``
+     - Always available.
+     - Surface elevation.
+   * - ``landmask``
+     - ``1``
+     - Always available.
+     - Land-sea mask. Land is ``1`` and sea is ``0``.
+   * - ``mapfac``
+     - ``1``
+     - Always available.
+     - Map factor at mass points.
+   * - ``lat_m``
+     - ``deg``
+     - Available when latitude data are present.
+     - Latitude at unstaggered mass points.
+   * - ``lon_m``
+     - ``deg``
+     - Available when longitude data are present.
+     - Longitude at unstaggered mass points.
+   * - ``u_star``
+     - ``m s^-1``
+     - ``-999`` if unavailable.
+     - Friction velocity from the surface layer.
+   * - ``w_star``
+     - ``m s^-1``
+     - ``-999`` if unavailable.
+     - Convective velocity scale from the surface layer.
+   * - ``t_star``
+     - ``K``
+     - ``-999`` if unavailable.
+     - Temperature scale from the surface layer.
+   * - ``q_star``
+     - ``kg kg^-1``
+     - ``-999`` if unavailable.
+     - Humidity scale from the surface layer.
+   * - ``Olen``
+     - ``m``
+     - ``-999`` if unavailable.
+     - Obukhov length from the surface layer.
+   * - ``pblh``
+     - ``m``
+     - ``-999`` if unavailable.
+     - Planetary boundary layer height. Native SHOC provides this value when
+       available; otherwise ERF uses SurfaceLayer when present.
+   * - ``t_surf``
+     - ``K``
+     - ``-999`` if unavailable.
+     - Surface temperature from the surface layer.
+   * - ``q_surf``
+     - ``kg kg^-1``
+     - ``-999`` if unavailable.
+     - Surface humidity from the surface layer.
+   * - ``z0``
+     - ``m``
+     - ``-999`` if unavailable.
+     - Roughness height from the surface layer.
+   * - ``OLR``
+     - ``W m^-2``
+     - ``-999`` if unavailable.
+     - Outgoing longwave radiation at the model top.
+   * - ``sens_flux``
+     - ``kg K m^-2 s^-1``
+     - ``-999`` if unavailable.
+     - Conservative surface sensible heat flux.
+   * - ``laten_flux``
+     - ``kg m^-2 s^-1``
+     - ``-999`` if unavailable.
+     - Conservative surface moisture flux. This is a legacy output name.
+   * - ``surf_pres``
+     - ``Pa``
+     - Always available.
+     - Surface pressure.
+   * - ``integrated_qv``
+     - ``kg m^-2``
+     - Zero when moisture is disabled.
+     - Column-integrated water vapor.
+   * - ``integrated_qc``
+     - ``kg m^-2``
+     - Available when the active moisture model has ``qc``.
+     - Column-integrated cloud liquid water.
+   * - ``integrated_qi``
+     - ``kg m^-2``
+     - Available when the active moisture model has ``qi``.
+     - Column-integrated cloud ice.
+   * - ``integrated_qr``
+     - ``kg m^-2``
+     - Available when the active moisture model has ``qr``.
+     - Column-integrated rain water.
+   * - ``integrated_qs``
+     - ``kg m^-2``
+     - Available when the active moisture model has ``qs``.
+     - Column-integrated snow.
+   * - ``integrated_qg``
+     - ``kg m^-2``
+     - Available when the active moisture model has ``qg``.
+     - Column-integrated graupel.
+   * - ``surface_diagnostic_source``
+     - ``1``
+     - ``-999`` when SurfaceLayer is not active.
+     - Source code for the cell-centered SurfaceLayer scalar diagnostic path.
+   * - ``sensible_heat_flux``
+     - ``W m^-2``
+     - ``-999`` if unavailable.
+     - Surface sensible heat flux computed from the same conservative source as
+       ``sens_flux``.
+   * - ``latent_heat_flux``
+     - ``W m^-2``
+     - ``-999`` if unavailable.
+     - Surface latent heat flux computed from the same conservative source as
+       ``laten_flux``.
+   * - ``shoc_u_star``
+     - ``m s^-1``
+     - ``-999`` if unavailable.
+     - Native SHOC friction velocity diagnostic.
+   * - ``shoc_Olen``
+     - ``m``
+     - ``-999`` if unavailable.
+     - Native SHOC Obukhov length diagnostic.
+   * - ``shoc_wthv_sfc``
+     - ``K m s^-1``
+     - ``-999`` if unavailable.
+     - Native SHOC surface virtual potential temperature flux.
+
+If a requested built-in diagnostic is not available for the active configuration,
+ERF warns and skips that diagnostic.
+
+Flux Diagnostics
+~~~~~~~~~~~~~~~~
 
 ``sens_flux`` and ``laten_flux`` are legacy ERF conservative scalar flux
 outputs. ``sensible_heat_flux`` and ``latent_heat_flux`` convert the same
-selected conservative flux sources to W m^-2 using ``Cp_d`` and ``L_v``,
+selected conservative flux sources to ``W m^-2`` using ``Cp_d`` and ``L_v``,
 respectively.
 
 For non-SHOC configurations and native SHOC host-diffusion mode, these outputs
@@ -857,7 +911,7 @@ use the host vertical surface flux arrays. In native SHOC ``state_update`` mode,
 SHOC consumes those surface fluxes before the host diffusion path clears the
 overlapping arrays. In that mode, the 2D flux diagnostics use SHOC's preserved
 consumed-flux snapshots, component by component. If the corresponding host flux
-field was unavailable before SHOC consumed it, ERF writes -999 rather than a
+field was unavailable before SHOC consumed it, ERF writes ``-999`` rather than a
 zero SHOC snapshot.
 
 The sign convention follows ERF's lower-boundary flux convention. No
@@ -889,10 +943,10 @@ flux snapshots, as described above, but the sidecar records the public
 diagnostic metadata for the selected variables.
 
 Native AMReX 2D plotfiles write sampled-level metadata in ``2DMetadata.json``.
-NetCDF 2D output uses the same sampled-level variable names, but this PR does
-not add NetCDF-specific metadata attributes. The sidecar format version is 2.
+NetCDF 2D output uses the same sampled-level variable names, but does not write
+sampled-level metadata attributes. The sidecar format version is ``2``.
 
-Example:
+Example built-in metadata:
 
 .. code-block:: json
 
@@ -922,7 +976,7 @@ Example:
      ]
    }
 
-Sampled-level example:
+Example sampled-level metadata:
 
 .. code-block:: json
 
@@ -951,20 +1005,6 @@ Sampled-level example:
        }
      ]
    }
-
-2D Diagnostic Assembly
-~~~~~~~~~~~~~~~~~~~~~~
-
-ERF assembles built-in 2D diagnostics from several source patterns. Most
-current fields are surface or single-level diagnostics. ``integrated_qv`` and
-the scheme-aware water-path diagnostics are column reductions. Future
-diagnostics may add interpolated horizontal surfaces, such as fields on
-pressure levels.
-
-This organization does not change the public names, component order, units, or
-missing-value conventions for built-in 2D diagnostics. Sampled-level
-diagnostics extend the native AMReX metadata sidecar in ``format_version = 2``
-with optional ``source_field`` and ``vertical_coordinate`` records.
 
 2D Sampled-Level Diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -1121,6 +1121,26 @@ Supported fields:
      - Graupel mixing ratio.
      - ``kg kg^-1``
      - Available when the active moisture model has ``qg``.
+   * - ``u_east``
+     - Eastward wind.
+     - ``m/s``
+     - Always available.
+   * - ``v_north``
+     - Northward wind.
+     - ``m/s``
+     - Always available.
+   * - ``w``
+     - Vertical wind.
+     - ``m/s``
+     - Always available.
+   * - ``wind_speed``
+     - Horizontal wind speed.
+     - ``m/s``
+     - Always available.
+   * - ``wind_dir``
+     - Meteorological wind direction.
+     - ``degrees``
+     - Always available. ERF writes the missing value for calm winds.
 
 Use the canonical sampled species names ``qv``, ``qc``, ``qi``, ``qr``, ``qs``,
 and ``qg``. Do not use 3D derived-variable aliases such as ``qrain``, ``qsnow``,
@@ -1176,6 +1196,23 @@ Examples:
    qc_z_agl_500m
    theta_z_msl_1000m
    theta_k_10
+   u_east_p_850hPa
+   v_north_p_850hPa
+   w_z_agl_500m
+   wind_speed_k_10
+   wind_speed_z_agl_500m
+   wind_dir_k_10
+
+Wind example:
+
+.. code-block:: text
+
+   erf.plot2d_level_sets_1 = upper_air_winds
+
+   erf.plot2d.level_set.upper_air_winds.coordinate = pressure
+   erf.plot2d.level_set.upper_air_winds.units = hPa
+   erf.plot2d.level_set.upper_air_winds.values = 850 700
+   erf.plot2d.level_set.upper_air_winds.fields = u_east v_north wind_speed wind_dir
 
 ERF writes sampled-level variables after built-in variables in the same 2D
 stream. Within sampled-level output, ERF writes variables in level-set order,
@@ -1208,6 +1245,20 @@ species as a conserved density :math:`\rho q_x`, so sampled output uses
 ERF uses ``qv = 0`` for dry-run pressure and temperature calculations, but it
 does not expose sampled ``qv`` unless the active moisture model has a water-vapor
 state component.
+
+Wind fields are cell-centered sampled-level diagnostics. ERF destaggers the
+native face-centered velocity components to scalar cell centers before vertical
+sampling. ``u_east`` and ``v_north`` are earth-relative horizontal winds. When
+map-rotation coefficients are available, ERF rotates grid-relative horizontal
+winds before output. Otherwise, ERF uses identity rotation. ``w`` is the
+cell-centered vertical wind.
+
+``wind_speed`` is the horizontal speed computed from ``u_east`` and
+``v_north``. ``wind_dir`` is the meteorological wind direction in degrees
+clockwise from north, indicating where the wind comes from. ERF writes the
+level-set missing value for ``wind_dir`` when the horizontal wind is calm.
+``wind_dir`` is derived from the interpolated vector; ERF does not vertically
+interpolate wind direction as a scalar angle.
 
 Sampled-level metadata records ``source_field`` and ``vertical_coordinate`` in
 the native AMReX ``2DMetadata.json`` sidecar. NetCDF 2D output uses the same

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -52,7 +52,7 @@ List of Parameters for Both 2D and 3D Plotfiles
 |                                  |                  | Values                |            |
 +----------------------------------+------------------+-----------------------+------------+
 | **erf.plotfile_type**            | AMReX or NETCDF  | "amrex" or            | "amrex"    |
-|                                  | format           | "netcdf / "NetCDF"    |            |
+|                                  | format           | "netcdf" or "NetCDF"  |            |
 +----------------------------------+------------------+-----------------------+------------+
 | **erf.use_real_time_in_pltname** | Use real time    | Boolean               | false      |
 |                                  | instead of time  |                       |            |
@@ -70,62 +70,51 @@ List of Parameters for Both 2D and 3D Plotfiles
 List of Parameters for 3D Plotfiles
 -----------------------------------
 
-+----------------------------------+------------------+-----------------------+------------+
-| Parameter                        | Definition       | Acceptable            | Default    |
-|                                  |                  | Values                |            |
-+==================================+==================+=======================+============+
-| **erf.plot_file_1**              | prefix for       | String                | “*plt_1_*” |
-|                                  | plotfiles        |                       |            |
-|                                  | at first freq.   |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_file_2**              | prefix for       | String                | “*plt_2_*” |
-|                                  | plotfiles        |                       |            |
-|                                  | at second freq.   |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_int_1**               | how often (by    | Integer               | -1         |
-|                                  | level-0 time     | :math:`> 0`           |            |
-|                                  | steps) to write  |                       |            |
-|                                  | plot files       |                       |            |
-|                                  | at first freq.   |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_int_2**               | how often (by    | Integer               | -1         |
-|                                  | level-0 time     | :math:`> 0`           |            |
-|                                  | steps) to write  |                       |            |
-|                                  | plot files       |                       |            |
-|                                  | at second freq.  |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_per_1**               | how often (in    | Real                  | -1.0       |
-|                                  | simulation time) | :math:`> 0`           |            |
-|                                  | to write         |                       |            |
-|                                  | plot files       |                       |            |
-|                                  | at first freq.   |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_per_2**               | how often (in    | Real                  | -1.0       |
-|                                  | simulation time) | :math:`> 0`           |            |
-|                                  | to write         |                       |            |
-|                                  | plot files       |                       |            |
-|                                  | at second freq.  |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_vars_1**              | name of          | list of names         | None       |
-|                                  | variables to     |                       |            |
-|                                  | include in       |                       |            |
-|                                  | plotfiles        |                       |            |
-|                                  | at first freq.   |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_vars_2**              | name of          | list of names         | None       |
-|                                  | variables to     |                       |            |
-|                                  | include in       |                       |            |
-|                                  | plotfiles        |                       |            |
-|                                  | at second freq.  |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
-| **erf.plot_face_vels**           | output plotfiles | Boolean               | false      |
-|                                  | "{prefix}U",     |                       |            |
-|                                  | "{prefix}V", and |                       |            |
-|                                  | "{prefix}W"      |                       |            |
-|                                  | with velocity    |                       |            |
-|                                  | components on the|                       |            |
-|                                  | staggered grid.  |                       |            |
-+----------------------------------+------------------+-----------------------+------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 30 24 14
+
+   * - Parameter
+     - Definition
+     - Acceptable Values
+     - Default
+   * - ``erf.plot_file_1``
+     - Prefix for plotfiles at first output frequency.
+     - String
+     - ``plt_1_*``
+   * - ``erf.plot_file_2``
+     - Prefix for plotfiles at second output frequency.
+     - String
+     - ``plt_2_*``
+   * - ``erf.plot_int_1``
+     - Write plot files every this many level-0 time steps for the first stream.
+     - Integer :math:`> 0`
+     - -1
+   * - ``erf.plot_int_2``
+     - Write plot files every this many level-0 time steps for the second stream.
+     - Integer :math:`> 0`
+     - -1
+   * - ``erf.plot_per_1``
+     - Write plot files every this much simulation time for the first stream.
+     - Real :math:`> 0`
+     - -1.0
+   * - ``erf.plot_per_2``
+     - Write plot files every this much simulation time for the second stream.
+     - Real :math:`> 0`
+     - -1.0
+   * - ``erf.plot_vars_1``
+     - Variables to include in the first plotfile stream.
+     - List of names
+     - None
+   * - ``erf.plot_vars_2``
+     - Variables to include in the second plotfile stream.
+     - List of names
+     - None
+   * - ``erf.plot_face_vels``
+     - Output ``{prefix}U``, ``{prefix}V``, and ``{prefix}W`` with velocity
+       components on the staggered grid.
+     - Boolean
+     - false
 
 List of Parameters for 2D Plotfiles
 -----------------------------------
@@ -761,7 +750,7 @@ variables in the catalog order shown below, not in input order. ERF then appends
 sampled-level variables in level-set order, target-value order, and field order.
 
 Built-In 2D Diagnostic Catalog
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. list-table::
    :header-rows: 1
@@ -899,7 +888,7 @@ If a requested built-in diagnostic is not available for the active configuration
 ERF warns and skips that diagnostic.
 
 Flux Diagnostics
-~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^
 
 ``sens_flux`` and ``laten_flux`` are legacy ERF conservative scalar flux
 outputs. ``sensible_heat_flux`` and ``latent_heat_flux`` convert the same
@@ -926,7 +915,7 @@ In native SHOC ``state_update`` mode, SHOC is the transport owner. The
 source path used before SHOC consumes it.
 
 2D AMReX Metadata Sidecar
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Native AMReX 2D plotfiles include a JSON metadata sidecar named
 ``2DMetadata.json`` in the plotfile directory. The sidecar lists the selected
@@ -1007,7 +996,7 @@ Example sampled-level metadata:
    }
 
 2D Sampled-Level Diagnostics
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ERF can write sampled-level 2D diagnostics from a vertical coordinate and a
 field registry. A sampled level set is defined under
@@ -1103,7 +1092,7 @@ vorticity, and staggered velocity fields after their sampling rules are
 defined.
 
 2D Water-Path Diagnostics
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ERF can write scheme-aware 2D water-path diagnostics for prognostic condensed
 water species. These diagnostics integrate the conserved ``rho*q`` species
@@ -1153,7 +1142,7 @@ with ``FillZeroWhenUnavailable`` missing-value policy. The sidecar schema is
 unchanged.
 
 Surface Diagnostic Source Codes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``surface_diagnostic_source`` is a cell-centered categorical diagnostic. It
 reports the source path used by the SurfaceLayer scalar diagnostic path. It

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -878,24 +878,25 @@ Native AMReX 2D plotfiles include a JSON metadata sidecar named
 ``2DMetadata.json`` in the plotfile directory. The sidecar lists the selected
 2D variables in output component order. For each variable it records the
 component index, name, long name, units, diagnostic category, missing-value
-policy, and documented missing value.
+policy, and documented missing value. Sampled-level outputs add a source field
+and vertical-coordinate record.
 
-The sidecar uses the same 2D diagnostic catalog that defines the plotfile
-variables. It does not change field values and does not record a separate
-runtime source-selection mask. For example, in native SHOC ``state_update``
-mode the flux fields may come from preserved SHOC-consumed flux snapshots, as
-described above, but the sidecar records the public diagnostic metadata for the
-selected variables.
+The sidecar uses the same 2D diagnostic catalog that defines the built-in
+plotfile variables. Sampled-level outputs carry their own metadata record. The
+sidecar does not change field values. For example, in native SHOC
+``state_update`` mode the flux fields may come from preserved SHOC-consumed
+flux snapshots, as described above, but the sidecar records the public
+diagnostic metadata for the selected variables.
 
 This sidecar is written for native AMReX 2D plotfiles. NetCDF metadata
-attributes are not changed by this feature.
+attributes are not changed by this feature. The sidecar format version is 2.
 
 Example:
 
 .. code-block:: json
 
    {
-     "format_version": 1,
+     "format_version": 2,
      "kind": "ERF 2D plotfile metadata",
      "n_variables": 2,
      "variables": [
@@ -931,6 +932,60 @@ pressure levels.
 
 This organization does not change the public 2D variable names, component
 order, units, missing-value conventions, or ``2DMetadata.json`` schema.
+
+2D Sampled-Level Diagnostics
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ERF can write sampled-level 2D diagnostics from a vertical coordinate and a
+field registry. A sampled level set is defined under
+``erf.plot2d.level_set.<name>.`` and is selected for each 2D output stream by
+``erf.plot2d_level_sets_1`` or ``erf.plot2d_level_sets_2``.
+
+The supported coordinates are:
+
++--------------+-------------------------------------------+
+| Coordinate   | Meaning                                   |
++==============+===========================================+
+| model_index  | Copy the requested model level exactly.   |
++--------------+-------------------------------------------+
+| height_msl   | Sample at cell-centered height above mean |
+|              | sea level.                                |
++--------------+-------------------------------------------+
+| height_agl   | Sample at cell-centered height above      |
+|              | local terrain.                            |
++--------------+-------------------------------------------+
+| pressure     | Sample at cell-centered pressure.         |
++--------------+-------------------------------------------+
+
+The supported fields are ``rho``, ``theta``, ``temp``, ``pressure``,
+``height_msl``, ``height_agl``, ``qv``, ``qc``, ``qi``, ``qr``, ``qs``, and
+``qg``. Density, potential temperature, temperature, pressure, and height use
+the existing ERF thermodynamic and terrain helpers. Microphysical mass species
+are sampled as mixing ratios.
+
+For linear sampling, ERF uses adjacent levels :math:`k_0` and :math:`k_1`
+that bracket the requested target coordinate :math:`C_t`.
+
+.. math::
+
+   F_t = (1 - w) F_{k_0} + w F_{k_1}
+
+.. math::
+
+   w = \frac{C_t - C_{k_0}}{C_{k_1} - C_{k_0}}
+
+Model-index sampling copies the requested level exactly. If the target lies
+outside the column, ERF writes the configured missing value.
+
+.. math::
+
+   q_x = \frac{\rho q_x}{\rho}
+
+The sampled-level metadata records the source field and the vertical
+coordinate. The metadata uses ``format_version = 2``. Future extensions can
+add isentropic coordinates, derived field providers, vorticity, potential
+vorticity, and staggered velocity fields after their sampling rules are
+defined.
 
 2D Water-Path Diagnostics
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -490,6 +490,10 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             // Sampled-level descriptors are dynamic. The interpolator owns
             // their vertical sampling so the writer remains an output
             // assembly layer.
+            plotfile2d::SampledWindSources wind_sources;
+            wind_sources.xvel = &vars_new[lev][Vars::xvel];
+            wind_sources.yvel = &vars_new[lev][Vars::yvel];
+            wind_sources.zvel = &vars_new[lev][Vars::zvel];
             plotfile2d::fill_sampled_level_component(
                 mf[lev], mf_comp, descriptor,
                 vars_new[lev][Vars::cons],
@@ -497,7 +501,8 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 *z_phys_nd[lev],
                 z_phys_cc[lev] != nullptr,
                 solverChoice.moisture_indices,
-                klo, khi);
+                klo, khi,
+                wind_sources);
             mf_comp++;
         }
 

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -2,6 +2,8 @@
 #include "ERF_Plotfile2DCatalog.H"
 #include "ERF_Plotfile2DFill.H"
 #include "ERF_Plotfile2DMetadata.H"
+#include "ERF_Plotfile2DSampledField.H"
+#include "ERF_Plotfile2DSampledLevel.H"
 #include "ERF_Plotfile2DWaterPath.H"
 #include "ERF_NCPlotFile.H"
 #include "ERF_Plotfile2DUtils.H"
@@ -89,6 +91,160 @@ void warn_for_unavailable_2d_plot_vars (const std::string& parameter_name,
     }
 }
 
+amrex::Real sampled_coordinate_value (plotfile2d::SampledCoordinate coordinate,
+                                      const Array4<const Real>& cons_arr,
+                                      const Array4<const Real>& z_phys_cc_arr,
+                                      const Array4<const Real>& z_phys_nd_arr,
+                                      bool have_z_phys_cc,
+                                      int i, int j, int k,
+                                      const MoistureComponentIndices& moisture_indices) noexcept
+{
+    if (coordinate == plotfile2d::SampledCoordinate::ModelIndex) {
+        return static_cast<Real>(k);
+    }
+
+    return plotfile2d::sampled_field_value(
+        coordinate == plotfile2d::SampledCoordinate::HeightMSL
+            ? plotfile2d::SampledFieldID::HeightMSL
+            : coordinate == plotfile2d::SampledCoordinate::HeightAGL
+                ? plotfile2d::SampledFieldID::HeightAGL
+                : plotfile2d::SampledFieldID::Pressure,
+        cons_arr, z_phys_cc_arr, z_phys_nd_arr, have_z_phys_cc,
+        i, j, k, moisture_indices);
+}
+
+bool find_sampled_bracket (plotfile2d::SampledCoordinate coordinate,
+                           amrex::Real target,
+                           int klo,
+                           int khi,
+                           int i, int j,
+                           const Array4<const Real>& cons_arr,
+                           const Array4<const Real>& z_phys_cc_arr,
+                           const Array4<const Real>& z_phys_nd_arr,
+                           bool have_z_phys_cc,
+                           const MoistureComponentIndices& moisture_indices,
+                           int& bracket_lo,
+                           int& bracket_hi,
+                           Real& coord_lo,
+                           Real& coord_hi) noexcept
+{
+    if (khi < klo) {
+        return false;
+    }
+
+    coord_lo = sampled_coordinate_value(coordinate, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                        have_z_phys_cc, i, j, klo, moisture_indices);
+    if (target == coord_lo) {
+        bracket_lo = klo;
+        bracket_hi = klo;
+        coord_hi = coord_lo;
+        return true;
+    }
+
+    for (int k = klo; k < khi; ++k) {
+        coord_hi = sampled_coordinate_value(coordinate, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                            have_z_phys_cc, i, j, k + 1, moisture_indices);
+        if ((coord_lo <= target && target <= coord_hi) ||
+            (coord_hi <= target && target <= coord_lo)) {
+            bracket_lo = k;
+            bracket_hi = k + 1;
+            return true;
+        }
+        coord_lo = coord_hi;
+    }
+
+    return false;
+}
+
+void fill_sampled_descriptor_component (MultiFab& dst,
+                                        int dst_comp,
+                                        const plotfile2d::Plotfile2DOutputDescriptor& descriptor,
+                                        const MultiFab& cons,
+                                        const MultiFab* z_phys_cc,
+                                        const MultiFab& z_phys_nd,
+                                        bool have_z_phys_cc,
+                                        const MoistureComponentIndices& moisture_indices,
+                                        int klo,
+                                        int khi)
+{
+    const auto* sampled = descriptor.sampled_level ? &*descriptor.sampled_level : nullptr;
+    if (sampled == nullptr) {
+        plotfile2d::fill_component_with_value(dst, dst_comp, descriptor.missing_value);
+        return;
+    }
+
+    const auto* field_descriptor = plotfile2d::find_sampled_field(sampled->source_field);
+    if (field_descriptor == nullptr) {
+        Abort("Unknown sampled-level source field '" + sampled->source_field + "'");
+    }
+
+    const auto coordinate = plotfile2d::sampled_coordinate_from_string(
+        sampled->vertical_coordinate.type);
+    const auto field_id = field_descriptor->id;
+    const amrex::Real target = sampled->vertical_coordinate.canonical_value;
+    const int target_k = static_cast<int>(std::nearbyint(target));
+    const amrex::Real missing_value = descriptor.missing_value;
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& dst_arr = dst.array(mfi);
+        const auto& cons_arr = cons.const_array(mfi);
+        const auto& z_phys_nd_arr = z_phys_nd.const_array(mfi);
+        const auto& z_phys_cc_arr = have_z_phys_cc && z_phys_cc != nullptr
+            ? z_phys_cc->const_array(mfi)
+            : cons.const_array(mfi);
+
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (coordinate == plotfile2d::SampledCoordinate::ModelIndex) {
+                if (target_k < klo || target_k > khi) {
+                    dst_arr(i, j, k, dst_comp) = missing_value;
+                    return;
+                }
+
+                dst_arr(i, j, k, dst_comp) =
+                    plotfile2d::sampled_field_value(field_id,
+                                                    cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                                    have_z_phys_cc,
+                                                    i, j, target_k, moisture_indices);
+                return;
+            }
+
+            int bracket_lo = -1;
+            int bracket_hi = -1;
+            Real coord_lo = 0.0;
+            Real coord_hi = 0.0;
+            if (!find_sampled_bracket(coordinate, target, klo, khi, i, j, cons_arr, z_phys_cc_arr,
+                                      z_phys_nd_arr, have_z_phys_cc, moisture_indices,
+                                      bracket_lo, bracket_hi, coord_lo, coord_hi)) {
+                dst_arr(i, j, k, dst_comp) = missing_value;
+                return;
+            }
+
+            const Real field_lo =
+                plotfile2d::sampled_field_value(field_id,
+                                                cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                                have_z_phys_cc,
+                                                i, j, bracket_lo, moisture_indices);
+            if (bracket_lo == bracket_hi || coord_hi == coord_lo) {
+                dst_arr(i, j, k, dst_comp) = field_lo;
+                return;
+            }
+
+            const Real field_hi =
+                plotfile2d::sampled_field_value(field_id,
+                                                cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                                have_z_phys_cc,
+                                                i, j, bracket_hi, moisture_indices);
+            const Real weight = (target - coord_lo) / (coord_hi - coord_lo);
+            dst_arr(i, j, k, dst_comp) = field_lo + weight * (field_hi - field_lo);
+        });
+    }
+}
+
 } // namespace
 void
 ERF::setPlotVariables2D (const std::string& pp_plot_var_names, Vector<std::string>& plot_var_names)
@@ -135,7 +291,15 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                                                            plot2d_file_1, plot2d_file_2,
                                                            file_name_digits);
 
-    const Vector<std::string> varnames = PlotFileVarNames(plot_var_names);
+    const auto output_descriptors =
+        plotfile2d::build_sampled_level_output_descriptors(pp_prefix, which,
+                                                           plot_var_names, solverChoice);
+
+    Vector<std::string> varnames;
+    varnames.reserve(output_descriptors.size());
+    for (const auto& descriptor : output_descriptors) {
+        varnames.push_back(descriptor.name);
+    }
     const int ncomp_mf = static_cast<int>(varnames.size());
 
     if (ncomp_mf == 0) return;
@@ -475,6 +639,19 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
             mf_comp++;
         } // shoc_wthv_sfc
 
+        const int static_output_count = static_cast<int>(plot_var_names.size());
+        for (int out_idx = static_output_count; out_idx < static_cast<int>(output_descriptors.size()); ++out_idx) {
+            const auto& descriptor = output_descriptors[out_idx];
+            fill_sampled_descriptor_component(mf[lev], mf_comp, descriptor,
+                                              vars_new[lev][Vars::cons],
+                                              z_phys_cc[lev].get(),
+                                              *z_phys_nd[lev],
+                                              z_phys_cc[lev] != nullptr,
+                                              solverChoice.moisture_indices,
+                                              klo, khi);
+            mf_comp++;
+        }
+
         if (mf_comp != ncomp_mf) {
             Abort(plotfile2d::format_2d_component_count_error(lev, mf_comp, ncomp_mf));
         }
@@ -490,7 +667,7 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                                 varnames, my_geom, t_new[0], istep, refRatio());
         // Native AMReX 2D plotfiles write a JSON sidecar with catalog
         // metadata for the selected output variables only.
-        plotfile2d::write_2d_metadata_json(plotfilename, varnames);
+        plotfile2d::write_2d_metadata_json(plotfilename, output_descriptors);
         writeJobInfo(plotfilename);
 
 #ifdef ERF_USE_NETCDF

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -2,8 +2,7 @@
 #include "ERF_Plotfile2DCatalog.H"
 #include "ERF_Plotfile2DFill.H"
 #include "ERF_Plotfile2DMetadata.H"
-#include "ERF_Plotfile2DSampledField.H"
-#include "ERF_Plotfile2DSampledLevel.H"
+#include "ERF_Plotfile2DInterpolator.H"
 #include "ERF_Plotfile2DWaterPath.H"
 #include "ERF_NCPlotFile.H"
 #include "ERF_Plotfile2DUtils.H"
@@ -88,160 +87,6 @@ void warn_for_unavailable_2d_plot_vars (const std::string& parameter_name,
 
     for (const auto& name : unavailable_names) {
         Warning(plotfile2d::format_unavailable_2d_plot_var_warning(parameter_name, name, available_names));
-    }
-}
-
-amrex::Real sampled_coordinate_value (plotfile2d::SampledCoordinate coordinate,
-                                      const Array4<const Real>& cons_arr,
-                                      const Array4<const Real>& z_phys_cc_arr,
-                                      const Array4<const Real>& z_phys_nd_arr,
-                                      bool have_z_phys_cc,
-                                      int i, int j, int k,
-                                      const MoistureComponentIndices& moisture_indices) noexcept
-{
-    if (coordinate == plotfile2d::SampledCoordinate::ModelIndex) {
-        return static_cast<Real>(k);
-    }
-
-    return plotfile2d::sampled_field_value(
-        coordinate == plotfile2d::SampledCoordinate::HeightMSL
-            ? plotfile2d::SampledFieldID::HeightMSL
-            : coordinate == plotfile2d::SampledCoordinate::HeightAGL
-                ? plotfile2d::SampledFieldID::HeightAGL
-                : plotfile2d::SampledFieldID::Pressure,
-        cons_arr, z_phys_cc_arr, z_phys_nd_arr, have_z_phys_cc,
-        i, j, k, moisture_indices);
-}
-
-bool find_sampled_bracket (plotfile2d::SampledCoordinate coordinate,
-                           amrex::Real target,
-                           int klo,
-                           int khi,
-                           int i, int j,
-                           const Array4<const Real>& cons_arr,
-                           const Array4<const Real>& z_phys_cc_arr,
-                           const Array4<const Real>& z_phys_nd_arr,
-                           bool have_z_phys_cc,
-                           const MoistureComponentIndices& moisture_indices,
-                           int& bracket_lo,
-                           int& bracket_hi,
-                           Real& coord_lo,
-                           Real& coord_hi) noexcept
-{
-    if (khi < klo) {
-        return false;
-    }
-
-    coord_lo = sampled_coordinate_value(coordinate, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                        have_z_phys_cc, i, j, klo, moisture_indices);
-    if (target == coord_lo) {
-        bracket_lo = klo;
-        bracket_hi = klo;
-        coord_hi = coord_lo;
-        return true;
-    }
-
-    for (int k = klo; k < khi; ++k) {
-        coord_hi = sampled_coordinate_value(coordinate, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                            have_z_phys_cc, i, j, k + 1, moisture_indices);
-        if ((coord_lo <= target && target <= coord_hi) ||
-            (coord_hi <= target && target <= coord_lo)) {
-            bracket_lo = k;
-            bracket_hi = k + 1;
-            return true;
-        }
-        coord_lo = coord_hi;
-    }
-
-    return false;
-}
-
-void fill_sampled_descriptor_component (MultiFab& dst,
-                                        int dst_comp,
-                                        const plotfile2d::Plotfile2DOutputDescriptor& descriptor,
-                                        const MultiFab& cons,
-                                        const MultiFab* z_phys_cc,
-                                        const MultiFab& z_phys_nd,
-                                        bool have_z_phys_cc,
-                                        const MoistureComponentIndices& moisture_indices,
-                                        int klo,
-                                        int khi)
-{
-    const auto* sampled = descriptor.sampled_level ? &*descriptor.sampled_level : nullptr;
-    if (sampled == nullptr) {
-        plotfile2d::fill_component_with_value(dst, dst_comp, descriptor.missing_value);
-        return;
-    }
-
-    const auto* field_descriptor = plotfile2d::find_sampled_field(sampled->source_field);
-    if (field_descriptor == nullptr) {
-        Abort("Unknown sampled-level source field '" + sampled->source_field + "'");
-    }
-
-    const auto coordinate = plotfile2d::sampled_coordinate_from_string(
-        sampled->vertical_coordinate.type);
-    const auto field_id = field_descriptor->id;
-    const amrex::Real target = sampled->vertical_coordinate.canonical_value;
-    const int target_k = static_cast<int>(std::nearbyint(target));
-    const amrex::Real missing_value = descriptor.missing_value;
-
-#ifdef _OPENMP
-#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
-#endif
-    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
-    {
-        const Box& bx = mfi.tilebox();
-        const auto& dst_arr = dst.array(mfi);
-        const auto& cons_arr = cons.const_array(mfi);
-        const auto& z_phys_nd_arr = z_phys_nd.const_array(mfi);
-        const auto& z_phys_cc_arr = have_z_phys_cc && z_phys_cc != nullptr
-            ? z_phys_cc->const_array(mfi)
-            : cons.const_array(mfi);
-
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            if (coordinate == plotfile2d::SampledCoordinate::ModelIndex) {
-                if (target_k < klo || target_k > khi) {
-                    dst_arr(i, j, k, dst_comp) = missing_value;
-                    return;
-                }
-
-                dst_arr(i, j, k, dst_comp) =
-                    plotfile2d::sampled_field_value(field_id,
-                                                    cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                                    have_z_phys_cc,
-                                                    i, j, target_k, moisture_indices);
-                return;
-            }
-
-            int bracket_lo = -1;
-            int bracket_hi = -1;
-            Real coord_lo = 0.0;
-            Real coord_hi = 0.0;
-            if (!find_sampled_bracket(coordinate, target, klo, khi, i, j, cons_arr, z_phys_cc_arr,
-                                      z_phys_nd_arr, have_z_phys_cc, moisture_indices,
-                                      bracket_lo, bracket_hi, coord_lo, coord_hi)) {
-                dst_arr(i, j, k, dst_comp) = missing_value;
-                return;
-            }
-
-            const Real field_lo =
-                plotfile2d::sampled_field_value(field_id,
-                                                cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                                have_z_phys_cc,
-                                                i, j, bracket_lo, moisture_indices);
-            if (bracket_lo == bracket_hi || coord_hi == coord_lo) {
-                dst_arr(i, j, k, dst_comp) = field_lo;
-                return;
-            }
-
-            const Real field_hi =
-                plotfile2d::sampled_field_value(field_id,
-                                                cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                                have_z_phys_cc,
-                                                i, j, bracket_hi, moisture_indices);
-            const Real weight = (target - coord_lo) / (coord_hi - coord_lo);
-            dst_arr(i, j, k, dst_comp) = field_lo + weight * (field_hi - field_lo);
-        });
     }
 }
 
@@ -642,13 +487,17 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         const int static_output_count = static_cast<int>(plot_var_names.size());
         for (int out_idx = static_output_count; out_idx < static_cast<int>(output_descriptors.size()); ++out_idx) {
             const auto& descriptor = output_descriptors[out_idx];
-            fill_sampled_descriptor_component(mf[lev], mf_comp, descriptor,
-                                              vars_new[lev][Vars::cons],
-                                              z_phys_cc[lev].get(),
-                                              *z_phys_nd[lev],
-                                              z_phys_cc[lev] != nullptr,
-                                              solverChoice.moisture_indices,
-                                              klo, khi);
+            // Sampled-level descriptors are dynamic. The interpolator owns
+            // their vertical sampling so the writer remains an output
+            // assembly layer.
+            plotfile2d::fill_sampled_level_component(
+                mf[lev], mf_comp, descriptor,
+                vars_new[lev][Vars::cons],
+                z_phys_cc[lev].get(),
+                *z_phys_nd[lev],
+                z_phys_cc[lev] != nullptr,
+                solverChoice.moisture_indices,
+                klo, khi);
             mf_comp++;
         }
 

--- a/Source/IO/ERF_Plotfile2DCatalog.H
+++ b/Source/IO/ERF_Plotfile2DCatalog.H
@@ -50,7 +50,8 @@ enum class DiagnosticCategory
     SurfaceFlux,
     PBL,
     SurfaceState,
-    ColumnIntegral
+    ColumnIntegral,
+    SampledLevel
 };
 
 enum class MissingPolicy

--- a/Source/IO/ERF_Plotfile2DInterpolator.H
+++ b/Source/IO/ERF_Plotfile2DInterpolator.H
@@ -21,6 +21,15 @@ struct SampledBracket
     bool found = false;
 };
 
+struct SampledWindSources
+{
+    const amrex::MultiFab* xvel = nullptr;
+    const amrex::MultiFab* yvel = nullptr;
+    const amrex::MultiFab* zvel = nullptr;
+    const amrex::MultiFab* cos_alpha = nullptr;
+    const amrex::MultiFab* sin_alpha = nullptr;
+};
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 bool sampled_target_is_bracketed (amrex::Real target,
                                   amrex::Real c0,
@@ -54,7 +63,8 @@ void fill_sampled_level_component (amrex::MultiFab& dst,
                                    bool have_z_phys_cc,
                                    const MoistureComponentIndices& moisture_indices,
                                    int klo,
-                                   int khi);
+                                   int khi,
+                                   const SampledWindSources& wind_sources = {});
 
 } // namespace plotfile2d
 

--- a/Source/IO/ERF_Plotfile2DInterpolator.H
+++ b/Source/IO/ERF_Plotfile2DInterpolator.H
@@ -1,0 +1,52 @@
+#ifndef ERF_PLOTFILE2DINTERPOLATOR_H_
+#define ERF_PLOTFILE2DINTERPOLATOR_H_
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_REAL.H>
+
+// Vertical sampling helpers for ERF 2D plotfiles. These helpers copy model
+// levels or linearly interpolate cell-centered fields onto one target level.
+
+namespace plotfile2d
+{
+
+struct SampledBracket
+{
+    int klo = -1;
+    int khi = -1;
+    bool found = false;
+};
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+SampledBracket find_sampled_bracket (amrex::Real target,
+                                     amrex::Real lo_value,
+                                     amrex::Real hi_value) noexcept
+{
+    SampledBracket bracket;
+    if ((lo_value <= target && target <= hi_value) ||
+        (hi_value <= target && target <= lo_value)) {
+        bracket.klo = 0;
+        bracket.khi = 1;
+        bracket.found = true;
+    }
+    return bracket;
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real linear_interpolate (amrex::Real lo_value,
+                                amrex::Real hi_value,
+                                amrex::Real lo_coord,
+                                amrex::Real hi_coord,
+                                amrex::Real target) noexcept
+{
+    if (hi_coord == lo_coord) {
+        return lo_value;
+    }
+
+    const amrex::Real weight = (target - lo_coord) / (hi_coord - lo_coord);
+    return lo_value + weight * (hi_value - lo_value);
+}
+
+} // namespace plotfile2d
+
+#endif

--- a/Source/IO/ERF_Plotfile2DInterpolator.H
+++ b/Source/IO/ERF_Plotfile2DInterpolator.H
@@ -1,11 +1,15 @@
 #ifndef ERF_PLOTFILE2DINTERPOLATOR_H_
 #define ERF_PLOTFILE2DINTERPOLATOR_H_
 
+#include <AMReX_MultiFab.H>
 #include <AMReX_GpuQualifiers.H>
 #include <AMReX_REAL.H>
 
+#include "ERF_Plotfile2DSampledLevel.H"
+
 // Vertical sampling helpers for ERF 2D plotfiles. These helpers copy model
 // levels or linearly interpolate cell-centered fields onto one target level.
+// The 2D writer calls this layer after it allocates output components.
 
 namespace plotfile2d
 {
@@ -18,18 +22,12 @@ struct SampledBracket
 };
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
-SampledBracket find_sampled_bracket (amrex::Real target,
-                                     amrex::Real lo_value,
-                                     amrex::Real hi_value) noexcept
+bool sampled_target_is_bracketed (amrex::Real target,
+                                  amrex::Real c0,
+                                  amrex::Real c1) noexcept
 {
-    SampledBracket bracket;
-    if ((lo_value <= target && target <= hi_value) ||
-        (hi_value <= target && target <= lo_value)) {
-        bracket.klo = 0;
-        bracket.khi = 1;
-        bracket.found = true;
-    }
-    return bracket;
+    return (c0 <= target && target <= c1) ||
+           (c1 <= target && target <= c0);
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
@@ -46,6 +44,17 @@ amrex::Real linear_interpolate (amrex::Real lo_value,
     const amrex::Real weight = (target - lo_coord) / (hi_coord - lo_coord);
     return lo_value + weight * (hi_value - lo_value);
 }
+
+void fill_sampled_level_component (amrex::MultiFab& dst,
+                                   int dst_comp,
+                                   const Plotfile2DOutputDescriptor& descriptor,
+                                   const amrex::MultiFab& cons,
+                                   const amrex::MultiFab* z_phys_cc,
+                                   const amrex::MultiFab& z_phys_nd,
+                                   bool have_z_phys_cc,
+                                   const MoistureComponentIndices& moisture_indices,
+                                   int klo,
+                                   int khi);
 
 } // namespace plotfile2d
 

--- a/Source/IO/ERF_Plotfile2DInterpolator.cpp
+++ b/Source/IO/ERF_Plotfile2DInterpolator.cpp
@@ -12,6 +12,99 @@ namespace plotfile2d
 namespace
 {
 
+struct SampledEarthWind
+{
+    Real u_east = Real(0.0);
+    Real v_north = Real(0.0);
+    Real w = Real(0.0);
+};
+
+struct SampledRotation
+{
+    Real cos_alpha = Real(1.0);
+    Real sin_alpha = Real(0.0);
+};
+
+constexpr Real sampled_wind_dir_pi = Real(3.141592653589793238462643383279502884L);
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+SampledRotation rotation_at_mass_point (int i, int j,
+                                        const Array4<const Real>& cos_alpha_arr,
+                                        const Array4<const Real>& sin_alpha_arr,
+                                        bool have_rotation) noexcept
+{
+    if (!have_rotation) {
+        return {};
+    }
+
+    return {cos_alpha_arr(i, j, 0), sin_alpha_arr(i, j, 0)};
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+SampledEarthWind earth_wind_at_cell_center (int i, int j, int k,
+                                            const Array4<const Real>& xvel_arr,
+                                            const Array4<const Real>& yvel_arr,
+                                            const Array4<const Real>& zvel_arr,
+                                            const Array4<const Real>& cos_alpha_arr,
+                                            const Array4<const Real>& sin_alpha_arr,
+                                            bool have_rotation) noexcept
+{
+    const Real u_cc = Real(0.5) * (xvel_arr(i, j, k) + xvel_arr(i + 1, j, k));
+    const Real v_cc = Real(0.5) * (yvel_arr(i, j, k) + yvel_arr(i, j + 1, k));
+    const Real w_cc = Real(0.5) * (zvel_arr(i, j, k) + zvel_arr(i, j, k + 1));
+
+    const SampledRotation rot = rotation_at_mass_point(i, j, cos_alpha_arr, sin_alpha_arr,
+                                                       have_rotation);
+
+    SampledEarthWind wind;
+    wind.u_east = u_cc * rot.cos_alpha - v_cc * rot.sin_alpha;
+    wind.v_north = u_cc * rot.sin_alpha + v_cc * rot.cos_alpha;
+    wind.w = w_cc;
+    return wind;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real horizontal_wind_speed (const SampledEarthWind& wind) noexcept
+{
+    return std::sqrt(wind.u_east * wind.u_east + wind.v_north * wind.v_north);
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real meteorological_wind_direction (const SampledEarthWind& wind,
+                                    Real missing_value) noexcept
+{
+    const Real speed = horizontal_wind_speed(wind);
+    if (speed <= Real(1.0e-12)) {
+        return missing_value;
+    }
+
+    Real direction = Real(270.0)
+        - std::atan2(wind.v_north, wind.u_east) * Real(180.0) / sampled_wind_dir_pi;
+    while (direction < Real(0.0)) {
+        direction += Real(360.0);
+    }
+    while (direction >= Real(360.0)) {
+        direction -= Real(360.0);
+    }
+    return direction;
+}
+
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
+Real wind_field_from_earth_wind (SampledFieldID field_id,
+                                 const SampledEarthWind& wind,
+                                 Real missing_value) noexcept
+{
+    switch (field_id) {
+    case SampledFieldID::UEast:     return wind.u_east;
+    case SampledFieldID::VNorth:    return wind.v_north;
+    case SampledFieldID::W:         return wind.w;
+    case SampledFieldID::WindSpeed:  return horizontal_wind_speed(wind);
+    case SampledFieldID::WindDir:    return meteorological_wind_direction(wind, missing_value);
+    default:                        break;
+    }
+    return Real(0.0);
+}
+
 // A target is bracketed when it lies between adjacent coordinate values. This
 // test works for increasing height and decreasing pressure.
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
@@ -80,7 +173,8 @@ fill_sampled_level_component (MultiFab& dst,
                               bool have_z_phys_cc,
                               const MoistureComponentIndices& moisture_indices,
                               int klo,
-                              int khi)
+                              int khi,
+                              const SampledWindSources& wind_sources)
 {
     const auto* sampled = descriptor.sampled_level ? &*descriptor.sampled_level : nullptr;
     if (sampled == nullptr) {
@@ -98,6 +192,17 @@ fill_sampled_level_component (MultiFab& dst,
     const Real target = sampled->vertical_coordinate.canonical_value;
     const int target_k = static_cast<int>(std::nearbyint(target));
     const Real missing_value = descriptor.missing_value;
+    const bool is_wind_field = sampled_field_is_wind(field_id);
+    const bool have_rotation = (wind_sources.cos_alpha != nullptr) || (wind_sources.sin_alpha != nullptr);
+
+    if (is_wind_field) {
+        if (wind_sources.xvel == nullptr || wind_sources.yvel == nullptr || wind_sources.zvel == nullptr) {
+            Abort("Sampled-level wind field '" + sampled->source_field + "' requires xvel, yvel, and zvel sources");
+        }
+        if ((wind_sources.cos_alpha == nullptr) != (wind_sources.sin_alpha == nullptr)) {
+            Abort("Sampled-level wind field '" + sampled->source_field + "' requires both cos_alpha and sin_alpha when rotation is supplied");
+        }
+    }
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -111,6 +216,11 @@ fill_sampled_level_component (MultiFab& dst,
         const auto& z_phys_cc_arr = have_z_phys_cc && z_phys_cc != nullptr
             ? z_phys_cc->const_array(mfi)
             : cons.const_array(mfi);
+        const auto& xvel_arr = is_wind_field ? wind_sources.xvel->const_array(mfi) : cons.const_array(mfi);
+        const auto& yvel_arr = is_wind_field ? wind_sources.yvel->const_array(mfi) : cons.const_array(mfi);
+        const auto& zvel_arr = is_wind_field ? wind_sources.zvel->const_array(mfi) : cons.const_array(mfi);
+        const auto& cos_alpha_arr = have_rotation ? wind_sources.cos_alpha->const_array(mfi) : cons.const_array(mfi);
+        const auto& sin_alpha_arr = have_rotation ? wind_sources.sin_alpha->const_array(mfi) : cons.const_array(mfi);
 
         ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             if (coordinate == SampledCoordinate::ModelIndex) {
@@ -119,9 +229,16 @@ fill_sampled_level_component (MultiFab& dst,
                     return;
                 }
 
-                dst_arr(i, j, k, dst_comp) =
-                    sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                        have_z_phys_cc, i, j, target_k, moisture_indices);
+                if (is_wind_field) {
+                    const SampledEarthWind wind = earth_wind_at_cell_center(
+                        i, j, target_k, xvel_arr, yvel_arr, zvel_arr, cos_alpha_arr, sin_alpha_arr,
+                        have_rotation);
+                    dst_arr(i, j, k, dst_comp) = wind_field_from_earth_wind(field_id, wind, missing_value);
+                } else {
+                    dst_arr(i, j, k, dst_comp) =
+                        sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                            have_z_phys_cc, i, j, target_k, moisture_indices);
+                }
                 return;
             }
 
@@ -133,17 +250,6 @@ fill_sampled_level_component (MultiFab& dst,
                 return;
             }
 
-            const Real field_lo =
-                sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                    have_z_phys_cc, i, j, bracket.klo, moisture_indices);
-            if (bracket.klo == bracket.khi) {
-                dst_arr(i, j, k, dst_comp) = field_lo;
-                return;
-            }
-
-            const Real field_hi =
-                sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
-                                    have_z_phys_cc, i, j, bracket.khi, moisture_indices);
             const Real coord_lo =
                 sampled_field_value((coordinate == SampledCoordinate::HeightMSL)
                                         ? SampledFieldID::HeightMSL
@@ -160,8 +266,38 @@ fill_sampled_level_component (MultiFab& dst,
                                             : SampledFieldID::Pressure,
                                     cons_arr, z_phys_cc_arr, z_phys_nd_arr,
                                     have_z_phys_cc, i, j, bracket.khi, moisture_indices);
-            dst_arr(i, j, k, dst_comp) =
-                linear_interpolate(field_lo, field_hi, coord_lo, coord_hi, target);
+            if (is_wind_field) {
+                const SampledEarthWind wind_lo = earth_wind_at_cell_center(
+                    i, j, bracket.klo, xvel_arr, yvel_arr, zvel_arr, cos_alpha_arr, sin_alpha_arr,
+                    have_rotation);
+                if (bracket.klo == bracket.khi) {
+                    dst_arr(i, j, k, dst_comp) = wind_field_from_earth_wind(field_id, wind_lo, missing_value);
+                    return;
+                }
+
+                const SampledEarthWind wind_hi = earth_wind_at_cell_center(
+                    i, j, bracket.khi, xvel_arr, yvel_arr, zvel_arr, cos_alpha_arr, sin_alpha_arr,
+                    have_rotation);
+                SampledEarthWind wind_interp;
+                wind_interp.u_east = linear_interpolate(wind_lo.u_east, wind_hi.u_east, coord_lo, coord_hi, target);
+                wind_interp.v_north = linear_interpolate(wind_lo.v_north, wind_hi.v_north, coord_lo, coord_hi, target);
+                wind_interp.w = linear_interpolate(wind_lo.w, wind_hi.w, coord_lo, coord_hi, target);
+                dst_arr(i, j, k, dst_comp) = wind_field_from_earth_wind(field_id, wind_interp, missing_value);
+            } else {
+                const Real field_lo =
+                    sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                        have_z_phys_cc, i, j, bracket.klo, moisture_indices);
+                if (bracket.klo == bracket.khi) {
+                    dst_arr(i, j, k, dst_comp) = field_lo;
+                    return;
+                }
+
+                const Real field_hi =
+                    sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                        have_z_phys_cc, i, j, bracket.khi, moisture_indices);
+                dst_arr(i, j, k, dst_comp) =
+                    linear_interpolate(field_lo, field_hi, coord_lo, coord_hi, target);
+            }
         });
     }
 }

--- a/Source/IO/ERF_Plotfile2DInterpolator.cpp
+++ b/Source/IO/ERF_Plotfile2DInterpolator.cpp
@@ -1,0 +1,6 @@
+#include "ERF_Plotfile2DInterpolator.H"
+
+namespace plotfile2d
+{
+
+} // namespace plotfile2d

--- a/Source/IO/ERF_Plotfile2DInterpolator.cpp
+++ b/Source/IO/ERF_Plotfile2DInterpolator.cpp
@@ -14,6 +14,7 @@ namespace
 
 // A target is bracketed when it lies between adjacent coordinate values. This
 // test works for increasing height and decreasing pressure.
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 SampledBracket find_sampled_bracket (SampledCoordinate coordinate,
                                      Real target,
                                      int klo,

--- a/Source/IO/ERF_Plotfile2DInterpolator.cpp
+++ b/Source/IO/ERF_Plotfile2DInterpolator.cpp
@@ -31,7 +31,7 @@ SampledBracket find_sampled_bracket (SampledCoordinate coordinate,
         return bracket;
     }
 
-    auto coordinate_value = [=] AMREX_GPU_HOST_DEVICE (int kk) noexcept -> Real {
+    auto coordinate_value = [=] AMREX_GPU_DEVICE (int kk) noexcept -> Real {
         if (coordinate == SampledCoordinate::ModelIndex) {
             return static_cast<Real>(kk);
         }

--- a/Source/IO/ERF_Plotfile2DInterpolator.cpp
+++ b/Source/IO/ERF_Plotfile2DInterpolator.cpp
@@ -1,6 +1,168 @@
 #include "ERF_Plotfile2DInterpolator.H"
+#include "ERF_Plotfile2DFill.H"
+
+#include <cmath>
+#include <sstream>
+
+using namespace amrex;
 
 namespace plotfile2d
 {
+
+namespace
+{
+
+// A target is bracketed when it lies between adjacent coordinate values. This
+// test works for increasing height and decreasing pressure.
+SampledBracket find_sampled_bracket (SampledCoordinate coordinate,
+                                     Real target,
+                                     int klo,
+                                     int khi,
+                                     int i, int j,
+                                     const Array4<const Real>& cons_arr,
+                                     const Array4<const Real>& z_phys_cc_arr,
+                                     const Array4<const Real>& z_phys_nd_arr,
+                                     bool have_z_phys_cc,
+                                     const MoistureComponentIndices& moisture_indices) noexcept
+{
+    SampledBracket bracket;
+    if (khi < klo) {
+        return bracket;
+    }
+
+    auto coordinate_value = [=] AMREX_GPU_HOST_DEVICE (int kk) noexcept -> Real {
+        if (coordinate == SampledCoordinate::ModelIndex) {
+            return static_cast<Real>(kk);
+        }
+
+        const auto field_id = (coordinate == SampledCoordinate::HeightMSL)
+            ? SampledFieldID::HeightMSL
+            : (coordinate == SampledCoordinate::HeightAGL)
+                ? SampledFieldID::HeightAGL
+                : SampledFieldID::Pressure;
+        return sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                   have_z_phys_cc, i, j, kk, moisture_indices);
+    };
+
+    const Real c0 = coordinate_value(klo);
+    if (target == c0) {
+        bracket.klo = klo;
+        bracket.khi = klo;
+        bracket.found = true;
+        return bracket;
+    }
+
+    Real lo = c0;
+    for (int k = klo; k < khi; ++k) {
+        const Real hi = coordinate_value(k + 1);
+        if (sampled_target_is_bracketed(target, lo, hi)) {
+            bracket.klo = k;
+            bracket.khi = k + 1;
+            bracket.found = true;
+            return bracket;
+        }
+        lo = hi;
+    }
+
+    return bracket;
+}
+
+} // namespace
+
+void
+fill_sampled_level_component (MultiFab& dst,
+                              int dst_comp,
+                              const Plotfile2DOutputDescriptor& descriptor,
+                              const MultiFab& cons,
+                              const MultiFab* z_phys_cc,
+                              const MultiFab& z_phys_nd,
+                              bool have_z_phys_cc,
+                              const MoistureComponentIndices& moisture_indices,
+                              int klo,
+                              int khi)
+{
+    const auto* sampled = descriptor.sampled_level ? &*descriptor.sampled_level : nullptr;
+    if (sampled == nullptr) {
+        fill_component_with_value(dst, dst_comp, descriptor.missing_value);
+        return;
+    }
+
+    const auto* field_descriptor = find_sampled_field(sampled->source_field);
+    if (field_descriptor == nullptr) {
+        Abort("Unknown sampled-level source field '" + sampled->source_field + "'");
+    }
+
+    const auto coordinate = sampled_coordinate_from_string(sampled->vertical_coordinate.type);
+    const auto field_id = field_descriptor->id;
+    const Real target = sampled->vertical_coordinate.canonical_value;
+    const int target_k = static_cast<int>(std::nearbyint(target));
+    const Real missing_value = descriptor.missing_value;
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(dst, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.tilebox();
+        const auto& dst_arr = dst.array(mfi);
+        const auto& cons_arr = cons.const_array(mfi);
+        const auto& z_phys_nd_arr = z_phys_nd.const_array(mfi);
+        const auto& z_phys_cc_arr = have_z_phys_cc && z_phys_cc != nullptr
+            ? z_phys_cc->const_array(mfi)
+            : cons.const_array(mfi);
+
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            if (coordinate == SampledCoordinate::ModelIndex) {
+                if (target_k < klo || target_k > khi) {
+                    dst_arr(i, j, k, dst_comp) = missing_value;
+                    return;
+                }
+
+                dst_arr(i, j, k, dst_comp) =
+                    sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                        have_z_phys_cc, i, j, target_k, moisture_indices);
+                return;
+            }
+
+            const auto bracket = find_sampled_bracket(coordinate, target, klo, khi, i, j,
+                                                      cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                                      have_z_phys_cc, moisture_indices);
+            if (!bracket.found) {
+                dst_arr(i, j, k, dst_comp) = missing_value;
+                return;
+            }
+
+            const Real field_lo =
+                sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                    have_z_phys_cc, i, j, bracket.klo, moisture_indices);
+            if (bracket.klo == bracket.khi) {
+                dst_arr(i, j, k, dst_comp) = field_lo;
+                return;
+            }
+
+            const Real field_hi =
+                sampled_field_value(field_id, cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                    have_z_phys_cc, i, j, bracket.khi, moisture_indices);
+            const Real coord_lo =
+                sampled_field_value((coordinate == SampledCoordinate::HeightMSL)
+                                        ? SampledFieldID::HeightMSL
+                                        : (coordinate == SampledCoordinate::HeightAGL)
+                                            ? SampledFieldID::HeightAGL
+                                            : SampledFieldID::Pressure,
+                                    cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                    have_z_phys_cc, i, j, bracket.klo, moisture_indices);
+            const Real coord_hi =
+                sampled_field_value((coordinate == SampledCoordinate::HeightMSL)
+                                        ? SampledFieldID::HeightMSL
+                                        : (coordinate == SampledCoordinate::HeightAGL)
+                                            ? SampledFieldID::HeightAGL
+                                            : SampledFieldID::Pressure,
+                                    cons_arr, z_phys_cc_arr, z_phys_nd_arr,
+                                    have_z_phys_cc, i, j, bracket.khi, moisture_indices);
+            dst_arr(i, j, k, dst_comp) =
+                linear_interpolate(field_lo, field_hi, coord_lo, coord_hi, target);
+        });
+    }
+}
 
 } // namespace plotfile2d

--- a/Source/IO/ERF_Plotfile2DMetadata.H
+++ b/Source/IO/ERF_Plotfile2DMetadata.H
@@ -6,6 +6,7 @@
 #include <AMReX_Vector.H>
 
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DSampledLevel.H"
 
 // Utilities for writing machine-readable metadata for native AMReX 2D
 // plotfiles. This layer formats the existing 2D diagnostic catalog. It must not
@@ -21,9 +22,13 @@ std::string missing_value_json (MissingPolicy policy);
 
 std::string escape_json_string (const std::string& value);
 
+std::string format_2d_metadata_json (const amrex::Vector<Plotfile2DOutputDescriptor>& descriptors);
 std::string format_2d_metadata_json (const amrex::Vector<std::string>& varnames);
 
 std::string metadata_json_filename (const std::string& plotfilename);
+
+void write_2d_metadata_json (const std::string& plotfilename,
+                             const amrex::Vector<Plotfile2DOutputDescriptor>& descriptors);
 
 void write_2d_metadata_json (const std::string& plotfilename,
                              const amrex::Vector<std::string>& varnames);

--- a/Source/IO/ERF_Plotfile2DMetadata.cpp
+++ b/Source/IO/ERF_Plotfile2DMetadata.cpp
@@ -26,8 +26,32 @@ void append_json_string (std::ostringstream& os, const std::string& value)
     os << '\"' << escape_json_string(value) << '\"';
 }
 
+void append_sampled_level_metadata (std::ostringstream& os,
+                                    const SampledLevelMetadata& metadata)
+{
+    os << "      \"source_field\": ";
+    append_json_string(os, metadata.source_field);
+    os << ",\n";
+    os << "      \"vertical_coordinate\": {\n";
+    os << "        \"type\": ";
+    append_json_string(os, metadata.vertical_coordinate.type);
+    os << ",\n";
+    os << "        \"value\": " << metadata.vertical_coordinate.value << ",\n";
+    os << "        \"units\": ";
+    append_json_string(os, metadata.vertical_coordinate.units);
+    os << ",\n";
+    os << "        \"canonical_value\": " << metadata.vertical_coordinate.canonical_value << ",\n";
+    os << "        \"canonical_units\": ";
+    append_json_string(os, metadata.vertical_coordinate.canonical_units);
+    os << ",\n";
+    os << "        \"interpolation\": ";
+    append_json_string(os, metadata.vertical_coordinate.interpolation);
+    os << "\n";
+    os << "      }\n";
+}
+
 void append_variable_record (std::ostringstream& os,
-                             const DiagnosticDescriptor& descriptor,
+                             const Plotfile2DOutputDescriptor& descriptor,
                              int component_index,
                              bool is_last)
 {
@@ -48,7 +72,18 @@ void append_variable_record (std::ostringstream& os,
     os << "      \"missing_policy\": ";
     append_json_string(os, missing_policy_to_string(descriptor.missing_policy));
     os << ",\n";
-    os << "      \"missing_value\": " << missing_value_json(descriptor.missing_policy) << "\n";
+    os << "      \"missing_value\": ";
+    if (descriptor.sampled_level) {
+        os << descriptor.missing_value;
+    } else {
+        os << missing_value_json(descriptor.missing_policy);
+    }
+    if (descriptor.sampled_level) {
+        os << ",\n";
+        append_sampled_level_metadata(os, *descriptor.sampled_level);
+    } else {
+        os << "\n";
+    }
     os << "    }";
     if (!is_last) {
         os << ",";
@@ -69,6 +104,7 @@ diagnostic_category_to_string (DiagnosticCategory category) noexcept
     case DiagnosticCategory::PBL:              return "PBL";
     case DiagnosticCategory::SurfaceState:     return "SurfaceState";
     case DiagnosticCategory::ColumnIntegral:   return "ColumnIntegral";
+    case DiagnosticCategory::SampledLevel:     return "SampledLevel";
     }
 
     amrex::Abort("Unhandled DiagnosticCategory in 2D metadata writer");
@@ -136,23 +172,47 @@ metadata_json_filename (const std::string& plotfilename)
 std::string
 format_2d_metadata_json (const amrex::Vector<std::string>& varnames)
 {
-    // Native AMReX 2D plotfiles get a metadata sidecar for the selected
-    // output variables only. The writer formats catalog metadata; it does not
-    // compute diagnostics or encode runtime source selection.
-    std::ostringstream os;
-    os << "{\n";
-    os << "  \"format_version\": 1,\n";
-    os << "  \"kind\": \"ERF 2D plotfile metadata\",\n";
-    os << "  \"n_variables\": " << static_cast<int>(varnames.size()) << ",\n";
-    os << "  \"variables\": [\n";
+    amrex::Vector<Plotfile2DOutputDescriptor> descriptors;
+    descriptors.reserve(varnames.size());
 
-    for (int i = 0; i < static_cast<int>(varnames.size()); ++i) {
-        const auto* descriptor = find_diagnostic(varnames[i]);
-        if (descriptor == nullptr) {
-            amrex::Abort("2D metadata requested for unknown diagnostic '" + varnames[i] + "'");
+    for (const auto& name : varnames) {
+        const auto* static_descriptor = find_diagnostic(name);
+        if (static_descriptor == nullptr) {
+            amrex::Abort("2D metadata requested for unknown diagnostic '" + name + "'");
         }
 
-        append_variable_record(os, *descriptor, i, i == static_cast<int>(varnames.size()) - 1);
+        Plotfile2DOutputDescriptor descriptor;
+        descriptor.name = static_descriptor->name;
+        descriptor.long_name = static_descriptor->long_name;
+        descriptor.units = static_descriptor->units;
+        descriptor.category = static_descriptor->category;
+        descriptor.missing_policy = static_descriptor->missing_policy;
+        descriptor.missing_value =
+            (descriptor.missing_policy == MissingPolicy::FillZeroWhenUnavailable) ? amrex::Real(0.0)
+                                                                                  : amrex::Real(-999.0);
+        descriptor.static_diagnostic = static_descriptor;
+        descriptors.push_back(std::move(descriptor));
+    }
+
+    return format_2d_metadata_json(descriptors);
+}
+
+std::string
+format_2d_metadata_json (const amrex::Vector<Plotfile2DOutputDescriptor>& descriptors)
+{
+    // Native AMReX 2D plotfiles get a metadata sidecar for the selected
+    // output variables only. The writer formats catalog metadata and sampled-
+    // level metadata; it does not compute diagnostics or encode runtime
+    // source selection.
+    std::ostringstream os;
+    os << "{\n";
+    os << "  \"format_version\": 2,\n";
+    os << "  \"kind\": \"ERF 2D plotfile metadata\",\n";
+    os << "  \"n_variables\": " << static_cast<int>(descriptors.size()) << ",\n";
+    os << "  \"variables\": [\n";
+
+    for (int i = 0; i < static_cast<int>(descriptors.size()); ++i) {
+        append_variable_record(os, descriptors[i], i, i == static_cast<int>(descriptors.size()) - 1);
     }
 
     os << "  ]\n";
@@ -177,6 +237,26 @@ write_2d_metadata_json (const std::string& plotfilename,
     }
 
     outfile << format_2d_metadata_json(varnames);
+    if (!outfile.good()) {
+        amrex::FileOpenFailed(filename);
+    }
+}
+
+void
+write_2d_metadata_json (const std::string& plotfilename,
+                        const amrex::Vector<Plotfile2DOutputDescriptor>& descriptors)
+{
+    if (!amrex::ParallelDescriptor::IOProcessor()) {
+        return;
+    }
+
+    const std::string filename = metadata_json_filename(plotfilename);
+    std::ofstream outfile(filename, std::ios::out | std::ios::trunc);
+    if (!outfile.good()) {
+        amrex::FileOpenFailed(filename);
+    }
+
+    outfile << format_2d_metadata_json(descriptors);
     if (!outfile.good()) {
         amrex::FileOpenFailed(filename);
     }

--- a/Source/IO/ERF_Plotfile2DSampledField.H
+++ b/Source/IO/ERF_Plotfile2DSampledField.H
@@ -30,7 +30,12 @@ enum class SampledFieldID
     Qi,
     Qr,
     Qs,
-    Qg
+    Qg,
+    UEast,
+    VNorth,
+    W,
+    WindSpeed,
+    WindDir
 };
 
 struct SampledFieldDescriptor
@@ -57,6 +62,27 @@ SampledFieldSelection select_requested_sampled_fields (const amrex::Vector<std::
                                                        const SolverChoice& solver_choice);
 
 std::string sampled_field_id_to_string (SampledFieldID field_id);
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool sampled_field_is_wind (SampledFieldID field_id) noexcept
+{
+    switch (field_id) {
+    case SampledFieldID::UEast:
+    case SampledFieldID::VNorth:
+    case SampledFieldID::W:
+    case SampledFieldID::WindSpeed:
+    case SampledFieldID::WindDir:
+        return true;
+    default:
+        return false;
+    }
+}
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+bool sampled_field_is_scalar_state (SampledFieldID field_id) noexcept
+{
+    return !sampled_field_is_wind(field_id);
+}
 
 AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real sampled_field_value (SampledFieldID field_id,
@@ -103,6 +129,12 @@ amrex::Real sampled_field_value (SampledFieldID field_id,
         return (moisture_indices.qs >= 0) ? cons_arr(i, j, k, moisture_indices.qs) / rho : amrex::Real(0.0);
     case SampledFieldID::Qg:
         return (moisture_indices.qg >= 0) ? cons_arr(i, j, k, moisture_indices.qg) / rho : amrex::Real(0.0);
+    case SampledFieldID::UEast:
+    case SampledFieldID::VNorth:
+    case SampledFieldID::W:
+    case SampledFieldID::WindSpeed:
+    case SampledFieldID::WindDir:
+        return amrex::Real(0.0);
     }
 
     return amrex::Real(0.0);
@@ -124,6 +156,11 @@ sampled_field_name (SampledFieldID field_id) noexcept
     case SampledFieldID::Qr:        return "qr";
     case SampledFieldID::Qs:        return "qs";
     case SampledFieldID::Qg:        return "qg";
+    case SampledFieldID::UEast:     return "u_east";
+    case SampledFieldID::VNorth:    return "v_north";
+    case SampledFieldID::W:         return "w";
+    case SampledFieldID::WindSpeed: return "wind_speed";
+    case SampledFieldID::WindDir:    return "wind_dir";
     }
 
     return "unknown";

--- a/Source/IO/ERF_Plotfile2DSampledField.H
+++ b/Source/IO/ERF_Plotfile2DSampledField.H
@@ -1,0 +1,132 @@
+#ifndef ERF_PLOTFILE2DSAMPLED_FIELD_H_
+#define ERF_PLOTFILE2DSAMPLED_FIELD_H_
+
+#include <string>
+
+#include <AMReX_GpuQualifiers.H>
+#include <AMReX_Vector.H>
+
+#include "ERF_DataStruct.H"
+#include "ERF_EOS.H"
+#include "ERF_TerrainMetrics.H"
+
+// Field registry for sampled-level 2D diagnostics. Each field defines its
+// public name, units, availability, and cell-centered value. Derived fields can
+// be added here without changing the sampled-level parser.
+
+namespace plotfile2d
+{
+
+enum class SampledFieldID
+{
+    Rho,
+    Theta,
+    Temp,
+    Pressure,
+    HeightMSL,
+    HeightAGL,
+    Qv,
+    Qc,
+    Qi,
+    Qr,
+    Qs,
+    Qg
+};
+
+struct SampledFieldDescriptor
+{
+    SampledFieldID id;
+    const char* name;
+    const char* long_name;
+    const char* units;
+};
+
+struct SampledFieldSelection
+{
+    amrex::Vector<SampledFieldDescriptor> accepted;
+    amrex::Vector<std::string> unavailable;
+};
+
+const amrex::Vector<SampledFieldDescriptor>& sampled_field_catalog ();
+
+const SampledFieldDescriptor* find_sampled_field (const std::string& name);
+
+amrex::Vector<std::string> available_sampled_field_names (const SolverChoice& solver_choice);
+
+SampledFieldSelection select_requested_sampled_fields (const amrex::Vector<std::string>& requested,
+                                                       const SolverChoice& solver_choice);
+
+std::string sampled_field_id_to_string (SampledFieldID field_id);
+
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real sampled_field_value (SampledFieldID field_id,
+                                 const amrex::Array4<const amrex::Real>& cons_arr,
+                                 const amrex::Array4<const amrex::Real>& z_phys_cc_arr,
+                                 const amrex::Array4<const amrex::Real>& z_phys_nd_arr,
+                                 bool have_z_phys_cc,
+                                 int i, int j, int k,
+                                 const MoistureComponentIndices& moisture_indices) noexcept
+{
+    const amrex::Real rho = cons_arr(i, j, k, Rho_comp);
+    const bool has_moisture = (moisture_indices.qv >= 0);
+    const amrex::Real qv_for_eos = has_moisture
+        ? cons_arr(i, j, k, moisture_indices.qv) / rho
+        : amrex::Real(0.0);
+
+    switch (field_id) {
+    case SampledFieldID::Rho:
+        return rho;
+    case SampledFieldID::Theta:
+        return cons_arr(i, j, k, RhoTheta_comp) / rho;
+    case SampledFieldID::Temp:
+        return getTgivenRandRTh(rho, cons_arr(i, j, k, RhoTheta_comp), qv_for_eos);
+    case SampledFieldID::Pressure:
+        return getPgivenRTh(cons_arr(i, j, k, RhoTheta_comp), qv_for_eos);
+    case SampledFieldID::HeightMSL:
+        if (have_z_phys_cc) {
+            return z_phys_cc_arr(i, j, k);
+        }
+        return Compute_Z_AtCellCenter(i, j, k, z_phys_nd_arr);
+    case SampledFieldID::HeightAGL:
+        return Compute_Zrel_AtCellCenter(i, j, k, z_phys_nd_arr);
+    case SampledFieldID::Qv:
+        return has_moisture ? cons_arr(i, j, k, moisture_indices.qv) / rho : amrex::Real(0.0);
+    case SampledFieldID::Qc:
+        return (moisture_indices.qc >= 0) ? cons_arr(i, j, k, moisture_indices.qc) / rho : amrex::Real(0.0);
+    case SampledFieldID::Qi:
+        return (moisture_indices.qi >= 0) ? cons_arr(i, j, k, moisture_indices.qi) / rho : amrex::Real(0.0);
+    case SampledFieldID::Qr:
+        return (moisture_indices.qr >= 0) ? cons_arr(i, j, k, moisture_indices.qr) / rho : amrex::Real(0.0);
+    case SampledFieldID::Qs:
+        return (moisture_indices.qs >= 0) ? cons_arr(i, j, k, moisture_indices.qs) / rho : amrex::Real(0.0);
+    case SampledFieldID::Qg:
+        return (moisture_indices.qg >= 0) ? cons_arr(i, j, k, moisture_indices.qg) / rho : amrex::Real(0.0);
+    }
+
+    return amrex::Real(0.0);
+}
+
+inline const char*
+sampled_field_name (SampledFieldID field_id) noexcept
+{
+    switch (field_id) {
+    case SampledFieldID::Rho:       return "rho";
+    case SampledFieldID::Theta:     return "theta";
+    case SampledFieldID::Temp:      return "temp";
+    case SampledFieldID::Pressure:  return "pressure";
+    case SampledFieldID::HeightMSL: return "height_msl";
+    case SampledFieldID::HeightAGL: return "height_agl";
+    case SampledFieldID::Qv:        return "qv";
+    case SampledFieldID::Qc:        return "qc";
+    case SampledFieldID::Qi:        return "qi";
+    case SampledFieldID::Qr:        return "qr";
+    case SampledFieldID::Qs:        return "qs";
+    case SampledFieldID::Qg:        return "qg";
+    }
+
+    return "unknown";
+}
+
+} // namespace plotfile2d
+
+#endif

--- a/Source/IO/ERF_Plotfile2DSampledField.H
+++ b/Source/IO/ERF_Plotfile2DSampledField.H
@@ -58,7 +58,7 @@ SampledFieldSelection select_requested_sampled_fields (const amrex::Vector<std::
 
 std::string sampled_field_id_to_string (SampledFieldID field_id);
 
-AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+AMREX_GPU_DEVICE AMREX_FORCE_INLINE
 amrex::Real sampled_field_value (SampledFieldID field_id,
                                  const amrex::Array4<const amrex::Real>& cons_arr,
                                  const amrex::Array4<const amrex::Real>& z_phys_cc_arr,

--- a/Source/IO/ERF_Plotfile2DSampledField.H
+++ b/Source/IO/ERF_Plotfile2DSampledField.H
@@ -69,6 +69,8 @@ amrex::Real sampled_field_value (SampledFieldID field_id,
 {
     const amrex::Real rho = cons_arr(i, j, k, Rho_comp);
     const bool has_moisture = (moisture_indices.qv >= 0);
+    // Microphysical fields are sampled as mixing ratios. The conserved state
+    // stores rho*q, so field evaluation divides by rho before interpolation.
     const amrex::Real qv_for_eos = has_moisture
         ? cons_arr(i, j, k, moisture_indices.qv) / rho
         : amrex::Real(0.0);

--- a/Source/IO/ERF_Plotfile2DSampledField.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledField.cpp
@@ -23,6 +23,11 @@ const amrex::Vector<SampledFieldDescriptor>& field_catalog_storage ()
         {SampledFieldID::Qr,        "qr",        "Rain mixing ratio sampled at the target level",         "kg/kg"},
         {SampledFieldID::Qs,        "qs",        "Snow mixing ratio sampled at the target level",         "kg/kg"},
         {SampledFieldID::Qg,        "qg",        "Graupel mixing ratio sampled at the target level",      "kg/kg"},
+        {SampledFieldID::UEast,     "u_east",    "Eastward wind sampled at the target level",             "m/s"},
+        {SampledFieldID::VNorth,    "v_north",   "Northward wind sampled at the target level",            "m/s"},
+        {SampledFieldID::W,         "w",         "Vertical wind sampled at the target level",             "m/s"},
+        {SampledFieldID::WindSpeed,  "wind_speed","Horizontal wind speed sampled at the target level",     "m/s"},
+        {SampledFieldID::WindDir,    "wind_dir",  "Meteorological wind direction sampled at the target level", "degrees"},
     };
 
     return catalog;
@@ -51,6 +56,12 @@ bool field_is_available (SampledFieldID field_id, const SolverChoice& solver_cho
         return mi.qs >= 0;
     case SampledFieldID::Qg:
         return mi.qg >= 0;
+    case SampledFieldID::UEast:
+    case SampledFieldID::VNorth:
+    case SampledFieldID::W:
+    case SampledFieldID::WindSpeed:
+    case SampledFieldID::WindDir:
+        return true;
     }
 
     return false;

--- a/Source/IO/ERF_Plotfile2DSampledField.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledField.cpp
@@ -1,0 +1,128 @@
+#include "ERF_Plotfile2DSampledField.H"
+
+#include <unordered_set>
+
+namespace plotfile2d
+{
+
+namespace
+{
+
+const amrex::Vector<SampledFieldDescriptor>& field_catalog_storage ()
+{
+    static const amrex::Vector<SampledFieldDescriptor> catalog{
+        {SampledFieldID::Rho,       "rho",       "Density sampled at the target level",                  "kg/m^3"},
+        {SampledFieldID::Theta,     "theta",     "Potential temperature sampled at the target level",    "K"},
+        {SampledFieldID::Temp,      "temp",      "Temperature sampled at the target level",              "K"},
+        {SampledFieldID::Pressure,  "pressure",  "Pressure sampled at the target level",                 "Pa"},
+        {SampledFieldID::HeightMSL, "height_msl","Height above mean sea level sampled at the target level","m"},
+        {SampledFieldID::HeightAGL, "height_agl","Height above ground level sampled at the target level", "m"},
+        {SampledFieldID::Qv,        "qv",        "Water vapor mixing ratio sampled at the target level", "kg/kg"},
+        {SampledFieldID::Qc,        "qc",        "Cloud liquid water mixing ratio sampled at the target level", "kg/kg"},
+        {SampledFieldID::Qi,        "qi",        "Cloud ice mixing ratio sampled at the target level",    "kg/kg"},
+        {SampledFieldID::Qr,        "qr",        "Rain mixing ratio sampled at the target level",         "kg/kg"},
+        {SampledFieldID::Qs,        "qs",        "Snow mixing ratio sampled at the target level",         "kg/kg"},
+        {SampledFieldID::Qg,        "qg",        "Graupel mixing ratio sampled at the target level",      "kg/kg"},
+    };
+
+    return catalog;
+}
+
+bool field_is_available (SampledFieldID field_id, const SolverChoice& solver_choice) noexcept
+{
+    const auto& mi = solver_choice.moisture_indices;
+    switch (field_id) {
+    case SampledFieldID::Rho:
+    case SampledFieldID::Theta:
+    case SampledFieldID::Temp:
+    case SampledFieldID::Pressure:
+    case SampledFieldID::HeightMSL:
+    case SampledFieldID::HeightAGL:
+        return true;
+    case SampledFieldID::Qv:
+        return mi.qv >= 0;
+    case SampledFieldID::Qc:
+        return mi.qc >= 0;
+    case SampledFieldID::Qi:
+        return mi.qi >= 0;
+    case SampledFieldID::Qr:
+        return mi.qr >= 0;
+    case SampledFieldID::Qs:
+        return mi.qs >= 0;
+    case SampledFieldID::Qg:
+        return mi.qg >= 0;
+    }
+
+    return false;
+}
+
+} // namespace
+
+const amrex::Vector<SampledFieldDescriptor>&
+sampled_field_catalog ()
+{
+    return field_catalog_storage();
+}
+
+const SampledFieldDescriptor*
+find_sampled_field (const std::string& name)
+{
+    for (const auto& descriptor : sampled_field_catalog()) {
+        if (name == descriptor.name) {
+            return &descriptor;
+        }
+    }
+
+    return nullptr;
+}
+
+amrex::Vector<std::string>
+available_sampled_field_names (const SolverChoice& solver_choice)
+{
+    amrex::Vector<std::string> names;
+    names.reserve(sampled_field_catalog().size());
+
+    for (const auto& descriptor : sampled_field_catalog()) {
+        if (field_is_available(descriptor.id, solver_choice)) {
+            names.push_back(descriptor.name);
+        }
+    }
+
+    return names;
+}
+
+SampledFieldSelection
+select_requested_sampled_fields (const amrex::Vector<std::string>& requested,
+                                 const SolverChoice& solver_choice)
+{
+    SampledFieldSelection selection;
+
+    std::unordered_set<std::string> seen;
+
+    for (const auto& name : requested) {
+        const auto* descriptor = find_sampled_field(name);
+        if (descriptor == nullptr) {
+            selection.unavailable.push_back(name);
+            continue;
+        }
+
+        if (!field_is_available(descriptor->id, solver_choice)) {
+            selection.unavailable.push_back(name);
+            continue;
+        }
+
+        if (seen.insert(name).second) {
+            selection.accepted.push_back(*descriptor);
+        }
+    }
+
+    return selection;
+}
+
+std::string
+sampled_field_id_to_string (SampledFieldID field_id)
+{
+    return sampled_field_name(field_id);
+}
+
+} // namespace plotfile2d

--- a/Source/IO/ERF_Plotfile2DSampledLevel.H
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.H
@@ -98,6 +98,11 @@ SampledLevelDefinition parse_sampled_level_definition (const std::string& level_
 amrex::Vector<std::string> parse_requested_sampled_level_sets (const std::string& pp_prefix,
                                                                int which);
 
+amrex::Vector<Plotfile2DOutputDescriptor> build_sampled_level_output_descriptors_from_definitions (
+    const amrex::Vector<SampledLevelDefinition>& level_sets,
+    const amrex::Vector<std::string>& static_plot_vars,
+    const SolverChoice& solver_choice);
+
 amrex::Vector<Plotfile2DOutputDescriptor> build_sampled_level_output_descriptors (
     const std::string& pp_prefix,
     int which,

--- a/Source/IO/ERF_Plotfile2DSampledLevel.H
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.H
@@ -1,0 +1,109 @@
+#ifndef ERF_PLOTFILE2DSAMPLED_LEVEL_H_
+#define ERF_PLOTFILE2DSAMPLED_LEVEL_H_
+
+#include <optional>
+#include <string>
+
+#include <AMReX_ParmParse.H>
+#include <AMReX_REAL.H>
+#include <AMReX_Vector.H>
+
+#include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DSampledField.H"
+
+// User-facing sampled-level definitions for ERF 2D plotfiles. A level set
+// names a vertical coordinate, target values, and fields to sample. This module
+// parses and validates those definitions. It does not interpolate fields.
+
+namespace plotfile2d
+{
+
+enum class SampledCoordinate
+{
+    ModelIndex,
+    HeightMSL,
+    HeightAGL,
+    Pressure
+};
+
+enum class SampledInterpolation
+{
+    None,
+    Linear
+};
+
+struct SampledVerticalCoordinateMetadata
+{
+    std::string type;
+    amrex::Real value = amrex::Real(0.0);
+    std::string units;
+    amrex::Real canonical_value = amrex::Real(0.0);
+    std::string canonical_units;
+    std::string interpolation;
+};
+
+struct SampledLevelMetadata
+{
+    std::string level_set_name;
+    std::string source_field;
+    SampledVerticalCoordinateMetadata vertical_coordinate;
+};
+
+struct Plotfile2DOutputDescriptor
+{
+    std::string name;
+    std::string long_name;
+    std::string units;
+    DiagnosticCategory category = DiagnosticCategory::SampledLevel;
+    MissingPolicy missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    amrex::Real missing_value = amrex::Real(-999.0);
+    const DiagnosticDescriptor* static_diagnostic = nullptr;
+    std::optional<SampledLevelMetadata> sampled_level;
+};
+
+struct SampledLevelDefinition
+{
+    std::string name;
+    SampledCoordinate coordinate = SampledCoordinate::ModelIndex;
+    std::string units;
+    amrex::Vector<amrex::Real> values;
+    amrex::Vector<std::string> fields;
+    SampledInterpolation interpolation = SampledInterpolation::None;
+    amrex::Real missing_value = amrex::Real(-999.0);
+};
+
+const char* sampled_coordinate_to_string (SampledCoordinate coordinate) noexcept;
+const char* sampled_coordinate_tag (SampledCoordinate coordinate) noexcept;
+const char* sampled_coordinate_default_units (SampledCoordinate coordinate) noexcept;
+const char* sampled_coordinate_default_interpolation (SampledCoordinate coordinate) noexcept;
+
+const char* sampled_interpolation_to_string (SampledInterpolation interpolation) noexcept;
+SampledCoordinate sampled_coordinate_from_string (const std::string& value);
+SampledInterpolation sampled_interpolation_from_string (const std::string& value);
+
+std::string sampled_level_error_prefix (const std::string& level_set_name,
+                                       const std::string& parameter_name);
+
+std::string sampled_level_value_tag (amrex::Real value, const std::string& units);
+std::string sampled_output_name (const std::string& field_name,
+                                SampledCoordinate coordinate,
+                                amrex::Real value,
+                                const std::string& units);
+
+std::string validate_sampled_level_definition (const SampledLevelDefinition& level_set);
+
+SampledLevelDefinition parse_sampled_level_definition (const std::string& level_set_name,
+                                                      const std::string& pp_prefix);
+
+amrex::Vector<std::string> parse_requested_sampled_level_sets (const std::string& pp_prefix,
+                                                               int which);
+
+amrex::Vector<Plotfile2DOutputDescriptor> build_sampled_level_output_descriptors (
+    const std::string& pp_prefix,
+    int which,
+    const amrex::Vector<std::string>& static_plot_vars,
+    const SolverChoice& solver_choice);
+
+} // namespace plotfile2d
+
+#endif

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -275,7 +275,10 @@ validate_sampled_level_definition (const SampledLevelDefinition& level_set)
     }
 
     std::unordered_set<std::string> unique_fields(level_set.fields.begin(), level_set.fields.end());
-    if (unique_fields.size() != level_set.fields.size()) {
+    const auto n_unique_fields = unique_fields.size();
+    const auto n_requested_fields =
+        static_cast<decltype(n_unique_fields)>(level_set.fields.size());
+    if (n_unique_fields != n_requested_fields) {
         return sampled_level_error_prefix(level_set.name, "fields") +
                build_duplicate_output_error(level_set.name);
     }

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -319,6 +319,10 @@ parse_sampled_level_definition (const std::string& level_set_name,
     if (!pp.query((base + "coordinate").c_str(), coordinate_value)) {
         amrex::Abort(build_missing_field_error(level_set_name, "coordinate"));
     }
+    if (string_iequals(coordinate_value, "isentropic")) {
+        amrex::Abort(sampled_level_error_prefix(level_set_name, "coordinate") +
+                     "isentropic output needs a crossing policy");
+    }
     level_set.coordinate = sampled_coordinate_from_string(coordinate_value);
 
     if (pp.query((base + "units").c_str(), level_set.units) == 0) {
@@ -378,10 +382,10 @@ parse_requested_sampled_level_sets (const std::string& pp_prefix,
 }
 
 amrex::Vector<Plotfile2DOutputDescriptor>
-build_sampled_level_output_descriptors (const std::string& pp_prefix,
-                                        int which,
-                                        const amrex::Vector<std::string>& static_plot_vars,
-                                        const SolverChoice& solver_choice)
+build_sampled_level_output_descriptors_from_definitions (
+    const amrex::Vector<SampledLevelDefinition>& level_sets,
+    const amrex::Vector<std::string>& static_plot_vars,
+    const SolverChoice& solver_choice)
 {
     amrex::Vector<Plotfile2DOutputDescriptor> descriptors;
     descriptors.reserve(static_plot_vars.size());
@@ -412,13 +416,7 @@ build_sampled_level_output_descriptors (const std::string& pp_prefix,
         descriptors.push_back(std::move(descriptor));
     }
 
-    const auto level_set_names = parse_requested_sampled_level_sets(pp_prefix, which);
-    amrex::ParmParse pp(pp_prefix);
-
-    for (const auto& level_set_name : level_set_names) {
-        const SampledLevelDefinition level_set =
-            parse_sampled_level_definition(level_set_name, pp_prefix);
-
+    for (const auto& level_set : level_sets) {
         const auto field_selection = select_requested_sampled_fields(level_set.fields, solver_choice);
         if (!field_selection.unavailable.empty()) {
             if (amrex::ParallelDescriptor::IOProcessor()) {
@@ -481,6 +479,22 @@ build_sampled_level_output_descriptors (const std::string& pp_prefix,
     }
 
     return descriptors;
+}
+
+amrex::Vector<Plotfile2DOutputDescriptor>
+build_sampled_level_output_descriptors (const std::string& pp_prefix,
+                                        int which,
+                                        const amrex::Vector<std::string>& static_plot_vars,
+                                        const SolverChoice& solver_choice)
+{
+    amrex::Vector<SampledLevelDefinition> level_sets;
+    for (const auto& level_set_name : parse_requested_sampled_level_sets(pp_prefix, which)) {
+        level_sets.push_back(parse_sampled_level_definition(level_set_name, pp_prefix));
+    }
+
+    return build_sampled_level_output_descriptors_from_definitions(level_sets,
+                                                                   static_plot_vars,
+                                                                   solver_choice);
 }
 
 } // namespace plotfile2d

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -94,18 +94,6 @@ std::string format_numeric_tag (amrex::Real value)
     return tag;
 }
 
-std::string join_fields (const amrex::Vector<std::string>& fields)
-{
-    std::ostringstream os;
-    for (int i = 0; i < static_cast<int>(fields.size()); ++i) {
-        if (i > 0) {
-            os << ' ';
-        }
-        os << fields[i];
-    }
-    return os.str();
-}
-
 std::string build_duplicate_output_error (const std::string& name)
 {
     std::ostringstream os;
@@ -119,16 +107,6 @@ std::string build_missing_field_error (const std::string& level_set_name,
     std::ostringstream os;
     os << "Sampled-level definition '" << level_set_name << "' is missing required parameter '"
        << parameter_name << "'";
-    return os.str();
-}
-
-std::string build_unsupported_value_error (const std::string& level_set_name,
-                                           const std::string& parameter_name,
-                                           const std::string& value)
-{
-    std::ostringstream os;
-    os << "Sampled-level definition '" << level_set_name << "' has unsupported value '"
-       << value << "' for parameter '" << parameter_name << "'";
     return os.str();
 }
 

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -1,0 +1,486 @@
+#include "ERF_Plotfile2DSampledLevel.H"
+
+#include <cctype>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <sstream>
+#include <utility>
+#include <unordered_set>
+
+#include <AMReX_ParallelDescriptor.H>
+
+namespace plotfile2d
+{
+
+namespace
+{
+
+const char*
+coordinate_units_default (SampledCoordinate coordinate) noexcept
+{
+    switch (coordinate) {
+    case SampledCoordinate::ModelIndex: return "1";
+    case SampledCoordinate::HeightMSL:   return "m";
+    case SampledCoordinate::HeightAGL:   return "m";
+    case SampledCoordinate::Pressure:    return "Pa";
+    }
+    return "";
+}
+
+const char*
+coordinate_interpolation_default (SampledCoordinate coordinate) noexcept
+{
+    switch (coordinate) {
+    case SampledCoordinate::ModelIndex: return "none";
+    case SampledCoordinate::HeightMSL:   return "linear";
+    case SampledCoordinate::HeightAGL:   return "linear";
+    case SampledCoordinate::Pressure:    return "linear";
+    }
+    return "";
+}
+
+bool string_iequals (const std::string& lhs, const char* rhs) noexcept
+{
+    if (lhs.size() != std::char_traits<char>::length(rhs)) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < lhs.size(); ++i) {
+        if (std::tolower(static_cast<unsigned char>(lhs[i])) !=
+            std::tolower(static_cast<unsigned char>(rhs[i]))) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::string trim_trailing_zeros (std::string value)
+{
+    auto pos = value.find('.');
+    if (pos == std::string::npos) {
+        return value;
+    }
+
+    while (!value.empty() && value.back() == '0') {
+        value.pop_back();
+    }
+    if (!value.empty() && value.back() == '.') {
+        value.pop_back();
+    }
+    if (value.empty() || value == "-") {
+        return "0";
+    }
+    return value;
+}
+
+std::string format_numeric_tag (amrex::Real value)
+{
+    std::ostringstream os;
+    os.setf(std::ios::fixed, std::ios::floatfield);
+    os.precision(8);
+    os << value;
+
+    std::string tag = trim_trailing_zeros(os.str());
+    for (char& c : tag) {
+        if (c == '.') {
+            c = 'p';
+        }
+    }
+    if (!tag.empty() && tag.front() == '-') {
+        tag.front() = 'm';
+    }
+    return tag;
+}
+
+std::string join_fields (const amrex::Vector<std::string>& fields)
+{
+    std::ostringstream os;
+    for (int i = 0; i < static_cast<int>(fields.size()); ++i) {
+        if (i > 0) {
+            os << ' ';
+        }
+        os << fields[i];
+    }
+    return os.str();
+}
+
+std::string build_duplicate_output_error (const std::string& name)
+{
+    std::ostringstream os;
+    os << "Duplicate sampled-level output variable name '" << name << "'";
+    return os.str();
+}
+
+std::string build_missing_field_error (const std::string& level_set_name,
+                                       const std::string& parameter_name)
+{
+    std::ostringstream os;
+    os << "Sampled-level definition '" << level_set_name << "' is missing required parameter '"
+       << parameter_name << "'";
+    return os.str();
+}
+
+std::string build_unsupported_value_error (const std::string& level_set_name,
+                                           const std::string& parameter_name,
+                                           const std::string& value)
+{
+    std::ostringstream os;
+    os << "Sampled-level definition '" << level_set_name << "' has unsupported value '"
+       << value << "' for parameter '" << parameter_name << "'";
+    return os.str();
+}
+
+} // namespace
+
+const char*
+sampled_coordinate_to_string (SampledCoordinate coordinate) noexcept
+{
+    switch (coordinate) {
+    case SampledCoordinate::ModelIndex: return "model_index";
+    case SampledCoordinate::HeightMSL:   return "height_msl";
+    case SampledCoordinate::HeightAGL:   return "height_agl";
+    case SampledCoordinate::Pressure:    return "pressure";
+    }
+    return "unknown";
+}
+
+const char*
+sampled_coordinate_tag (SampledCoordinate coordinate) noexcept
+{
+    switch (coordinate) {
+    case SampledCoordinate::ModelIndex: return "k";
+    case SampledCoordinate::HeightMSL:   return "z_msl";
+    case SampledCoordinate::HeightAGL:   return "z_agl";
+    case SampledCoordinate::Pressure:    return "p";
+    }
+    return "unknown";
+}
+
+const char*
+sampled_coordinate_default_units (SampledCoordinate coordinate) noexcept
+{
+    return coordinate_units_default(coordinate);
+}
+
+const char*
+sampled_coordinate_default_interpolation (SampledCoordinate coordinate) noexcept
+{
+    return coordinate_interpolation_default(coordinate);
+}
+
+const char*
+sampled_interpolation_to_string (SampledInterpolation interpolation) noexcept
+{
+    switch (interpolation) {
+    case SampledInterpolation::None:   return "none";
+    case SampledInterpolation::Linear: return "linear";
+    }
+    return "unknown";
+}
+
+SampledCoordinate
+sampled_coordinate_from_string (const std::string& value)
+{
+    if (string_iequals(value, "model_index")) {
+        return SampledCoordinate::ModelIndex;
+    }
+    if (string_iequals(value, "height_msl")) {
+        return SampledCoordinate::HeightMSL;
+    }
+    if (string_iequals(value, "height_agl")) {
+        return SampledCoordinate::HeightAGL;
+    }
+    if (string_iequals(value, "pressure")) {
+        return SampledCoordinate::Pressure;
+    }
+
+    amrex::Abort("Unknown sampled-level coordinate '" + value + "'");
+    return SampledCoordinate::ModelIndex;
+}
+
+SampledInterpolation
+sampled_interpolation_from_string (const std::string& value)
+{
+    if (string_iequals(value, "none")) {
+        return SampledInterpolation::None;
+    }
+    if (string_iequals(value, "linear")) {
+        return SampledInterpolation::Linear;
+    }
+
+    amrex::Abort("Unknown sampled-level interpolation '" + value + "'");
+    return SampledInterpolation::None;
+}
+
+std::string
+sampled_level_error_prefix (const std::string& level_set_name,
+                            const std::string& parameter_name)
+{
+    std::ostringstream os;
+    os << "Sampled-level definition '" << level_set_name << "' parameter '"
+       << parameter_name << "': ";
+    return os.str();
+}
+
+std::string
+sampled_level_value_tag (amrex::Real value, const std::string& units)
+{
+    std::string tag = format_numeric_tag(value);
+    if (!units.empty() && units != "1") {
+        tag += units;
+    }
+    return tag;
+}
+
+std::string
+sampled_output_name (const std::string& field_name,
+                     SampledCoordinate coordinate,
+                     amrex::Real value,
+                     const std::string& units)
+{
+    std::ostringstream os;
+    os << field_name << "_" << sampled_coordinate_tag(coordinate) << "_"
+       << sampled_level_value_tag(value, units);
+    return os.str();
+}
+
+std::string
+validate_sampled_level_definition (const SampledLevelDefinition& level_set)
+{
+    if (level_set.name.empty()) {
+        return "Sampled-level definition name is empty";
+    }
+
+    if (level_set.fields.empty()) {
+        return sampled_level_error_prefix(level_set.name, "fields") + "missing fields";
+    }
+
+    if (level_set.values.empty()) {
+        return sampled_level_error_prefix(level_set.name, "values") + "missing values";
+    }
+
+    const char* default_units = sampled_coordinate_default_units(level_set.coordinate);
+    if (level_set.units.empty() || level_set.units == default_units) {
+        // valid
+    } else if (level_set.coordinate == SampledCoordinate::Pressure &&
+               (level_set.units == "Pa" || level_set.units == "hPa")) {
+        // valid
+    } else {
+        return sampled_level_error_prefix(level_set.name, "units") +
+               "unsupported units '" + level_set.units + "'";
+    }
+
+    const char* default_interp = sampled_coordinate_default_interpolation(level_set.coordinate);
+    if (level_set.interpolation == SampledInterpolation::None) {
+        if (std::string(default_interp) != "none") {
+            return sampled_level_error_prefix(level_set.name, "interpolation") +
+                   "unsupported interpolation 'none' for coordinate '" +
+                   sampled_coordinate_to_string(level_set.coordinate) + "'";
+        }
+    } else if (level_set.interpolation == SampledInterpolation::Linear) {
+        if (std::string(default_interp) == "none" && level_set.coordinate == SampledCoordinate::ModelIndex) {
+            return sampled_level_error_prefix(level_set.name, "interpolation") +
+                   "unsupported interpolation 'linear' for coordinate 'model_index'";
+        }
+    }
+
+    if (level_set.coordinate == SampledCoordinate::ModelIndex) {
+        for (const auto value : level_set.values) {
+            const auto rounded = std::nearbyint(value);
+            if (std::abs(value - rounded) > amrex::Real(1.0e-12)) {
+                return sampled_level_error_prefix(level_set.name, "values") +
+                       "non-integer model_index value '" + std::to_string(value) + "'";
+            }
+        }
+    }
+
+    std::unordered_set<std::string> unique_fields(level_set.fields.begin(), level_set.fields.end());
+    if (unique_fields.size() != level_set.fields.size()) {
+        return sampled_level_error_prefix(level_set.name, "fields") +
+               build_duplicate_output_error(level_set.name);
+    }
+
+    return {};
+}
+
+SampledLevelDefinition
+parse_sampled_level_definition (const std::string& level_set_name,
+                                const std::string& pp_prefix)
+{
+    SampledLevelDefinition level_set;
+    level_set.name = level_set_name;
+
+    amrex::ParmParse pp(pp_prefix);
+    const std::string base = "plot2d.level_set." + level_set_name + ".";
+
+    std::string coordinate_value;
+    if (!pp.query((base + "coordinate").c_str(), coordinate_value)) {
+        amrex::Abort(build_missing_field_error(level_set_name, "coordinate"));
+    }
+    level_set.coordinate = sampled_coordinate_from_string(coordinate_value);
+
+    if (pp.query((base + "units").c_str(), level_set.units) == 0) {
+        level_set.units = sampled_coordinate_default_units(level_set.coordinate);
+    }
+
+    std::string interpolation_value;
+    if (pp.query((base + "interpolation").c_str(), interpolation_value) == 0) {
+        level_set.interpolation =
+            sampled_interpolation_from_string(sampled_coordinate_default_interpolation(level_set.coordinate));
+    } else {
+        level_set.interpolation = sampled_interpolation_from_string(interpolation_value);
+    }
+
+    if (pp.query((base + "missing_value").c_str(), level_set.missing_value) == 0) {
+        level_set.missing_value = amrex::Real(-999.0);
+    }
+
+    int n_values = pp.countval((base + "values").c_str());
+    if (n_values <= 0) {
+        amrex::Abort(build_missing_field_error(level_set_name, "values"));
+    }
+    level_set.values.resize(n_values);
+    pp.getarr((base + "values").c_str(), level_set.values, 0, n_values);
+
+    int n_fields = pp.countval((base + "fields").c_str());
+    if (n_fields <= 0) {
+        amrex::Abort(build_missing_field_error(level_set_name, "fields"));
+    }
+    level_set.fields.resize(n_fields);
+    pp.getarr((base + "fields").c_str(), level_set.fields, 0, n_fields);
+
+    const std::string error = validate_sampled_level_definition(level_set);
+    if (!error.empty()) {
+        amrex::Abort(error);
+    }
+
+    return level_set;
+}
+
+amrex::Vector<std::string>
+parse_requested_sampled_level_sets (const std::string& pp_prefix,
+                                    int which)
+{
+    amrex::Vector<std::string> names;
+    amrex::ParmParse pp(pp_prefix);
+
+    const std::string param_name = "plot2d_level_sets_" + std::to_string(which);
+    if (!pp.contains(param_name.c_str())) {
+        return names;
+    }
+
+    const int n_sets = pp.countval(param_name.c_str());
+    names.resize(n_sets);
+    pp.getarr(param_name.c_str(), names, 0, n_sets);
+    return names;
+}
+
+amrex::Vector<Plotfile2DOutputDescriptor>
+build_sampled_level_output_descriptors (const std::string& pp_prefix,
+                                        int which,
+                                        const amrex::Vector<std::string>& static_plot_vars,
+                                        const SolverChoice& solver_choice)
+{
+    amrex::Vector<Plotfile2DOutputDescriptor> descriptors;
+    descriptors.reserve(static_plot_vars.size());
+
+    std::unordered_set<std::string> output_names;
+
+    for (const auto& name : static_plot_vars) {
+        const auto* static_descriptor = find_diagnostic(name);
+        if (static_descriptor == nullptr) {
+            amrex::Abort("Unknown built-in 2D plotfile diagnostic '" + name + "'");
+        }
+
+        Plotfile2DOutputDescriptor descriptor;
+        descriptor.name = static_descriptor->name;
+        descriptor.long_name = static_descriptor->long_name;
+        descriptor.units = static_descriptor->units;
+        descriptor.category = static_descriptor->category;
+        descriptor.missing_policy = static_descriptor->missing_policy;
+        descriptor.missing_value =
+            (descriptor.missing_policy == MissingPolicy::FillZeroWhenUnavailable) ? amrex::Real(0.0)
+                                                                                  : amrex::Real(-999.0);
+        descriptor.static_diagnostic = static_descriptor;
+
+        if (!output_names.insert(descriptor.name).second) {
+            amrex::Abort(build_duplicate_output_error(descriptor.name));
+        }
+
+        descriptors.push_back(std::move(descriptor));
+    }
+
+    const auto level_set_names = parse_requested_sampled_level_sets(pp_prefix, which);
+    amrex::ParmParse pp(pp_prefix);
+
+    for (const auto& level_set_name : level_set_names) {
+        const SampledLevelDefinition level_set =
+            parse_sampled_level_definition(level_set_name, pp_prefix);
+
+        const auto field_selection = select_requested_sampled_fields(level_set.fields, solver_choice);
+        if (!field_selection.unavailable.empty()) {
+            if (amrex::ParallelDescriptor::IOProcessor()) {
+                for (const auto& field_name : field_selection.unavailable) {
+                    amrex::Warning(sampled_level_error_prefix(level_set.name, "fields") +
+                                   "skipping unavailable field '" + field_name + "'");
+                }
+            }
+        }
+
+        if (field_selection.accepted.empty()) {
+            amrex::Abort(sampled_level_error_prefix(level_set.name, "fields") +
+                         "all requested fields unavailable");
+        }
+
+        const std::string coordinate_units = level_set.units.empty()
+            ? sampled_coordinate_default_units(level_set.coordinate)
+            : level_set.units;
+        const std::string interpolation_name = sampled_interpolation_to_string(level_set.interpolation);
+        const std::string canonical_units =
+            (level_set.coordinate == SampledCoordinate::Pressure && coordinate_units == "hPa") ? "Pa"
+                                                                                               : coordinate_units;
+
+        for (const auto& value : level_set.values) {
+            amrex::Real canonical_value = value;
+            if (level_set.coordinate == SampledCoordinate::Pressure &&
+                coordinate_units == "hPa") {
+                canonical_value = value * amrex::Real(100.0);
+            }
+
+            for (const auto& field : field_selection.accepted) {
+                Plotfile2DOutputDescriptor descriptor;
+                descriptor.name = sampled_output_name(field.name, level_set.coordinate, value, coordinate_units);
+                descriptor.long_name = std::string(field.long_name) + " sampled on " +
+                                       sampled_coordinate_to_string(level_set.coordinate) + " levels";
+                descriptor.units = field.units;
+                descriptor.category = DiagnosticCategory::SampledLevel;
+                descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+                descriptor.missing_value = level_set.missing_value;
+                descriptor.sampled_level = SampledLevelMetadata{
+                    level_set.name,
+                    field.name,
+                    SampledVerticalCoordinateMetadata{
+                        sampled_coordinate_to_string(level_set.coordinate),
+                        value,
+                        coordinate_units,
+                        canonical_value,
+                        canonical_units,
+                        interpolation_name
+                    }
+                };
+
+                if (!output_names.insert(descriptor.name).second) {
+                    amrex::Abort(build_duplicate_output_error(descriptor.name));
+                }
+
+                descriptors.push_back(std::move(descriptor));
+            }
+        }
+    }
+
+    return descriptors;
+}
+
+} // namespace plotfile2d

--- a/Source/IO/Make.package
+++ b/Source/IO/Make.package
@@ -5,6 +5,9 @@ CEXE_sources += ERF_Plotfile2D.cpp
 CEXE_sources += ERF_Plotfile2DFill.cpp
 CEXE_sources += ERF_Plotfile2DMetadata.cpp
 CEXE_sources += ERF_Plotfile2DWaterPath.cpp
+CEXE_sources += ERF_Plotfile2DSampledField.cpp
+CEXE_sources += ERF_Plotfile2DSampledLevel.cpp
+CEXE_sources += ERF_Plotfile2DInterpolator.cpp
 CEXE_sources += ERF_Plotfile2DUtils.cpp
 CEXE_sources += ERF_Checkpoint.cpp
 CEXE_sources += ERF_WriteJobInfo.cpp
@@ -28,6 +31,9 @@ CEXE_headers += ERF_ReadFromERFBdy.H
 CEXE_sources += ERF_ReadFromERFBdy.cpp
 
 CEXE_headers += ERF_SampleData.H
+CEXE_headers += ERF_Plotfile2DSampledField.H
+CEXE_headers += ERF_Plotfile2DSampledLevel.H
+CEXE_headers += ERF_Plotfile2DInterpolator.H
 
 ifeq ($(USE_NETCDF), TRUE)
   CEXE_sources += ERF_ReadFromWRFBdy.cpp

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cmath>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -58,6 +59,27 @@ amrex::BoxArray make_test_slab_boxarray ()
 amrex::BoxArray make_test_nodal_boxarray ()
 {
     return amrex::convert(make_test_boxarray(), amrex::IntVect(1, 1, 1));
+}
+
+amrex::BoxArray make_test_xface_boxarray ()
+{
+    auto ba = make_test_boxarray();
+    ba.surroundingNodes(0);
+    return ba;
+}
+
+amrex::BoxArray make_test_yface_boxarray ()
+{
+    auto ba = make_test_boxarray();
+    ba.surroundingNodes(1);
+    return ba;
+}
+
+amrex::BoxArray make_test_zface_boxarray ()
+{
+    auto ba = make_test_boxarray();
+    ba.surroundingNodes(2);
+    return ba;
 }
 
 amrex::Geometry make_test_geometry ()
@@ -451,7 +473,8 @@ TEST(Plotfile2DSampledField, DryRunExcludesMoistureSpecies)
 
     const auto available = available_sampled_field_names(sc);
 
-    for (const char* name : {"rho", "theta", "temp", "pressure", "height_msl", "height_agl"}) {
+    for (const char* name : {"rho", "theta", "temp", "pressure", "height_msl", "height_agl",
+                             "u_east", "v_north", "w", "wind_speed", "wind_dir"}) {
         EXPECT_NE(std::find(available.begin(), available.end(), name), available.end());
     }
     for (const char* name : {"qv", "qc", "qi", "qr", "qs", "qg"}) {
@@ -536,6 +559,26 @@ TEST(Plotfile2DSampledField, DryRunUsesZeroVaporForThermodynamicFields)
     EXPECT_DOUBLE_EQ(dst.max(0), getPgivenRTh(amrex::Real(500.0), amrex::Real(0.0)));
     EXPECT_DOUBLE_EQ(dst.min(1), getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
     EXPECT_DOUBLE_EQ(dst.max(1), getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
+}
+
+// Motivation: Wind fields should be first-class sampled-level fields, not
+// special-case output names that bypass descriptor metadata.
+TEST(Plotfile2DSampledField, WindFieldsAreCataloguedAndAlwaysAvailable)
+{
+    SolverChoice sc;
+    const auto available = available_sampled_field_names(sc);
+
+    for (const char* name : {"u_east", "v_north", "w", "wind_speed", "wind_dir"}) {
+        EXPECT_NE(std::find(available.begin(), available.end(), name), available.end());
+        const auto* descriptor = find_sampled_field(name);
+        ASSERT_NE(descriptor, nullptr);
+        EXPECT_STRNE(descriptor->long_name, "");
+        if (std::string(name) == "wind_dir") {
+            EXPECT_STREQ(descriptor->units, "degrees");
+        } else {
+            EXPECT_STREQ(descriptor->units, "m/s");
+        }
+    }
 }
 
 // Motivation: Scheme-aware availability should follow the active moisture
@@ -896,6 +939,364 @@ TEST(Plotfile2DInterpolator, MicrophysicsFieldsUseMixingRatio)
 
     EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(0.002));
     EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(0.002));
+}
+
+// Motivation: Sampled winds should be cell-centered outputs even though their
+// source velocities live on staggered faces.
+TEST(Plotfile2DInterpolator, SampledWindsDestaggerWithoutRotation)
+{
+    const auto cell_ba = make_test_boxarray();
+    const auto xba = make_test_xface_boxarray();
+    const auto yba = make_test_yface_boxarray();
+    const auto zba = make_test_zface_boxarray();
+    amrex::DistributionMapping dm(cell_ba);
+    amrex::MultiFab cons(cell_ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(cell_ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab xvel(xba, dm, 1, 0);
+    amrex::MultiFab yvel(yba, dm, 1, 0);
+    amrex::MultiFab zvel(zba, dm, 1, 0);
+    amrex::MultiFab dst(cell_ba, dm, 5, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    xvel.setVal(amrex::Real(1.0));
+    yvel.setVal(amrex::Real(2.0));
+    zvel.setVal(amrex::Real(3.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    const auto wind_sources = plotfile2d::SampledWindSources{&xvel, &yvel, &zvel, nullptr, nullptr};
+
+    auto make_descriptor = [](const char* field_name, const char* units) {
+        Plotfile2DOutputDescriptor descriptor;
+        descriptor.name = field_name;
+        descriptor.long_name = field_name;
+        descriptor.units = units;
+        descriptor.category = DiagnosticCategory::SampledLevel;
+        descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+        descriptor.missing_value = amrex::Real(-999.0);
+        descriptor.sampled_level = SampledLevelMetadata{
+            "upper_air_winds",
+            field_name,
+            SampledVerticalCoordinateMetadata{
+                "model_index",
+                amrex::Real(0.0),
+                "1",
+                amrex::Real(0.0),
+                "1",
+                "none"
+            }
+        };
+        return descriptor;
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, make_descriptor("u_east", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 1, make_descriptor("v_north", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 2, make_descriptor("w", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 3, make_descriptor("wind_speed", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 4, make_descriptor("wind_dir", "degrees"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::Real pi = amrex::Real(3.141592653589793238462643383279502884L);
+    const amrex::Real expected_dir =
+        amrex::Real(270.0) - std::atan2(amrex::Real(2.0), amrex::Real(1.0)) * amrex::Real(180.0) / pi;
+    const amrex::Real expected_speed = std::sqrt(amrex::Real(5.0));
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.min(1), amrex::Real(2.0));
+    EXPECT_DOUBLE_EQ(dst.max(1), amrex::Real(2.0));
+    EXPECT_DOUBLE_EQ(dst.min(2), amrex::Real(3.0));
+    EXPECT_DOUBLE_EQ(dst.max(2), amrex::Real(3.0));
+    EXPECT_DOUBLE_EQ(dst.min(3), expected_speed);
+    EXPECT_DOUBLE_EQ(dst.max(3), expected_speed);
+    EXPECT_NEAR(dst.min(4), expected_dir, 1.0e-12);
+    EXPECT_NEAR(dst.max(4), expected_dir, 1.0e-12);
+}
+
+// Motivation: Plotting winds must use earth-relative components when rotation
+// coefficients are supplied.
+TEST(Plotfile2DInterpolator, SampledWindsApplyRotation)
+{
+    const auto cell_ba = make_test_boxarray();
+    const auto xba = make_test_xface_boxarray();
+    const auto yba = make_test_yface_boxarray();
+    const auto zba = make_test_zface_boxarray();
+    amrex::DistributionMapping dm(cell_ba);
+    amrex::MultiFab cons(cell_ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(cell_ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab xvel(xba, dm, 1, 0);
+    amrex::MultiFab yvel(yba, dm, 1, 0);
+    amrex::MultiFab zvel(zba, dm, 1, 0);
+    amrex::MultiFab cos_alpha(cell_ba, dm, 1, 0);
+    amrex::MultiFab sin_alpha(cell_ba, dm, 1, 0);
+    amrex::MultiFab dst(cell_ba, dm, 4, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    xvel.setVal(amrex::Real(1.0));
+    yvel.setVal(amrex::Real(2.0));
+    zvel.setVal(amrex::Real(3.0));
+    cos_alpha.setVal(amrex::Real(0.0));
+    sin_alpha.setVal(amrex::Real(1.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    const auto wind_sources = plotfile2d::SampledWindSources{&xvel, &yvel, &zvel, &cos_alpha, &sin_alpha};
+
+    auto make_descriptor = [](const char* field_name, const char* units) {
+        Plotfile2DOutputDescriptor descriptor;
+        descriptor.name = field_name;
+        descriptor.long_name = field_name;
+        descriptor.units = units;
+        descriptor.category = DiagnosticCategory::SampledLevel;
+        descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+        descriptor.missing_value = amrex::Real(-999.0);
+        descriptor.sampled_level = SampledLevelMetadata{
+            "upper_air_winds",
+            field_name,
+            SampledVerticalCoordinateMetadata{
+                "model_index",
+                amrex::Real(0.0),
+                "1",
+                amrex::Real(0.0),
+                "1",
+                "none"
+            }
+        };
+        return descriptor;
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, make_descriptor("u_east", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 1, make_descriptor("v_north", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 2, make_descriptor("wind_speed", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 3, make_descriptor("wind_dir", "degrees"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::Real pi = amrex::Real(3.141592653589793238462643383279502884L);
+    const amrex::Real expected_dir =
+        amrex::Real(270.0) - std::atan2(amrex::Real(1.0), amrex::Real(-2.0)) * amrex::Real(180.0) / pi;
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(-2.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(-2.0));
+    EXPECT_DOUBLE_EQ(dst.min(1), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.max(1), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.min(2), std::sqrt(amrex::Real(5.0)));
+    EXPECT_DOUBLE_EQ(dst.max(2), std::sqrt(amrex::Real(5.0)));
+    EXPECT_NEAR(dst.min(3), expected_dir, 1.0e-12);
+    EXPECT_NEAR(dst.max(3), expected_dir, 1.0e-12);
+}
+
+// Motivation: Wind direction is undefined for calm winds, so the output should
+// use the configured missing value instead of an arbitrary angle.
+TEST(Plotfile2DInterpolator, WindDirReturnsMissingForCalmWinds)
+{
+    const auto cell_ba = make_test_boxarray();
+    const auto xba = make_test_xface_boxarray();
+    const auto yba = make_test_yface_boxarray();
+    const auto zba = make_test_zface_boxarray();
+    amrex::DistributionMapping dm(cell_ba);
+    amrex::MultiFab cons(cell_ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(cell_ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab xvel(xba, dm, 1, 0);
+    amrex::MultiFab yvel(yba, dm, 1, 0);
+    amrex::MultiFab zvel(zba, dm, 1, 0);
+    amrex::MultiFab dst(cell_ba, dm, 2, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    xvel.setVal(amrex::Real(0.0));
+    yvel.setVal(amrex::Real(0.0));
+    zvel.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    const auto wind_sources = plotfile2d::SampledWindSources{&xvel, &yvel, &zvel, nullptr, nullptr};
+
+    Plotfile2DOutputDescriptor speed_descriptor;
+    speed_descriptor.name = "wind_speed_k_0";
+    speed_descriptor.long_name = "Horizontal wind speed sampled on model index levels";
+    speed_descriptor.units = "m/s";
+    speed_descriptor.category = DiagnosticCategory::SampledLevel;
+    speed_descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    speed_descriptor.missing_value = amrex::Real(-999.0);
+    speed_descriptor.sampled_level = SampledLevelMetadata{
+        "upper_air_winds",
+        "wind_speed",
+        SampledVerticalCoordinateMetadata{
+            "model_index",
+            amrex::Real(0.0),
+            "1",
+            amrex::Real(0.0),
+            "1",
+            "none"
+        }
+    };
+
+    Plotfile2DOutputDescriptor dir_descriptor = speed_descriptor;
+    dir_descriptor.name = "wind_dir_k_0";
+    dir_descriptor.long_name = "Meteorological wind direction sampled on model index levels";
+    dir_descriptor.units = "degrees";
+    dir_descriptor.sampled_level->source_field = "wind_dir";
+
+    plotfile2d::fill_sampled_level_component(dst, 0, speed_descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 1, dir_descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2, wind_sources);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(0.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(0.0));
+    EXPECT_DOUBLE_EQ(dst.min(1), amrex::Real(-999.0));
+    EXPECT_DOUBLE_EQ(dst.max(1), amrex::Real(-999.0));
+}
+
+// Motivation: Wind direction is circular, so ERF should interpolate the wind
+// vector and derive direction from the interpolated vector.
+TEST(Plotfile2DInterpolator, SampledWindsInterpolateVectorComponents)
+{
+    const auto cell_ba = make_test_boxarray();
+    const auto xba = make_test_xface_boxarray();
+    const auto yba = make_test_yface_boxarray();
+    const auto zba = make_test_zface_boxarray();
+    amrex::DistributionMapping dm(cell_ba);
+    amrex::MultiFab cons(cell_ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(cell_ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab xvel(xba, dm, 1, 0);
+    amrex::MultiFab yvel(yba, dm, 1, 0);
+    amrex::MultiFab zvel(zba, dm, 1, 0);
+    amrex::MultiFab dst(cell_ba, dm, 5, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    set_component_value_at_k(xvel, 0, 0, amrex::Real(0.0));
+    set_component_value_at_k(xvel, 0, 1, amrex::Real(2.0));
+    set_component_value_at_k(yvel, 0, 0, amrex::Real(2.0));
+    set_component_value_at_k(yvel, 0, 1, amrex::Real(0.0));
+    zvel.setVal(amrex::Real(3.0));
+    set_component_value_at_k(z_phys_cc, 0, 0, amrex::Real(0.0));
+    set_component_value_at_k(z_phys_cc, 0, 1, amrex::Real(1000.0));
+
+    const auto wind_sources = plotfile2d::SampledWindSources{&xvel, &yvel, &zvel, nullptr, nullptr};
+
+    Plotfile2DOutputDescriptor base_descriptor;
+    base_descriptor.category = DiagnosticCategory::SampledLevel;
+    base_descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    base_descriptor.missing_value = amrex::Real(-999.0);
+    base_descriptor.sampled_level = SampledLevelMetadata{
+        "upper_air_winds",
+        "u_east",
+        SampledVerticalCoordinateMetadata{
+            "height_msl",
+            amrex::Real(500.0),
+            "m",
+            amrex::Real(500.0),
+            "m",
+            "linear"
+        }
+    };
+
+    auto make_descriptor = [&](const char* field_name, const char* units) {
+        Plotfile2DOutputDescriptor descriptor = base_descriptor;
+        descriptor.name = std::string(field_name) + "_z_msl_500m";
+        descriptor.long_name = field_name;
+        descriptor.units = units;
+        descriptor.sampled_level->source_field = field_name;
+        return descriptor;
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, make_descriptor("u_east", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 1, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 1, make_descriptor("v_north", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 1, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 2, make_descriptor("w", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 1, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 3, make_descriptor("wind_speed", "m/s"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 1, wind_sources);
+    plotfile2d::fill_sampled_level_component(dst, 4, make_descriptor("wind_dir", "degrees"),
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 1, wind_sources);
+    amrex::Gpu::streamSynchronize();
+
+    const amrex::Real pi = amrex::Real(3.141592653589793238462643383279502884L);
+    const amrex::Real expected_dir =
+        amrex::Real(270.0) - std::atan2(amrex::Real(1.0), amrex::Real(1.0)) * amrex::Real(180.0) / pi;
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.min(1), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.max(1), amrex::Real(1.0));
+    EXPECT_DOUBLE_EQ(dst.min(2), amrex::Real(3.0));
+    EXPECT_DOUBLE_EQ(dst.max(2), amrex::Real(3.0));
+    EXPECT_DOUBLE_EQ(dst.min(3), std::sqrt(amrex::Real(2.0)));
+    EXPECT_DOUBLE_EQ(dst.max(3), std::sqrt(amrex::Real(2.0)));
+    EXPECT_NEAR(dst.min(4), expected_dir, 1.0e-12);
+    EXPECT_NEAR(dst.max(4), expected_dir, 1.0e-12);
+}
+
+// Motivation: Sampled wind fields should use the same deterministic naming and
+// descriptor metadata path as thermodynamic sampled fields.
+TEST(Plotfile2DMetadata, FormatsSampledWindLevelMetadata)
+{
+    SampledLevelDefinition upper_air;
+    upper_air.name = "upper_air_winds";
+    upper_air.coordinate = SampledCoordinate::Pressure;
+    upper_air.units = "hPa";
+    upper_air.values = {amrex::Real(850.0)};
+    upper_air.fields = {"u_east", "v_north", "wind_speed", "wind_dir"};
+    upper_air.interpolation = SampledInterpolation::Linear;
+
+    const auto descriptors =
+        build_sampled_level_output_descriptors_from_definitions(
+            amrex::Vector<SampledLevelDefinition>{upper_air},
+            amrex::Vector<std::string>{},
+            SolverChoice());
+
+    ASSERT_EQ(descriptors.size(), 4u);
+    EXPECT_EQ(descriptors[0].name, "u_east_p_850hPa");
+    EXPECT_EQ(descriptors[1].name, "v_north_p_850hPa");
+    EXPECT_EQ(descriptors[2].name, "wind_speed_p_850hPa");
+    EXPECT_EQ(descriptors[3].name, "wind_dir_p_850hPa");
+    EXPECT_EQ(descriptors[0].units, "m/s");
+    EXPECT_EQ(descriptors[1].units, "m/s");
+    EXPECT_EQ(descriptors[2].units, "m/s");
+    EXPECT_EQ(descriptors[3].units, "degrees");
+    EXPECT_EQ(descriptors[0].category, DiagnosticCategory::SampledLevel);
+    ASSERT_TRUE(descriptors[3].sampled_level.has_value());
+    EXPECT_EQ(descriptors[3].sampled_level->source_field, "wind_dir");
+    EXPECT_EQ(descriptors[3].sampled_level->vertical_coordinate.canonical_value, amrex::Real(85000.0));
+    EXPECT_EQ(descriptors[3].sampled_level->vertical_coordinate.canonical_units, "Pa");
 }
 
 // Motivation: Water-path diagnostics should disappear from the available list
@@ -1615,6 +2016,16 @@ TEST(Plotfile2DSampledLevel, FormatsOutputNames)
               "qv_z_agl_500m");
     EXPECT_EQ(sampled_output_name("qg", SampledCoordinate::ModelIndex, amrex::Real(10.0), "1"),
               "qg_k_10");
+    EXPECT_EQ(sampled_output_name("u_east", SampledCoordinate::Pressure, amrex::Real(850.0), "hPa"),
+              "u_east_p_850hPa");
+    EXPECT_EQ(sampled_output_name("v_north", SampledCoordinate::Pressure, amrex::Real(850.0), "hPa"),
+              "v_north_p_850hPa");
+    EXPECT_EQ(sampled_output_name("w", SampledCoordinate::HeightAGL, amrex::Real(500.0), "m"),
+              "w_z_agl_500m");
+    EXPECT_EQ(sampled_output_name("wind_speed", SampledCoordinate::ModelIndex, amrex::Real(10.0), "1"),
+              "wind_speed_k_10");
+    EXPECT_EQ(sampled_output_name("wind_dir", SampledCoordinate::Pressure, amrex::Real(700.0), "hPa"),
+              "wind_dir_p_700hPa");
 }
 
 // Motivation: The metadata file should travel with the native AMReX 2D

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -245,6 +245,7 @@ TEST(Plotfile2D, CatalogDescriptorsHaveRequiredMetadata)
         case plotfile2d::DiagnosticCategory::PBL:
         case plotfile2d::DiagnosticCategory::SurfaceState:
         case plotfile2d::DiagnosticCategory::ColumnIntegral:
+        case plotfile2d::DiagnosticCategory::SampledLevel:
             valid_category = true;
             break;
         }
@@ -770,7 +771,7 @@ TEST(Plotfile2DMetadata, FormatsSelectedVariablesInOutputOrder)
 
     const std::string json = format_2d_metadata_json(selected);
 
-    EXPECT_TRUE(contains(json, "\"format_version\": 1"));
+    EXPECT_TRUE(contains(json, "\"format_version\": 2"));
     EXPECT_TRUE(contains(json, "\"kind\": \"ERF 2D plotfile metadata\""));
     EXPECT_TRUE(contains(json, "\"n_variables\": 4"));
     EXPECT_TRUE(contains(json, "\"component_index\": 0"));
@@ -833,6 +834,59 @@ TEST(Plotfile2DMetadata, FormatsEveryCatalogDiagnostic)
     for (const auto& name : names) {
         EXPECT_TRUE(contains(json, "\"name\": \"" + name + "\""));
     }
+}
+
+// Motivation: Sampled-level metadata must preserve the sampled source field
+// and vertical-coordinate contract without looking up dynamic names in the
+// static catalog.
+TEST(Plotfile2DMetadata, FormatsSampledLevelVerticalCoordinate)
+{
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "theta_p_850hPa";
+    descriptor.long_name = "Potential temperature sampled on pressure levels";
+    descriptor.units = "K";
+    descriptor.category = plotfile2d::DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = plotfile2d::MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = plotfile2d::SampledLevelMetadata{
+        "upper_air",
+        "theta",
+        plotfile2d::SampledVerticalCoordinateMetadata{
+            "pressure",
+            amrex::Real(850.0),
+            "hPa",
+            amrex::Real(85000.0),
+            "Pa",
+            "linear"
+        }
+    };
+
+    const amrex::Vector<Plotfile2DOutputDescriptor> descriptors{descriptor};
+    const std::string json = format_2d_metadata_json(descriptors);
+
+    EXPECT_TRUE(contains(json, "\"format_version\": 2"));
+    EXPECT_TRUE(contains(json, "\"name\": \"theta_p_850hPa\""));
+    EXPECT_TRUE(contains(json, "\"category\": \"SampledLevel\""));
+    EXPECT_TRUE(contains(json, "\"source_field\": \"theta\""));
+    EXPECT_TRUE(contains(json, "\"vertical_coordinate\""));
+    EXPECT_TRUE(contains(json, "\"type\": \"pressure\""));
+    EXPECT_TRUE(contains(json, "\"value\": 850"));
+    EXPECT_TRUE(contains(json, "\"units\": \"hPa\""));
+    EXPECT_TRUE(contains(json, "\"canonical_value\": 85000"));
+    EXPECT_TRUE(contains(json, "\"canonical_units\": \"Pa\""));
+    EXPECT_TRUE(contains(json, "\"interpolation\": \"linear\""));
+}
+
+// Motivation: Sampled-level output names are a public plotfile contract, so
+// the coordinate and value tags must stay deterministic.
+TEST(Plotfile2DSampledLevel, FormatsOutputNames)
+{
+    EXPECT_EQ(sampled_output_name("theta", SampledCoordinate::Pressure, amrex::Real(850.0), "hPa"),
+              "theta_p_850hPa");
+    EXPECT_EQ(sampled_output_name("qv", SampledCoordinate::HeightAGL, amrex::Real(500.0), "m"),
+              "qv_z_agl_500m");
+    EXPECT_EQ(sampled_output_name("qg", SampledCoordinate::ModelIndex, amrex::Real(10.0), "1"),
+              "qg_k_10");
 }
 
 // Motivation: The metadata file should travel with the native AMReX 2D

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 #include <AMReX_Box.H>
 #include <AMReX_BoxArray.H>
@@ -8,11 +9,15 @@
 #include <AMReX_Geometry.H>
 #include <AMReX_Gpu.H>
 #include <AMReX_MultiFab.H>
+#include <AMReX_ParmParse.H>
 #include <gtest/gtest.h>
 
 #include "ERF_Plotfile2DCatalog.H"
+#include "ERF_Plotfile2DInterpolator.H"
 #include "ERF_Plotfile2DFill.H"
 #include "ERF_Plotfile2DMetadata.H"
+#include "ERF_Plotfile2DSampledField.H"
+#include "ERF_Plotfile2DSampledLevel.H"
 #include "ERF_Plotfile2DWaterPath.H"
 #include "ERF_Plotfile2DUtils.H"
 #include "ERF_DataStruct.H"
@@ -50,6 +55,11 @@ amrex::BoxArray make_test_slab_boxarray ()
     return amrex::BoxArray(std::move(bl));
 }
 
+amrex::BoxArray make_test_nodal_boxarray ()
+{
+    return amrex::convert(make_test_boxarray(), amrex::IntVect(1, 1, 1));
+}
+
 amrex::Geometry make_test_geometry ()
 {
     amrex::Geometry geom;
@@ -73,6 +83,30 @@ void set_component_value_at_k (amrex::MultiFab& mf, int comp, int k_level, amrex
         });
     }
     amrex::Gpu::streamSynchronize();
+}
+
+void add_sampled_level_definition (const std::string& level_name,
+                                   const std::string& coordinate,
+                                   const std::vector<amrex::Real>& values,
+                                   const std::vector<std::string>& fields,
+                                   const char* units = nullptr,
+                                   const char* interpolation = nullptr,
+                                   const char* missing_value = nullptr)
+{
+    amrex::ParmParse pp("erf");
+    const std::string base = "plot2d.level_set." + level_name + ".";
+    pp.add(base + "coordinate", coordinate);
+    if (units != nullptr) {
+        pp.add(base + "units", units);
+    }
+    if (interpolation != nullptr) {
+        pp.add(base + "interpolation", interpolation);
+    }
+    if (missing_value != nullptr) {
+        pp.add(base + "missing_value", missing_value);
+    }
+    pp.addarr(base + "values", values);
+    pp.addarr(base + "fields", fields);
 }
 
 } // namespace
@@ -304,6 +338,501 @@ TEST(Plotfile2D, FindDiagnosticReturnsDescriptorForSurfaceDiagnosticSource)
     EXPECT_FALSE(std::string(descriptor->long_name).empty());
     EXPECT_FALSE(std::string(descriptor->units).empty());
     EXPECT_EQ(descriptor->missing_policy, plotfile2d::MissingPolicy::FillMinus999WhenUnavailable);
+}
+
+// Motivation: Pressure sampled-level definitions must parse with the provided
+// units and preserve the requested value list and field order.
+TEST(Plotfile2DSampledLevel, ParsesPressureLevelSet)
+{
+    add_sampled_level_definition("pressure_parse_pressure",
+                                 "pressure",
+                                 {850.0, 700.0},
+                                 {"theta", "temp", "qv", "qc"},
+                                 "hPa",
+                                 "linear");
+
+    const auto level_set = parse_sampled_level_definition("pressure_parse_pressure", "erf");
+
+    EXPECT_EQ(level_set.coordinate, SampledCoordinate::Pressure);
+    EXPECT_EQ(level_set.units, "hPa");
+    ASSERT_EQ(level_set.values.size(), 2u);
+    EXPECT_DOUBLE_EQ(level_set.values[0], 850.0);
+    EXPECT_DOUBLE_EQ(level_set.values[1], 700.0);
+    ASSERT_EQ(level_set.fields.size(), 4u);
+    EXPECT_EQ(level_set.fields[0], "theta");
+    EXPECT_EQ(level_set.fields[1], "temp");
+    EXPECT_EQ(level_set.fields[2], "qv");
+    EXPECT_EQ(level_set.fields[3], "qc");
+    EXPECT_EQ(level_set.interpolation, SampledInterpolation::Linear);
+    EXPECT_EQ(validate_sampled_level_definition(level_set), "");
+}
+
+// Motivation: Height-agl sampled-level definitions should default to meters
+// and linear interpolation when those keys are omitted.
+TEST(Plotfile2DSampledLevel, ParsesHeightAGLLevelSet)
+{
+    add_sampled_level_definition("height_agl_parse_height",
+                                 "height_agl",
+                                 {100.0, 500.0},
+                                 {"theta", "qv", "qc"});
+
+    const auto level_set = parse_sampled_level_definition("height_agl_parse_height", "erf");
+
+    EXPECT_EQ(level_set.coordinate, SampledCoordinate::HeightAGL);
+    EXPECT_EQ(level_set.units, "m");
+    EXPECT_EQ(level_set.interpolation, SampledInterpolation::Linear);
+    ASSERT_EQ(level_set.values.size(), 2u);
+    EXPECT_DOUBLE_EQ(level_set.values[0], 100.0);
+    EXPECT_DOUBLE_EQ(level_set.values[1], 500.0);
+}
+
+// Motivation: Unknown coordinates should fail fast with a clear parser error
+// instead of falling through to a later interpolation failure.
+TEST(Plotfile2DSampledLevel, RejectsUnknownCoordinate)
+{
+    add_sampled_level_definition("bad_coordinate",
+                                 "bogus_coordinate",
+                                 {10.0},
+                                 {"theta"});
+
+    EXPECT_DEATH(parse_sampled_level_definition("bad_coordinate", "erf"),
+                 "Unknown sampled-level coordinate");
+}
+
+// Motivation: Unsupported units should be rejected at parse time so sampled
+// metadata cannot advertise a unit that the sampler does not canonicalize.
+TEST(Plotfile2DSampledLevel, RejectsUnsupportedUnits)
+{
+    add_sampled_level_definition("bad_units",
+                                 "pressure",
+                                 {850.0},
+                                 {"theta"},
+                                 "kPa",
+                                 "linear");
+
+    EXPECT_DEATH(parse_sampled_level_definition("bad_units", "erf"),
+                 "unsupported units");
+}
+
+// Motivation: Isentropic output needs a crossing policy, so it must stay
+// rejected until that policy exists.
+TEST(Plotfile2DSampledLevel, RejectsIsentropicUntilCrossingPolicyExists)
+{
+    add_sampled_level_definition("bad_isentropic",
+                                 "isentropic",
+                                 {300.0},
+                                 {"theta"});
+
+    EXPECT_DEATH(parse_sampled_level_definition("bad_isentropic", "erf"),
+                 "crossing policy");
+}
+
+// Motivation: Derived moisture aliases are out of scope for this sampled
+// output path and must not be accepted as canonical field names.
+TEST(Plotfile2DSampledLevel, RejectsDerivedMoistureAliases)
+{
+    const amrex::Vector<std::string> requested{"qrain", "qsnow", "qgraup"};
+    SolverChoice sc;
+    const auto selection = select_requested_sampled_fields(requested, sc);
+
+    EXPECT_TRUE(selection.accepted.empty());
+    ASSERT_EQ(selection.unavailable.size(), 3u);
+    EXPECT_EQ(selection.unavailable[0], "qrain");
+    EXPECT_EQ(selection.unavailable[1], "qsnow");
+    EXPECT_EQ(selection.unavailable[2], "qgraup");
+}
+
+// Motivation: Dry runs should expose the thermodynamic and geometric sampled
+// fields but not moisture species.
+TEST(Plotfile2DSampledField, DryRunExcludesMoistureSpecies)
+{
+    SolverChoice sc;
+    sc.moisture_type = MoistureType::None;
+
+    const auto available = available_sampled_field_names(sc);
+
+    for (const char* name : {"rho", "theta", "temp", "pressure", "height_msl", "height_agl"}) {
+        EXPECT_NE(std::find(available.begin(), available.end(), name), available.end());
+    }
+    for (const char* name : {"qv", "qc", "qi", "qr", "qs", "qg"}) {
+        EXPECT_EQ(std::find(available.begin(), available.end(), name), available.end());
+    }
+}
+
+// Motivation: Dry-run thermodynamic sampled fields still use qv = 0 in the
+// EOS helpers even when the sampled qv field itself is unavailable.
+TEST(Plotfile2DSampledField, DryRunUsesZeroVaporForThermodynamicFields)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(2.0));
+    set_component_value_at_k(cons, RhoTheta_comp, 0, amrex::Real(500.0));
+
+    SolverChoice sc;
+    sc.moisture_type = MoistureType::None;
+    const auto& mi = sc.moisture_indices;
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const auto& cons_arr = cons.const_array(mfi);
+        const auto& z_cc_arr = z_phys_cc.const_array(mfi);
+        const auto& z_nd_arr = z_phys_nd.const_array(mfi);
+
+        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Pressure, cons_arr, z_cc_arr, z_nd_arr,
+                                             true, 0, 0, 0, mi),
+                         getPgivenRTh(amrex::Real(500.0), amrex::Real(0.0)));
+        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Temp, cons_arr, z_cc_arr, z_nd_arr,
+                                             true, 0, 0, 0, mi),
+                         getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
+        break;
+    }
+}
+
+// Motivation: Scheme-aware availability should follow the active moisture
+// indices rather than a hard-coded microphysics switch.
+TEST(Plotfile2DSampledField, KesslerAvailabilityMatchesMoistureIndices)
+{
+    SolverChoice sc;
+    sc.moisture_type = MoistureType::Kessler;
+    sc.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, RhoQ3_comp);
+
+    const auto available = available_sampled_field_names(sc);
+
+    for (const char* name : {"qv", "qc", "qr"}) {
+        EXPECT_NE(std::find(available.begin(), available.end(), name), available.end());
+    }
+    for (const char* name : {"qi", "qs", "qg"}) {
+        EXPECT_EQ(std::find(available.begin(), available.end(), name), available.end());
+    }
+}
+
+// Motivation: Full bulk schemes should expose all sampled microphysical mass
+// species.
+TEST(Plotfile2DSampledField, FullIceAvailabilityIncludesAllMassSpecies)
+{
+    SolverChoice sc;
+    sc.moisture_type = MoistureType::Morrison;
+    sc.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp,
+                                                   RhoQ3_comp, RhoQ4_comp,
+                                                   RhoQ5_comp, RhoQ6_comp);
+
+    const auto available = available_sampled_field_names(sc);
+
+    for (const char* name : {"qv", "qc", "qi", "qr", "qs", "qg"}) {
+        EXPECT_NE(std::find(available.begin(), available.end(), name), available.end());
+    }
+}
+
+// Motivation: The bracket rule must work for both increasing and decreasing
+// coordinates so sampled pressure and height behave the same way.
+TEST(Plotfile2DInterpolator, BracketRuleHandlesIncreasingAndDecreasingCoordinates)
+{
+    EXPECT_TRUE(sampled_target_is_bracketed(amrex::Real(5.0), amrex::Real(0.0), amrex::Real(10.0)));
+    EXPECT_TRUE(sampled_target_is_bracketed(amrex::Real(5.0), amrex::Real(10.0), amrex::Real(0.0)));
+    EXPECT_FALSE(sampled_target_is_bracketed(amrex::Real(15.0), amrex::Real(0.0), amrex::Real(10.0)));
+}
+
+// Motivation: Linear interpolation is the core numerical step for sampled
+// height and pressure outputs.
+TEST(Plotfile2DInterpolator, LinearInterpolateMatchesSyntheticValues)
+{
+    EXPECT_DOUBLE_EQ(linear_interpolate(amrex::Real(10.0), amrex::Real(20.0),
+                                        amrex::Real(0.0), amrex::Real(10.0),
+                                        amrex::Real(5.0)),
+                     amrex::Real(15.0));
+}
+
+// Motivation: Model-index sampling should copy the requested level exactly.
+TEST(Plotfile2DInterpolator, ModelIndexCopiesExactLevel)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    set_component_value_at_k(cons, Rho_comp, 1, amrex::Real(2.0));
+    set_component_value_at_k(cons, RhoTheta_comp, 1, amrex::Real(520.0));
+
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "theta_k_1";
+    descriptor.long_name = "Potential temperature sampled on model index levels";
+    descriptor.units = "K";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "native_k",
+        "theta",
+        SampledVerticalCoordinateMetadata{
+            "model_index",
+            amrex::Real(1.0),
+            "1",
+            amrex::Real(1.0),
+            "1",
+            "none"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(520.0) / amrex::Real(2.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(520.0) / amrex::Real(2.0));
+}
+
+// Motivation: Height-msl sampling should interpolate a simple synthetic
+// column without changing the sampled-value convention.
+TEST(Plotfile2DInterpolator, HeightMSLInterpolatesSyntheticColumn)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(10.0));
+    set_component_value_at_k(cons, Rho_comp, 1, amrex::Real(20.0));
+    set_component_value_at_k(cons, Rho_comp, 2, amrex::Real(30.0));
+    set_component_value_at_k(z_phys_cc, 0, 0, amrex::Real(0.0));
+    set_component_value_at_k(z_phys_cc, 0, 1, amrex::Real(1000.0));
+    set_component_value_at_k(z_phys_cc, 0, 2, amrex::Real(2000.0));
+
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "rho_z_msl_500m";
+    descriptor.long_name = "Density sampled on height-msl levels";
+    descriptor.units = "kg/m^3";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "upper_air",
+        "rho",
+        SampledVerticalCoordinateMetadata{
+            "height_msl",
+            amrex::Real(500.0),
+            "m",
+            amrex::Real(500.0),
+            "m",
+            "linear"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(), 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(15.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(15.0));
+}
+
+// Motivation: Height-agl sampling should use the local terrain height rather
+// than a global altitude origin.
+TEST(Plotfile2DInterpolator, HeightAGLUsesLocalSurfaceHeight)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(10.0));
+    set_component_value_at_k(cons, Rho_comp, 1, amrex::Real(20.0));
+    set_component_value_at_k(cons, Rho_comp, 2, amrex::Real(30.0));
+    set_component_value_at_k(z_phys_nd, 0, 0, amrex::Real(100.0));
+    set_component_value_at_k(z_phys_nd, 0, 1, amrex::Real(200.0));
+    set_component_value_at_k(z_phys_nd, 0, 2, amrex::Real(300.0));
+    set_component_value_at_k(z_phys_nd, 0, 3, amrex::Real(400.0));
+
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "rho_z_agl_50m";
+    descriptor.long_name = "Density sampled on height-agl levels";
+    descriptor.units = "kg/m^3";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "bl",
+        "rho",
+        SampledVerticalCoordinateMetadata{
+            "height_agl",
+            amrex::Real(50.0),
+            "m",
+            amrex::Real(50.0),
+            "m",
+            "linear"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, nullptr, z_phys_nd, false,
+                                             MoistureComponentIndices(), 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(10.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(10.0));
+}
+
+// Motivation: Pressure sampling should interpolate a monotonic column using
+// the EOS-derived pressure coordinate.
+TEST(Plotfile2DInterpolator, PressureInterpolatesMonotonicColumn)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    const amrex::Real qv = amrex::Real(0.0);
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(300.0));
+    set_component_value_at_k(cons, Rho_comp, 1, amrex::Real(310.0));
+    set_component_value_at_k(cons, Rho_comp, 2, amrex::Real(320.0));
+    set_component_value_at_k(cons, RhoTheta_comp, 0, getRhoThetagivenP(amrex::Real(90000.0), qv));
+    set_component_value_at_k(cons, RhoTheta_comp, 1, getRhoThetagivenP(amrex::Real(80000.0), qv));
+    set_component_value_at_k(cons, RhoTheta_comp, 2, getRhoThetagivenP(amrex::Real(70000.0), qv));
+
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "rho_p_85000Pa";
+    descriptor.long_name = "Density sampled on pressure levels";
+    descriptor.units = "kg/m^3";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "upper_air",
+        "rho",
+        SampledVerticalCoordinateMetadata{
+            "pressure",
+            amrex::Real(85000.0),
+            "Pa",
+            amrex::Real(85000.0),
+            "Pa",
+            "linear"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, nullptr, z_phys_nd, false,
+                                             MoistureComponentIndices(), 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(305.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(305.0));
+}
+
+// Motivation: Targets outside the sampled column must write the configured
+// missing value rather than extrapolating.
+TEST(Plotfile2DInterpolator, OutOfRangeTargetFillsMissingValue)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
+
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(300.0));
+    set_component_value_at_k(cons, Rho_comp, 1, amrex::Real(310.0));
+    set_component_value_at_k(cons, Rho_comp, 2, amrex::Real(320.0));
+    set_component_value_at_k(cons, RhoTheta_comp, 0, getRhoThetagivenP(amrex::Real(90000.0), amrex::Real(0.0)));
+    set_component_value_at_k(cons, RhoTheta_comp, 1, getRhoThetagivenP(amrex::Real(80000.0), amrex::Real(0.0)));
+    set_component_value_at_k(cons, RhoTheta_comp, 2, getRhoThetagivenP(amrex::Real(70000.0), amrex::Real(0.0)));
+
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "rho_p_65000Pa";
+    descriptor.long_name = "Density sampled on pressure levels";
+    descriptor.units = "kg/m^3";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "upper_air",
+        "rho",
+        SampledVerticalCoordinateMetadata{
+            "pressure",
+            amrex::Real(65000.0),
+            "Pa",
+            amrex::Real(65000.0),
+            "Pa",
+            "linear"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, nullptr, z_phys_nd, false,
+                                             MoistureComponentIndices(), 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(-999.0));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(-999.0));
+}
+
+// Motivation: Microphysical sampled fields are reported as mixing ratios, so
+// the conserved rho*q state must be divided by rho before output.
+TEST(Plotfile2DInterpolator, MicrophysicsFieldsUseMixingRatio)
+{
+    const auto ba = make_test_boxarray();
+    amrex::DistributionMapping dm(ba);
+    amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
+    amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
+    amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+
+    cons.setVal(amrex::Real(0.0));
+    z_phys_cc.setVal(amrex::Real(0.0));
+    z_phys_nd.setVal(amrex::Real(0.0));
+
+    set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(2.0));
+    set_component_value_at_k(cons, RhoQ2_comp, 0, amrex::Real(0.004));
+
+    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
+        const auto& cons_arr = cons.const_array(mfi);
+        const auto& z_cc_arr = z_phys_cc.const_array(mfi);
+        const auto& z_nd_arr = z_phys_nd.const_array(mfi);
+
+        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Qc, cons_arr, z_cc_arr, z_nd_arr,
+                                             true, 0, 0, 0, MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, -1)),
+                         amrex::Real(0.002));
+        break;
+    }
 }
 
 // Motivation: Water-path diagnostics should disappear from the available list
@@ -734,6 +1263,7 @@ TEST(Plotfile2DMetadata, CategoryStringsMatchPublicMetadataSchema)
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::PBL), "PBL");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SurfaceState), "SurfaceState");
     EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::ColumnIntegral), "ColumnIntegral");
+    EXPECT_STREQ(diagnostic_category_to_string(DiagnosticCategory::SampledLevel), "SampledLevel");
 }
 
 // Motivation: Downstream readers need to distinguish always-available fields
@@ -875,6 +1405,141 @@ TEST(Plotfile2DMetadata, FormatsSampledLevelVerticalCoordinate)
     EXPECT_TRUE(contains(json, "\"canonical_value\": 85000"));
     EXPECT_TRUE(contains(json, "\"canonical_units\": \"Pa\""));
     EXPECT_TRUE(contains(json, "\"interpolation\": \"linear\""));
+}
+
+// Motivation: Static diagnostics remain on metadata version 2 so existing
+// plotfile readers see the same public catalog fields.
+TEST(Plotfile2DMetadata, StaticDiagnosticsRemainMetadataVersionTwo)
+{
+    const std::string json = format_2d_metadata_json(amrex::Vector<std::string>{"z_surf"});
+
+    EXPECT_TRUE(contains(json, "\"format_version\": 2"));
+    EXPECT_TRUE(contains(json, "\"name\": \"z_surf\""));
+    EXPECT_FALSE(contains(json, "\"source_field\""));
+}
+
+// Motivation: Sampled-level metadata must preserve the output component
+// order that the writer assembles.
+TEST(Plotfile2DMetadata, SampledLevelMetadataPreservesOutputOrder)
+{
+    SampledLevelDefinition upper_air;
+    upper_air.name = "upper_air";
+    upper_air.coordinate = SampledCoordinate::Pressure;
+    upper_air.units = "hPa";
+    upper_air.values = {amrex::Real(850.0), amrex::Real(700.0)};
+    upper_air.fields = {"theta", "qv"};
+    upper_air.interpolation = SampledInterpolation::Linear;
+
+    SolverChoice sc;
+    sc.moisture_type = MoistureType::Kessler;
+    sc.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, RhoQ3_comp);
+
+    const auto descriptors =
+        build_sampled_level_output_descriptors_from_definitions(
+            amrex::Vector<SampledLevelDefinition>{upper_air},
+            amrex::Vector<std::string>{"z_surf"},
+            sc);
+
+    ASSERT_EQ(descriptors.size(), 5u);
+    EXPECT_EQ(descriptors[0].name, "z_surf");
+    EXPECT_EQ(descriptors[1].name, "theta_p_850hPa");
+    EXPECT_EQ(descriptors[2].name, "qv_p_850hPa");
+    EXPECT_EQ(descriptors[3].name, "theta_p_700hPa");
+    EXPECT_EQ(descriptors[4].name, "qv_p_700hPa");
+
+    const std::string json = format_2d_metadata_json(descriptors);
+    EXPECT_TRUE(contains(json, "\"component_index\": 0"));
+    EXPECT_TRUE(contains(json, "\"component_index\": 4"));
+    EXPECT_TRUE(contains(json, "\"source_field\": \"theta\""));
+    EXPECT_TRUE(contains(json, "\"source_field\": \"qv\""));
+}
+
+// Motivation: A sampled-only 2D stream should still build a descriptor list
+// with one output per requested field and target value.
+TEST(Plotfile2D, SampledOnlyStreamBuildsOutputDescriptorList)
+{
+    SampledLevelDefinition upper_air;
+    upper_air.name = "upper_air";
+    upper_air.coordinate = SampledCoordinate::Pressure;
+    upper_air.units = "hPa";
+    upper_air.values = {amrex::Real(850.0)};
+    upper_air.fields = {"theta", "temp"};
+    upper_air.interpolation = SampledInterpolation::Linear;
+
+    const auto descriptors =
+        build_sampled_level_output_descriptors_from_definitions(
+            amrex::Vector<SampledLevelDefinition>{upper_air},
+            amrex::Vector<std::string>{},
+            SolverChoice());
+
+    ASSERT_EQ(descriptors.size(), 2u);
+    EXPECT_EQ(descriptors[0].name, "theta_p_850hPa");
+    EXPECT_EQ(descriptors[1].name, "temp_p_850hPa");
+    EXPECT_EQ(descriptors[0].category, DiagnosticCategory::SampledLevel);
+    EXPECT_EQ(descriptors[0].missing_policy, MissingPolicy::FillMinus999WhenUnavailable);
+    ASSERT_TRUE(descriptors[0].sampled_level.has_value());
+    EXPECT_EQ(descriptors[0].sampled_level->level_set_name, "upper_air");
+    EXPECT_EQ(descriptors[0].sampled_level->source_field, "theta");
+}
+
+// Motivation: Static built-in diagnostics must stay ahead of sampled-level
+// diagnostics in the assembled output descriptor list.
+TEST(Plotfile2D, SampledDescriptorsAppendAfterStaticDiagnostics)
+{
+    SampledLevelDefinition upper_air;
+    upper_air.name = "upper_air";
+    upper_air.coordinate = SampledCoordinate::Pressure;
+    upper_air.units = "hPa";
+    upper_air.values = {amrex::Real(850.0)};
+    upper_air.fields = {"theta", "temp"};
+    upper_air.interpolation = SampledInterpolation::Linear;
+
+    const auto descriptors =
+        build_sampled_level_output_descriptors_from_definitions(
+            amrex::Vector<SampledLevelDefinition>{upper_air},
+            amrex::Vector<std::string>{"z_surf", "landmask"},
+            SolverChoice());
+
+    ASSERT_EQ(descriptors.size(), 4u);
+    EXPECT_EQ(descriptors[0].name, "z_surf");
+    EXPECT_EQ(descriptors[1].name, "landmask");
+    EXPECT_EQ(descriptors[2].name, "theta_p_850hPa");
+    EXPECT_EQ(descriptors[3].name, "temp_p_850hPa");
+    EXPECT_NE(descriptors[0].static_diagnostic, nullptr);
+    EXPECT_NE(descriptors[1].static_diagnostic, nullptr);
+}
+
+// Motivation: Sampled descriptors must keep level-set order, target order,
+// and field order so the output layout stays deterministic.
+TEST(Plotfile2D, SampledDescriptorOrderIsLevelSetTargetField)
+{
+    SampledLevelDefinition upper_air;
+    upper_air.name = "upper_air";
+    upper_air.coordinate = SampledCoordinate::Pressure;
+    upper_air.units = "hPa";
+    upper_air.values = {amrex::Real(850.0), amrex::Real(700.0)};
+    upper_air.fields = {"theta", "temp"};
+    upper_air.interpolation = SampledInterpolation::Linear;
+
+    SampledLevelDefinition native_k;
+    native_k.name = "native_k";
+    native_k.coordinate = SampledCoordinate::ModelIndex;
+    native_k.values = {amrex::Real(10.0)};
+    native_k.fields = {"temp"};
+    native_k.interpolation = SampledInterpolation::None;
+
+    const auto descriptors =
+        build_sampled_level_output_descriptors_from_definitions(
+            amrex::Vector<SampledLevelDefinition>{upper_air, native_k},
+            amrex::Vector<std::string>{},
+            SolverChoice());
+
+    ASSERT_EQ(descriptors.size(), 5u);
+    EXPECT_EQ(descriptors[0].name, "theta_p_850hPa");
+    EXPECT_EQ(descriptors[1].name, "temp_p_850hPa");
+    EXPECT_EQ(descriptors[2].name, "theta_p_700hPa");
+    EXPECT_EQ(descriptors[3].name, "temp_p_700hPa");
+    EXPECT_EQ(descriptors[4].name, "temp_k_10");
 }
 
 // Motivation: Sampled-level output names are a public plotfile contract, so

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -468,10 +468,12 @@ TEST(Plotfile2DSampledField, DryRunUsesZeroVaporForThermodynamicFields)
     amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
     amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
     amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 2, 0);
 
     cons.setVal(amrex::Real(0.0));
     z_phys_cc.setVal(amrex::Real(0.0));
     z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
 
     set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(2.0));
     set_component_value_at_k(cons, RhoTheta_comp, 0, amrex::Real(500.0));
@@ -479,20 +481,61 @@ TEST(Plotfile2DSampledField, DryRunUsesZeroVaporForThermodynamicFields)
     SolverChoice sc;
     sc.moisture_type = MoistureType::None;
     const auto& mi = sc.moisture_indices;
+    const auto available = available_sampled_field_names(sc);
+    EXPECT_EQ(std::find(available.begin(), available.end(), "qv"), available.end());
 
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const auto& cons_arr = cons.const_array(mfi);
-        const auto& z_cc_arr = z_phys_cc.const_array(mfi);
-        const auto& z_nd_arr = z_phys_nd.const_array(mfi);
+    Plotfile2DOutputDescriptor pressure_descriptor;
+    pressure_descriptor.name = "pressure_k_0";
+    pressure_descriptor.long_name = "Pressure sampled on model index levels";
+    pressure_descriptor.units = "Pa";
+    pressure_descriptor.category = DiagnosticCategory::SampledLevel;
+    pressure_descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    pressure_descriptor.missing_value = amrex::Real(-999.0);
+    pressure_descriptor.sampled_level = SampledLevelMetadata{
+        "dry_run",
+        "pressure",
+        SampledVerticalCoordinateMetadata{
+            "model_index",
+            amrex::Real(0.0),
+            "1",
+            amrex::Real(0.0),
+            "1",
+            "none"
+        }
+    };
 
-        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Pressure, cons_arr, z_cc_arr, z_nd_arr,
-                                             true, 0, 0, 0, mi),
-                         getPgivenRTh(amrex::Real(500.0), amrex::Real(0.0)));
-        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Temp, cons_arr, z_cc_arr, z_nd_arr,
-                                             true, 0, 0, 0, mi),
-                         getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
-        break;
-    }
+    Plotfile2DOutputDescriptor temp_descriptor;
+    temp_descriptor.name = "temp_k_0";
+    temp_descriptor.long_name = "Temperature sampled on model index levels";
+    temp_descriptor.units = "K";
+    temp_descriptor.category = DiagnosticCategory::SampledLevel;
+    temp_descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    temp_descriptor.missing_value = amrex::Real(-999.0);
+    temp_descriptor.sampled_level = SampledLevelMetadata{
+        "dry_run",
+        "temp",
+        SampledVerticalCoordinateMetadata{
+            "model_index",
+            amrex::Real(0.0),
+            "1",
+            amrex::Real(0.0),
+            "1",
+            "none"
+        }
+    };
+
+    plotfile2d::fill_sampled_level_component(dst, 0, pressure_descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             mi, 0, 2);
+    plotfile2d::fill_sampled_level_component(dst, 1, temp_descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             mi, 0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), getPgivenRTh(amrex::Real(500.0), amrex::Real(0.0)));
+    EXPECT_DOUBLE_EQ(dst.max(0), getPgivenRTh(amrex::Real(500.0), amrex::Real(0.0)));
+    EXPECT_DOUBLE_EQ(dst.min(1), getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
+    EXPECT_DOUBLE_EQ(dst.max(1), getTgivenRandRTh(amrex::Real(2.0), amrex::Real(500.0), amrex::Real(0.0)));
 }
 
 // Motivation: Scheme-aware availability should follow the active moisture
@@ -815,24 +858,44 @@ TEST(Plotfile2DInterpolator, MicrophysicsFieldsUseMixingRatio)
     amrex::MultiFab cons(ba, dm, RhoQ6_comp + 1, 0);
     amrex::MultiFab z_phys_cc(ba, dm, 1, 0);
     amrex::MultiFab z_phys_nd(make_test_nodal_boxarray(), dm, 1, 0);
+    amrex::MultiFab dst(ba, dm, 1, 0);
 
     cons.setVal(amrex::Real(0.0));
     z_phys_cc.setVal(amrex::Real(0.0));
     z_phys_nd.setVal(amrex::Real(0.0));
+    dst.setVal(amrex::Real(-7.0));
 
     set_component_value_at_k(cons, Rho_comp, 0, amrex::Real(2.0));
     set_component_value_at_k(cons, RhoQ2_comp, 0, amrex::Real(0.004));
 
-    for (amrex::MFIter mfi(cons, amrex::TilingIfNotGPU()); mfi.isValid(); ++mfi) {
-        const auto& cons_arr = cons.const_array(mfi);
-        const auto& z_cc_arr = z_phys_cc.const_array(mfi);
-        const auto& z_nd_arr = z_phys_nd.const_array(mfi);
+    Plotfile2DOutputDescriptor descriptor;
+    descriptor.name = "qc_k_0";
+    descriptor.long_name = "Cloud water sampled on model index levels";
+    descriptor.units = "kg/kg";
+    descriptor.category = DiagnosticCategory::SampledLevel;
+    descriptor.missing_policy = MissingPolicy::FillMinus999WhenUnavailable;
+    descriptor.missing_value = amrex::Real(-999.0);
+    descriptor.sampled_level = SampledLevelMetadata{
+        "microphysics",
+        "qc",
+        SampledVerticalCoordinateMetadata{
+            "model_index",
+            amrex::Real(0.0),
+            "1",
+            amrex::Real(0.0),
+            "1",
+            "none"
+        }
+    };
 
-        EXPECT_DOUBLE_EQ(sampled_field_value(SampledFieldID::Qc, cons_arr, z_cc_arr, z_nd_arr,
-                                             true, 0, 0, 0, MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, -1)),
-                         amrex::Real(0.002));
-        break;
-    }
+    plotfile2d::fill_sampled_level_component(dst, 0, descriptor,
+                                             cons, &z_phys_cc, z_phys_nd, true,
+                                             MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp, -1, -1),
+                                             0, 2);
+    amrex::Gpu::streamSynchronize();
+
+    EXPECT_DOUBLE_EQ(dst.min(0), amrex::Real(0.002));
+    EXPECT_DOUBLE_EQ(dst.max(0), amrex::Real(0.002));
 }
 
 // Motivation: Water-path diagnostics should disappear from the available list


### PR DESCRIPTION
## Summary

This PR adds descriptor-based sampled-level diagnostics to ERF 2D plotfiles.

Users can now define named 2D level sets and sample fields on:

- model-index levels,
- height above mean sea level,
- height above ground level,
- pressure levels.

The PR also adds cell-centered sampled wind diagnostics for plotting:

- `u_east`
- `v_north`
- `w`
- `wind_speed`
- `wind_dir`

Horizontal winds are earth-relative when map-rotation coefficients are available. Otherwise, ERF uses identity rotation. `wind_speed` and `wind_dir` are derived from the sampled horizontal wind vector. `wind_dir` uses meteorological convention: degrees clockwise from north, indicating where the wind comes from.

## User interface

Sampled-level diagnostics use the existing 2D plotfile streams:

```text
erf.plot2d_level_sets_1 = upper_air bl_heights
erf.plot2d.level_set.upper_air.coordinate = pressure
erf.plot2d.level_set.upper_air.units = hPa
erf.plot2d.level_set.upper_air.values = 850 700 500
erf.plot2d.level_set.upper_air.fields = theta temp qv qc u_east v_north wind_speed wind_dir
```

Required level-set keys:

```text
coordinate
values
fields
```

Optional keys:

```text
units
interpolation
missing_value
```

Sampled output names are deterministic:

```text
theta_p_850hPa
qv_p_700hPa
u_east_p_850hPa
v_north_p_850hPa
wind_speed_z_agl_500m
wind_dir_k_10
```

## Supported sampled fields

This PR supports:

```text
rho
theta
temp
pressure
height_msl
height_agl
qv
qc
qi
qr
qs
qg
u_east
v_north
w
wind_speed
wind_dir
```

Moisture fields are available only when the active moisture model exposes the corresponding species. Wind fields are cell-centered sampled-level diagnostics. ERF destaggers native face-centered velocities to scalar cell centers before vertical sampling.

## Metadata

Native AMReX 2D plotfiles now write descriptor-based `2DMetadata.json` entries for sampled-level output. Sampled diagnostics include:

```text
source_field
vertical_coordinate
canonical coordinate value and units
interpolation
missing value
category = SampledLevel
```

NetCDF output uses the same deterministic sampled variable names. Sampled-level metadata attributes remain native-AMReX sidecar metadata only.

## Implementation notes

- Keeps `ERF_Plotfile2D.cpp` as an output assembly layer.
- Moves sampled-level parsing, descriptor construction, field catalogs, and interpolation into dedicated IO helpers.
- Samples scalar fields through the existing conserved-state and terrain sources.
- Samples wind fields from `Vars::xvel`, `Vars::yvel`, and `Vars::zvel`.
- Destaggers winds to cell centers before sampling.
- Rotates horizontal winds to earth-relative components when rotation coefficients are available.
- Computes wind direction from the interpolated vector rather than interpolating direction as a scalar angle.
- Preserves the static 2D diagnostic catalog and compatibility path for built-in diagnostics.
- Keeps native face-centered velocity output separate from sampled-level 2D scalar output.

## Documentation

Updates `Docs/sphinx_doc/Plotfiles.rst` with user-facing documentation for:

- 2D plotfile controls,
- built-in 2D diagnostics,
- sampled-level syntax,
- supported coordinates,
- supported sampled fields,
- sampled wind semantics,
- output naming,
- metadata behavior,
- water-path diagnostics.

## Tests

Adds and updates unit tests covering:

- sampled-level parser validation,
- deterministic output naming,
- descriptor metadata,
- unavailable moisture fields,
- pressure unit canonicalization,
- model-index sampling,
- height and pressure interpolation,
- missing-value behavior outside the column,
- microphysical mixing-ratio output,
- dry-run thermodynamic behavior with `qv = 0`,
- sampled wind field catalog entries,
- wind metadata,
- face-to-cell wind destaggering,
- earth-relative wind rotation,
- calm-wind `wind_dir` missing-value behavior,
- vector-based wind interpolation.