### PR TITLE
Avoid sampled-level parser death tests

### DIFF
--- a/Source/IO/ERF_Plotfile2DSampledLevel.H
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.H
@@ -80,6 +80,8 @@ const char* sampled_coordinate_default_interpolation (SampledCoordinate coordina
 const char* sampled_interpolation_to_string (SampledInterpolation interpolation) noexcept;
 SampledCoordinate sampled_coordinate_from_string (const std::string& value);
 SampledInterpolation sampled_interpolation_from_string (const std::string& value);
+std::string validate_sampled_coordinate_string (const std::string& level_set_name,
+                                                const std::string& value);
 
 std::string sampled_level_error_prefix (const std::string& level_set_name,
                                        const std::string& parameter_name);

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -193,6 +193,25 @@ sampled_interpolation_from_string (const std::string& value)
 }
 
 std::string
+validate_sampled_coordinate_string (const std::string& level_set_name,
+                                    const std::string& value)
+{
+    if (string_iequals(value, "isentropic")) {
+        return sampled_level_error_prefix(level_set_name, "coordinate") +
+               "isentropic output needs a crossing policy";
+    }
+
+    if (string_iequals(value, "model_index") ||
+        string_iequals(value, "height_msl") ||
+        string_iequals(value, "height_agl") ||
+        string_iequals(value, "pressure")) {
+        return {};
+    }
+
+    return "Unknown sampled-level coordinate '" + value + "'";
+}
+
+std::string
 sampled_level_error_prefix (const std::string& level_set_name,
                             const std::string& parameter_name)
 {
@@ -275,8 +294,9 @@ validate_sampled_level_definition (const SampledLevelDefinition& level_set)
     }
 
     std::unordered_set<std::string> unique_fields(level_set.fields.begin(), level_set.fields.end());
