### PR TITLE
Correct SurfaceLayer LSM/MOST stress unit conversions

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -1,4 +1,5 @@
 #include "ERF_SurfaceLayer.H"
+#include "ERF_SurfaceLayerStress.H"
 
 using namespace amrex;
 
@@ -552,6 +553,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         auto lsm_q_flux_arr = Array4<Real> {};
         auto lsm_tau13_arr  = Array4<Real> {};
         auto lsm_tau23_arr  = Array4<Real> {};
+        // LSM tau fields are cell-centered kinematic stresses [m2 s-2].
+        // Tau_lev tau13/tau23 are face-centered conservative stresses [N m-2].
         for (int n(0); n<m_lsm_flux_lev[lev].size(); ++n) {
             if (toLower(m_lsm_flux_name[n]) == "t_flux") { lsm_t_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }
             if (toLower(m_lsm_flux_name[n]) == "q_flux") { lsm_q_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }
@@ -654,42 +657,39 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 Real stressx;
                 int is_land_hi = (lmask_arr) ? lmask_arr(i  ,j,0) : 1;
                 int is_land_lo = (lmask_arr) ? lmask_arr(i-1,j,0) : 1;
-                const bool lsm_hi_flux_is_valid = (lsm_tau13_arr) ? (lsm_tau13_arr(i  ,j,0) < lsm_undefined) :
-                                                                    false;
-                const bool lsm_lo_flux_is_valid = (lsm_tau13_arr) ? (lsm_tau13_arr(i-1,j,0) < lsm_undefined) :
-                                                                    false;
+                const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
+                    static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_hi),
+                    lsm_tau13_arr ? lsm_tau13_arr(i  ,j,0) : zero, lsm_undefined);
+                const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
+                    static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_lo),
+                    lsm_tau13_arr ? lsm_tau13_arr(i-1,j,0) : zero, lsm_undefined);
                 const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
                 const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
                 if (lsm_tau13_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
-                    stressx = zero;
-                    if (!has_land_and_flux_hi || !has_land_and_flux_lo) {
-                        stressx += myhalf * flux_comp.compute_u_flux(i, j, k,
-                                                                     cons_arr, velx_arr, vely_arr,
-                                                                     umm_arr, um_arr, u_star_arr);
-                        if (!has_land_and_flux_hi) {
-                            lsm_tau13_arr(i  ,j,0) = two * stressx;
-                        }
-                        if (!has_land_and_flux_lo) {
-                            lsm_tau13_arr(i-1,j,0) = two * stressx;
-                        }
-                    }
-                    if (has_land_and_flux_hi) {
-                        const Real rho_hi = cons_arr(i  ,j,k,Rho_comp);
-                        // LSM tau13 is kinematic for u_star; Tau stores conservative stress.
-                        stressx += myhalf * rho_hi * lsm_tau13_arr(i  ,j,0);
-                    }
-                    if (has_land_and_flux_lo) {
-                        const Real rho_lo = cons_arr(i-1,j,k,Rho_comp);
-                        // LSM tau13 is kinematic for u_star; Tau stores conservative stress.
-                        stressx += myhalf * rho_lo * lsm_tau13_arr(i-1,j,0);
-                    }
+                    const Real rho_hi = cons_arr(i  ,j,k,Rho_comp);
+                    const Real rho_lo = cons_arr(i-1,j,k,Rho_comp);
+                    const Real most_stress = (!has_land_and_flux_hi || !has_land_and_flux_lo) ?
+                        flux_comp.compute_u_flux(i, j, k,
+                                                 cons_arr, velx_arr, vely_arr,
+                                                 umm_arr, um_arr, u_star_arr) : zero;
+                    const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+                        rho_lo, rho_hi, lsm_tau13_arr(i-1,j,0), lsm_tau13_arr(i,j,0),
+                        has_land_and_flux_lo, has_land_and_flux_hi, most_stress);
+                    stressx = result.face_stress;
+                    if (!has_land_and_flux_lo) { lsm_tau13_arr(i-1,j,0) = result.low_kinematic_cache; }
+                    if (!has_land_and_flux_hi) { lsm_tau13_arr(i  ,j,0) = result.high_kinematic_cache; }
                 } else {
                     stressx = flux_comp.compute_u_flux(i, j, k,
                                                        cons_arr, velx_arr, vely_arr,
                                                        umm_arr, um_arr, u_star_arr);
                     if (lsm_tau13_arr) {
-                        lsm_tau13_arr(i  ,j,0) = stressx / cons_arr(i  ,j,k,Rho_comp);
-                        lsm_tau13_arr(i-1,j,0) = stressx / cons_arr(i-1,j,k,Rho_comp);
+                        // LSM tau13 is cell-centered kinematic stress [m2 s-2].
+                        // Tau_lev tau13 is a face-centered conservative stress [N m-2].
+                        // MOST compute_u_flux returns the conservative face stress.
+                        lsm_tau13_arr(i  ,j,0) = surface_layer_stress::conservative_to_kinematic_stress(
+                            stressx, cons_arr(i  ,j,k,Rho_comp));
+                        lsm_tau13_arr(i-1,j,0) = surface_layer_stress::conservative_to_kinematic_stress(
+                            stressx, cons_arr(i-1,j,k,Rho_comp));
                     }
                 }
 
