### PR TITLE
Adding a refinement zone to an anelastic checkpoint simulation

### DIFF
--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -478,6 +478,25 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     // ********************************************************************************************
     if (solverChoice.anelastic[lev]) {
         double dummy_dt = 1.0;
+
+        // ****************************************************************************************
+        // Define grids[lev]/dmap[lev] to be the passed-in ba/dm *before* projecting.
+        //
+        // AmrCore::regrid does not call SetBoxArray/SetDistributionMap for this new level
+        // until MakeNewLevelFromCoarse returns, so grids[lev]/dmap[lev] are still empty here.
+        // project_momenta builds its per-subdomain RHS from grids[lev]/dmap[lev]; with those
+        // empty the subdomain box array is empty and the singular-solvability mean-subtraction
+        // divides by a zero-cell volume (0/0 -> NaN). That NaN traps with fpe_trap_invalid=1;
+        // with it off the projection is silently a no-op on the new level (empty RHS, early
+        // return) so the divergence-free constraint is never enforced. Setting them now
+        // (mirroring MakeNewLevelFromScratch) makes grids[lev] match the momentum MultiFabs
+        // built in init_stuff on the same ba/dm. This is idempotent with the
+        // SetBoxArray/SetDistributionMap that AmrCore performs with the identical ba/dm after
+        // this function returns.
+        // ****************************************************************************************
+        SetBoxArray(lev, ba);
+        SetDistributionMap(lev, dm);
+
         project_initial_velocity(lev, time, dummy_dt);
         pp_inc[lev].setVal(0.0);
     }


### PR DESCRIPTION
# Problem
I ran a coarse, anelastic LES simulation using a simulation without any refinement zones and allowed turbulence to develop. Then I launched a new simulation from the previous simulation but now with a checkpoint. That simulation crashed. The crash did not occur when running in compressible mode or when running with `amrex.fpe_trap_invalid = 0`.

The Backtrace pointed to these lines in `ERF_PoissonSolve.cpp`:
```
vol = rhs_sub[0].boxArray().numPts();
sum /= (vol * dx[0] * dx[1] * dx[2]);
```

# Debugging
I turned off `amrex.fpe_trap_invalid` and added some temporary print statements to see what was going on. I checked three spots inside the projection:

1. Right after the fine level was filled in by interpolation — the density and velocities all looked fine (no NaNs).
2. Right after converting velocity to momentum — the momenta looked fine too.
3. Right after computing the divergence (the right-hand side of the solve) — this is where things looked wrong. The RHS for the subdomain came back with min=+DBL_MAX, max=-DBL_MAX`, which is what AMReX reports when you take a min/max over *zero* cells. So the RHS was empty.

That told me the data wasn't bad — the box array the solver was working on was empty. I added one more print right before the projection call and found the problem: `grids[lev]` was empty.

The reason is an ordering issue. `AmrCore::regrid` doesn't actually set `grids[lev]` and `dmap[lev]` for the new level until after `MakeNewLevelFromCoarse` returns. But the anelastic projection runs inside `MakeNewLevelFromCoarse`, before that happens.

# Solution
Set `grids[lev]` and `dmap[lev]` from the passed-in `ba`/`dm` right before the projection, in `MakeNewLevelFromCoarse`. This is the same thing `MakeNewLevelFromScratch` already does. Now the solver sees the real grid.

```
    Source/ERF_MakeNewLevel.cpp
    if (solverChoice.anelastic[lev]) {
        double dummy_dt = 1.0;

        SetBoxArray(lev, ba);
        SetDistributionMap(lev, dm);

        project_initial_velocity(lev, time, dummy_dt);
        pp_inc[lev].setVal(0.0);
    }
```

As implemented, the change only runs on the anelastic path (it's inside `if (solverChoice.anelastic[lev])`), so compressible runs and anelastic-from-scratch runs are untouched.

The AI agent also added a lengthy comment box above the substantial code change. Let me know if you'd like that adjusted. 