### PR TITLE
Add persistent restart lineage to native checkpoints and plotfiles

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -380,6 +380,7 @@ function(build_erf_lib erf_lib_name)
        ${SRC_DIR}/Initialization/ERF_InitImmersedForcing.cpp
        ${SRC_DIR}/Initialization/ERF_InitForEnsemble.cpp
        ${SRC_DIR}/IO/ERF_Checkpoint.cpp
+       ${SRC_DIR}/IO/ERF_Provenance.cpp
        ${SRC_DIR}/IO/ERF_ReadBndryPlanes.cpp
        ${SRC_DIR}/IO/ERF_WriteBndryPlanes.cpp
        ${SRC_DIR}/IO/ERF_TrackerOutput.cpp

--- a/Docs/sphinx_doc/Checkpoint.rst
+++ b/Docs/sphinx_doc/Checkpoint.rst
@@ -11,6 +11,8 @@ Checkpoint / Restart
 
 ERF has a standard sort of checkpointing and restarting capability and
 uses the native AMReX format for reading and writing checkpoints.
+Each native checkpoint also contains a provenance block in its ``job_info``
+file. See :ref:`sec:Provenance` for the execution and restart-lineage fields.
 In the inputs file, the following options control the generation of
 checkpoint files (which are really directories):
 
@@ -84,4 +86,3 @@ Examples of Usage
 To restart from *chk_run00061*,for example, then set
 
 -  **amr.restart** = *chk_run00061*
-

--- a/Docs/sphinx_doc/Checkpoint.rst
+++ b/Docs/sphinx_doc/Checkpoint.rst
@@ -11,8 +11,9 @@ Checkpoint / Restart
 
 ERF has a standard sort of checkpointing and restarting capability and
 uses the native AMReX format for reading and writing checkpoints.
-Each native checkpoint also contains a provenance block in its ``job_info``
-file. See :ref:`sec:Provenance` for the execution and restart-lineage fields.
+Each native checkpoint contains a provenance block in ``job_info``. The block
+records the checkpoint artifact, the ERF execution that wrote it, and the
+known restart ancestry. See :ref:`sec:Provenance`.
 In the inputs file, the following options control the generation of
 checkpoint files (which are really directories):
 
@@ -50,17 +51,18 @@ List of Parameters
 Restarting
 ==========
 
-+---------------------------------+----------------+----------------+----------------+
-| Parameter                       | Definition     | Acceptable     | Default        |
-|                                 |                | Values         |                |
-+=================================+================+================+================+
-| **erf.restart**                 | name of the    | String         | not used if    |
-|                                 | file           |                | not set        |
-|                                 | (directory)    |                |                |
-|                                 | from which to  |                |                |
-|                                 | restart        |                |                |
-|                                 | files          |                |                |
-+---------------------------------+----------------+----------------+----------------+
+.. list-table:: Restart parameters
+   :header-rows: 1
+   :widths: 30 45 15 20
+
+   * - Parameter
+     - Definition
+     - Acceptable values
+     - Default
+   * - ``erf.restart`` or ``amr.restart``
+     - Checkpoint directory from which to restart. ``amr.restart`` takes precedence if both are set.
+     - String
+     - Not used if unset
 
 .. _examples-of-usage-7:
 
@@ -83,6 +85,11 @@ Examples of Usage
    passes a multiple of 5.0.  The directory names will reflect the
    integer number of steps which have elapsed.
 
-To restart from *chk_run00061*,for example, then set
+To restart from *chk_run00061*, for example, set **erf.restart** to that
+directory:
 
--  **amr.restart** = *chk_run00061*
+-  **erf.restart** = *chk_run00061*
+
+ERF also accepts **amr.restart** for compatibility with AMReX and existing
+regression inputs. When both keys are present, **amr.restart** takes
+precedence because ``ReadParameters()`` queries it after ``erf.restart``.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -20,9 +20,10 @@ diagnostics, selected surface fluxes, surface pressure, and column-integrated
 water vapor.
 
 The subvolume plotfile writes 3D data from one selected region of the domain.
-Primary native 2D and 3D plotfiles contain provenance in their existing
-``job_info`` files. The provenance block does not alter the diagnostic JSON
-file or NetCDF output. See :ref:`sec:Provenance` for the schema.
+Primary native 2D and 3D AMReX plotfiles contain the same execution and
+ancestry record in ``job_info``, with a distinct artifact UUID for each
+output. NetCDF output does not yet contain this metadata. See
+:ref:`sec:Provenance`.
 
 Controlling PlotFile Generation
 ===============================

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -20,6 +20,9 @@ diagnostics, selected surface fluxes, surface pressure, and column-integrated
 water vapor.
 
 The subvolume plotfile writes 3D data from one selected region of the domain.
+Primary native 2D and 3D plotfiles contain provenance in their existing
+``job_info`` files. The provenance block does not alter the diagnostic JSON
+file or NetCDF output. See :ref:`sec:Provenance` for the schema.
 
 Controlling PlotFile Generation
 ===============================

--- a/Docs/sphinx_doc/Provenance.rst
+++ b/Docs/sphinx_doc/Provenance.rst
@@ -1,0 +1,138 @@
+.. _sec:Provenance:
+
+******************************
+Provenance and Restart Lineage
+******************************
+
+Purpose
+=======
+
+ERF records the identity of each native checkpoint and primary native AMReX
+plotfile. The record also describes the ERF invocation that wrote the output
+and the known restart lineage. Provenance is auxiliary metadata. It does not
+change model state or restart calculations.
+
+Identifiers
+===========
+
+ERF uses three identities:
+
+* A **simulation UUID** identifies one restart lineage.
+* An **execution UUID** identifies one ERF invocation.
+* An **artifact UUID** identifies one checkpoint or plotfile directory.
+
+The parent execution UUID identifies the immediate producer of a restart.
+The complete known execution lineage records every known execution in order.
+Both fields are present because one execution can write several checkpoints.
+The source checkpoint UUID identifies the exact checkpoint used for restart.
+
+The following fields appear in every provenance block.
+
+.. list-table:: Provenance fields
+   :header-rows: 1
+   :widths: 25 50 25
+
+   * - Field
+     - Meaning
+     - Lifetime
+   * - simulation UUID
+     - Root identity shared by one restart lineage
+     - Entire lineage
+   * - execution UUID
+     - Identity of one ERF invocation
+     - One invocation
+   * - parent execution UUID
+     - Immediate producer execution
+     - One restart edge
+   * - execution lineage
+     - Ordered known execution history
+     - Accumulates
+   * - artifact UUID
+     - Identity of one checkpoint or plotfile
+     - One artifact
+   * - source checkpoint UUID
+     - Exact checkpoint used for restart
+     - One invocation
+   * - restart generation
+     - Number of restarts from the root, or ``-1`` if unknown
+     - One invocation
+   * - lineage status
+     - Completeness or the reason metadata could not be recovered
+     - One invocation
+
+Cold Starts
+===========
+
+On a cold start, the simulation UUID and execution UUID are equal. The
+lineage contains one UUID, the parent is empty, and the restart generation is
+zero. The lineage status is ``complete``.
+
+Checkpoint Restarts
+===================
+
+Suppose execution ``A`` writes checkpoint ``CHK_A`` and execution ``B``
+restarts from it. Execution ``B`` keeps the simulation UUID from ``A``, sets
+its parent execution UUID to ``A``, appends ``B`` to the lineage, and stores
+``CHK_A`` as its source checkpoint UUID. Its restart generation is one.
+
+Repeated Restarts
+=================
+
+The full known lineage is copied into every new artifact. A sequence
+``A -> B -> C`` therefore appears as ``[A, B, C]`` in artifacts written by
+``C``. ERF does not need the ``A`` directory to inspect ``C``'s lineage.
+
+Branching Restarts
+==================
+
+Two executions may restart from the same checkpoint. For example, children
+``C`` and ``D`` of ``B`` share the simulation UUID, parent ``B``, and known
+lineage prefix ``[A, B]``. They have different execution UUIDs and their
+lineages end in ``C`` and ``D`` respectively.
+
+Legacy Checkpoints
+==================
+
+Older checkpoints have no provenance block. Missing ``job_info``, a missing
+block, malformed fields, invalid UUIDs, failed lineage validation, an
+unsupported schema, or a non-checkpoint artifact record produces one warning
+on the I/O rank. ERF then reads the physical checkpoint normally.
+
+The new execution starts a known lineage segment. Its lineage contains only
+the current execution, its restart generation is ``-1``, and its lineage is
+incomplete. The status records the specific failure. A later restart from an
+artifact written by this execution preserves the known segment and appends
+the child, while keeping the generation unknown.
+
+Native File Locations
+=====================
+
+The block is embedded near the top of the existing human-readable
+``job_info`` file. ERF writes it to native checkpoints and to primary native
+2D and 3D AMReX plotfiles. It does not write a sidecar.
+
+NetCDF output, NetCDF column files, 2D diagnostic JSON, subvolumes, staggered
+velocity plotfiles, boundary-plane files, and particle-only files are outside
+this implementation.
+
+Schema and Validation
+=====================
+
+Schema version one uses fixed-order ``key=value`` lines between
+``ERF_PROVENANCE_BEGIN`` and ``ERF_PROVENANCE_END``. Paths are split at the
+first equals sign. The parser accepts CRLF line endings, ignores unknown keys,
+rejects duplicate required keys, and validates UUIDs and lineage invariants.
+The checkpoint ``Header`` remains unchanged.
+
+UUIDs are generated on the I/O rank with an independent host-side generator
+and broadcast to all ranks. This generator does not use AMReX's scientific
+random-number stream. UUIDs identify records but do not prove authenticity;
+they are not signatures or cryptographic evidence.
+
+Scope and Limits
+================
+
+This feature deliberately does not compute configuration hashes, classify
+configuration changes, digest input files or executables, export W3C PROV or
+RO-Crate records, sign metadata, or reject a restart based on provenance.
+Configuration identity and restart lineage remain separate concerns.

--- a/Docs/sphinx_doc/Provenance.rst
+++ b/Docs/sphinx_doc/Provenance.rst
@@ -212,12 +212,16 @@ needed on non-I/O ranks. UUID generation does not use AMReX's scientific
 random-number stream. UUIDs identify records but do not authenticate their
 contents; they are not signatures or cryptographic evidence.
 
-Scope and Limits
-================
+What Provenance Covers
+=====================
 
-The checkpoint ``Header`` remains unchanged. NetCDF output, NetCDF column
-files, 2D diagnostic JSON, subvolumes, staggered velocity plotfiles,
-boundary-plane files, and particle-only files are outside this implementation.
-This feature does not compute configuration hashes, digest input files or
-executables, export W3C PROV or RO-Crate records, sign metadata, or reject a
-restart based on provenance.
+Provenance is available for native checkpoints and primary native 2D and 3D
+AMReX plotfiles. It is stored in each output's ``job_info`` file and helps
+identify the output and trace the restart history that produced it.
+
+It is not currently included in NetCDF output, NetCDF column files, 2D
+diagnostic JSON, subvolume or staggered-velocity plotfiles, boundary-plane
+files, or particle-only files. Provenance is supplemental metadata: it does
+not change the physical checkpoint state or the checkpoint ``Header``. If the
+metadata is missing or invalid, ERF continues the restart and records the
+lineage as incomplete rather than refusing to read the checkpoint.

--- a/Docs/sphinx_doc/Provenance.rst
+++ b/Docs/sphinx_doc/Provenance.rst
@@ -8,93 +8,187 @@ Purpose
 =======
 
 ERF records the identity of each native checkpoint and primary native AMReX
-plotfile. The record also describes the ERF invocation that wrote the output
-and the known restart lineage. Provenance is auxiliary metadata. It does not
-change model state or restart calculations.
+plotfile. The record describes the ERF invocation that wrote the output and
+the known ancestry path that led to it. Provenance is auxiliary metadata. It
+does not change model state or restart calculations.
 
 Identifiers
 ===========
 
-ERF uses three identities:
+The **simulation UUID** identifies one rooted restart family. A family may
+contain several branches. The **execution UUID** identifies one ERF process
+invocation. The **artifact UUID** identifies one checkpoint or primary native
+plotfile directory.
 