@@ -706,42 +706,39 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 Real stressy;
                 int is_land_hi = (lmask_arr) ? lmask_arr(i,j  ,0) : 1;
                 int is_land_lo = (lmask_arr) ? lmask_arr(i,j-1,0) : 1;
-                const bool lsm_hi_flux_is_valid = (lsm_tau13_arr) ? (lsm_tau23_arr(i,j  ,0) < lsm_undefined) :
-                                                                    false;
-                const bool lsm_lo_flux_is_valid = (lsm_tau13_arr) ? (lsm_tau23_arr(i,j-1,0) < lsm_undefined) :
-                                                                    false;
+                const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
+                    static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_hi),
+                    lsm_tau23_arr ? lsm_tau23_arr(i,j  ,0) : zero, lsm_undefined);
+                const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
+                    static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_lo),
+                    lsm_tau23_arr ? lsm_tau23_arr(i,j-1,0) : zero, lsm_undefined);
                 const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
                 const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
                 if (lsm_tau23_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
-                    stressy = zero;
-                    if (!has_land_and_flux_hi || !has_land_and_flux_lo) {
-                        stressy += myhalf * flux_comp.compute_v_flux(i, j, k,
-                                                                  cons_arr, velx_arr, vely_arr,
-                                                                  umm_arr, vm_arr, u_star_arr);
-                        if (!has_land_and_flux_hi) {
-                            lsm_tau23_arr(i,j  ,0) = two * stressy;
-                        }
-                        if (!has_land_and_flux_lo) {
-                            lsm_tau23_arr(i,j-1,0) = two * stressy;
-                        }
-                    }
-                    if (has_land_and_flux_hi) {
-                        const Real rho_hi = cons_arr(i,j  ,k,Rho_comp);
-                        // LSM tau23 is kinematic for u_star; Tau stores conservative stress.
-                        stressy += myhalf * rho_hi * lsm_tau23_arr(i,j  ,0);
-                    }
-                    if (has_land_and_flux_lo) {
-                        const Real rho_lo = cons_arr(i,j-1,k,Rho_comp);
-                        // LSM tau23 is kinematic for u_star; Tau stores conservative stress.
-                        stressy += myhalf * rho_lo * lsm_tau23_arr(i,j-1,0);
-                    }
+                    const Real rho_hi = cons_arr(i,j  ,k,Rho_comp);
+                    const Real rho_lo = cons_arr(i,j-1,k,Rho_comp);
+                    const Real most_stress = (!has_land_and_flux_hi || !has_land_and_flux_lo) ?
+                        flux_comp.compute_v_flux(i, j, k,
+                                                 cons_arr, velx_arr, vely_arr,
+                                                 umm_arr, vm_arr, u_star_arr) : zero;
+                    const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+                        rho_lo, rho_hi, lsm_tau23_arr(i,j-1,0), lsm_tau23_arr(i,j,0),
+                        has_land_and_flux_lo, has_land_and_flux_hi, most_stress);
+                    stressy = result.face_stress;
+                    if (!has_land_and_flux_lo) { lsm_tau23_arr(i,j-1,0) = result.low_kinematic_cache; }
+                    if (!has_land_and_flux_hi) { lsm_tau23_arr(i,j  ,0) = result.high_kinematic_cache; }
                 } else {
                     stressy = flux_comp.compute_v_flux(i, j, k,
                                                        cons_arr, velx_arr, vely_arr,
                                                        umm_arr, vm_arr, u_star_arr);
                     if (lsm_tau23_arr) {
-                        lsm_tau23_arr(i,j  ,0) = stressy;
-                        lsm_tau23_arr(i,j-1,0) = stressy;
+                        // LSM tau23 is cell-centered kinematic stress [m2 s-2].
+                        // Tau_lev tau23 is a face-centered conservative stress [N m-2].
+                        // MOST compute_v_flux returns the conservative face stress.
+                        lsm_tau23_arr(i,j  ,0) = surface_layer_stress::conservative_to_kinematic_stress(
+                            stressy, cons_arr(i,j  ,k,Rho_comp));
+                        lsm_tau23_arr(i,j-1,0) = surface_layer_stress::conservative_to_kinematic_stress(
+                            stressy, cons_arr(i,j-1,k,Rho_comp));
                     }
                 }
 
