### PR TITLE
CPM vertical extent flexibility and vertical velocity option

### DIFF
--- a/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
+++ b/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
@@ -273,10 +273,10 @@ Below is an example of the input tags necessary for a simulation with CPM:
 Best practices are to set :math:`{Nx}_{pb}=8`, :math:`{Ny}_{pb}=8`, and
 :math:`{Nz}_{pb}=3` regardless of the physical size of the boxes/cells and to set
 ``erf.perturbation_layers = 3``. The user can also specify the vertical extent of
-the perturbation region using ``erf.perturbation_zlo`` and ``erf.perturbation_zhi``.
+the perturbation region using ``erf.perturbation_klo`` and ``erf.perturbation_khi``.
 For example, if the user would like to only perturb the atmospheric boundary layer up
-to a specified inversion height, they can use ``erf.perturbation_zhi`` to limit how
-high the perturbations extend. Best practice is to specify ``erf.perturbation_zl = 1``
+to a specified inversion height, they can use ``erf.perturbation_khi`` to limit how
+high the perturbations extend. Best practice is to specify ``erf.perturbation_klo = 1``
 to prevent any unphysical interactions with the bottom boundary conditions. If the user
 does not specify the perturbation extents, the perturbation region will extend the entire
 vertical column.
@@ -304,5 +304,5 @@ with an example also in ``Exec/RegTests/TurbulentInflow/``:
 
           erf.perturbation_w_amp = 1.5
 
-          erf.perturbation_zlo = 1
-          erf.perturbation_zhi = 40
+          erf.perturbation_klo = 1
+          erf.perturbation_khi = 40

--- a/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
+++ b/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
@@ -267,8 +267,8 @@ Below is an example of the input tags necessary for a simulation with CPM:
 
           erf.perturbation_Ug = 10.0
 
-          erf.perturbation_zlo = 1
-          erf.perturbation_zhi = 40
+          erf.perturbation_klo = 1
+          erf.perturbation_khi = 40
 
 Best practices are to set :math:`{Nx}_{pb}=8`, :math:`{Ny}_{pb}=8`, and
 :math:`{Nz}_{pb}=3` regardless of the physical size of the boxes/cells and to set

--- a/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
+++ b/Docs/sphinx_doc/InflowTurbulenceGeneration.rst
@@ -267,9 +267,42 @@ Below is an example of the input tags necessary for a simulation with CPM:
 
           erf.perturbation_Ug = 10.0
 
+          erf.perturbation_zlo = 1
+          erf.perturbation_zhi = 40
+
 Best practices are to set :math:`{Nx}_{pb}=8`, :math:`{Ny}_{pb}=8`, and
 :math:`{Nz}_{pb}=3` regardless of the physical size of the boxes/cells and to set
-``erf.perturbation_layers = 3``.
+``erf.perturbation_layers = 3``. The user can also specify the vertical extent of
+the perturbation region using ``erf.perturbation_zlo`` and ``erf.perturbation_zhi``.
+For example, if the user would like to only perturb the atmospheric boundary layer up
+to a specified inversion height, they can use ``erf.perturbation_zhi`` to limit how
+high the perturbations extend. Best practice is to specify ``erf.perturbation_zl = 1``
+to prevent any unphysical interactions with the bottom boundary conditions. If the user
+does not specify the perturbation extents, the perturbation region will extend the entire
+vertical column.
 
 An example using CPM with a stable atmospheric boundary layer inflow setup is
 available in ``Exec/RegTests/TurbulentInflow/``.
+
+A modified version of CPM is also available where the user can specify vertical velocity perturbations.
+This pathway can be specified using ``erf.perturbation_type = "CPM_W"``. The user can specify the range
+for the vertical velocity perturbations using ``erf.perturbation_w_amp``. For example, if the user
+specifies ``erf.perturbation_w_amp = 1.0``, the range of the vertical velocity perturbations will be
+[-1, 1].
+
+Below is an example of the input tags to utilize the vertical velocity perturbation modification of CPM
+with an example also in ``Exec/RegTests/TurbulentInflow/``:
+
+::
+
+          erf.perturbation_type = "CPM_W"
+
+          erf.perturbation_direction = 1 0 0 0 0 0
+          erf.perturbation_box_dims = 8 8 3
+          erf.perturbation_layers = 3
+          erf.perturbation_offset = 5
+
+          erf.perturbation_w_amp = 1.5
+
+          erf.perturbation_zlo = 1
+          erf.perturbation_zhi = 40

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs
@@ -1,5 +1,5 @@
 # ------------------  INPUTS TO MAIN PROGRAM  -------------------
-erf.prob_name = "Turbulent Inflow"
+erf.prob_name = "ABL"
 
 #max_step = 3000000
 stop_time = 2700.0

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs
@@ -92,4 +92,5 @@ erf.perturbation_layers = 3
 erf.perturbation_offset = 5
 erf.perturbation_box_dims = 8 8 3
 erf.perturbation_Ug = 13.5