-* A **simulation UUID** identifies one restart lineage.
-* An **execution UUID** identifies one ERF invocation.
-* An **artifact UUID** identifies one checkpoint or plotfile directory.
-
-The parent execution UUID identifies the immediate producer of a restart.
-The complete known execution lineage records every known execution in order.
-Both fields are present because one execution can write several checkpoints.
-The source checkpoint UUID identifies the exact checkpoint used for restart.
-
-The following fields appear in every provenance block.
-
-.. list-table:: Provenance fields
-   :header-rows: 1
-   :widths: 25 50 25
-
-   * - Field
-     - Meaning
-     - Lifetime
-   * - simulation UUID
-     - Root identity shared by one restart lineage
-     - Entire lineage
-   * - execution UUID
-     - Identity of one ERF invocation
-     - One invocation
-   * - parent execution UUID
-     - Immediate producer execution
-     - One restart edge
-   * - execution lineage
-     - Ordered known execution history
-     - Accumulates
-   * - artifact UUID
-     - Identity of one checkpoint or plotfile
-     - One artifact
-   * - source checkpoint UUID
-     - Exact checkpoint used for restart
-     - One invocation
-   * - restart generation
-     - Number of restarts from the root, or ``-1`` if unknown
-     - One invocation
-   * - lineage status
-     - Completeness or the reason metadata could not be recovered
-     - One invocation
+The **parent execution UUID** identifies the execution that wrote the source
+checkpoint used to start the current execution. The **execution lineage** is
+the ordered known ancestry path that leads to the current execution. The
+**source checkpoint UUID** identifies the exact checkpoint artifact used to
+start it. The parent field gives the immediate graph edge; the lineage makes
+the known ancestry path self-contained in every artifact. The source UUID is
+separate because one execution can write several checkpoints.
 
 Cold Starts
 ===========
 
 On a cold start, the simulation UUID and execution UUID are equal. The
-lineage contains one UUID, the parent is empty, and the restart generation is
-zero. The lineage status is ``complete``.
+lineage contains one UUID, the parent is empty, the restart generation is
+zero, and the lineage status is ``complete``.
 
 Checkpoint Restarts
 ===================
 
 Suppose execution ``A`` writes checkpoint ``CHK_A`` and execution ``B``
 restarts from it. Execution ``B`` keeps the simulation UUID from ``A``, sets
-its parent execution UUID to ``A``, appends ``B`` to the lineage, and stores
-``CHK_A`` as its source checkpoint UUID. Its restart generation is one.
+its parent to ``A``, appends ``B`` to its ancestry path, and stores ``CHK_A``
+as its source checkpoint UUID. Its restart generation is one.
 
 Repeated Restarts
 =================
 
-The full known lineage is copied into every new artifact. A sequence
+The known ancestry path is copied into every new artifact. A sequence
 ``A -> B -> C`` therefore appears as ``[A, B, C]`` in artifacts written by
-``C``. ERF does not need the ``A`` directory to inspect ``C``'s lineage.
+``C``. ERF does not need the ``A`` directory to inspect ``C``'s ancestry.
 
 Branching Restarts
 ==================
 
-Two executions may restart from the same checkpoint. For example, children
-``C`` and ``D`` of ``B`` share the simulation UUID, parent ``B``, and known
-lineage prefix ``[A, B]``. They have different execution UUIDs and their
-lineages end in ``C`` and ``D`` respectively.
+A restart family can branch:
+
+.. code-block:: text
+
+   A -> B -> C
+          \
+           -> D
+
+Both branches share the same simulation UUID. The ancestry path for ``C`` is
+``[A, B, C]``. The path for ``D`` is ``[A, B, D]``.
+
+Persisted Schema
+================
+
+The writer emits schema-1 keys in a stable order. The parser identifies
+fields by key, so a valid block may use another order. Marker lines must
+equal the complete marker after an optional trailing carriage return. The
+parser splits values at the first equals sign, ignores unknown keys, rejects
+duplicate required keys, and validates typed values and lineage invariants.
+
+Every schema-1 key is listed below.
+
+.. list-table:: Schema-1 provenance keys
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Key
+     - Meaning
+     - Scope or notes
+   * - ``schema_version``
+     - Version of the embedded provenance schema.
+     - Integer; this implementation writes ``1``.
+   * - ``simulation_uuid``
+     - Identity of the rooted restart family.
+     - Stable across complete restarts and branches.
+   * - ``execution_uuid``
+     - Identity of one ERF process invocation.
+     - New for each invocation.
+   * - ``parent_execution_uuid``
+     - Execution that wrote the source checkpoint.
+     - Empty on a cold start or unavailable parent metadata.
+   * - ``execution_lineage``
+     - Ordered known ancestry path ending at ``execution_uuid``.
+     - Comma-separated UUIDs in the file.
+   * - ``restart_generation``
+     - Number of restart edges from the known root.
+     - ``-1`` when the absolute generation is unknown.
+   * - ``lineage_complete``
+     - Whether the path begins at the original cold start.
+     - ``true`` or ``false``.
+   * - ``lineage_status``
+     - Completeness state or recovery-failure reason.
+     - Stable lowercase token.
+   * - ``source_checkpoint_uuid``
+     - UUID of the exact checkpoint used for restart.
+     - Empty on a cold start or when unavailable.
+   * - ``source_checkpoint_path``
+     - Configured path of the restart checkpoint.
+     - Location metadata; not content identity.
+   * - ``execution_start_utc``
+     - UTC start time of the ERF invocation.
+     - ISO 8601 format.
+   * - ``artifact_uuid``
+     - Identity of this output artifact.
+     - New for every checkpoint or primary native plotfile.
+   * - ``artifact_type``
+     - Type of this output artifact.
+     - ``checkpoint``, ``plotfile_2d``, or ``plotfile_3d``.
+   * - ``artifact_step``
+     - Level-0 step associated with the output.
+     - Nonnegative integer.
+   * - ``artifact_time_seconds``
+     - Simulation time associated with the output.
+     - Serialized with stable double precision.
+   * - ``artifact_created_utc``
+     - UTC time when ERF finalized the artifact metadata.
+     - ISO 8601 format.
+
+Status Values
+=============
+
+The ``lineage_status`` value uses these stable tokens:
+
+.. list-table:: Lineage status tokens
+   :header-rows: 1
+   :widths: 32 68
+
+   * - Token
+     - Meaning
+   * - ``complete``
+     - Ancestry is known back to the cold start.
+   * - ``incomplete_ancestor``
+     - The parent record was valid, but its earlier ancestry was incomplete.
+   * - ``missing_job_info``
+     - The source checkpoint had no readable ``job_info``.
+   * - ``missing_provenance_block``
+     - ``job_info`` existed but had no exact provenance block.
+   * - ``malformed_provenance``
+     - The block could not be parsed or failed validation.
+   * - ``unsupported_schema``
+     - The block used an unsupported schema version.
+   * - ``artifact_type_mismatch``
+     - The record did not describe a checkpoint during restart.
+
+Literal Example
+===============
+
+This restarted-checkpoint block is illustrative. Its UUIDs and timestamps
+are not real records.
+
+.. code-block:: text
+
+   ERF_PROVENANCE_BEGIN
+   schema_version=1
+   simulation_uuid=11111111-1111-4111-8111-111111111111
+   execution_uuid=22222222-2222-4222-8222-222222222222
+   parent_execution_uuid=11111111-1111-4111-8111-111111111111
+   execution_lineage=11111111-1111-4111-8111-111111111111,22222222-2222-4222-8222-222222222222
+   restart_generation=1
+   lineage_complete=true
+   lineage_status=complete
+   source_checkpoint_uuid=aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa
+   source_checkpoint_path=chk00010
+   execution_start_utc=2026-07-11T19:00:00Z
+   artifact_uuid=bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb
+   artifact_type=checkpoint
+   artifact_step=20
+   artifact_time_seconds=120
+   artifact_created_utc=2026-07-11T19:05:00Z
+   ERF_PROVENANCE_END
 
 Legacy Checkpoints
 ==================
 
 Older checkpoints have no provenance block. Missing ``job_info``, a missing
-block, malformed fields, invalid UUIDs, failed lineage validation, an
+exact block, malformed fields, invalid UUIDs, failed lineage validation, an
 unsupported schema, or a non-checkpoint artifact record produces one warning
 on the I/O rank. ERF then reads the physical checkpoint normally.
 
@@ -108,31 +202,22 @@ Native File Locations
 =====================
 
 The block is embedded near the top of the existing human-readable
-``job_info`` file. ERF writes it to native checkpoints and to primary native
-2D and 3D AMReX plotfiles. It does not write a sidecar.
+``job_info`` file. ERF writes it to native checkpoints and primary native 2D
+and 3D AMReX plotfiles. It does not write a sidecar.
 
-NetCDF output, NetCDF column files, 2D diagnostic JSON, subvolumes, staggered
-velocity plotfiles, boundary-plane files, and particle-only files are outside
-this implementation.
-
-Schema and Validation
-=====================
-
-Schema version one uses fixed-order ``key=value`` lines between
-``ERF_PROVENANCE_BEGIN`` and ``ERF_PROVENANCE_END``. Paths are split at the
-first equals sign. The parser accepts CRLF line endings, ignores unknown keys,
-rejects duplicate required keys, and validates UUIDs and lineage invariants.
-The checkpoint ``Header`` remains unchanged.
-
-UUIDs are generated on the I/O rank with an independent host-side generator
-and broadcast to all ranks. This generator does not use AMReX's scientific
-random-number stream. UUIDs identify records but do not prove authenticity;
-they are not signatures or cryptographic evidence.
+ERF generates the execution UUID on the I/O rank and broadcasts the execution
+record to all ranks. The I/O rank generates a separate artifact UUID when it
+writes each ``job_info``. Artifact UUIDs are output metadata and are not
+needed on non-I/O ranks. UUID generation does not use AMReX's scientific
+random-number stream. UUIDs identify records but do not authenticate their
+contents; they are not signatures or cryptographic evidence.
 
 Scope and Limits
 ================
 
-This feature deliberately does not compute configuration hashes, classify
-configuration changes, digest input files or executables, export W3C PROV or
-RO-Crate records, sign metadata, or reject a restart based on provenance.
-Configuration identity and restart lineage remain separate concerns.
+The checkpoint ``Header`` remains unchanged. NetCDF output, NetCDF column
+files, 2D diagnostic JSON, subvolumes, staggered velocity plotfiles,
+boundary-plane files, and particle-only files are outside this implementation.
+This feature does not compute configuration hashes, digest input files or
+executables, export W3C PROV or RO-Crate records, sign metadata, or reject a
+restart based on provenance.

--- a/Docs/sphinx_doc/index.rst
+++ b/Docs/sphinx_doc/index.rst
@@ -82,6 +82,7 @@ In addition to this documentation, there is API documentation for ERF generated 
    SurfaceLayer.rst
    DerivedQuantities.rst
    Checkpoint.rst
+   Provenance.rst
    Plotfiles.rst
    Visualization.rst
 

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -50,6 +50,7 @@
 #include <ERF_FillPatcher.H>
 #include <ERF_SampleData.H>
 #include <ERF_ForestDrag.H>
+#include <ERF_Provenance.H>
 
 #ifdef ERF_USE_PARTICLES
 #include "ERF_ParticleData.H"
@@ -1150,6 +1151,10 @@ private:
     // if >= 0 we restart from a checkpoint
     std::string restart_chkfile = "";
 
+    // Host-only metadata shared by all native output paths. It never enters
+    // device code or changes the model state read from a checkpoint.
+    erf_provenance::ExecutionProvenance execution_provenance;
+
     // Time step controls
     static amrex::Real cfl;
     static amrex::Real sub_cfl;
@@ -1762,7 +1767,10 @@ private:
 #endif
 
 public:
-    void writeJobInfo (const std::string& dir) const;
+    void writeJobInfo (const std::string& dir,
+                       erf_provenance::ArtifactType artifact_type,
+                       int artifact_step,
+                       double artifact_time_seconds) const;
     static void writeBuildInfo (std::ostream& os);
 
     static void print_banner(MPI_Comm /*comm*/, std::ostream& /*out*/);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1985,8 +1985,9 @@ ERF::ReadParameters ()
         pp.query("check_file", check_file);
 
         // The regression tests use "amr.restart" and "amr.m_check_int" so we allow
