### PR TITLE
Tests: use threadsafe sampled-level death tests

### DIFF
--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -412,6 +412,10 @@ TEST(Plotfile2DSampledLevel, ParsesHeightAGLLevelSet)
 // instead of falling through to a later interpolation failure.
 TEST(Plotfile2DSampledLevel, RejectsUnknownCoordinate)
 {
+    // AMReX initialization can leave helper threads alive, so use the
+    // threadsafe death-test style instead of fork-based death tests.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
     add_sampled_level_definition("bad_coordinate",
                                  "bogus_coordinate",
                                  {10.0},
@@ -425,6 +429,10 @@ TEST(Plotfile2DSampledLevel, RejectsUnknownCoordinate)
 // metadata cannot advertise a unit that the sampler does not canonicalize.
 TEST(Plotfile2DSampledLevel, RejectsUnsupportedUnits)
 {
+    // AMReX initialization can leave helper threads alive, so use the
+    // threadsafe death-test style instead of fork-based death tests.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
     add_sampled_level_definition("bad_units",
                                  "pressure",
                                  {850.0},
@@ -440,6 +448,10 @@ TEST(Plotfile2DSampledLevel, RejectsUnsupportedUnits)
 // rejected until that policy exists.
 TEST(Plotfile2DSampledLevel, RejectsIsentropicUntilCrossingPolicyExists)
 {
+    // AMReX initialization can leave helper threads alive, so use the
+    // threadsafe death-test style instead of fork-based death tests.
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
+
     add_sampled_level_definition("bad_isentropic",
                                  "isentropic",
                                  {300.0},


### PR DESCRIPTION
## Summary

- Force sampled-level parser death tests to use GoogleTest's `threadsafe` death-test style.
- Avoid fork-based death tests after AMReX initialization may have created runtime helper threads.
- Leave sampled-level parser behavior unchanged.

## Motivation

Hardware CI can hang in the sampled-level parser death tests after GoogleTest warns that `fork()` is unsafe while multiple threads are running. These tests intentionally exercise parser abort paths after `amrex::Initialize`, so using the threadsafe death-test style is the smallest test-harness-only fix.