-
+erf.perturbation_zlo = 1
+erf.perturbation_zhi = 40

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPM
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPM
@@ -92,5 +92,5 @@ erf.perturbation_layers = 3
 erf.perturbation_offset = 5
 erf.perturbation_box_dims = 8 8 3
 erf.perturbation_Ug = 13.5
-erf.perturbation_zlo = 1
-erf.perturbation_zhi = 40
+erf.perturbation_klo = 1
+erf.perturbation_khi = 40

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPM
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPM
@@ -36,7 +36,7 @@ erf.use_yhi_sponge_damping = true
 erf.yhi_sponge_start = 1950
 
 # TIME STEP CONTROL
-erf.cfl = 1.0 
+erf.cfl = 10.0 
 erf.substepping_cfl = 0.5
 
 # DIAGNOSTICS & VERBOSITY

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPMw
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPMw
@@ -92,5 +92,5 @@ erf.perturbation_layers = 3
 erf.perturbation_offset = 5
 erf.perturbation_box_dims = 8 8 3
 erf.perturbation_w_amp = 1.5
-erf.perturbation_zlo = 1
-erf.perturbation_zhi = 40
+erf.perturbation_klo = 1
+erf.perturbation_khi = 40

--- a/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPMw
+++ b/Exec/RegTests/TurbulentInflow/stable_5m_inflow_inputs_CPMw
@@ -1,0 +1,96 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+erf.prob_name = "ABL"
+
+#max_step = 3000000
+stop_time = 2700.0
+
+amrex.fpe_trap_invalid = 0
+
+fabarray.mfiter_tile_size = 1024 1024 1024
+
+## PROBLEM SIZE & GEOMETRY (dx=dy=dz=5m)
+geometry.prob_lo =   600    0    0
+geometry.prob_hi =  1600 2000   300
+amr.n_cell        = 200   400    60
+
+geometry.is_periodic = 1 0 0
+
+ylo.type = "Inflow"
+yhi.type = "Outflow"
+ylo.dirichlet_file = "stable_inflow.txt"
+    
+#zlo.type = "NoSlipWall"
+zlo.type                    = "surface_layer"
+erf.most.z0                 = 0.29 
+erf.most.k_arr_in = 0 0
+erf.most.surf_temp          = 306.0
+erf.most.surf_heating_rate  = -1.0
+
+zhi.type = "SlipWall"
+zhi.theta_grad = 0.0016666667
+
+erf.sponge_type = "input_sponge"
+erf.input_sponge_file = "stable_sponge.txt"
+erf.sponge_strength = 2.5
+erf.use_yhi_sponge_damping = true
+erf.yhi_sponge_start = 1950
+
+# TIME STEP CONTROL
+erf.cfl = 10.0 
+erf.substepping_cfl = 0.5
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval   = 1        # timesteps between computing mass
+erf.v              = 1        # verbosity in ERF.cpp
+amr.v              = 1        # verbosity in Amr.cpp
+
+# REFINEMENT / REGRIDDING
+amr.max_level       = 0       # maximum level number allowed
+
+# CHECKPOINT FILES
+erf.check_file      = chk     # root name of checkpoint file
+erf.check_int       = -1    # number of timesteps between checkpoints
+#erf.restart    	    = chk02000
+
+# PLOTFILES
+erf.plot_file_1     = plt     # prefix of plotfile name
+erf.plot_int_1      = 10     # number of timesteps between plotfiles
+erf.plot_vars_1     = nut scalar density x_velocity y_velocity z_velocity pressure theta pert_pres pert_dens
+
+# SOLVER CHOICE
+erf.dycore_horiz_adv_type  = "Upwind_3rd"
+erf.dycore_vert_adv_type   = "Upwind_3rd"
+erf.dryscal_horiz_adv_type = WENO3
+erf.dryscal_vert_adv_type  = WENO3
+erf.use_gravity = true
+erf.use_coriolis = false
+
+# Turbulence closure
+erf.molec_diff_type = "None"
+erf.les_type = "Deardorff"
+erf.Ck       = 0.1  # Coefficient in Moeng1984, Eqn. 19
+erf.Ce       = 0.7  # Note: Ce_lcoeff = C_e - 1.9*C_k
+erf.Ce_wall  = 3.9  # To account for "wall effects"
+erf.sigma_k  = 0.5  # TKE diffusion coeff = 2*Km = Km * inv_sigma_k, Moeng1984, Eqn. 15
+erf.theta_ref = 300.0 # don't specify for variable theta when diagnosing stability
+
+erf.rayleigh_damp_U = true
+erf.rayleigh_damp_V = true
+erf.rayleigh_damp_W = true
+erf.rayleigh_damp_T = true
+erf.rayleigh_zdamp =  50.0
+erf.rayleigh_dampcoef = 0.2
+
+erf.init_type = "input_sounding"
+erf.sounding_type = Ideal
+erf.input_sounding_file = "stable_sounding.txt"
+
+## Turbulent inflow generation
+erf.perturbation_type = "CPM_W"
+erf.perturbation_direction = 0 1 0 0 0 0
+erf.perturbation_layers = 3
+erf.perturbation_offset = 5
+erf.perturbation_box_dims = 8 8 3
+erf.perturbation_w_amp = 1.5
+erf.perturbation_zlo = 1
+erf.perturbation_zhi = 40

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -1370,18 +1370,25 @@ struct SolverChoice {
     {
         return pert_type[lev] == PerturbationType::Source ||
                pert_type[lev] == PerturbationType::Direct ||
-               pert_type[lev] == PerturbationType::CPM;
+               pert_type[lev] == PerturbationType::CPM ||
+               pert_type[lev] == PerturbationType::CPM_W;
     }
 
     bool use_direct_perturbation (int lev) const
     {
         return pert_type[lev] == PerturbationType::Direct ||
-               pert_type[lev] == PerturbationType::CPM;
+               pert_type[lev] == PerturbationType::CPM ||
+               pert_type[lev] == PerturbationType::CPM_W;
     }
 
     bool use_source_perturbation (int lev) const
     {
         return pert_type[lev] == PerturbationType::Source;
+    }
+
+    bool use_wvel_perturbation (int lev) const
+    {
+        return pert_type[lev] == PerturbationType::CPM_W;
     }
 
     bool uses_shoc_family () const noexcept

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -88,9 +88,14 @@ struct TurbulentPerturbation {
         pp.query("perturbation_w_amp",input_w_amp);
 
         perturbation_klo = zero;
+        bool have_klo = false;
         pp.query("perturbation_klo",perturbation_klo);
+        if (perturbation_klo != zero) { have_klo = true; }
+
         perturbation_khi = zero;
+        bool have_khi = false;
         pp.query("perturbation_khi",perturbation_khi);
+        if (perturbation_khi != zero) { have_khi = true; }
 
         // Check variables message
         if (tpi_offset < 0) { amrex::Abort("Please provide a valid inflow cell offset value for perturbation region (ie. 0-5)"); }
@@ -126,8 +131,8 @@ struct TurbulentPerturbation {
             const amrex::IntVect& valid_box_hi = subdomain_box.bigEnd();
 
             // default perturbation region to be the entire z extent if the user does not specify bounds
-            if (perturbation_klo == zero) { perturbation_klo = valid_box_lo[2]; }
-            if (perturbation_khi == zero) { perturbation_khi = valid_box_hi[2]; }
+            if (!have_klo) { perturbation_klo = valid_box_lo[2]; }
+            if (!have_khi) { perturbation_khi = valid_box_hi[2]; }
 
             // Creating perturbation regions and initializing with generic size.
             amrex::Box lo_x_bx(amrex::IntVect(0), amrex::IntVect(1), amrex::IntVect(0));

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -16,7 +16,7 @@
 */
 
 AMREX_ENUM(PerturbationType,
-    Source, Direct, CPM, None
+    Source, Direct, CPM, CPM_W, None
 );
 
 struct TurbulentPerturbation {
@@ -39,6 +39,8 @@ struct TurbulentPerturbation {
             pt_type[lev] = 1;
         } else if (pert_type == PerturbationType::CPM) {
             pt_type[lev] = 2;
+        } else if (pert_type == PerturbationType::CPM_W) {
+            pt_type[lev] = 3;
         } else {
             pt_type[lev] = -1;
         }
@@ -81,6 +83,9 @@ struct TurbulentPerturbation {
 
         input_Ug = zero;
         pp.query("perturbation_Ug",input_Ug);
+
+        input_w_amp = zero;
+        pp.query("perturbation_w_amp",input_w_amp);
 
         perturbation_zlo = zero;
         pp.query("perturbation_zlo",perturbation_zlo);
@@ -219,7 +224,11 @@ struct TurbulentPerturbation {
         pb_amp[lev].resize(pb_ba[lev].size(), zero);
 
         // Creating data array for perturbation amplitude storage
-        pb_cell[lev].define(ba, dm, 1, ngrow_state); // this is the only place ba is used. Maybe we can print here to determine what's valid...
+        if (pt_type[lev] == 3) { // CPM_W converts to the k-face ba.
+            pb_cell[lev].define(convert(ba, amrex::IntVect(0,0,1)), dm, 1, ngrow_state);
+        } else {
+            pb_cell[lev].define(ba, dm, 1, ngrow_state); // this is the only place ba is used. Maybe we can print here to determine what's valid...
+        }
         pb_cell[lev].setVal(0.);
 
         // Computing perturbation reference length
@@ -270,6 +279,7 @@ struct TurbulentPerturbation {
         srand( (unsigned) time(NULL) );
 
         auto m_ixtype = mf_cons.boxArray().ixType(); // safety step
+        if (pt_type[lev] == 3) { m_ixtype = amrex::IndexType(amrex::IntVect(0,0,1)); }
 
         // Seed the random generator at 1024UL for regression testing
         int fix_random_seed = 0;
@@ -287,7 +297,7 @@ struct TurbulentPerturbation {
 
             bool update_box = true; // initialize flag
             // Check if the local elapsed time is greater than the update interval and don't go into boxes the rank doesn't own
-            if (pt_type[lev] == 2) {
+            if (pt_type[lev] == 2 || pt_type[lev] == 3) {
                 // for CPM, perturbation boxes/cells refresh after boxes have advected box width/length * num_layers (advective time scale)
                 update_box = ((pb_local_etime[lev][boxIdx] >= pb_interval[lev][boxIdx]*tpi_layers) && pb_local_etime[lev][boxIdx] != -one);
             } else {
@@ -302,7 +312,7 @@ struct TurbulentPerturbation {
                 // Done for parallelism to avoid Inf being stored in array
                 if (pb_mag[lev][boxIdx] !=zero) {
                     double interval = 0.0;
-                    if (pt_type[lev] == 2) {
+                    if (pt_type[lev] == 2 || pt_type[lev] == 3) {
                         //  Wind direction correction for angled wind
                         amrex::Real wind_direction = pb_dir[lev][boxIdx];
                         if (wind_direction > PI / 4) { wind_direction = PI / 2 - wind_direction; }
@@ -330,7 +340,7 @@ struct TurbulentPerturbation {
 
             } else {
                 // set perturbation amplitudes to 0 for CPM. A little inefficient but leverages as much as existing code as possible.
-                if (pt_type[lev] == 2) { zero_amp(boxIdx, lev, m_ixtype); }
+                if (pt_type[lev] == 2 || pt_type[lev] == 3) { zero_amp(boxIdx, lev, m_ixtype); }
 
                 // Increase by timestep of level 0 (but only if the box is owned by this rank)
                 if (pb_local_etime[lev][boxIdx] != -one) { pb_local_etime[lev][boxIdx] += dt; }
@@ -368,16 +378,23 @@ struct TurbulentPerturbation {
     {
         for (int boxIdx = 0; boxIdx < pb_ba[lev].size(); boxIdx++) {
             amrex::Box pbx = amrex::convert(pb_ba[lev][boxIdx], m_ixtype);
+            if (pt_type[lev] == 3) { pbx.setBig(2, pbx.bigEnd(2) - 1); } // prevent double counting after converting to k-faces
             amrex::Box ubx = pbx & vbx;
             if (ubx.ok()) {
-                ParallelFor(ubx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    src_arr(i,j,k,comp) += pert_cell(i,j,k);
+                if (comp == -1) { // vertical velocity perturbations
+                    ParallelFor(ubx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        src_arr(i,j,k) += pert_cell(i,j,k);
+                    });
+                } else {
+                    ParallelFor(ubx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        src_arr(i,j,k,comp) += pert_cell(i,j,k);
 
-                    // For box region debug only
-                    #ifdef INDEX_PERTURB
-                    src_arr(i,j,k,comp) = (amrex::Real) (boxIdx + amrex::Real(5.));
-                    #endif
-                });
+                        // For box region debug only
+                        #ifdef INDEX_PERTURB
+                        src_arr(i,j,k,comp) = (amrex::Real) (boxIdx + 5.);
+                        #endif
+                    });
+                }
             }
         }
     }
@@ -392,6 +409,8 @@ struct TurbulentPerturbation {
             amrex::Real cp = 1004; // specific heat of air [J/(kg K)]
             amrex::Real Ec = amrex::Real(0.2); // Eckert number
             pb_amp[lev][boxIdx] = (input_Ug * input_Ug) / (Ec * cp);
+        } else if (pt_type[lev] == 3) {
+            pb_amp[lev][boxIdx] = input_w_amp;
         } else { // box perturbation
             amrex::Real Um = pb_mag[lev][boxIdx];
             amrex::Real beta = one/tpi_Tinf; // Thermal expansion coefficient
@@ -428,12 +447,13 @@ struct TurbulentPerturbation {
         for (amrex::MFIter mfi(pb_cell[lev],TileNoZ()); mfi.isValid(); ++mfi) {
             amrex::Box vbx = mfi.validbox();
             amrex::Box pbx = amrex::convert(pb_ba[lev][boxIdx], m_ixtype);
+            if (pt_type[lev] == 3) { pbx.setBig(2, pbx.bigEnd(2) - 1); } // prevent double counting after converting to k-faces
             amrex::Box ubx = pbx & vbx;
             if (ubx.ok()) {
                 amrex::Real amp_copy = pb_amp[lev][boxIdx];
                 const amrex::Array4<amrex::Real>& pert_cell = pb_cell[lev].array(mfi);
 
-                if (pt_type[lev] == 2) { // CPM
+                if (pt_type[lev] == 2  || pt_type[lev] == 3) { // CPM
                     amrex::Real rand_number_const = RandomReal(-one, one);
                     ParallelFor(ubx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                         pert_cell(i,j,k) = rand_number_const * amp_copy;
@@ -444,7 +464,6 @@ struct TurbulentPerturbation {
                         pert_cell(i,j,k) = (rand_double*two - one) * amp_copy;
                     });
                 }
-
             }
         }
     }
@@ -458,6 +477,7 @@ struct TurbulentPerturbation {
         for (amrex::MFIter mfi(pb_cell[lev],TileNoZ()); mfi.isValid(); ++mfi) {
             amrex::Box vbx = mfi.validbox();
             amrex::Box pbx = amrex::convert(pb_ba[lev][boxIdx], m_ixtype);
+            if (pt_type[lev] == 3) { pbx.setBig(2, pbx.bigEnd(2) - 1); } // prevent double counting after converting to k-faces
             amrex::Box ubx = pbx & vbx;
             if (ubx.ok()) {
                 const amrex::Array4<amrex::Real>& pert_cell = pb_cell[lev].array(mfi);
@@ -702,6 +722,7 @@ struct TurbulentPerturbation {
 
     amrex::Vector<amrex::IntVect> ref_ratio;  // ref_ratio for multilevel run
     amrex::Real input_Ug;                     // input geostrophic wind speed to scale perturbations when using CPM
+    amrex::Real input_w_amp;                  // input vertical velocity amplitude for w
     int         perturbation_zlo;             // upper bound in Nz for perturbations
     int         perturbation_zhi;             // lower bound in Nz for perturbations
 

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -87,10 +87,10 @@ struct TurbulentPerturbation {
         input_w_amp = zero;
         pp.query("perturbation_w_amp",input_w_amp);
 
-        perturbation_klo = zero;
+        perturbation_klo = 0;
         bool have_klo = pp.query("perturbation_klo", perturbation_klo);
 
-        perturbation_khi = zero;
+        perturbation_khi = 0;
         bool have_khi = pp.query("perturbation_khi", perturbation_khi);
 
         // Check variables message

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -87,10 +87,10 @@ struct TurbulentPerturbation {
         input_w_amp = zero;
         pp.query("perturbation_w_amp",input_w_amp);
 
-        perturbation_zlo = zero;
-        pp.query("perturbation_zlo",perturbation_zlo);
-        perturbation_zhi = zero;
-        pp.query("perturbation_zhi",perturbation_zhi);
+        perturbation_klo = zero;
+        pp.query("perturbation_klo",perturbation_klo);
+        perturbation_khi = zero;
+        pp.query("perturbation_khi",perturbation_khi);
 
         // Check variables message
         if (tpi_offset < 0) { amrex::Abort("Please provide a valid inflow cell offset value for perturbation region (ie. 0-5)"); }
@@ -126,8 +126,8 @@ struct TurbulentPerturbation {
             const amrex::IntVect& valid_box_hi = subdomain_box.bigEnd();
 
             // default perturbation region to be the entire z extent if the user does not specify bounds
-            if (perturbation_zlo == zero) { perturbation_zlo = valid_box_lo[2]; }
-            if (perturbation_zhi == zero) { perturbation_zhi = valid_box_hi[2]; }
+            if (perturbation_klo == zero) { perturbation_klo = valid_box_lo[2]; }
+            if (perturbation_khi == zero) { perturbation_khi = valid_box_hi[2]; }
 
             // Creating perturbation regions and initializing with generic size.
             amrex::Box lo_x_bx(amrex::IntVect(0), amrex::IntVect(1), amrex::IntVect(0));
@@ -139,27 +139,27 @@ struct TurbulentPerturbation {
             //amrex::PrintToFile("BoxPerturbationOutput") << "Setting perturbation region in:";
             // ***** X-direction perturbation *****
             if (tpi_direction[0]) { // West
-                lo_x_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_offset, valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_zlo));
-                lo_x_bx.setBig  (amrex::IntVect(valid_box_lo[0]+(tpi_layers*tpi_boxDim[0]-1)+tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_zhi));
+                lo_x_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_offset, valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_klo));
+                lo_x_bx.setBig  (amrex::IntVect(valid_box_lo[0]+(tpi_layers*tpi_boxDim[0]-1)+tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_khi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " West face";
             }
 
             if (tpi_direction[3]) { // East
-                hi_x_bx.setSmall(amrex::IntVect(valid_box_hi[0]-((tpi_layers*tpi_boxDim[0]-1)+tpi_offset), valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_zlo));
-                hi_x_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_zhi));
+                hi_x_bx.setSmall(amrex::IntVect(valid_box_hi[0]-((tpi_layers*tpi_boxDim[0]-1)+tpi_offset), valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_klo));
+                hi_x_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_khi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " East face";
             }
 
             // ***** Y-direction Perturbation *****
             if (tpi_direction[1]) { // North
-                lo_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_lo[1]+tpi_offset, perturbation_zlo));
-                lo_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_lo[1]+((tpi_layers*tpi_boxDim[1])-1)+tpi_offset, perturbation_zhi));
+                lo_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_lo[1]+tpi_offset, perturbation_klo));
+                lo_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_lo[1]+((tpi_layers*tpi_boxDim[1])-1)+tpi_offset, perturbation_khi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " North face";
             }
 
             if (tpi_direction[4]) { // South
-                hi_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_hi[1]-((tpi_layers*tpi_boxDim[1]-1)+tpi_offset), perturbation_zlo));
-                hi_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_hi[1]-tpi_offset, perturbation_zhi));
+                hi_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_hi[1]-((tpi_layers*tpi_boxDim[1]-1)+tpi_offset), perturbation_klo));
+                hi_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_hi[1]-tpi_offset, perturbation_khi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " South face";
             }
 
@@ -723,8 +723,8 @@ struct TurbulentPerturbation {
     amrex::Vector<amrex::IntVect> ref_ratio;  // ref_ratio for multilevel run
     amrex::Real input_Ug;                     // input geostrophic wind speed to scale perturbations when using CPM
     amrex::Real input_w_amp;                  // input vertical velocity amplitude for w
-    int         perturbation_zlo;             // upper bound in Nz for perturbations
-    int         perturbation_zhi;             // lower bound in Nz for perturbations
+    int         perturbation_klo;             // upper bound in Nz for perturbations
+    int         perturbation_khi;             // lower bound in Nz for perturbations
 
     // Perturbation data arrays
     amrex::Vector<amrex::Vector<double>> pb_interval;         // PB update time [s]

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -82,6 +82,11 @@ struct TurbulentPerturbation {
         input_Ug = zero;
         pp.query("perturbation_Ug",input_Ug);
 
+        perturbation_zlo = zero;
+        pp.query("perturbation_zlo",perturbation_zlo);
+        perturbation_zhi = zero;
+        pp.query("perturbation_zhi",perturbation_zhi);
+
         // Check variables message
         if (tpi_offset < 0) { amrex::Abort("Please provide a valid inflow cell offset value for perturbation region (ie. 0-5)"); }
         if (tpi_layers < 0) { amrex::Abort("Please provide a valid perturbation layer value (ie. 3-5)"); }
@@ -115,6 +120,10 @@ struct TurbulentPerturbation {
             const amrex::IntVect& valid_box_lo = subdomain_box.smallEnd();
             const amrex::IntVect& valid_box_hi = subdomain_box.bigEnd();
 
+            // default perturbation region to be the entire z extent if the user does not specify bounds
+            if (perturbation_zlo == zero) { perturbation_zlo = valid_box_lo[2]; }
+            if (perturbation_zhi == zero) { perturbation_zhi = valid_box_hi[2]; }
+
             // Creating perturbation regions and initializing with generic size.
             amrex::Box lo_x_bx(amrex::IntVect(0), amrex::IntVect(1), amrex::IntVect(0));
             amrex::Box hi_x_bx(amrex::IntVect(0), amrex::IntVect(1), amrex::IntVect(0));
@@ -125,27 +134,27 @@ struct TurbulentPerturbation {
             //amrex::PrintToFile("BoxPerturbationOutput") << "Setting perturbation region in:";
             // ***** X-direction perturbation *****
             if (tpi_direction[0]) { // West
-                lo_x_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_offset, valid_box_lo[1]+tpi_direction[1]*tpi_offset, valid_box_lo[2]));
-                lo_x_bx.setBig  (amrex::IntVect(valid_box_lo[0]+(tpi_layers*tpi_boxDim[0]-1)+tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), valid_box_hi[2]));
+                lo_x_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_offset, valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_zlo));
+                lo_x_bx.setBig  (amrex::IntVect(valid_box_lo[0]+(tpi_layers*tpi_boxDim[0]-1)+tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_zhi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " West face";
             }
 
             if (tpi_direction[3]) { // East
-                hi_x_bx.setSmall(amrex::IntVect(valid_box_hi[0]-((tpi_layers*tpi_boxDim[0]-1)+tpi_offset), valid_box_lo[1]+tpi_direction[1]*tpi_offset, valid_box_lo[2]));
-                hi_x_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), valid_box_hi[2]));
+                hi_x_bx.setSmall(amrex::IntVect(valid_box_hi[0]-((tpi_layers*tpi_boxDim[0]-1)+tpi_offset), valid_box_lo[1]+tpi_direction[1]*tpi_offset, perturbation_zlo));
+                hi_x_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_offset, valid_box_hi[1]-(tpi_direction[4]*tpi_offset), perturbation_zhi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " East face";
             }
 
             // ***** Y-direction Perturbation *****
             if (tpi_direction[1]) { // North
-                lo_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_lo[1]+tpi_offset, valid_box_lo[2]));
-                lo_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_lo[1]+((tpi_layers*tpi_boxDim[1])-1)+tpi_offset, valid_box_hi[2]));
+                lo_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_lo[1]+tpi_offset, perturbation_zlo));
+                lo_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_lo[1]+((tpi_layers*tpi_boxDim[1])-1)+tpi_offset, perturbation_zhi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " North face";
             }
 
             if (tpi_direction[4]) { // South
-                hi_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_hi[1]-((tpi_layers*tpi_boxDim[1]-1)+tpi_offset), valid_box_lo[2]));
-                hi_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_hi[1]-tpi_offset, valid_box_hi[2]));
+                hi_y_bx.setSmall(amrex::IntVect(valid_box_lo[0]+tpi_direction[0]*tpi_offset, valid_box_hi[1]-((tpi_layers*tpi_boxDim[1]-1)+tpi_offset), perturbation_zlo));
+                hi_y_bx.setBig(amrex::IntVect(valid_box_hi[0]-tpi_direction[3]*tpi_offset, valid_box_hi[1]-tpi_offset, perturbation_zhi));
                 amrex::PrintToFile("BoxPerturbationOutput") << " South face";
             }
 