-        //    for those or "erf.restart" / "erf.m_check_int" with the former taking
-        //    precedence if both are specified
+        //    for those or "erf.restart" / "erf.m_check_int". The amr.* values are
+        //    queried after the erf.* values and therefore take precedence if both
+        //    are specified.
         pp.query("check_int", m_check_int);
         pp.query("check_per", m_check_per);
         pp_amr.query("check_int", m_check_int);

--- a/Source/ERF_Constructors.cpp
+++ b/Source/ERF_Constructors.cpp
@@ -104,6 +104,9 @@ ERF::ERF_shared ()
     for (int lev = 0; lev <= max_level; ++lev) { m_forest_drag[lev] = nullptr;}
 
     ReadParameters();
+    // Create one invocation identity after inputs are available and before
+    // InitData can read restart metadata or write an output on restart.
+    execution_provenance = erf_provenance::initialize_execution_provenance();
     initializeMicrophysics(nlevs_max);
 
 #ifdef ERF_USE_WINDFARM

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -7,8 +7,16 @@
 #include "ERF.H"
 #include "AMReX_PlotFileUtil.H"
 #include "ERF_ReadFromERFBdy.H"
+#include "ERF_Provenance.H"
 
 using namespace amrex;
+
+namespace
+{
+
+bool provenance_warning_emitted = false;
+
+} // namespace
 
 /**
  * Utility to skip to next line in Header file input stream.
@@ -489,6 +497,11 @@ ERF::WriteCheckpointFile () const
 #endif
 #endif
 
+    // Write job_info after checkpoint state so the provenance record describes
+    // the completed output attempt and can seed a later restart lineage.
+    writeJobInfo(checkpointname, erf_provenance::ArtifactType::Checkpoint,
+                 istep[0], t_new[0]);
+
     if (verbose > 0)
     {
         auto dCheckTime = amrex::second() - dCheckTime0;
@@ -504,6 +517,31 @@ void
 ERF::ReadCheckpointFile ()
 {
     Print() << "Restart from native checkpoint " << restart_chkfile << "\n";
+
+    const auto provenance_result =
+        erf_provenance::read_job_info_file(restart_chkfile + "/job_info");
+    if (provenance_result.valid() &&
+        provenance_result.record.artifact.artifact_type == erf_provenance::ArtifactType::Checkpoint) {
+        execution_provenance = erf_provenance::make_restart_provenance(
+            execution_provenance, provenance_result.record, restart_chkfile);
+    } else {
+        // Provenance is auxiliary metadata. A missing or invalid record must not make
+        // a valid physical checkpoint unreadable.
+        if (ParallelDescriptor::IOProcessor() && !provenance_warning_emitted) {
+            provenance_warning_emitted = true;
+            const std::string reason = provenance_result.valid()
+                ? "a non-checkpoint artifact type"
+                : provenance_result.diagnostic;
+            Warning("Native checkpoint " + restart_chkfile + " has " +
+                    reason +
+                    "; ERF will continue with incomplete provenance.");
+        }
+        const auto failure_status = provenance_result.valid()
+            ? erf_provenance::ProvenanceReadStatus::ArtifactTypeMismatch
+            : provenance_result.status;
+        execution_provenance = erf_provenance::make_incomplete_restart_provenance(
+            execution_provenance, failure_status, restart_chkfile);
+    }
 
     // Header
     std::string File(restart_chkfile + "/Header");

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -530,11 +530,14 @@ ERF::ReadCheckpointFile ()
         if (ParallelDescriptor::IOProcessor() && !provenance_warning_emitted) {
             provenance_warning_emitted = true;
             const std::string reason = provenance_result.valid()
-                ? "a non-checkpoint artifact type"
+                ? "the provenance record has artifact_type=" +
+                  std::string(erf_provenance::artifact_type_token(
+                      provenance_result.record.artifact.artifact_type)) +
+                  ", not checkpoint"
                 : provenance_result.diagnostic;
-            Warning("Native checkpoint " + restart_chkfile + " has " +
-                    reason +
-                    "; ERF will continue with incomplete provenance.");
+            Warning("Cannot recover provenance from native checkpoint '" +
+                    restart_chkfile + "': " + reason +
+                    ". ERF will continue with incomplete provenance.");
         }
         const auto failure_status = provenance_result.valid()
             ? erf_provenance::ProvenanceReadStatus::ArtifactTypeMismatch

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -1743,7 +1743,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                                         varnames,
                                         Geom(), tnew, istep, refRatio());
             }
-            writeJobInfo(plotfilename);
+            writeJobInfo(plotfilename, erf_provenance::ArtifactType::Plotfile3D,
+                         istep[0], t_new[0]);
 
             if (m_plot_face_vels) {
                 Print() << "Writing face velocities" << std::endl;
@@ -1899,7 +1900,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 }
             } // ref_ratio test
 
-            writeJobInfo(plotfilename);
+            writeJobInfo(plotfilename, erf_provenance::ArtifactType::Plotfile3D,
+                         istep[0], t_new[0]);
 
 #ifdef ERF_USE_PARTICLES
             particleData.writePlotFile(plotfilename, z_phys_nd);

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -541,7 +541,8 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
         // Native AMReX 2D plotfiles write a JSON sidecar with catalog
         // metadata for the selected output variables only.
         plotfile2d::write_2d_metadata_json(plotfilename, output_descriptors);
-        writeJobInfo(plotfilename);
+        writeJobInfo(plotfilename, erf_provenance::ArtifactType::Plotfile2D,
+                     istep[0], t_new[0]);
 
 #ifdef ERF_USE_NETCDF
     } else if (plotfile_type == PlotFileType::Netcdf) {

--- a/Source/IO/ERF_Provenance.H
+++ b/Source/IO/ERF_Provenance.H
@@ -50,12 +50,14 @@ enum class ProvenanceReadStatus
 /**
  * Identity and known ancestry for one ERF process invocation.
  *
- * Simulation identity names one restart lineage. Execution identity names one
- * invocation. Artifact identity is kept separate because one invocation can
- * write many checkpoints and plotfiles. The complete known lineage is stored
- * in every artifact so old artifact directories are not needed to reconstruct
- * repeated restarts. These UUIDs identify records; they do not authenticate
- * their contents and are not cryptographic proof.
+ * Simulation identity names one rooted restart family, which may branch.
+ * Execution identity names one invocation. Artifact identity is kept separate
+ * because one invocation can write many checkpoints and plotfiles. The known
+ * ancestry path is stored in every artifact so old directories are not needed
+ * to reconstruct repeated restarts. The parent UUID gives the immediate edge;
+ * the source checkpoint UUID selects the exact checkpoint artifact. These UUIDs
+ * identify records; they do not authenticate contents or provide cryptographic
+ * proof.
  */
 struct ExecutionProvenance
 {

--- a/Source/IO/ERF_Provenance.H
+++ b/Source/IO/ERF_Provenance.H
@@ -1,0 +1,153 @@
+#ifndef ERF_PROVENANCE_H_
+#define ERF_PROVENANCE_H_
+
+#include <array>
+#include <cstdint>
+#include <ctime>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace erf_provenance
+{
+
+constexpr int schema_version = 1;
+constexpr const char* provenance_begin = "ERF_PROVENANCE_BEGIN";
+constexpr const char* provenance_end = "ERF_PROVENANCE_END";
+
+/**
+ * The reason a lineage is incomplete is part of the persisted contract.
+ * Missing or invalid metadata never prevents ERF from reading physical state.
+ */
+enum class LineageStatus
+{
+    Complete,
+    IncompleteAncestor,
+    MissingJobInfo,
+    MissingProvenanceBlock,
+    MalformedProvenance,
+    UnsupportedSchema,
+    ArtifactTypeMismatch
+};
+
+enum class ArtifactType
+{
+    Checkpoint,
+    Plotfile2D,
+    Plotfile3D
+};
+
+enum class ProvenanceReadStatus
+{
+    Valid,
+    MissingJobInfo,
+    MissingProvenanceBlock,
+    MalformedProvenance,
+    UnsupportedSchema,
+    ArtifactTypeMismatch
+};
+
+/**
+ * Identity and known ancestry for one ERF process invocation.
+ *
+ * Simulation identity names one restart lineage. Execution identity names one
+ * invocation. Artifact identity is kept separate because one invocation can
+ * write many checkpoints and plotfiles. The complete known lineage is stored
+ * in every artifact so old artifact directories are not needed to reconstruct
+ * repeated restarts. These UUIDs identify records; they do not authenticate
+ * their contents and are not cryptographic proof.
+ */
+struct ExecutionProvenance
+{
+    int schema_version = erf_provenance::schema_version;
+    std::string simulation_uuid;
+    std::string execution_uuid;
+    std::string parent_execution_uuid;
+    std::vector<std::string> execution_lineage;
+    int restart_generation = 0;
+    bool lineage_complete = true;
+    LineageStatus lineage_status = LineageStatus::Complete;
+    std::string source_checkpoint_uuid;
+    std::string source_checkpoint_path;
+    std::string execution_start_utc;
+};
+
+struct ArtifactProvenance
+{
+    std::string artifact_uuid;
+    ArtifactType artifact_type = ArtifactType::Checkpoint;
+    int artifact_step = -1;
+    double artifact_time_seconds = 0.0;
+    std::string artifact_created_utc;
+};
+
+struct ProvenanceRecord
+{
+    ExecutionProvenance execution;
+    ArtifactProvenance artifact;
+};
+
+struct ProvenanceParseResult
+{
+    ProvenanceReadStatus status = ProvenanceReadStatus::MissingProvenanceBlock;
+    ProvenanceRecord record;
+    std::string diagnostic;
+
+    [[nodiscard]] bool valid () const noexcept
+    {
+        return status == ProvenanceReadStatus::Valid;
+    }
+};
+
+using ProvenanceReadResult = ProvenanceParseResult;
+
+/** Format supplied bytes as a lowercase canonical RFC UUIDv4 string. */
+std::string uuid_v4_from_bytes (const std::array<std::uint8_t, 16>& bytes);
+
+/** Validate a lowercase or uppercase canonical RFC UUIDv4 string. */
+bool is_valid_uuid_v4 (std::string_view uuid);
+
+/** Generate a UUID without using AMReX's scientific random-number stream. */
+std::string generate_uuid_v4 ();
+
+/** Format a supplied clock value as an ISO 8601 UTC timestamp. */
+std::string format_utc (std::time_t time_value);
+
+/** Return the current time in the persisted UTC format. */
+std::string current_utc ();
+
+/** Serialize exactly one schema-1 machine-readable block. */
+std::string serialize_provenance_block (const ProvenanceRecord& record);
+
+/** Parse only delimited provenance markers from a human-readable job_info. */
+ProvenanceParseResult parse_provenance_block (std::string_view job_info_text);
+
+/** Read and broadcast one job_info before parsing the same bytes on every rank. */
+ProvenanceReadResult read_job_info_file (const std::string& job_info_path);
+
+/** Create the root record for one cold-start invocation. */
+ExecutionProvenance make_cold_start_provenance (const std::string& execution_uuid,
+                                                const std::string& execution_start_utc);
+
+/** Create a child record from a valid checkpoint record, including its artifact UUID. */
+ExecutionProvenance make_restart_provenance (const ExecutionProvenance& current_invocation,
+                                             const ProvenanceRecord& parent_checkpoint,
+                                             const std::string& checkpoint_path);
+
+/** Start a new known lineage segment after a nonfatal provenance read failure. */
+ExecutionProvenance make_incomplete_restart_provenance (const ExecutionProvenance& current_invocation,
+                                                         ProvenanceReadStatus failure,
+                                                         const std::string& checkpoint_path);
+
+/** Return the stable persisted token for a lineage status. */
+const char* lineage_status_token (LineageStatus status) noexcept;
+
+/** Return the stable persisted token for an artifact type. */
+const char* artifact_type_token (ArtifactType type) noexcept;
+
+/** Initialize one process-wide invocation record and share it across multiblock ERF objects. */
+ExecutionProvenance initialize_execution_provenance ();
+
+} // namespace erf_provenance
+
+#endif

--- a/Source/IO/ERF_Provenance.cpp
+++ b/Source/IO/ERF_Provenance.cpp
@@ -420,19 +420,19 @@ ProvenanceParseResult parse_provenance_block (std::string_view text)
         "artifact_uuid", "artifact_type", "artifact_step", "artifact_time_seconds",
         "artifact_created_utc"
     };