@@ -1003,6 +1000,8 @@ SurfaceLayer::compute_sfc_params_from_lsm_fluxes (const int& lev,
         auto lsm_q_flux_arr = Array4<Real> {};
         auto lsm_tau13_arr  = Array4<Real> {};
         auto lsm_tau23_arr  = Array4<Real> {};
+        // compute_sfc_params_from_lsm_fluxes consumes signed kinematic stress
+        // components; their vector magnitude determines u_star^2.
         for (int n(0); n<m_lsm_flux_lev[lev].size(); ++n) {
             if (toLower(m_lsm_flux_name[n]) == "t_flux") { lsm_t_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }
             if (toLower(m_lsm_flux_name[n]) == "q_flux") { lsm_q_flux_arr = m_lsm_flux_lev[lev][n]->array(mfi); }

--- a/Source/BoundaryConditions/ERF_SurfaceLayerStress.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayerStress.H
@@ -1,0 +1,80 @@
+#ifndef ERF_SURFACE_LAYER_STRESS_H_
+#define ERF_SURFACE_LAYER_STRESS_H_
+
+#include "AMReX_GpuQualifiers.H"
+#include "AMReX_REAL.H"
+
+namespace surface_layer_stress {
+
+/** LSM cache value from a conservative face stress. */
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+amrex::Real
+conservative_to_kinematic_stress(
+  amrex::Real conservative_stress, amrex::Real rho)
+{
+  return conservative_stress / rho;
+}
+
+/** Test one LSM side without coupling validity to another component's handle.
+ */
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+bool
+lsm_flux_is_valid(
+  bool has_flux, bool is_land, amrex::Real flux, amrex::Real undefined)
+{
+  return has_flux && is_land && flux < undefined;
+}
+
+struct FaceStressResult
+{
+  amrex::Real face_stress;
+  amrex::Real low_kinematic_cache;
+  amrex::Real high_kinematic_cache;
+};
+
+/**
+ * Combine cell-centered kinematic LSM stresses with a conservative MOST
+ * fallback stress at one face. The returned cache values are always
+ * kinematic, while face_stress is always conservative.
+ */
+AMREX_GPU_HOST_DEVICE
+AMREX_FORCE_INLINE
+FaceStressResult
+combine_lsm_and_most_stress(
+  amrex::Real rho_low,
+  amrex::Real rho_high,
+  amrex::Real kinematic_low,
+  amrex::Real kinematic_high,
+  bool low_valid,
+  bool high_valid,
+  amrex::Real most_face_stress)
+{
+  const amrex::Real half = amrex::Real(0.5);
+  FaceStressResult result{
+    amrex::Real(0.0),
+    low_valid ? kinematic_low
+              : conservative_to_kinematic_stress(most_face_stress, rho_low),
+    high_valid ? kinematic_high
+               : conservative_to_kinematic_stress(most_face_stress, rho_high)};
+
+  if (low_valid && high_valid) {
+    result.face_stress =
+      half * rho_low * kinematic_low + half * rho_high * kinematic_high;
+  } else if (low_valid) {
+    result.face_stress =
+      half * rho_low * kinematic_low + half * most_face_stress;
+  } else if (high_valid) {
+    result.face_stress =
+      half * rho_high * kinematic_high + half * most_face_stress;
+  } else {
+    result.face_stress = most_face_stress;
+  }
+
+  return result;
+}
+
+} // namespace surface_layer_stress
+
+#endif

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.cpp
@@ -685,7 +685,8 @@ NOAHMP::Advance_With_State (const int& lev,
                     // MOST form (no rho):
                     //   t_flux = <theta' w'>   [K m/s]   (ERF_MOSTStress.H, surf_temp_flux)
                     //   q_flux = <qv' w'>      [kg/kg m/s]
-                    //   tau13/23 = u*^2 comps  [m2/s2]   (SurfaceLayer.cpp: u*=sqrt(tau))
+                    //   tau13/23 = signed kinematic velocity-covariance components [m2/s2]
+                    //              whose vector magnitude determines u_star^2
                     // Noah-MP returns HFX,LH [W/m2] and TAU_EW/NS [N/m2] (rho INCLUDED),
                     // so we divide by rho. rho is dry-air density (~1.14 kg/m3).
                     //

--- a/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
+++ b/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
@@ -30,6 +30,9 @@ expect_result(
 
 } // namespace
 
+// Motivation: LSM stress caches are kinematic, while MOST and Tau_lev use
+// conservative stresses. The conversion must preserve both stress sign and
+// the conservative value reconstructed with the destination-cell density.
 TEST(SurfaceLayerStress, ConservativeToKinematicRoundTripHandlesSignedStress)
 {
   for (const Real conservative : {Real(2.4), Real(-2.4)}) {
@@ -40,6 +43,8 @@ TEST(SurfaceLayerStress, ConservativeToKinematicRoundTripHandlesSignedStress)
   }
 }
 
+// Motivation: When both neighboring LSM values are valid, the face stress
+// must be the density-weighted average of the two kinematic contributions.
 TEST(SurfaceLayerStress, BothValidUsesDensityWeightedFaceAverage)
 {
   const auto result = surface_layer_stress::combine_lsm_and_most_stress(
@@ -48,6 +53,8 @@ TEST(SurfaceLayerStress, BothValidUsesDensityWeightedFaceAverage)
     result, Real(0.5) * (rho_low * k_low + rho_high * k_high), k_low, k_high);
 }
 
+// Motivation: A missing low-side LSM value is populated from the conservative
+// MOST stress, but the cache must be divided by the low cell's own density.
 TEST(SurfaceLayerStress, HighValidCachesMostStressInLowCellUnits)
 {
   const auto result = surface_layer_stress::combine_lsm_and_most_stress(
@@ -56,6 +63,8 @@ TEST(SurfaceLayerStress, HighValidCachesMostStressInLowCellUnits)
     result, Real(0.5) * (rho_high * k_high + most), most / rho_low, k_high);
 }
 
+// Motivation: The opposite mixed branch must use the high cell's density when
+// converting the same conservative MOST stress back to a kinematic cache.
 TEST(SurfaceLayerStress, LowValidCachesMostStressInHighCellUnits)
 {
   const auto result = surface_layer_stress::combine_lsm_and_most_stress(
@@ -64,6 +73,8 @@ TEST(SurfaceLayerStress, LowValidCachesMostStressInHighCellUnits)
     result, Real(0.5) * (rho_low * k_low + most), k_low, most / rho_high);
 }
 
+// Motivation: With no valid LSM side, the applied face stress remains the
+// conservative MOST result while each neighboring cache remains kinematic.
 TEST(SurfaceLayerStress, NeitherValidKeepsMostFaceStressAndConvertsBothCaches)
 {
   const auto result = surface_layer_stress::combine_lsm_and_most_stress(
@@ -73,6 +84,9 @@ TEST(SurfaceLayerStress, NeitherValidKeepsMostFaceStressAndConvertsBothCaches)
   EXPECT_NEAR(rho_high * result.high_kinematic_cache, most, Real(1.e-12));
 }
 
+// Motivation: tau13 and tau23 represent equivalent directional momentum
+// covariances; a unit correction in one staggered branch must apply identically
+// to the other.
 TEST(SurfaceLayerStress, XAndYComponentsUseIdenticalBranchAlgebra)
 {
   const auto x_result = surface_layer_stress::combine_lsm_and_most_stress(
@@ -84,6 +98,8 @@ TEST(SurfaceLayerStress, XAndYComponentsUseIdenticalBranchAlgebra)
     x_result.high_kinematic_cache);
 }
 
+// Motivation: The tau23 fallback decision must depend on the tau23 MultiFab,
+// otherwise an absent tau13 field can incorrectly disable valid tau23 data.
 TEST(SurfaceLayerStress, Tau23ValidityUsesItsOwnHandle)
 {
   const bool has_tau13 = false;
@@ -96,6 +112,8 @@ TEST(SurfaceLayerStress, Tau23ValidityUsesItsOwnHandle)
     has_tau23, false, Real(-0.4), Real(9999.0)));
 }
 
+// Motivation: Fallback caches are reused on later calls. Storing a conservative
+// value in a kinematic field would multiply the reconstructed stress by rho.
 TEST(SurfaceLayerStress, ReusingFallbackCacheReconstructsMostStress)
 {
   const auto fallback = surface_layer_stress::combine_lsm_and_most_stress(
@@ -106,6 +124,10 @@ TEST(SurfaceLayerStress, ReusingFallbackCacheReconstructsMostStress)
   EXPECT_NEAR(reused.face_stress, most, Real(1.e-12));
 }
 
+// Motivation: Surface stresses reach the prognostic face momenta through the
+// diffusion RHS. Negative upward momentum fluxes at the lower boundary must
+// produce negative u- and v-momentum tendencies and the expected explicit
+// update.
 TEST(SurfaceLayerStress, DiffusionSrcForMomAppliesSignedBottomStresses)
 {
   const Box cell_box(IntVect(0), IntVect(1, 1, 0));

--- a/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
+++ b/Tests/Unit/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
@@ -1,0 +1,186 @@
+#include "AMReX.H"
+#include "AMReX_MultiFab.H"
+
+#include "ERF_Diffusion.H"
+#include "ERF_SurfaceLayerStress.H"
+
+#include <gtest/gtest.h>
+
+using namespace amrex;
+
+namespace {
+
+constexpr Real rho_low = Real(0.8);
+constexpr Real rho_high = Real(1.3);
+constexpr Real k_low = Real(-0.7);
+constexpr Real k_high = Real(0.45);
+constexpr Real most = Real(-2.6);
+
+void
+expect_result(
+  const surface_layer_stress::FaceStressResult& result,
+  Real expected_face,
+  Real expected_low,
+  Real expected_high)
+{
+  EXPECT_NEAR(result.face_stress, expected_face, Real(1.e-12));
+  EXPECT_NEAR(result.low_kinematic_cache, expected_low, Real(1.e-12));
+  EXPECT_NEAR(result.high_kinematic_cache, expected_high, Real(1.e-12));
+}
+
+} // namespace
+
+TEST(SurfaceLayerStress, ConservativeToKinematicRoundTripHandlesSignedStress)
+{
+  for (const Real conservative : {Real(2.4), Real(-2.4)}) {
+    const Real kinematic =
+      surface_layer_stress::conservative_to_kinematic_stress(
+        conservative, rho_low);
+    EXPECT_NEAR(rho_low * kinematic, conservative, Real(1.e-12));
+  }
+}
+
+TEST(SurfaceLayerStress, BothValidUsesDensityWeightedFaceAverage)
+{
+  const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, true, true, most);
+  expect_result(
+    result, Real(0.5) * (rho_low * k_low + rho_high * k_high), k_low, k_high);
+}
+
+TEST(SurfaceLayerStress, HighValidCachesMostStressInLowCellUnits)
+{
+  const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, false, true, most);
+  expect_result(
+    result, Real(0.5) * (rho_high * k_high + most), most / rho_low, k_high);
+}
+
+TEST(SurfaceLayerStress, LowValidCachesMostStressInHighCellUnits)
+{
+  const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, true, false, most);
+  expect_result(
+    result, Real(0.5) * (rho_low * k_low + most), k_low, most / rho_high);
+}
+
+TEST(SurfaceLayerStress, NeitherValidKeepsMostFaceStressAndConvertsBothCaches)
+{
+  const auto result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, false, false, most);
+  expect_result(result, most, most / rho_low, most / rho_high);
+  EXPECT_NEAR(rho_low * result.low_kinematic_cache, most, Real(1.e-12));
+  EXPECT_NEAR(rho_high * result.high_kinematic_cache, most, Real(1.e-12));
+}
+
+TEST(SurfaceLayerStress, XAndYComponentsUseIdenticalBranchAlgebra)
+{
+  const auto x_result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, false, true, most);
+  const auto y_result = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, false, true, most);
+  expect_result(
+    y_result, x_result.face_stress, x_result.low_kinematic_cache,
+    x_result.high_kinematic_cache);
+}
+
+TEST(SurfaceLayerStress, Tau23ValidityUsesItsOwnHandle)
+{
+  const bool has_tau13 = false;
+  const bool has_tau23 = true;
+  EXPECT_FALSE(surface_layer_stress::lsm_flux_is_valid(
+    has_tau13, true, Real(-0.4), Real(9999.0)));
+  EXPECT_TRUE(surface_layer_stress::lsm_flux_is_valid(
+    has_tau23, true, Real(-0.4), Real(9999.0)));
+  EXPECT_FALSE(surface_layer_stress::lsm_flux_is_valid(
+    has_tau23, false, Real(-0.4), Real(9999.0)));
+}
+
+TEST(SurfaceLayerStress, ReusingFallbackCacheReconstructsMostStress)
+{
+  const auto fallback = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, k_low, k_high, false, false, most);
+  const auto reused = surface_layer_stress::combine_lsm_and_most_stress(
+    rho_low, rho_high, fallback.low_kinematic_cache,
+    fallback.high_kinematic_cache, true, true, Real(0.0));
+  EXPECT_NEAR(reused.face_stress, most, Real(1.e-12));
+}
+
+TEST(SurfaceLayerStress, DiffusionSrcForMomAppliesSignedBottomStresses)
+{
+  const Box cell_box(IntVect(0), IntVect(1, 1, 0));
+  const BoxArray ba(cell_box);
+  const DistributionMapping dm(ba);
+
+  MultiFab rho_u_rhs(BoxArray(surroundingNodes(cell_box, 0)), dm, 1, 0);
+  MultiFab rho_v_rhs(BoxArray(surroundingNodes(cell_box, 1)), dm, 1, 0);
+  MultiFab rho_w_rhs(BoxArray(surroundingNodes(cell_box, 2)), dm, 1, 0);
+  rho_u_rhs.setVal(Real(0.0));
+  rho_v_rhs.setVal(Real(0.0));
+  rho_w_rhs.setVal(Real(0.0));
+
+  MultiFab tau11(ba, dm, 1, 1);
+  MultiFab tau22(ba, dm, 1, 1);
+  MultiFab tau33(ba, dm, 1, 1);
+  MultiFab tau12(BoxArray(convert(cell_box, IntVect(1, 1, 0))), dm, 1, 1);
+  MultiFab tau21(BoxArray(convert(cell_box, IntVect(1, 1, 0))), dm, 1, 1);
+  MultiFab tau13(BoxArray(convert(cell_box, IntVect(1, 0, 1))), dm, 1, 1);
+  MultiFab tau31(BoxArray(convert(cell_box, IntVect(1, 0, 1))), dm, 1, 1);
+  MultiFab tau23(BoxArray(convert(cell_box, IntVect(0, 1, 1))), dm, 1, 1);
+  MultiFab tau32(BoxArray(convert(cell_box, IntVect(0, 1, 1))), dm, 1, 1);
+  tau11.setVal(Real(0.0));
+  tau22.setVal(Real(0.0));
+  tau33.setVal(Real(0.0));
+  tau12.setVal(Real(0.0));
+  tau21.setVal(Real(0.0));
+  tau13.setVal(Real(0.0));
+  tau31.setVal(Real(0.0));
+  tau23.setVal(Real(0.0));
+  tau32.setVal(Real(0.0));
+
+  const Real tx = Real(-1.7);
+  const Real ty = Real(-0.9);
+  tau13[0].array()(0, 0, 0) = tx;
+  tau23[0].array()(0, 0, 0) = ty;
+
+  MultiFab detJ(ba, dm, 1, 1);
+  MultiFab mf_mx(ba, dm, 1, 1);
+  MultiFab mf_ux(ba, dm, 1, 1);
+  MultiFab mf_vx(ba, dm, 1, 1);
+  MultiFab mf_my(ba, dm, 1, 1);
+  MultiFab mf_uy(ba, dm, 1, 1);
+  MultiFab mf_vy(ba, dm, 1, 1);
+  detJ.setVal(Real(1.0));
+  mf_mx.setVal(Real(1.0));
+  mf_ux.setVal(Real(1.0));
+  mf_vx.setVal(Real(1.0));
+  mf_my.setVal(Real(1.0));
+  mf_uy.setVal(Real(1.0));
+  mf_vy.setVal(Real(1.0));
+
+  Gpu::DeviceVector<Real> stretched_dz_d;
+  GpuArray<Real, AMREX_SPACEDIM> dxInv{Real(1.0), Real(1.0), Real(1.0)};
+
+  DiffusionSrcForMom(
+    surroundingNodes(cell_box, 0), surroundingNodes(cell_box, 1),
+    surroundingNodes(cell_box, 2), rho_u_rhs[0].array(), rho_v_rhs[0].array(),
+    rho_w_rhs[0].array(), tau11[0].const_array(), tau22[0].const_array(),
+    tau33[0].const_array(), tau12[0].const_array(), tau21[0].const_array(),
+    tau13[0].const_array(), tau31[0].const_array(), tau23[0].const_array(),
+    tau32[0].const_array(), detJ[0].const_array(), stretched_dz_d, dxInv,
+    mf_mx[0].const_array(), mf_ux[0].const_array(), mf_vx[0].const_array(),
+    mf_my[0].const_array(), mf_uy[0].const_array(), mf_vy[0].const_array(),
+    false, false);
+  Gpu::streamSynchronize();
+
+  EXPECT_NEAR(rho_u_rhs[0].array()(0, 0, 0), tx, Real(1.e-12));
+  EXPECT_NEAR(rho_v_rhs[0].array()(0, 0, 0), ty, Real(1.e-12));
+
+  const Real dt = Real(0.25);
+  const Real old_u = Real(2.0);
+  const Real old_v = Real(1.0);
+  EXPECT_NEAR(
+    old_u + dt * rho_u_rhs[0].array()(0, 0, 0), old_u + dt * tx, Real(1.e-12));
+  EXPECT_NEAR(
+    old_v + dt * rho_v_rhs[0].array()(0, 0, 0), old_v + dt * ty, Real(1.e-12));
+}

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -64,6 +64,7 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestHelloWorld.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/BoundaryConditions/ERF_GTestSurfaceDiagnosticSource.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Diagnostics/ERF_GTestSurfaceFluxDiagnostics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestPlotfile2D.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp


### PR DESCRIPTION
# Summary

This PR fixes inconsistent stress units in the SurfaceLayer coupling between land-surface-model fluxes and MOST fallback stresses.

The LSM `tau13` and `tau23` fields store cell-centered kinematic stresses with units of m² s⁻², while the face-centered `Tau_lev` fields passed to momentum diffusion store conservative stresses with units of N m⁻². Several fallback paths previously wrote conservative MOST stresses directly into the kinematic LSM fields. When those cached values were reused, ERF multiplied them by density again, producing an incorrectly scaled momentum stress.

This PR:

* adds a small GPU-compatible helper that explicitly distinguishes kinematic LSM cache values from conservative face stresses;
* converts conservative MOST stresses to kinematic form using the density of the destination cell before writing fallback values into `tau13` or `tau23`;
* applies the same conversion in full and mixed LSM/MOST fallback paths;
* fixes the `tau23` validity checks to use the `tau23` field rather than the `tau13` handle;
* preserves the existing density-weighted face interpolation when both neighboring LSM stresses are valid; and
* documents the stress-unit contract at the Noah-MP and SurfaceLayer interfaces.

## Testing

Adds unit coverage for:

* conservative-to-kinematic stress conversion for positive and negative stresses;
* both-valid, one-sided fallback, and full-fallback face combinations;
* use of each destination cell’s density;
* reuse of a fallback-populated cache without introducing an additional density factor;
* equivalent x- and y-component branch algebra;
* independent `tau23` validity handling; and
* application of signed lower-boundary `tau13` and `tau23` stresses through `DiffusionSrcForMom` into the prognostic momentum tendencies.

The tests deliberately use unequal, non-unit densities so the previous density-scaling error cannot be hidden.