@@ -693,6 +702,8 @@ struct TurbulentPerturbation {
 
     amrex::Vector<amrex::IntVect> ref_ratio;  // ref_ratio for multilevel run
     amrex::Real input_Ug;                     // input geostrophic wind speed to scale perturbations when using CPM
+    int         perturbation_zlo;             // upper bound in Nz for perturbations
+    int         perturbation_zhi;             // lower bound in Nz for perturbations
 
     // Perturbation data arrays
     amrex::Vector<amrex::Vector<double>> pb_interval;         // PB update time [s]

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -70,7 +70,8 @@ struct TurbulentPerturbation {
         pp.get("perturbation_layers",tpi_layers);
         pp.get("perturbation_offset",tpi_offset);
 
-        pp.get("perturbation_nondimensional",tpi_nonDim);
+        tpi_nonDim = zero;
+        pp.query("perturbation_nondimensional",tpi_nonDim);
 
         tpi_Tinf = amrex::Real(300.);
         pp.query("perturbation_T_infinity",tpi_Tinf);

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -88,14 +88,10 @@ struct TurbulentPerturbation {
         pp.query("perturbation_w_amp",input_w_amp);
 
         perturbation_klo = zero;
-        bool have_klo = false;
-        pp.query("perturbation_klo",perturbation_klo);
-        if (perturbation_klo != zero) { have_klo = true; }
+        bool have_klo = pp.query("perturbation_klo", perturbation_klo);
 
         perturbation_khi = zero;
-        bool have_khi = false;
-        pp.query("perturbation_khi",perturbation_khi);
-        if (perturbation_khi != zero) { have_khi = true; }
+        bool have_khi = pp.query("perturbation_khi", perturbation_khi);
 
         // Check variables message
         if (tpi_offset < 0) { amrex::Abort("Please provide a valid inflow cell offset value for perturbation region (ie. 0-5)"); }

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -723,6 +723,7 @@ private:
     // Initialize the Turbulent perturbation
     void turbPert_update (const int lev, const double dt);
     void turbPert_amplitude (const int lev);
+    void turbPert_amplitude_w (const int lev);
 
     // Initialize the integrator object
     void initialize_integrator (int lev, amrex::MultiFab& cons_mf, amrex::MultiFab& vel_mf);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1957,7 +1957,11 @@ ERF::init_only (int lev, double elapsed_time)
     // Initialize turbulent perturbation
     if (solverChoice.use_perturbation(lev)) {
         turbPert_update(lev, zero);
-        turbPert_amplitude(lev);
+        if (solverChoice.use_wvel_perturbation(lev)) {
+            turbPert_amplitude_w(lev);
+        } else {
+            turbPert_amplitude(lev);
+        }
     }
 
     // Set initial velocity field for immersed cells to be close to 0

--- a/Source/Initialization/ERF_InitTurbPert.cpp
+++ b/Source/Initialization/ERF_InitTurbPert.cpp
@@ -53,3 +53,30 @@ ERF::turbPert_amplitude (int lev)
         turbPert.apply_tpi(lev, bx, RhoTheta_comp, m_ixtype, cons_pert_arr, pert_cell);
     } // mfi
 }
+
+// Calculate the perturbation region amplitude. This function is for vertical velocity perturbations.
+// This function heavily emmulates the ERF::init_custom ()
+void
+ERF::turbPert_amplitude_w (int lev)
+{
+    // Accessing data
+    auto& lev_new = vars_new[lev];
+
+    // Creating local data
+    int ncomps = lev_new[Vars::zvel].nComp();
+    MultiFab wvel_data(lev_new[Vars::zvel], make_alias, 0, ncomps);
+
+    // Defining BoxArray type
+    auto m_ixtype = wvel_data.boxArray().ixType();
+
+#ifdef _OPENMP
+#pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
+#endif
+    for (MFIter mfi(lev_new[Vars::zvel], TileNoZ()); mfi.isValid(); ++mfi) {
+        const Box &bx  = mfi.validbox();
+        const auto &wvel_pert_arr = wvel_data.array(mfi); // Address of perturbation array
+        const amrex::Array4<const amrex::Real> &pert_cell = turbPert.pb_cell[lev].array(mfi); // per-cell perturbation stored in structure
+
+        turbPert.apply_tpi(lev, bx, -1, m_ixtype, wvel_pert_arr, pert_cell);
+    } // mfi
+}

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -78,12 +78,22 @@ ERF::Advance (int lev, double time, double dt_lev, int iteration, int /*ncycle*/
     // on the conserved field
     if (solverChoice.use_direct_perturbation(lev))
     {
-        auto m_ixtype = S_old.boxArray().ixType(); // Conserved term
-        for (MFIter mfi(S_old,TileNoZ()); mfi.isValid(); ++mfi) {
-            Box bx  = mfi.tilebox();
-            const Array4<Real> &cell_data  = S_old.array(mfi);
-            const Array4<const Real> &pert_cell = turbPert.pb_cell[lev].array(mfi);
-            turbPert.apply_tpi(lev, bx, RhoTheta_comp, m_ixtype, cell_data, pert_cell);
+        if (solverChoice.use_wvel_perturbation(lev)) { // CPM_W
+            auto m_ixtype = W_old.boxArray().ixType();
+            for (MFIter mfi(W_old,TileNoZ()); mfi.isValid(); ++mfi) {
+                Box bx  = mfi.tilebox();
+                const Array4<Real> &cell_data  = W_old.array(mfi);
+                const Array4<const Real> &pert_cell = turbPert.pb_cell[lev].array(mfi);
+                turbPert.apply_tpi(lev, bx, -1, m_ixtype, cell_data, pert_cell);
+            }
+        } else {
+            auto m_ixtype = S_old.boxArray().ixType(); // Conserved term
+            for (MFIter mfi(S_old,TileNoZ()); mfi.isValid(); ++mfi) {
+                Box bx  = mfi.tilebox();
+                const Array4<Real> &cell_data  = S_old.array(mfi);
+                const Array4<const Real> &pert_cell = turbPert.pb_cell[lev].array(mfi);
+                turbPert.apply_tpi(lev, bx, RhoTheta_comp, m_ixtype, cell_data, pert_cell);
+            }
         }
     }
 


### PR DESCRIPTION
This PR contains two updates to inflow perturbations. The first is that the user can now specify the vertical extent of the perturbations using `erf.perturbation_klo` and `erf.perturbation_khi`. These correspond to the k indices for the lower and upper extent of the perturbation region. I have modified the CPM example file in `Exec/RegTests/TurbulentInflow/` for how someone would use these inputs. 

For the example inputs, we have a stable boundary layer with an inversion located at z = 200m. I have modified the inputs so that the perturbations only extend up to the inversion height:

<img width="1102" height="672" alt="image" src="https://github.com/user-attachments/assets/f57a9c77-7559-4406-8c69-fcb8e002cecc" />

If the user does not specify the bounds, the default behavior is that the perturbations extend the entire column as was the default previously.

<img width="1099" height="668" alt="image" src="https://github.com/user-attachments/assets/4b2ce29d-0c96-4837-949a-13fc04a65dc0" />


The second update is an additional pathway where we perturb the vertical velocity instead of theta for CPM. The user can simply specify the range of the vertical velocity perturbations using `erf.perturbation_w_amp` when specifying `erf.perturbation_type = "CPM_W"`. An example input file demonstrating this pathway has also been added. Here is how the vertical velocity perturbations look at initialization:

<img width="1100" height="673" alt="image" src="https://github.com/user-attachments/assets/fc74c0b6-6ca8-4fa0-b30d-d2b30a9bec1a" />

The motivation for this pathway is that CPM breaks down for scales other than the atmosphere (i.e., wind tunnel scales). 

Documentation has been updated relating to both of these changes.