-    for (const auto& line : block_lines) {
-        if (line.empty()) continue;
-        const std::size_t equals = line.find('=');
+    for (const auto& block_line : block_lines) {
+        if (block_line.empty()) continue;
+        const std::size_t equals = block_line.find('=');
         if (equals == std::string::npos || equals == 0) {
             return failure(ProvenanceReadStatus::MalformedProvenance,
                            "provenance line is not a key=value pair");
         }
-        const std::string key = line.substr(0, equals);
+        const std::string key = block_line.substr(0, equals);
         if (required.count(key) != 0 && fields.count(key) != 0) {
             return failure(ProvenanceReadStatus::MalformedProvenance,
                            "duplicate required provenance key: " + key);
         }
-        if (required.count(key) != 0) fields.emplace(key, line.substr(equals + 1));
+        if (required.count(key) != 0) fields.emplace(key, block_line.substr(equals + 1));
     }
     ProvenanceParseResult result;
     int schema = 0;

--- a/Source/IO/ERF_Provenance.cpp
+++ b/Source/IO/ERF_Provenance.cpp
@@ -1,0 +1,563 @@
+#include "ERF_Provenance.H"
+
+#include <AMReX_ParallelDescriptor.H>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iterator>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace
+{
+
+using erf_provenance::ArtifactType;
+using erf_provenance::LineageStatus;
+using erf_provenance::ProvenanceReadStatus;
+
+bool is_hex (char c)
+{
+    return (c >= '0' && c <= '9') ||
+           (c >= 'a' && c <= 'f') ||
+           (c >= 'A' && c <= 'F');
+}
+
+bool is_canonical_uuid_layout (std::string_view uuid)
+{
+    if (uuid.size() != 36) {
+        return false;
+    }
+    for (std::size_t i = 0; i < uuid.size(); ++i) {
+        const bool hyphen_position = i == 8 || i == 13 || i == 18 || i == 23;
+        if (hyphen_position ? uuid[i] != '-' : !is_hex(uuid[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+int hex_value (char c)
+{
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    return c - 'A' + 10;
+}
+
+std::vector<std::string> split_lineage (std::string_view value)
+{
+    std::vector<std::string> result;
+    std::size_t start = 0;
+    while (start <= value.size()) {
+        const std::size_t comma = value.find(',', start);
+        const std::size_t end = comma == std::string_view::npos ? value.size() : comma;
+        if (end == start) {
+            return {};
+        }
+        result.emplace_back(value.substr(start, end - start));
+        if (comma == std::string_view::npos) break;
+        start = comma + 1;
+    }
+    return result;
+}
+
+bool parse_int (std::string_view text, int& value)
+{
+    try {
+        std::size_t used = 0;
+        const std::string input(text);
+        const long parsed = std::stol(input, &used, 10);
+        if (used != input.size() || parsed < std::numeric_limits<int>::min() ||
+            parsed > std::numeric_limits<int>::max()) {
+            return false;
+        }
+        value = static_cast<int>(parsed);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+bool parse_double (std::string_view text, double& value)
+{
+    try {
+        std::size_t used = 0;
+        const std::string input(text);
+        value = std::stod(input, &used);
+        return used == input.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+bool parse_bool (std::string_view text, bool& value)
+{
+    if (text == "true") {
+        value = true;
+        return true;
+    }
+    if (text == "false") {
+        value = false;
+        return true;
+    }
+    return false;
+}
+
+bool parse_artifact_type (std::string_view text, ArtifactType& type)
+{
+    if (text == "checkpoint") {
+        type = ArtifactType::Checkpoint;
+    } else if (text == "plotfile_2d") {
+        type = ArtifactType::Plotfile2D;
+    } else if (text == "plotfile_3d") {
+        type = ArtifactType::Plotfile3D;
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool parse_lineage_status (std::string_view text, LineageStatus& status)
+{
+    if (text == "complete") status = LineageStatus::Complete;
+    else if (text == "incomplete_ancestor") status = LineageStatus::IncompleteAncestor;
+    else if (text == "missing_job_info") status = LineageStatus::MissingJobInfo;
+    else if (text == "missing_provenance_block") status = LineageStatus::MissingProvenanceBlock;
+    else if (text == "malformed_provenance") status = LineageStatus::MalformedProvenance;
+    else if (text == "unsupported_schema") status = LineageStatus::UnsupportedSchema;
+    else if (text == "artifact_type_mismatch") status = LineageStatus::ArtifactTypeMismatch;
+    else return false;
+    return true;
+}
+
+LineageStatus failure_lineage_status (ProvenanceReadStatus status)
+{
+    switch (status) {
+    case ProvenanceReadStatus::MissingJobInfo: return LineageStatus::MissingJobInfo;
+    case ProvenanceReadStatus::MissingProvenanceBlock: return LineageStatus::MissingProvenanceBlock;
+    case ProvenanceReadStatus::MalformedProvenance: return LineageStatus::MalformedProvenance;
+    case ProvenanceReadStatus::UnsupportedSchema: return LineageStatus::UnsupportedSchema;
+    case ProvenanceReadStatus::ArtifactTypeMismatch: return LineageStatus::ArtifactTypeMismatch;
+    case ProvenanceReadStatus::Valid: break;
+    }
+    return LineageStatus::MalformedProvenance;
+}
+
+void broadcast_string (std::string& value)
+{
+    const int io_rank = amrex::ParallelDescriptor::IOProcessorNumber();
+    int length = amrex::ParallelDescriptor::IOProcessor()
+               ? static_cast<int>(value.size()) : 0;
+    amrex::ParallelDescriptor::Bcast(&length, 1, io_rank);
+    value.resize(static_cast<std::size_t>(length));
+    if (length > 0) {
+        amrex::ParallelDescriptor::Bcast(value.data(), length, io_rank);
+    }
+}
+
+std::string strip_cr (std::string line)
+{
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    return line;
+}
+
+bool validate_record (const erf_provenance::ProvenanceRecord& record, std::string& diagnostic)
+{
+    const auto& execution = record.execution;
+    const auto& artifact = record.artifact;
+    if (execution.schema_version != erf_provenance::schema_version) {
+        diagnostic = "unsupported provenance schema";
+        return false;
+    }
+    if (!erf_provenance::is_valid_uuid_v4(execution.simulation_uuid) ||
+        !erf_provenance::is_valid_uuid_v4(execution.execution_uuid) ||
+        (!execution.parent_execution_uuid.empty() &&
+         !erf_provenance::is_valid_uuid_v4(execution.parent_execution_uuid)) ||
+        !erf_provenance::is_valid_uuid_v4(artifact.artifact_uuid)) {
+        diagnostic = "provenance contains an invalid UUID";
+        return false;
+    }
+    if (execution.execution_lineage.empty()) {
+        diagnostic = "execution lineage is empty";
+        return false;
+    }
+    for (const auto& uuid : execution.execution_lineage) {
+        if (!erf_provenance::is_valid_uuid_v4(uuid)) {
+            diagnostic = "execution lineage contains an invalid UUID";
+            return false;
+        }
+    }
+    if (execution.execution_lineage.back() != execution.execution_uuid) {
+        diagnostic = "lineage does not end at execution UUID";
+        return false;
+    }
+    if (execution.lineage_complete) {
+        if (execution.execution_lineage.front() != execution.simulation_uuid ||
+            execution.restart_generation != static_cast<int>(execution.execution_lineage.size()) - 1 ||
+            (execution.execution_lineage.size() == 1 && !execution.parent_execution_uuid.empty()) ||
+            (execution.execution_lineage.size() > 1 &&
+             execution.parent_execution_uuid != execution.execution_lineage[execution.execution_lineage.size()-2]) ||
+            execution.lineage_status != LineageStatus::Complete) {
+            diagnostic = "complete lineage invariants failed";
+            return false;
+        }
+    } else {
+        if (execution.restart_generation != -1 ||
+            execution.lineage_status == LineageStatus::Complete ||
+            (execution.execution_lineage.size() == 1 && !execution.parent_execution_uuid.empty()) ||
+            (execution.execution_lineage.size() > 1 &&
+             execution.parent_execution_uuid != execution.execution_lineage[execution.execution_lineage.size()-2])) {
+            diagnostic = "incomplete lineage invariants failed";
+            return false;
+        }
+    }
+    if (!execution.source_checkpoint_uuid.empty() &&
+        !erf_provenance::is_valid_uuid_v4(execution.source_checkpoint_uuid)) {
+        diagnostic = "source checkpoint UUID is invalid";
+        return false;
+    }
+    if (execution.execution_lineage.size() > 1 &&
+        execution.source_checkpoint_uuid.empty()) {
+        diagnostic = "restart lineage has no source checkpoint UUID";
+        return false;
+    }
+    if (!std::isfinite(artifact.artifact_time_seconds)) {
+        diagnostic = "artifact time is not finite";
+        return false;
+    }
+    if (artifact.artifact_step < 0 || execution.execution_start_utc.empty() ||
+        artifact.artifact_created_utc.empty()) {
+        diagnostic = "required provenance value is empty or invalid";
+        return false;
+    }
+    return true;
+}
+
+erf_provenance::ProvenanceParseResult failure (ProvenanceReadStatus status,
+                                               std::string diagnostic)
+{
+    erf_provenance::ProvenanceParseResult result;
+    result.status = status;
+    result.diagnostic = std::move(diagnostic);
+    return result;
+}
+
+} // namespace
+
+namespace erf_provenance
+{
+
+std::string uuid_v4_from_bytes (const std::array<std::uint8_t, 16>& bytes)
+{
+    static constexpr char digits[] = "0123456789abcdef";
+    std::string result;
+    result.reserve(36);
+    for (std::size_t i = 0; i < bytes.size(); ++i) {
+        if (i == 4 || i == 6 || i == 8 || i == 10) result.push_back('-');
+        result.push_back(digits[(bytes[i] >> 4) & 0x0f]);
+        result.push_back(digits[bytes[i] & 0x0f]);
+    }
+    return result;
+}
+
+bool is_valid_uuid_v4 (std::string_view uuid)
+{
+    if (!is_canonical_uuid_layout(uuid) || uuid[14] != '4') return false;
+    const char variant = uuid[19];
+    return variant == '8' || variant == '9' || variant == 'a' || variant == 'b' ||
+           variant == 'A' || variant == 'B';
+}
+
+std::string generate_uuid_v4 ()
+{
+    std::array<std::uint8_t, 16> bytes{};
+    bool generated = false;
+    try {
+        std::random_device random;
+        for (auto& byte : bytes) byte = static_cast<std::uint8_t>(random());
+        generated = true;
+    } catch (...) {
+        generated = false;
+    }
+    const auto now = std::chrono::high_resolution_clock::now().time_since_epoch().count();
+    const auto steady = std::chrono::steady_clock::now().time_since_epoch().count();
+    const auto address = reinterpret_cast<std::uintptr_t>(&bytes);
+    if (!generated) {
+        for (std::size_t i = 0; i < bytes.size(); ++i) {
+            bytes[i] = static_cast<std::uint8_t>((now >> ((i % 8) * 8)) ^
+                                                 (steady >> (((i + 3) % 8) * 8)) ^
+                                                 (address >> ((i % sizeof(std::uintptr_t)) * 8)));
+        }
+    } else {
+        for (std::size_t i = 0; i < bytes.size(); ++i) {
+            bytes[i] ^= static_cast<std::uint8_t>((now >> ((i % 8) * 8)) ^
+                                                   (steady >> (((i + 3) % 8) * 8)) ^
+                                                   (address >> ((i % sizeof(std::uintptr_t)) * 8)));
+        }
+    }
+    bytes[6] = static_cast<std::uint8_t>((bytes[6] & 0x0f) | 0x40);
+    bytes[8] = static_cast<std::uint8_t>((bytes[8] & 0x3f) | 0x80);
+    return uuid_v4_from_bytes(bytes);
+}
+
+std::string format_utc (std::time_t time_value)
+{
+    std::tm utc{};
+#if defined(_WIN32)
+    gmtime_s(&utc, &time_value);
+#else
+    gmtime_r(&time_value, &utc);
+#endif
+    std::ostringstream out;
+    out << std::put_time(&utc, "%Y-%m-%dT%H:%M:%SZ");
+    return out.str();
+}
+
+std::string current_utc ()
+{
+    return format_utc(std::time(nullptr));
+}
+
+const char* lineage_status_token (LineageStatus status) noexcept
+{
+    switch (status) {
+    case LineageStatus::Complete: return "complete";
+    case LineageStatus::IncompleteAncestor: return "incomplete_ancestor";
+    case LineageStatus::MissingJobInfo: return "missing_job_info";
+    case LineageStatus::MissingProvenanceBlock: return "missing_provenance_block";
+    case LineageStatus::MalformedProvenance: return "malformed_provenance";
+    case LineageStatus::UnsupportedSchema: return "unsupported_schema";
+    case LineageStatus::ArtifactTypeMismatch: return "artifact_type_mismatch";
+    }
+    return "malformed_provenance";
+}
+
+const char* artifact_type_token (ArtifactType type) noexcept
+{
+    switch (type) {
+    case ArtifactType::Checkpoint: return "checkpoint";
+    case ArtifactType::Plotfile2D: return "plotfile_2d";
+    case ArtifactType::Plotfile3D: return "plotfile_3d";
+    }
+    return "checkpoint";
+}
+
+std::string serialize_provenance_block (const ProvenanceRecord& record)
+{
+    std::ostringstream out;
+    out << provenance_begin << '\n';
+    out << "schema_version=" << record.execution.schema_version << '\n';
+    out << "simulation_uuid=" << record.execution.simulation_uuid << '\n';
+    out << "execution_uuid=" << record.execution.execution_uuid << '\n';
+    out << "parent_execution_uuid=" << record.execution.parent_execution_uuid << '\n';
+    out << "execution_lineage=";
+    for (std::size_t i = 0; i < record.execution.execution_lineage.size(); ++i) {
+        if (i != 0) out << ',';
+        out << record.execution.execution_lineage[i];
+    }
+    out << '\n';
+    out << "restart_generation=" << record.execution.restart_generation << '\n';
+    out << "lineage_complete=" << (record.execution.lineage_complete ? "true" : "false") << '\n';
+    out << "lineage_status=" << lineage_status_token(record.execution.lineage_status) << '\n';
+    out << "source_checkpoint_uuid=" << record.execution.source_checkpoint_uuid << '\n';
+    out << "source_checkpoint_path=" << record.execution.source_checkpoint_path << '\n';
+    out << "execution_start_utc=" << record.execution.execution_start_utc << '\n';
+    out << "artifact_uuid=" << record.artifact.artifact_uuid << '\n';
+    out << "artifact_type=" << artifact_type_token(record.artifact.artifact_type) << '\n';
+    out << "artifact_step=" << record.artifact.artifact_step << '\n';
+    out << "artifact_time_seconds=" << std::setprecision(17)
+        << record.artifact.artifact_time_seconds << '\n';
+    out << "artifact_created_utc=" << record.artifact.artifact_created_utc << '\n';
+    out << provenance_end << '\n';
+    return out.str();
+}
+
+ProvenanceParseResult parse_provenance_block (std::string_view text)
+{
+    const std::size_t begin = text.find(provenance_begin);
+    const std::size_t end = text.find(provenance_end);
+    if (begin == std::string_view::npos) {
+        return failure(ProvenanceReadStatus::MissingProvenanceBlock,
+                       "job_info has no ERF provenance block");
+    }
+    if (end == std::string_view::npos || end < begin ||
+        text.find(provenance_begin, begin + 1) != std::string_view::npos ||
+        text.find(provenance_end, end + 1) != std::string_view::npos) {
+        return failure(ProvenanceReadStatus::MalformedProvenance,
+                       "job_info has multiple or unterminated provenance blocks");
+    }
+
+    std::unordered_map<std::string, std::string> fields;
+    static const std::unordered_set<std::string> required = {
+        "schema_version", "simulation_uuid", "execution_uuid", "parent_execution_uuid",
+        "execution_lineage", "restart_generation", "lineage_complete", "lineage_status",
+        "source_checkpoint_uuid", "source_checkpoint_path", "execution_start_utc",
+        "artifact_uuid", "artifact_type", "artifact_step", "artifact_time_seconds",
+        "artifact_created_utc"
+    };
+    std::istringstream lines(std::string(text.substr(begin + std::string(provenance_begin).size(),
+                                                     end - begin - std::string(provenance_begin).size())));
+    std::string line;
+    while (std::getline(lines, line)) {
+        line = strip_cr(std::move(line));
+        if (line.empty()) continue;
+        const std::size_t equals = line.find('=');
+        if (equals == std::string::npos || equals == 0) {
+            return failure(ProvenanceReadStatus::MalformedProvenance,
+                           "provenance line is not a key=value pair");
+        }
+        const std::string key = line.substr(0, equals);
+        if (required.count(key) != 0 && fields.count(key) != 0) {
+            return failure(ProvenanceReadStatus::MalformedProvenance,
+                           "duplicate required provenance key: " + key);
+        }
+        if (required.count(key) != 0) fields.emplace(key, line.substr(equals + 1));
+    }
+    ProvenanceParseResult result;
+    int schema = 0;
+    if (fields.count("schema_version") == 0 ||
+        !parse_int(fields.at("schema_version"), schema)) {
+        return failure(ProvenanceReadStatus::MalformedProvenance, "invalid provenance schema_version");
+    }
+    if (schema != erf_provenance::schema_version) {
+        return failure(ProvenanceReadStatus::UnsupportedSchema, "unsupported provenance schema_version");
+    }
+    for (const auto& key : required) {
+        if (fields.count(key) == 0) {
+            return failure(ProvenanceReadStatus::MalformedProvenance,
+                           "missing required provenance key: " + key);
+        }
+    }
+    result.record.execution.schema_version = schema;
+    result.record.execution.simulation_uuid = fields.at("simulation_uuid");
+    result.record.execution.execution_uuid = fields.at("execution_uuid");
+    result.record.execution.parent_execution_uuid = fields.at("parent_execution_uuid");
+    result.record.execution.execution_lineage = split_lineage(fields.at("execution_lineage"));
+    if (result.record.execution.execution_lineage.empty()) {
+        return failure(ProvenanceReadStatus::MalformedProvenance, "invalid execution_lineage");
+    }
+    if (!parse_int(fields.at("restart_generation"), result.record.execution.restart_generation) ||
+        !parse_bool(fields.at("lineage_complete"), result.record.execution.lineage_complete) ||
+        !parse_lineage_status(fields.at("lineage_status"), result.record.execution.lineage_status) ||
+        !parse_artifact_type(fields.at("artifact_type"), result.record.artifact.artifact_type) ||
+        !parse_int(fields.at("artifact_step"), result.record.artifact.artifact_step) ||
+        !parse_double(fields.at("artifact_time_seconds"), result.record.artifact.artifact_time_seconds)) {
+        return failure(ProvenanceReadStatus::MalformedProvenance, "invalid typed provenance field");
+    }
+    result.record.execution.source_checkpoint_uuid = fields.at("source_checkpoint_uuid");
+    result.record.execution.source_checkpoint_path = fields.at("source_checkpoint_path");
+    result.record.execution.execution_start_utc = fields.at("execution_start_utc");
+    result.record.artifact.artifact_uuid = fields.at("artifact_uuid");
+    result.record.artifact.artifact_created_utc = fields.at("artifact_created_utc");
+
+    std::string diagnostic;
+    if (!validate_record(result.record, diagnostic)) {
+        return failure(ProvenanceReadStatus::MalformedProvenance, std::move(diagnostic));
+    }
+    result.status = ProvenanceReadStatus::Valid;
+    return result;
+}
+
+ProvenanceReadResult read_job_info_file (const std::string& path)
+{
+    int read_status = static_cast<int>(ProvenanceReadStatus::Valid);
+    std::string contents;
+    if (amrex::ParallelDescriptor::IOProcessor()) {
+        std::ifstream input(path, std::ios::in | std::ios::binary);
+        if (!input.good()) {
+            read_status = static_cast<int>(ProvenanceReadStatus::MissingJobInfo);
+        } else {
+            contents.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+            if (!input.good() && !input.eof()) {
+                read_status = static_cast<int>(ProvenanceReadStatus::MalformedProvenance);
+            }
+        }
+    }
+    const int io_rank = amrex::ParallelDescriptor::IOProcessorNumber();
+    amrex::ParallelDescriptor::Bcast(&read_status, 1, io_rank);
+    broadcast_string(contents);
+    if (read_status != static_cast<int>(ProvenanceReadStatus::Valid)) {
+        return failure(static_cast<ProvenanceReadStatus>(read_status),
+                       read_status == static_cast<int>(ProvenanceReadStatus::MissingJobInfo)
+                           ? "job_info does not exist" : "job_info could not be read");
+    }
+    return parse_provenance_block(contents);
+}
+
+ExecutionProvenance make_cold_start_provenance (const std::string& execution_uuid,
+                                                const std::string& execution_start_utc)
+{
+    ExecutionProvenance result;
+    result.simulation_uuid = execution_uuid;
+    result.execution_uuid = execution_uuid;
+    result.execution_lineage = {execution_uuid};
+    result.execution_start_utc = execution_start_utc;
+    return result;
+}
+
+ExecutionProvenance make_restart_provenance (const ExecutionProvenance& current_invocation,
+                                             const ProvenanceRecord& parent_checkpoint,
+                                             const std::string& checkpoint_path)
+{
+    ExecutionProvenance result = current_invocation;
+    const auto& parent = parent_checkpoint.execution;
+    result.simulation_uuid = parent.simulation_uuid;
+    result.parent_execution_uuid = parent.execution_uuid;
+    result.execution_lineage = parent.execution_lineage;
+    result.execution_lineage.push_back(current_invocation.execution_uuid);
+    result.source_checkpoint_uuid = parent_checkpoint.artifact.artifact_uuid;
+    result.source_checkpoint_path = checkpoint_path;
+    if (parent.lineage_complete) {
+        result.restart_generation = parent.restart_generation + 1;
+        result.lineage_complete = true;
+        result.lineage_status = LineageStatus::Complete;
+    } else {
+        result.restart_generation = -1;
+        result.lineage_complete = false;
+        result.lineage_status = LineageStatus::IncompleteAncestor;
+    }
+    return result;
+}
+
+ExecutionProvenance make_incomplete_restart_provenance (const ExecutionProvenance& current_invocation,
+                                                         ProvenanceReadStatus failure_status,
+                                                         const std::string& checkpoint_path)
+{
+    ExecutionProvenance result = current_invocation;
+    result.simulation_uuid = current_invocation.execution_uuid;
+    result.parent_execution_uuid.clear();
+    result.execution_lineage = {current_invocation.execution_uuid};
+    result.restart_generation = -1;
+    result.lineage_complete = false;
+    result.lineage_status = failure_lineage_status(failure_status);
+    result.source_checkpoint_uuid.clear();
+    result.source_checkpoint_path = checkpoint_path;
+    return result;
+}
+
+ExecutionProvenance initialize_execution_provenance ()
+{
+    static bool initialized = false;
+    static ExecutionProvenance invocation;
+    if (!initialized) {
+        std::string execution_uuid;
+        std::string execution_start_utc;
+        if (amrex::ParallelDescriptor::IOProcessor()) {
+            execution_uuid = generate_uuid_v4();
+            execution_start_utc = current_utc();
+        }
+        broadcast_string(execution_uuid);
+        broadcast_string(execution_start_utc);
+        invocation = make_cold_start_provenance(execution_uuid, execution_start_utc);
+        initialized = true;
+    }
+    return invocation;
+}
+
+} // namespace erf_provenance

--- a/Source/IO/ERF_Provenance.cpp
+++ b/Source/IO/ERF_Provenance.cpp
@@ -43,13 +43,6 @@ bool is_canonical_uuid_layout (std::string_view uuid)
     return true;
 }
 
-int hex_value (char c)
-{
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    return c - 'A' + 10;
-}
-
 std::vector<std::string> split_lineage (std::string_view value)
 {
     std::vector<std::string> result;

--- a/Source/IO/ERF_Provenance.cpp
+++ b/Source/IO/ERF_Provenance.cpp
@@ -373,17 +373,43 @@ std::string serialize_provenance_block (const ProvenanceRecord& record)
 
 ProvenanceParseResult parse_provenance_block (std::string_view text)
 {
-    const std::size_t begin = text.find(provenance_begin);
-    const std::size_t end = text.find(provenance_end);
-    if (begin == std::string_view::npos) {
-        return failure(ProvenanceReadStatus::MissingProvenanceBlock,
-                       "job_info has no ERF provenance block");
+    enum class BlockState { BeforeBlock, InsideBlock, AfterBlock };
+    BlockState state = BlockState::BeforeBlock;
+    std::vector<std::string> block_lines;
+    std::istringstream input{std::string(text)};
+    std::string line;
+    while (std::getline(input, line)) {
+        line = strip_cr(std::move(line));
+        const bool is_begin = line == provenance_begin;
+        const bool is_end = line == provenance_end;
+        if (state == BlockState::BeforeBlock) {
+            if (is_end) {
+                return failure(ProvenanceReadStatus::MalformedProvenance,
+                               "provenance end marker precedes begin marker");
+            }
+            if (is_begin) state = BlockState::InsideBlock;
+        } else if (state == BlockState::InsideBlock) {
+            if (is_begin) {
+                return failure(ProvenanceReadStatus::MalformedProvenance,
+                               "provenance block has a nested begin marker");
+            }
+            if (is_end) {
+                state = BlockState::AfterBlock;
+            } else {
+                block_lines.push_back(line);
+            }
+        } else if (is_begin || is_end) {
+            return failure(ProvenanceReadStatus::MalformedProvenance,
+                           "job_info has multiple provenance blocks");
+        }
     }
-    if (end == std::string_view::npos || end < begin ||
-        text.find(provenance_begin, begin + 1) != std::string_view::npos ||
-        text.find(provenance_end, end + 1) != std::string_view::npos) {
+    if (state == BlockState::BeforeBlock) {
+        return failure(ProvenanceReadStatus::MissingProvenanceBlock,
+                       "job_info has no exact ERF provenance block");
+    }
+    if (state == BlockState::InsideBlock) {
         return failure(ProvenanceReadStatus::MalformedProvenance,
-                       "job_info has multiple or unterminated provenance blocks");
+                       "provenance block has no matching end marker");
     }
 
     std::unordered_map<std::string, std::string> fields;
@@ -394,11 +420,7 @@ ProvenanceParseResult parse_provenance_block (std::string_view text)
         "artifact_uuid", "artifact_type", "artifact_step", "artifact_time_seconds",
         "artifact_created_utc"
     };
-    std::istringstream lines(std::string(text.substr(begin + std::string(provenance_begin).size(),
-                                                     end - begin - std::string(provenance_begin).size())));
-    std::string line;
-    while (std::getline(lines, line)) {
-        line = strip_cr(std::move(line));
+    for (const auto& line : block_lines) {
         if (line.empty()) continue;
         const std::size_t equals = line.find('=');
         if (equals == std::string::npos || equals == 0) {

--- a/Source/IO/ERF_WriteJobInfo.cpp
+++ b/Source/IO/ERF_WriteJobInfo.cpp
@@ -2,17 +2,38 @@
 #include <ERF_InputsName.H>
 #include <ERF_EpochTime.H>
 #include <AMReX_buildInfo.H>
+#include <ERF_Provenance.H>
+
+#include <iomanip>
 
 using namespace amrex;
 
 void
-ERF::writeJobInfo (const std::string& dir) const
+ERF::writeJobInfo (const std::string& dir,
+                   erf_provenance::ArtifactType artifact_type,
+                   int artifact_step,
+                   double artifact_time_seconds) const
 {
+    if (!ParallelDescriptor::IOProcessor()) {
+        return;
+    }
+
     // job_info file with details about the run
     std::ofstream jobInfoFile;
     std::string FullPathJobInfoFile = dir;
     FullPathJobInfoFile += "/job_info";
-    jobInfoFile.open(FullPathJobInfoFile.c_str(), std::ios::out);
+    jobInfoFile.open(FullPathJobInfoFile.c_str(), std::ios::out | std::ios::trunc);
+    if (!jobInfoFile.good()) {
+        FileOpenFailed(FullPathJobInfoFile);
+    }
+
+    erf_provenance::ProvenanceRecord provenance;
+    provenance.execution = execution_provenance;
+    provenance.artifact.artifact_uuid = erf_provenance::generate_uuid_v4();
+    provenance.artifact.artifact_type = artifact_type;
+    provenance.artifact.artifact_step = artifact_step;
+    provenance.artifact.artifact_time_seconds = artifact_time_seconds;
+    provenance.artifact.artifact_created_utc = erf_provenance::current_utc();
 
     std::string PrettyLine = "==================================================="
       "============================\n";
@@ -24,6 +45,9 @@ ERF::writeJobInfo (const std::string& dir) const
     jobInfoFile << PrettyLine;
     jobInfoFile << " ERF Job Information\n";
     jobInfoFile << PrettyLine;
+
+    jobInfoFile << erf_provenance::serialize_provenance_block(provenance);
+    jobInfoFile << "\n";
 
     jobInfoFile << "inputs file: " << inputs_name << "\n\n";
 
@@ -45,10 +69,18 @@ ERF::writeJobInfo (const std::string& dir) const
         jobInfoFile << "\n\n";
     }
 
-    // plotfile information
+    // Output information
     jobInfoFile << PrettyLine;
-    jobInfoFile << " Plotfile Information\n";
+    jobInfoFile << " Output Information\n";
     jobInfoFile << PrettyLine;
+
+    jobInfoFile << "artifact type:    "
+                << erf_provenance::artifact_type_token(artifact_type) << "\n";
+    jobInfoFile << "artifact step:    " << artifact_step << "\n";
+    const auto existing_precision = jobInfoFile.precision();
+    jobInfoFile << std::setprecision(17)
+                << "simulation time:  " << artifact_time_seconds << "\n";
+    jobInfoFile.precision(existing_precision);
 
     time_t now = time(nullptr);
 

--- a/Source/IO/Make.package
+++ b/Source/IO/Make.package
@@ -11,7 +11,9 @@ CEXE_sources += ERF_Plotfile2DSampledLevel.cpp
 CEXE_sources += ERF_Plotfile2DInterpolator.cpp
 CEXE_sources += ERF_Plotfile2DUtils.cpp
 CEXE_sources += ERF_Checkpoint.cpp
+CEXE_sources += ERF_Provenance.cpp
 CEXE_sources += ERF_WriteJobInfo.cpp
+CEXE_headers += ERF_Provenance.H
 
 CEXE_headers += ERF_WriteBndryPlanes.H
 CEXE_headers += ERF_ReadBndryPlanes.H

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -67,6 +67,7 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/BoundaryConditions/ERF_GTestSurfaceLayerStress.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Diagnostics/ERF_GTestSurfaceFluxDiagnostics.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestPlotfile2D.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestProvenance.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/Interpolation/ERF_GTestInterpolationScalar.cpp
@@ -168,6 +169,7 @@ if(ERF_ENABLE_MPI)
       ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestParallelMain.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestParallelHelloWorld.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/ERF_GTestRuntimeStubs.cpp
+      ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestProvenanceParallel.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjParallel.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SAM/ERF_GTestSAMParallel.cpp
   )

--- a/Tests/Unit/IO/ERF_GTestProvenance.cpp
+++ b/Tests/Unit/IO/ERF_GTestProvenance.cpp
@@ -1,0 +1,288 @@
+#include "ERF_Provenance.H"
+
+#include <gtest/gtest.h>
+
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace
+{
+
+using namespace erf_provenance;
+
+const std::string uuid_a = "11111111-1111-4111-8111-111111111111";
+const std::string uuid_b = "22222222-2222-4222-8222-222222222222";
+const std::string uuid_c = "33333333-3333-4333-8333-333333333333";
+const std::string uuid_d = "44444444-4444-4444-8444-444444444444";
+const std::string artifact_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const std::string artifact_b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const std::string artifact_c = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+ProvenanceRecord checkpoint_record (const ExecutionProvenance& execution,
+                                    const std::string& artifact_uuid,
+                                    int step = 4)
+{
+    ProvenanceRecord record;
+    record.execution = execution;
+    record.artifact.artifact_uuid = artifact_uuid;
+    record.artifact.artifact_type = ArtifactType::Checkpoint;
+    record.artifact.artifact_step = step;
+    record.artifact.artifact_time_seconds = 12.5;
+    record.artifact.artifact_created_utc = "2026-07-11T18:42:17Z";
+    return record;
+}
+
+std::string replace_once (std::string text, const std::string& from, const std::string& to)
+{
+    const std::size_t position = text.find(from);
+    EXPECT_NE(position, std::string::npos);
+    if (position != std::string::npos) text.replace(position, from.size(), to);
+    return text;
+}
+
+} // namespace
+
+TEST(ERFProvenance, UUIDFormatting)
+{
+    // Motivation: Provenance identifiers must use one canonical UUIDv4 form so checkpoints and analysis tools can validate and compare them reliably.
+    const std::array<std::uint8_t, 16> bytes{
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x4a, 0x77,
+        0x8f, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff};
+    const std::string uuid = uuid_v4_from_bytes(bytes);
+    EXPECT_EQ(uuid, "00112233-4455-4a77-8f99-aabbccddeeff");
+    EXPECT_EQ(uuid.size(), 36u);
+    EXPECT_EQ(uuid[8], '-');
+    EXPECT_EQ(uuid[13], '-');
+    EXPECT_EQ(uuid[18], '-');
+    EXPECT_EQ(uuid[23], '-');
+}
+
+TEST(ERFProvenance, UUIDValidation)
+{
+    // Motivation: Restart metadata must reject malformed identifiers without rejecting the physical checkpoint that contains them.
+    EXPECT_TRUE(is_valid_uuid_v4(uuid_a));
+    EXPECT_TRUE(is_valid_uuid_v4("AAAAAAAA-AAAA-4AAA-8AAA-AAAAAAAAAAAA"));
+    EXPECT_FALSE(is_valid_uuid_v4("11111111-1111-4111-8111-11111111111"));
+    EXPECT_FALSE(is_valid_uuid_v4("111111111111-4111-8111-111111111111"));
+    EXPECT_FALSE(is_valid_uuid_v4("11111111-1111-5111-8111-111111111111"));
+    EXPECT_FALSE(is_valid_uuid_v4("11111111-1111-4111-7111-111111111111"));
+    EXPECT_FALSE(is_valid_uuid_v4("11111111-1111-4111-8111-11111111111g"));
+}
+
+TEST(ERFProvenance, ColdStart)
+{
+    // Motivation: A cold start defines the root of a simulation lineage and must not claim a parent or a restart generation.
+    const auto execution = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    EXPECT_EQ(execution.simulation_uuid, uuid_a);
+    EXPECT_EQ(execution.execution_uuid, uuid_a);
+    EXPECT_TRUE(execution.parent_execution_uuid.empty());
+    ASSERT_EQ(execution.execution_lineage.size(), 1u);
+    EXPECT_EQ(execution.execution_lineage.front(), uuid_a);
+    EXPECT_EQ(execution.restart_generation, 0);
+    EXPECT_TRUE(execution.lineage_complete);
+    EXPECT_EQ(execution.lineage_status, LineageStatus::Complete);
+    EXPECT_TRUE(execution.source_checkpoint_uuid.empty());
+    EXPECT_TRUE(execution.source_checkpoint_path.empty());
+}
+
+TEST(ERFProvenance, CompleteRestart)
+{
+    // Motivation: A restart must preserve the simulation identity, identify its parent execution and source checkpoint, and append exactly one execution.
+    const auto parent = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    const auto child = make_restart_provenance(make_cold_start_provenance(uuid_b, "2026-07-11T19:00:00Z"),
+                                               checkpoint_record(parent, artifact_a), "/tmp/chk00004");
+    EXPECT_EQ(child.simulation_uuid, uuid_a);
+    EXPECT_EQ(child.execution_uuid, uuid_b);
+    EXPECT_EQ(child.parent_execution_uuid, uuid_a);
+    EXPECT_EQ(child.execution_lineage, (std::vector<std::string>{uuid_a, uuid_b}));
+    EXPECT_EQ(child.restart_generation, 1);
+    EXPECT_TRUE(child.lineage_complete);
+    EXPECT_EQ(child.lineage_status, LineageStatus::Complete);
+    EXPECT_EQ(child.source_checkpoint_uuid, artifact_a);
+    EXPECT_EQ(child.source_checkpoint_path, "/tmp/chk00004");
+}
+
+TEST(ERFProvenance, MultipleRestartGenerations)
+{
+    // Motivation: Full lineage must survive repeated checkpoint restarts without requiring older checkpoint directories to remain available.
+    const auto a = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    const auto b = make_restart_provenance(make_cold_start_provenance(uuid_b, "2026-07-11T19:00:00Z"),
+                                           checkpoint_record(a, artifact_a), "/tmp/chk-a");
+    const auto c = make_restart_provenance(make_cold_start_provenance(uuid_c, "2026-07-11T20:00:00Z"),
+                                           checkpoint_record(b, artifact_b), "/tmp/chk-b");
+    EXPECT_EQ(c.execution_lineage, (std::vector<std::string>{uuid_a, uuid_b, uuid_c}));
+    EXPECT_EQ(c.restart_generation, 2);
+    EXPECT_EQ(c.source_checkpoint_uuid, artifact_b);
+}
+
+TEST(ERFProvenance, BranchingRestarts)
+{
+    // Motivation: Two executions may restart from the same checkpoint, so they must share a parent and simulation UUID while retaining distinct identities.
+    const auto a = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    const auto b = make_restart_provenance(make_cold_start_provenance(uuid_b, "2026-07-11T19:00:00Z"),
+                                           checkpoint_record(a, artifact_a), "/tmp/chk-a");
+    const auto c = make_restart_provenance(make_cold_start_provenance(uuid_c, "2026-07-11T20:00:00Z"),
+                                           checkpoint_record(b, artifact_b), "/tmp/chk-b");
+    const auto d = make_restart_provenance(make_cold_start_provenance(uuid_d, "2026-07-11T20:30:00Z"),
+                                           checkpoint_record(b, artifact_b), "/tmp/chk-b");
+    EXPECT_EQ(c.simulation_uuid, d.simulation_uuid);
+    EXPECT_EQ(c.parent_execution_uuid, d.parent_execution_uuid);
+    EXPECT_NE(c.execution_uuid, d.execution_uuid);
+    EXPECT_EQ(c.execution_lineage.back(), uuid_c);
+    EXPECT_EQ(d.execution_lineage.back(), uuid_d);
+}
+
+TEST(ERFProvenance, IncompleteLegacyLineage)
+{
+    // Motivation: Legacy checkpoints must remain restartable while clearly marking that ancestry before the current execution is unknown.
+    const auto child = make_incomplete_restart_provenance(
+        make_cold_start_provenance(uuid_b, "2026-07-11T19:00:00Z"),
+        ProvenanceReadStatus::MissingJobInfo, "/tmp/legacy");
+    EXPECT_EQ(child.simulation_uuid, uuid_b);
+    EXPECT_EQ(child.execution_lineage, (std::vector<std::string>{uuid_b}));
+    EXPECT_EQ(child.restart_generation, -1);
+    EXPECT_FALSE(child.lineage_complete);
+    EXPECT_EQ(child.lineage_status, LineageStatus::MissingJobInfo);
+    EXPECT_TRUE(child.source_checkpoint_uuid.empty());
+    EXPECT_EQ(child.source_checkpoint_path, "/tmp/legacy");
+}
+
+TEST(ERFProvenance, IncompleteLineagePropagation)
+{
+    // Motivation: Once ancestry is incomplete, later restarts must preserve the known suffix without falsely claiming that the full history was recovered.
+    auto parent_execution = make_incomplete_restart_provenance(
+        make_cold_start_provenance(uuid_b, "2026-07-11T19:00:00Z"),
+        ProvenanceReadStatus::MissingProvenanceBlock, "/tmp/legacy");
+    auto parent = checkpoint_record(parent_execution, artifact_a);
+    const auto child = make_restart_provenance(make_cold_start_provenance(uuid_c, "2026-07-11T20:00:00Z"),
+                                               parent, "/tmp/chk-b");
+    EXPECT_EQ(child.simulation_uuid, uuid_b);
+    EXPECT_EQ(child.execution_lineage, (std::vector<std::string>{uuid_b, uuid_c}));
+    EXPECT_EQ(child.parent_execution_uuid, uuid_b);
+    EXPECT_EQ(child.restart_generation, -1);
+    EXPECT_FALSE(child.lineage_complete);
+    EXPECT_EQ(child.lineage_status, LineageStatus::IncompleteAncestor);
+    EXPECT_EQ(child.source_checkpoint_uuid, artifact_a);
+}
+
+TEST(ERFProvenance, SerializationRoundTrip)
+{
+    // Motivation: The checkpoint reader and job_info writer must agree on every schema-1 field so a written checkpoint can reconstruct its lineage.
+    auto execution = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    execution.source_checkpoint_path = "/tmp/checkpoint=a";
+    const auto original = checkpoint_record(execution, artifact_a);
+    const auto parsed = parse_provenance_block(serialize_provenance_block(original));
+    ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(serialize_provenance_block(parsed.record), serialize_provenance_block(original));
+}
+
+TEST(ERFProvenance, HumanTextAroundBlock)
+{
+    // Motivation: job_info contains build and input text, so the parser must read only the delimited provenance block.
+    const auto record = checkpoint_record(make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z"), artifact_a);
+    const std::string text = "input=value=with=equals UUID-like=" + uuid_d + "\n" +
+                             serialize_provenance_block(record) +
+                             "build hash=" + uuid_c + "\n";
+    const auto parsed = parse_provenance_block(text);
+    ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(parsed.record.artifact.artifact_uuid, artifact_a);
+}
+
+TEST(ERFProvenance, MissingBlock)
+{
+    // Motivation: Checkpoints written before provenance support contain no block and must produce a nonfatal, explicit status.
+    const auto parsed = parse_provenance_block("old job_info\ninputs=foo\n");
+    EXPECT_EQ(parsed.status, ProvenanceReadStatus::MissingProvenanceBlock);
+    EXPECT_FALSE(parsed.valid());
+}
+
+TEST(ERFProvenance, MalformedAndDuplicateFields)
+{
+    // Motivation: Ambiguous provenance must be rejected rather than silently constructing a false lineage.
+    const auto serialized = serialize_provenance_block(
+        checkpoint_record(make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z"), artifact_a));
+    EXPECT_EQ(parse_provenance_block(replace_once(serialized, "artifact_step=4\n", "artifact_step=bad\n")).status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block(replace_once(serialized, "artifact_uuid=" + artifact_a + "\n",
+                                                  "artifact_uuid=" + artifact_a + "\nartifact_uuid=" + artifact_b + "\n")).status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block(replace_once(serialized, "lineage_complete=true", "lineage_complete=TRUE")).status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block(replace_once(serialized, "execution_uuid=" + uuid_a,
+                                                  "execution_uuid=not-a-uuid")).status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block(replace_once(serialized, "parent_execution_uuid=\n",
+                                                  "parent_execution_uuid=" + uuid_b + "\n")).status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block(serialized + serialized).status,
+              ProvenanceReadStatus::MalformedProvenance);
+}
+
+TEST(ERFProvenance, UnsupportedSchema)
+{
+    // Motivation: New ERF versions must not make older physical checkpoint data unreadable when provenance schema support differs.
+    auto serialized = serialize_provenance_block(
+        checkpoint_record(make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z"), artifact_a));
+    serialized = replace_once(serialized, "schema_version=1", "schema_version=99");
+    const auto parsed = parse_provenance_block(serialized);
+    EXPECT_EQ(parsed.status, ProvenanceReadStatus::UnsupportedSchema);
+    EXPECT_FALSE(parsed.valid());
+}
+
+TEST(ERFProvenance, ArtifactIdentity)
+{
+    // Motivation: Multiple outputs from one execution must share execution provenance while each output keeps a distinct artifact identity.
+    auto execution = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    const auto checkpoint = checkpoint_record(execution, artifact_a);
+    const auto plotfile = checkpoint_record(execution, artifact_b);
+    EXPECT_EQ(checkpoint.execution.execution_uuid, plotfile.execution.execution_uuid);
+    EXPECT_NE(checkpoint.artifact.artifact_uuid, plotfile.artifact.artifact_uuid);
+}
+
+TEST(ERFProvenance, CRLFAndEqualsInPath)
+{
+    // Motivation: Provenance parsing must tolerate common line endings and paths that contain equals signs without corrupting checkpoint identity.
+    auto execution = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    execution.source_checkpoint_path = "/scratch/run=a/chk00004";
+    const auto serialized = serialize_provenance_block(checkpoint_record(execution, artifact_a));
+    std::string crlf;
+    for (const char character : serialized) {
+        if (character == '\n') crlf += '\r';
+        crlf += character;
+    }
+    const auto parsed = parse_provenance_block(crlf);
+    ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(parsed.record.execution.source_checkpoint_path, "/scratch/run=a/chk00004");
+}
+
+TEST(ERFProvenance, FileReadStatuses)
+{
+    // Motivation: File-level restart metadata failures must return structured nonfatal statuses without relying on an abort or death test.
+    const auto directory = std::filesystem::temp_directory_path() / "erf-provenance-file-test";
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directories(directory);
+    const auto path = directory / "job_info";
+    const auto missing = read_job_info_file(path.string());
+    EXPECT_EQ(missing.status, ProvenanceReadStatus::MissingJobInfo);
+    {
+        std::ofstream output(path);
+        output << "legacy text\n";
+    }
+    EXPECT_EQ(read_job_info_file(path.string()).status, ProvenanceReadStatus::MissingProvenanceBlock);
+    {
+        std::ofstream output(path, std::ios::trunc);
+        output << "ERF_PROVENANCE_BEGIN\nartifact_step=bad\nERF_PROVENANCE_END\n";
+    }
+    EXPECT_EQ(read_job_info_file(path.string()).status, ProvenanceReadStatus::MalformedProvenance);
+    {
+        std::ofstream output(path, std::ios::trunc);
+        auto block = serialize_provenance_block(
+            checkpoint_record(make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z"), artifact_a));
+        output << replace_once(block, "schema_version=1", "schema_version=88");
+    }
+    EXPECT_EQ(read_job_info_file(path.string()).status, ProvenanceReadStatus::UnsupportedSchema);
+    std::filesystem::remove_all(directory);
+}

--- a/Tests/Unit/IO/ERF_GTestProvenance.cpp
+++ b/Tests/Unit/IO/ERF_GTestProvenance.cpp
@@ -20,7 +20,6 @@ const std::string uuid_c = "33333333-3333-4333-8333-333333333333";
 const std::string uuid_d = "44444444-4444-4444-8444-444444444444";
 const std::string artifact_a = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const std::string artifact_b = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
-const std::string artifact_c = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 
 ProvenanceRecord checkpoint_record (const ExecutionProvenance& execution,
                                     const std::string& artifact_uuid,

--- a/Tests/Unit/IO/ERF_GTestProvenance.cpp
+++ b/Tests/Unit/IO/ERF_GTestProvenance.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -41,6 +42,20 @@ std::string replace_once (std::string text, const std::string& from, const std::
     EXPECT_NE(position, std::string::npos);
     if (position != std::string::npos) text.replace(position, from.size(), to);
     return text;
+}
+
+std::string reorder_schema_keys (const std::string& serialized)
+{
+    std::istringstream input(serialized);
+    std::vector<std::string> lines;
+    std::string line;
+    while (std::getline(input, line)) lines.push_back(line);
+    EXPECT_EQ(lines.size(), 18u);
+    if (lines.size() == 18u) std::swap(lines[1], lines[12]);
+
+    std::ostringstream output;
+    for (const auto& value : lines) output << value << '\n';
+    return output.str();
 }
 
 } // namespace
@@ -188,6 +203,50 @@ TEST(ERFProvenance, HumanTextAroundBlock)
                              "build hash=" + uuid_c + "\n";
     const auto parsed = parse_provenance_block(text);
     ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(parsed.record.artifact.artifact_uuid, artifact_a);
+}
+
+TEST(ERFProvenance, ExactMarkersIgnoreSurroundingText)
+{
+    // Motivation: Parameter values and human-readable job_info text may contain marker tokens, so only exact marker lines may delimit provenance.
+    auto execution = make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z");
+    execution.source_checkpoint_path = "/scratch/ERF_PROVENANCE_BEGIN/run=one/chk00010";
+    const auto record = checkpoint_record(execution, artifact_a);
+    const std::string text = "note=ERF_PROVENANCE_BEGIN\n"
+                             "prefix ERF_PROVENANCE_END suffix\n" +
+                             serialize_provenance_block(record) +
+                             "after=ERF_PROVENANCE_BEGIN\n";
+    const auto parsed = parse_provenance_block(text);
+    ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(parsed.record.execution.source_checkpoint_path,
+              "/scratch/ERF_PROVENANCE_BEGIN/run=one/chk00010");
+}
+
+TEST(ERFProvenance, MarkerSubstringsDoNotCreateABlock)
+{
+    // Motivation: A marker token inside ordinary text must not be mistaken for an exact provenance delimiter.
+    const auto parsed = parse_provenance_block(
+        "note=ERF_PROVENANCE_BEGIN\nprefix ERF_PROVENANCE_END suffix\n");
+    EXPECT_EQ(parsed.status, ProvenanceReadStatus::MissingProvenanceBlock);
+}
+
+TEST(ERFProvenance, UnterminatedAndUnexpectedEndMarkersAreMalformed)
+{
+    // Motivation: An incomplete or incorrectly ordered exact marker pair must never produce a partially trusted provenance record.
+    EXPECT_EQ(parse_provenance_block("ERF_PROVENANCE_BEGIN\n").status,
+              ProvenanceReadStatus::MalformedProvenance);
+    EXPECT_EQ(parse_provenance_block("ERF_PROVENANCE_END\n").status,
+              ProvenanceReadStatus::MalformedProvenance);
+}
+
+TEST(ERFProvenance, ReorderedKeysRemainValid)
+{
+    // Motivation: External tools may preserve schema-1 keys in a different order, so the reader must identify required fields by key rather than position.
+    const auto record = checkpoint_record(
+        make_cold_start_provenance(uuid_a, "2026-07-11T18:42:17Z"), artifact_a);
+    const auto parsed = parse_provenance_block(reorder_schema_keys(serialize_provenance_block(record)));
+    ASSERT_TRUE(parsed.valid()) << parsed.diagnostic;
+    EXPECT_EQ(parsed.record.execution.execution_uuid, uuid_a);
     EXPECT_EQ(parsed.record.artifact.artifact_uuid, artifact_a);
 }
 

--- a/Tests/Unit/IO/ERF_GTestProvenanceParallel.cpp
+++ b/Tests/Unit/IO/ERF_GTestProvenanceParallel.cpp
@@ -3,13 +3,83 @@
 #include <AMReX_ParallelDescriptor.H>
 #include <gtest/gtest.h>
 
+#include <string>
+#include <vector>
+
+namespace
+{
+
+void broadcast_reference_string (std::string& value)
+{
+    const int root = amrex::ParallelDescriptor::IOProcessorNumber();
+    int length = amrex::ParallelDescriptor::IOProcessor()
+               ? static_cast<int>(value.size()) : 0;
+    amrex::ParallelDescriptor::Bcast(&length, 1, root);
+    value.resize(static_cast<std::size_t>(length));
+    if (length > 0) {
+        amrex::ParallelDescriptor::Bcast(value.data(), length, root);
+    }
+}
+
+} // namespace
+
 TEST(ERFProvenanceParallel, BroadcastExecutionIdentity)
 {
-    // Motivation: Every MPI rank must attach the same execution identity and lineage to collectively written ERF outputs.
+    // Motivation: Every MPI rank must attach the same execution identity and
+    // lineage to collectively written ERF outputs. Valid but different
+    // per-rank UUIDs must fail this test.
     const auto execution = erf_provenance::initialize_execution_provenance();
+    const bool is_io = amrex::ParallelDescriptor::IOProcessor();
+    std::string reference_execution_uuid = is_io ? execution.execution_uuid : "";
+    std::string reference_simulation_uuid = is_io ? execution.simulation_uuid : "";
+    std::string reference_start_utc = is_io ? execution.execution_start_utc : "";
+    std::string reference_parent_uuid = is_io ? execution.parent_execution_uuid : "";
+    std::string reference_lineage_status = is_io
+        ? erf_provenance::lineage_status_token(execution.lineage_status) : "";
+    broadcast_reference_string(reference_execution_uuid);
+    broadcast_reference_string(reference_simulation_uuid);
+    broadcast_reference_string(reference_start_utc);
+    broadcast_reference_string(reference_parent_uuid);
+    broadcast_reference_string(reference_lineage_status);
+
+    int reference_generation = is_io ? execution.restart_generation : 0;
+    int reference_lineage_complete = is_io && execution.lineage_complete ? 1 : 0;
+    int reference_lineage_size = is_io
+        ? static_cast<int>(execution.execution_lineage.size()) : 0;
+    const int root = amrex::ParallelDescriptor::IOProcessorNumber();
+    amrex::ParallelDescriptor::Bcast(&reference_generation, 1, root);
+    amrex::ParallelDescriptor::Bcast(&reference_lineage_complete, 1, root);
+    amrex::ParallelDescriptor::Bcast(&reference_lineage_size, 1, root);
+    std::vector<std::string> reference_lineage(static_cast<std::size_t>(reference_lineage_size));
+    for (int i = 0; i < reference_lineage_size; ++i) {
+        reference_lineage[static_cast<std::size_t>(i)] = is_io
+            ? execution.execution_lineage[static_cast<std::size_t>(i)] : "";
+        broadcast_reference_string(reference_lineage[static_cast<std::size_t>(i)]);
+    }
+
+    bool lineage_equal = execution.execution_lineage.size() == reference_lineage.size();
+    if (lineage_equal) {
+        for (std::size_t i = 0; i < reference_lineage.size(); ++i) {
+            lineage_equal = lineage_equal &&
+                execution.execution_lineage[i] == reference_lineage[i];
+        }
+    }
     int local_equal = erf_provenance::is_valid_uuid_v4(execution.execution_uuid) &&
+                      execution.execution_uuid == reference_execution_uuid &&
+                      execution.simulation_uuid == reference_simulation_uuid &&
+                      execution.execution_start_utc == reference_start_utc &&
+                      execution.parent_execution_uuid == reference_parent_uuid &&
+                      lineage_equal &&
+                      execution.restart_generation == reference_generation &&
+                      (execution.lineage_complete ? 1 : 0) == reference_lineage_complete &&
+                      std::string(erf_provenance::lineage_status_token(execution.lineage_status)) ==
+                          reference_lineage_status &&
                       execution.simulation_uuid == execution.execution_uuid &&
-                      execution.execution_lineage.size() == 1u ? 1 : 0;
+                      execution.parent_execution_uuid.empty() &&
+                      execution.execution_lineage == std::vector<std::string>{execution.execution_uuid} &&
+                      execution.restart_generation == 0 &&
+                      execution.lineage_complete &&
+                      execution.lineage_status == erf_provenance::LineageStatus::Complete ? 1 : 0;
     amrex::ParallelDescriptor::ReduceIntSum(local_equal);
     EXPECT_EQ(local_equal, amrex::ParallelDescriptor::NProcs());
 }

--- a/Tests/Unit/IO/ERF_GTestProvenanceParallel.cpp
+++ b/Tests/Unit/IO/ERF_GTestProvenanceParallel.cpp
@@ -1,0 +1,15 @@
+#include "ERF_Provenance.H"
+
+#include <AMReX_ParallelDescriptor.H>
+#include <gtest/gtest.h>
+
+TEST(ERFProvenanceParallel, BroadcastExecutionIdentity)
+{
+    // Motivation: Every MPI rank must attach the same execution identity and lineage to collectively written ERF outputs.
+    const auto execution = erf_provenance::initialize_execution_provenance();
+    int local_equal = erf_provenance::is_valid_uuid_v4(execution.execution_uuid) &&
+                      execution.simulation_uuid == execution.execution_uuid &&
+                      execution.execution_lineage.size() == 1u ? 1 : 0;
+    amrex::ParallelDescriptor::ReduceIntSum(local_equal);
+    EXPECT_EQ(local_equal, amrex::ParallelDescriptor::NProcs());
+}


### PR DESCRIPTION
## Summary

This PR extends ERF’s existing job_info metadata with persistent restart ancestry and stable identities for simulations, executions, checkpoints, and primary native plotfiles.

Each ERF invocation now receives a new execution UUID. A simulation UUID remains stable across checkpoint restarts, including branched restart workflows. Each checkpoint and plotfile also receives a distinct artifact UUID.

The provenance record is written into the existing human-readable `job_info` file. The checkpoint `Header` format is unchanged.

## Provenance model

The record distinguishes:

- `simulation_uuid`: identifies one rooted restart family, including branches;
- `execution_uuid`: identifies one ERF process invocation;
- `parent_execution_uuid`: identifies the execution that wrote the source checkpoint;
- `execution_lineage`: stores the complete known ancestry path to the current execution;
- `artifact_uuid`: identifies one checkpoint or plotfile;
- `source_checkpoint_uuid`: identifies the exact checkpoint used for restart;
- `restart_generation`: records the number of restart edges from the known root;
- `lineage_complete` and `lineage_status`: describe whether the full ancestry was recovered.

For example:

```text
A -> B -> C
       \
        -> D
````

Executions `C` and `D` share the same simulation UUID, but retain distinct execution UUIDs and ancestry paths:

```text
C: [A, B, C]
D: [A, B, D]
```

The complete known ancestry is stored in every artifact, so earlier checkpoint directories are not required to inspect a later artifact’s lineage.

## Restart behavior

On restart, ERF reads the provenance block from the source checkpoint’s `job_info`.

For a valid provenance record, ERF:

* preserves the simulation UUID;
* assigns a new execution UUID;
* records the parent execution UUID;
* records the exact source checkpoint UUID;
* appends the new execution to the ancestry path;
* increments the restart generation.

Older checkpoints remain fully restartable. If `job_info` is missing, the provenance block is absent, or the metadata is malformed or unsupported, ERF prints one warning and continues with incomplete provenance. Provenance metadata never changes physical checkpoint state or restart calculations.

Both `erf.restart` and `amr.restart` are accepted. `amr.restart` takes precedence when both are set.

## Native output coverage

This PR adds provenance to:

* native checkpoints;
* primary native 3D AMReX plotfiles;
* primary native 2D AMReX plotfiles.

Each output contains one versioned block between:

```text
ERF_PROVENANCE_BEGIN
ERF_PROVENANCE_END
```

The existing build, grid, boundary-condition, and runtime-parameter sections of `job_info` remain intact.

## Implementation notes

* Adds a host-only provenance module with UUID generation, serialization, parsing, validation, and restart-state transitions.
* Generates execution UUIDs on the I/O rank and broadcasts the execution record to all MPI ranks.
* Generates artifact UUIDs on the I/O rank when each `job_info` is written.
* Uses an independent UUID generator and does not consume AMReX scientific random-number state.
* Parses provenance markers as exact lines to avoid conflicts with ordinary `job_info` or parameter text.
* Preserves the positional checkpoint `Header` format.
* Adds support to both CMake and GNU Make builds.

## Tests

Adds motivated serial and MPI unit coverage for:

* canonical UUIDv4 formatting and validation;
* cold-start provenance;
* complete and incomplete restart transitions;
* repeated restart generations;
* branching restart histories;
* serialization and parsing round trips;
* exact-line marker recognition;
* reordered schema keys;
* CRLF input;
* malformed, duplicated, missing, and unsupported metadata;
* file-level read statuses;
* exact cross-rank provenance equality.