-    const auto n_unique_fields    = static_cast<int>(unique_fields.size());
-    const auto n_requested_fields = static_cast<int>(level_set.fields.size());
+    const auto n_unique_fields = unique_fields.size();
+    const auto n_requested_fields =
+        static_cast<decltype(n_unique_fields)>(level_set.fields.size());
     if (n_unique_fields != n_requested_fields) {
         return sampled_level_error_prefix(level_set.name, "fields") +
                build_duplicate_output_error(level_set.name);
@@ -299,9 +319,10 @@ parse_sampled_level_definition (const std::string& level_set_name,
     if (!pp.query((base + "coordinate").c_str(), coordinate_value)) {
         amrex::Abort(build_missing_field_error(level_set_name, "coordinate"));
     }
-    if (string_iequals(coordinate_value, "isentropic")) {
-        amrex::Abort(sampled_level_error_prefix(level_set_name, "coordinate") +
-                     "isentropic output needs a crossing policy");
+    const std::string coordinate_error =
+        validate_sampled_coordinate_string(level_set_name, coordinate_value);
+    if (!coordinate_error.empty()) {
+        amrex::Abort(coordinate_error);
     }
     level_set.coordinate = sampled_coordinate_from_string(coordinate_value);
 

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -294,9 +294,8 @@ validate_sampled_level_definition (const SampledLevelDefinition& level_set)
     }
 
     std::unordered_set<std::string> unique_fields(level_set.fields.begin(), level_set.fields.end());
-    const auto n_unique_fields = unique_fields.size();
-    const auto n_requested_fields =
-        static_cast<decltype(n_unique_fields)>(level_set.fields.size());
+    const auto n_unique_fields    = static_cast<int>(unique_fields.size());
+    const auto n_requested_fields = static_cast<int>(level_set.fields.size());
     if (n_unique_fields != n_requested_fields) {
         return sampled_level_error_prefix(level_set.name, "fields") +
                build_duplicate_output_error(level_set.name);

--- a/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
+++ b/Tests/Unit/IO/ERF_GTestPlotfile2D.cpp
@@ -412,53 +412,50 @@ TEST(Plotfile2DSampledLevel, ParsesHeightAGLLevelSet)
 // instead of falling through to a later interpolation failure.
 TEST(Plotfile2DSampledLevel, RejectsUnknownCoordinate)
 {
-    // AMReX initialization can leave helper threads alive, so use the
-    // threadsafe death-test style instead of fork-based death tests.
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    const auto error = validate_sampled_coordinate_string("bad_coordinate", "bogus_coordinate");
 
-    add_sampled_level_definition("bad_coordinate",
-                                 "bogus_coordinate",
-                                 {10.0},
-                                 {"theta"});
-
-    EXPECT_DEATH(parse_sampled_level_definition("bad_coordinate", "erf"),
-                 "Unknown sampled-level coordinate");
+    EXPECT_TRUE(contains(error, "Unknown sampled-level coordinate"));
+    EXPECT_TRUE(contains(error, "bogus_coordinate"));
 }
 
 // Motivation: Unsupported units should be rejected at parse time so sampled
 // metadata cannot advertise a unit that the sampler does not canonicalize.
 TEST(Plotfile2DSampledLevel, RejectsUnsupportedUnits)
 {
-    // AMReX initialization can leave helper threads alive, so use the
-    // threadsafe death-test style instead of fork-based death tests.
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    SampledLevelDefinition level_set;
+    level_set.name = "bad_units";
+    level_set.coordinate = SampledCoordinate::Pressure;
+    level_set.units = "kPa";
+    level_set.values = {amrex::Real(850.0)};
+    level_set.fields = {"theta"};
+    level_set.interpolation = SampledInterpolation::Linear;
 
-    add_sampled_level_definition("bad_units",
-                                 "pressure",
-                                 {850.0},
-                                 {"theta"},
-                                 "kPa",
-                                 "linear");
+    const auto error = validate_sampled_level_definition(level_set);
 
-    EXPECT_DEATH(parse_sampled_level_definition("bad_units", "erf"),
-                 "unsupported units");
+    EXPECT_TRUE(contains(error, "unsupported units"));
+    EXPECT_TRUE(contains(error, "kPa"));
 }
 
 // Motivation: Isentropic output needs a crossing policy, so it must stay
 // rejected until that policy exists.
 TEST(Plotfile2DSampledLevel, RejectsIsentropicUntilCrossingPolicyExists)
 {
-    // AMReX initialization can leave helper threads alive, so use the
-    // threadsafe death-test style instead of fork-based death tests.
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
+    const auto error =
+        validate_sampled_coordinate_string("bad_isentropic", "isentropic");
 
-    add_sampled_level_definition("bad_isentropic",
-                                 "isentropic",
-                                 {300.0},
-                                 {"theta"});
+    EXPECT_TRUE(contains(error, "crossing policy"));
+    EXPECT_TRUE(contains(error, "bad_isentropic"));
+}
 
-    EXPECT_DEATH(parse_sampled_level_definition("bad_isentropic", "erf"),
-                 "crossing policy");
+// Motivation: Coordinate validation must accept the same public names as the
+// parser, including case-insensitive input.
+TEST(Plotfile2DSampledLevel, ValidCoordinateStringsPassValidation)
+{
+    for (const char* coordinate :
+         {"model_index", "height_msl", "height_agl", "pressure",
+          "MODEL_INDEX", "HEIGHT_MSL", "HEIGHT_AGL", "PRESSURE"}) {
+        EXPECT_EQ(validate_sampled_coordinate_string("valid_coordinate", coordinate), "");
+    }
 }
 
 // Motivation: Derived moisture aliases are out of scope for this sampled


### PR DESCRIPTION
## Summary

This PR fixes sampled-level 2D plotfile unit-test timeouts by replacing parser death tests with non-aborting validation tests.

The failing tests launched `EXPECT_DEATH(...)` subprocesses around sampled-level parser paths that call `amrex::Abort()`. In CI, those subprocesses can hang inside the AMReX/MPI unit-test environment until CTest times out.

This PR keeps production behavior unchanged: invalid sampled-level runtime input still aborts with the same user-facing error messages.

## Changes

- Adds `validate_sampled_coordinate_string(...)`.
- Uses that helper inside `parse_sampled_level_definition()` before converting the coordinate string.
- Keeps `sampled_coordinate_from_string()` aborting on unknown coordinate strings.
- Rewrites these tests to avoid `EXPECT_DEATH(...)`:
  - `Plotfile2DSampledLevel.RejectsUnknownCoordinate`
  - `Plotfile2DSampledLevel.RejectsUnsupportedUnits`
  - `Plotfile2DSampledLevel.RejectsIsentropicUntilCrossingPolicyExists`
- Adds `Plotfile2DSampledLevel.ValidCoordinateStringsPassValidation`.
- Removes all `EXPECT_DEATH`, `ASSERT_DEATH`, and `death_test_style` usage from the unit tests.