### PR TITLE
Change defaults for immersed forcing depending on solver + doc bug fix

### DIFF
--- a/Docs/sphinx_doc/theory/Forcings.rst
+++ b/Docs/sphinx_doc/theory/Forcings.rst
@@ -186,7 +186,7 @@ The goal is to force interior cells to near-zero velocities using the following 
 
 .. math::
 
-    F_{\rho u_i} = -C_{d,m} \beta_r \sqrt[3]{\Delta x \Delta y \Delta z} \rho u_i U
+    F_{\rho u_i} = -C_{d,m} \beta_r \left(\sqrt[3]{\Delta x_1 \Delta x_2 \Delta x_3}\right)^{-1} \rho u_i U
 
 where :math:`C_{d,m}` is a drag coefficient and :math:`U` is the wind speed magnitude.
 The drag coefficient can be specified by the user using ``erf.if_Cd_momentum``, which defaults to a value of 10.
@@ -198,7 +198,7 @@ If the user does specify MOST, then the following formulation is applied to part
 
 .. math::
 
-    F_{\rho u_i} = -C_{d,m} (1 - \beta_r) \sqrt[3]{\Delta x \Delta y \Delta z} \rho |U_s| (u_i - u_{i,target})
+    F_{\rho u_i} = -C_{d,m} (1 - \beta_r) \left(\sqrt[3]{\Delta x_1 \Delta x_2 \Delta x_3}\right)^{-1} \rho |U_s| (u_i - u_{i,target})
 
 where :math:`u_{i,target}` is a value determined through MOST and :math:`|U_s|` is a unit velocity scale.
 This formulation essentially forces the velocity at the wall to a value determined by using MOST, but the strength forcing is inversely related to how immersed the cell is.
@@ -210,7 +210,7 @@ The temperature forcing is then formulated as follows:
 
 .. math::
 
-    F_{\rho\theta} = -C_{d,s} \beta_r \sqrt[3]{\Delta x \Delta y \Delta z} |U_s| (\rho \theta_{target} - \rho\theta)
+    F_{\rho\theta} = -C_{d,s} \beta_r \left(\sqrt[3]{\Delta x_1 \Delta x_2 \Delta x_3}\right)^{-1} |U_s| (\rho \theta_{target} - \rho\theta)
 
 The target temperature :math:`\theta_{target}`` is straightforward when using a surface temperature and heating rate; when specifying a surface flux or Obukhov length, the target temperature is determined using MOST.
 The following inputs are available when representing terrain using immersed forcing:
@@ -241,7 +241,7 @@ The momentum forcing is defined as follows:
 
 .. math::
 
-    F_{\rho u_i} = -C_{d,m} \beta_r V_f \sqrt[3]{\Delta x \Delta y \Delta z} \rho u_i U
+    F_{\rho u_i} = -C_{d,m} \beta_r V_f \left(\sqrt[3]{\Delta x_1 \Delta x_2 \Delta x_3}\right)^{-1} \rho u_i U
 
 Temperature forcing for building walls and roofs can similar be specified following the same formulation as immersed forcing for terrain; however, only the option to specify a surface temperature and heating rate is currently available.
 

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -427,14 +427,31 @@ struct SolverChoice {
         read_int_string(max_level, "fixed_density", fixed_density, 0);
         read_int_string(max_level, "project_initial_velocity", project_initial_velocity, 0);
 
+        bool any_anelastic = false;
+        bool any_compress  = false;
         for (int i = 0; i <= max_level; ++i) {
             if (anelastic[i] == 1) {
                 project_initial_velocity[i] = 1;
                 fixed_density[i]            = 1; // We default to true but are allowed to override below
                 buoyancy_type[i]            = 3; // (This isn't actually used when anelastic is set)
+                any_anelastic               = true;
+            } else {
+                any_compress                = true;
             }
         }
 
+        // Want to have different immersed forcing defaults depending on anelastic or fully compressible.
+        // We should have different starting values because the stability of the method is dependent on dt.
+        // dt is coarser for anelastic --> need to loosen stiffness of immersed forcing.
+        if (any_anelastic) {
+            immersed_forcing_substep  = false;
+            if_Cd_momentum            = amrex::Real(50.0);
+            if_Cd_scalar              = amrex::Real(5.0);
+        } else {
+            immersed_forcing_substep  = true;
+            if_Cd_momentum            = amrex::Real(500.0);
+            if_Cd_scalar              = amrex::Real(50.0);
+        }
 
         // *******************************************************************************
         // Read substepping_type and allow for different values at each level
@@ -494,8 +511,8 @@ struct SolverChoice {
         pp.query("forest_substep", forest_substep);                     // apply canopy-related source terms in substep only
 
         // immersed forcing parameters
-        pp.query("if_Cd_scalar", if_Cd_scalar);
         pp.query("if_Cd_momentum", if_Cd_momentum);
+        pp.query("if_Cd_scalar", if_Cd_scalar);
         pp.query("if_z0", if_z0);
         pp.query("if_surf_temp_flux", if_surf_temp_flux);
         pp.query("if_init_surf_temp", if_init_surf_temp);
@@ -776,15 +793,6 @@ struct SolverChoice {
         pp.query_enum_case_insensitive("coupling_type",coupling_type);
 
         // Test for hybrid (compressible + anelastic) -- in this case we must use one-way coupling
-        bool any_anelastic = false;
-        bool any_compress  = false;
-        for (int lev = 0; lev <= max_level; lev++) {
-            if (anelastic[lev] == 0) {
-                any_compress = true;
-            } else {
-                any_anelastic = true;
-            }
-        }
         if (any_anelastic && any_compress) {
             coupling_type = CouplingType::OneWay;
         }
@@ -1280,8 +1288,8 @@ struct SolverChoice {
     bool        forest_substep            = false;
 
     // immersed forcing parameters
+    amrex::Real if_Cd_momentum        = amrex::Real(50.0);
     amrex::Real if_Cd_scalar          = amrex::Real(10.0);
-    amrex::Real if_Cd_momentum        = amrex::Real(10.0);
     // immersed forcing MOST parameters.
     amrex::Real if_z0                 = amrex::Real(0.1);   // [m]
     amrex::Real if_surf_temp_flux     = amrex::Real(1e-8);  // [K m/s]


### PR DESCRIPTION
I changed the defaults of the drag coefficients for immersed forcing to be dependent on the solver. 

For fully compressible, we are sub stepping and the default should be to apply the forcing on the substep. Because we are applying the term on the substep, the dt is smaller and we can use a stronger drag coefficient without the code becoming numerically unstable. The stability limit of the forcing term is a function of the time step.

For anelastic, the forcing term cannot be applied on the substep and we have a coarser dt; therefore, the drag coefficient needs to be weaker to be numerically stable.

I leveraged some code that was being used further down in the function that checked if any level is anelastic or fully compressible but moved it up to where we initially read which solver we are using at what level. The IF parameters are not per level so that's why I just check whether any single level is anelastic. Using IF with the hybrid (compressible + anelastic) solver has not been tested.

Let me know if this makes sense or not, happy to iterate on it. I did run some print statements to confirm the three IF parameters that now have different defaults depending on the solver.