### PR TITLE
Device Capture Constants

### DIFF
--- a/Source/Advection/ERF_AdvectionSrcForMom.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom.cpp
@@ -111,13 +111,13 @@ AdvectionSrcForMom (const MFIter& mfi,
                                              terrain_type == TerrainType::MovingFittedMesh);
 
     ParallelFor(box2d_u, box2d_v,
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_u_inv(i,j,0) = one / mf_ux(i,j,0);
+        mf_u_inv(i,j,0) = one_d / mf_ux(i,j,0);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_v_inv(i,j,0) = one / mf_vy(i,j,0);
+        mf_v_inv(i,j,0) = one_d / mf_vy(i,j,0);
     });
 
     if (mesh_type == MeshType::ConstantDz && terrain_type != TerrainType::EB)
@@ -261,4 +261,3 @@ AdvectionSrcForMom (const MFIter& mfi,
                                            domhi_z);
     }
 }
-

--- a/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
@@ -81,31 +81,31 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
     const Array4<Real>& mf_vy_inv = mf_vy_invFAB.array();
 
     ParallelFor(box2d_u, box2d_v,
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_ux_inv(i,j,0) = one / mf_ux(i,j,0);
-        mf_uy_inv(i,j,0) = one / mf_uy(i,j,0);
+        mf_ux_inv(i,j,0) = one_d / mf_ux(i,j,0);
+        mf_uy_inv(i,j,0) = one_d / mf_uy(i,j,0);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_vx_inv(i,j,0) = one / mf_vx(i,j,0);
-        mf_vy_inv(i,j,0) = one / mf_vy(i,j,0);
+        mf_vx_inv(i,j,0) = one_d / mf_vx(i,j,0);
+        mf_vy_inv(i,j,0) = one_d / mf_vy(i,j,0);
     });
 
     // Inline with 2nd order for efficiency
     if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
     {
             ParallelFor(bxx, bxy, bxz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real xflux_hi = fourth * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i+1, j  , k) * mf_uy_inv(i+1,j,0)) * (u(i+1,j,k) + u(i,j,k));
-                Real xflux_lo = fourth * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i-1, j  , k) * mf_uy_inv(i-1,j,0)) * (u(i-1,j,k) + u(i,j,k));
+                Real xflux_hi = fourth_d * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i+1, j  , k) * mf_uy_inv(i+1,j,0)) * (u(i+1,j,k) + u(i,j,k));
+                Real xflux_lo = fourth_d * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i-1, j  , k) * mf_uy_inv(i-1,j,0)) * (u(i-1,j,k) + u(i,j,k));
 
-                Real yflux_hi = fourth * (rho_v(i, j+1, k) * mf_vx_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_vx_inv(i-1,j+1,0)) * (u(i,j+1,k) + u(i,j,k));
-                Real yflux_lo = fourth * (rho_v(i, j  , k) * mf_vx_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_vx_inv(i-1,j  ,0)) * (u(i,j-1,k) + u(i,j,k));
+                Real yflux_hi = fourth_d * (rho_v(i, j+1, k) * mf_vx_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_vx_inv(i-1,j+1,0)) * (u(i,j+1,k) + u(i,j,k));
+                Real yflux_lo = fourth_d * (rho_v(i, j  , k) * mf_vx_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_vx_inv(i-1,j  ,0)) * (u(i,j-1,k) + u(i,j,k));
 
-                Real zflux_hi = fourth * (omega(i, j, k+1) + omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
-                Real zflux_lo = fourth * (omega(i, j, k  ) + omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
+                Real zflux_hi = fourth_d * (omega(i, j, k+1) + omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
+                Real zflux_lo = fourth_d * (omega(i, j, k  ) + omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
 
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
@@ -114,16 +114,16 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                   + (zflux_hi - zflux_lo) * dzInv;
                 rho_u_rhs(i, j, k) = -advectionSrc;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-                Real xflux_hi = fourth * (rho_u(i+1, j, k) * mf_uy_inv(i+1,j,0) + rho_u(i+1, j-1, k) * mf_uy_inv(i+1,j-1,0)) * (v(i+1,j,k) + v(i,j,k));
-                Real xflux_lo = fourth * (rho_u(i  , j, k) * mf_uy_inv(i  ,j,0) + rho_u(i  , j-1, k) * mf_uy_inv(i  ,j-1,0)) * (v(i-1,j,k) + v(i,j,k));
+                Real xflux_hi = fourth_d * (rho_u(i+1, j, k) * mf_uy_inv(i+1,j,0) + rho_u(i+1, j-1, k) * mf_uy_inv(i+1,j-1,0)) * (v(i+1,j,k) + v(i,j,k));
+                Real xflux_lo = fourth_d * (rho_u(i  , j, k) * mf_uy_inv(i  ,j,0) + rho_u(i  , j-1, k) * mf_uy_inv(i  ,j-1,0)) * (v(i-1,j,k) + v(i,j,k));
 
-                Real yflux_hi = fourth * (rho_v(i  ,j+1,k) * mf_vx_inv(i,j+1,0) + rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0)) * (v(i,j+1,k) + v(i,j,k));
-                Real yflux_lo = fourth * (rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0) + rho_v(i  ,j-1,k) * mf_vx_inv(i,j-1,0)) * (v(i,j-1,k) + v(i,j,k));
+                Real yflux_hi = fourth_d * (rho_v(i  ,j+1,k) * mf_vx_inv(i,j+1,0) + rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0)) * (v(i,j+1,k) + v(i,j,k));
+                Real yflux_lo = fourth_d * (rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0) + rho_v(i  ,j-1,k) * mf_vx_inv(i,j-1,0)) * (v(i,j-1,k) + v(i,j,k));
 
-                Real zflux_hi = fourth * (omega(i, j, k+1) + omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
-                Real zflux_lo = fourth * (omega(i, j, k  ) + omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
+                Real zflux_hi = fourth_d * (omega(i, j, k+1) + omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
+                Real zflux_lo = fourth_d * (omega(i, j, k  ) + omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
 
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
@@ -132,18 +132,18 @@ AdvectionSrcForMom_ConstantDz (const Box& bxx, const Box& bxy, const Box& bxz,
                                   + (zflux_hi - zflux_lo) * dzInv;
                 rho_v_rhs(i, j, k) = -advectionSrc;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-                Real xflux_hi = fourth*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * mf_uy_inv(i+1,j  ,0) * (w(i+1,j,k) + w(i,j,k));
-                Real xflux_lo = fourth*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * mf_uy_inv(i  ,j  ,0) * (w(i-1,j,k) + w(i,j,k));
+                Real xflux_hi = fourth_d*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * mf_uy_inv(i+1,j  ,0) * (w(i+1,j,k) + w(i,j,k));
+                Real xflux_lo = fourth_d*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * mf_uy_inv(i  ,j  ,0) * (w(i-1,j,k) + w(i,j,k));
 
-                Real yflux_hi = fourth*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * mf_vx_inv(i  ,j+1,0) * (w(i,j+1,k) + w(i,j,k));
-                Real yflux_lo = fourth*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * mf_vx_inv(i  ,j  ,0) * (w(i,j-1,k) + w(i,j,k));
+                Real yflux_hi = fourth_d*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * mf_vx_inv(i  ,j+1,0) * (w(i,j+1,k) + w(i,j,k));
+                Real yflux_lo = fourth_d*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * mf_vx_inv(i  ,j  ,0) * (w(i,j-1,k) + w(i,j,k));
 
-                Real zflux_lo = fourth * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
+                Real zflux_lo = fourth_d * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
 
                 Real zflux_hi = (k == hi_z_face) ? omega(i,j,k) * w(i,j,k) :
-                    fourth * (omega(i,j,k) + omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1));
+                    fourth_d * (omega(i,j,k) + omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1));
 
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 

--- a/Source/Advection/ERF_AdvectionSrcForMom_EB.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_EB.cpp
@@ -95,15 +95,15 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
     const Array4<Real>& mf_vy_inv = mf_vy_invFAB.array();
 
     ParallelFor(box2d_u, box2d_v,
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_ux_inv(i,j,0) = one / mf_ux(i,j,0);
-        mf_uy_inv(i,j,0) = one / mf_uy(i,j,0);
+        mf_ux_inv(i,j,0) = one_d / mf_ux(i,j,0);
+        mf_uy_inv(i,j,0) = one_d / mf_uy(i,j,0);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_vx_inv(i,j,0) = one / mf_vx(i,j,0);
-        mf_vy_inv(i,j,0) = one / mf_vy(i,j,0);
+        mf_vx_inv(i,j,0) = one_d / mf_vx(i,j,0);
+        mf_vy_inv(i,j,0) = one_d / mf_vy(i,j,0);
     });
 
     // EB u-factory
@@ -141,93 +141,93 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
     {
         // Fluxes for x-momentum
         ParallelFor(bxx_grown[0], bxx_grown[1], bxx_grown[2],
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( u_afrac_x(i,j,k)>zero){
-                flx_u_arr[0](i,j,k) = fourth * u_afrac_x(i,j,k)
+            if ( u_afrac_x(i,j,k)>zero_d){
+                flx_u_arr[0](i,j,k) = fourth_d * u_afrac_x(i,j,k)
                                     * (rho_u(i,j,k) * mf_ux_inv(i,j,0) + rho_u(i-1,j,k) * mf_ux_inv(i-1,j,0))
                                     * (u(i-1,j,k) + u(i,j,k));
             } else {
-                flx_u_arr[0](i,j,k) = zero;
+                flx_u_arr[0](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( u_afrac_y(i,j,k)>zero){
-                flx_u_arr[1](i,j,k) = fourth * u_afrac_y(i,j,k)
+            if ( u_afrac_y(i,j,k)>zero_d){
+                flx_u_arr[1](i,j,k) = fourth_d * u_afrac_y(i,j,k)
                                     * (rho_v(i,j,k) * mf_vy_inv(i,j,0) + rho_v(i-1,j,k) * mf_vy_inv(i-1,j,0))
                                     * (u(i,j-1,k) + u(i,j,k));
             } else {
-                flx_u_arr[1](i,j,k) = zero;
+                flx_u_arr[1](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( u_afrac_z(i,j,k)>zero){
-                flx_u_arr[2](i,j,k) = fourth * (omega(i,j,k) + omega(i-1,j,k)) * (u(i,j,k-1) + u(i,j,k));
+            if ( u_afrac_z(i,j,k)>zero_d){
+                flx_u_arr[2](i,j,k) = fourth_d * (omega(i,j,k) + omega(i-1,j,k)) * (u(i,j,k-1) + u(i,j,k));
             } else {
-                flx_u_arr[2](i,j,k) = zero;
+                flx_u_arr[2](i,j,k) = zero_d;
             }
         });
         // Fluxes for y-momentum
         ParallelFor(bxy_grown[0], bxy_grown[1], bxy_grown[2],
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( v_afrac_x(i,j,k)>zero){
-                flx_v_arr[0](i,j,k) = fourth * v_afrac_x(i,j,k)
+            if ( v_afrac_x(i,j,k)>zero_d){
+                flx_v_arr[0](i,j,k) = fourth_d * v_afrac_x(i,j,k)
                                     * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i,j-1,k) * mf_uy_inv(i,j-1,0))
                                     * (v(i-1,j,k) + v(i,j,k));
             } else {
-                flx_v_arr[0](i,j,k) = zero;
+                flx_v_arr[0](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( v_afrac_y(i,j,k)>zero){
-                flx_v_arr[1](i,j,k) = fourth * v_afrac_y(i,j,k)
+            if ( v_afrac_y(i,j,k)>zero_d){
+                flx_v_arr[1](i,j,k) = fourth_d * v_afrac_y(i,j,k)
                                     * (rho_v(i,j,k) * mf_vy_inv(i,j,0) + rho_v(i,j-1,k) * mf_vy_inv(i,j-1,0))
                                     * (v(i,j-1,k) + v(i,j,k));
             } else {
-                flx_v_arr[1](i,j,k) = zero;
+                flx_v_arr[1](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( v_afrac_z(i,j,k)>zero){
-                flx_v_arr[2](i,j,k) = fourth * (omega(i,j,k) + omega(i,j-1,k)) * (v(i,j,k-1) + v(i,j,k));
+            if ( v_afrac_z(i,j,k)>zero_d){
+                flx_v_arr[2](i,j,k) = fourth_d * (omega(i,j,k) + omega(i,j-1,k)) * (v(i,j,k-1) + v(i,j,k));
             } else {
-                flx_v_arr[2](i,j,k) = zero;
+                flx_v_arr[2](i,j,k) = zero_d;
             }
         });
         // Fluxes for z-momentum
         ParallelFor(bxz_grown[0], bxz_grown[1], bxz_grown[2],
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( w_afrac_x(i,j,k)>zero){
-                flx_w_arr[0](i,j,k) = fourth * w_afrac_x(i,j,k)
+            if ( w_afrac_x(i,j,k)>zero_d){
+                flx_w_arr[0](i,j,k) = fourth_d * w_afrac_x(i,j,k)
                                     * (rho_u(i,j,k) + rho_u(i,j, k-1)) * mf_ux_inv(i,j,0)
                                     * (w(i-1,j,k) + w(i,j,k));
             } else {
-                flx_w_arr[0](i,j,k) = zero;
+                flx_w_arr[0](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( w_afrac_y(i,j,k)>zero){
-                flx_w_arr[1](i,j,k) = fourth * w_afrac_y(i,j,k)
+            if ( w_afrac_y(i,j,k)>zero_d){
+                flx_w_arr[1](i,j,k) = fourth_d * w_afrac_y(i,j,k)
                                     * (rho_v(i,j,k) + rho_v(i,j,k-1)) * mf_vy_inv(i,j,0)
                                     * (w(i,j-1,k) + w(i,j,k));
             } else {
-                flx_w_arr[1](i,j,k) = zero;
+                flx_w_arr[1](i,j,k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if ( w_afrac_z(i,j,k)>zero){
+            if ( w_afrac_z(i,j,k)>zero_d){
                 flx_w_arr[2](i,j,k) = (k==hi_z_face+1) ? omega(i,j,k) * w(i,j,k) : // Not sure for this line
-                                    fourth * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
+                                    fourth_d * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
             } else {
-                flx_w_arr[2](i,j,k) = zero;
+                flx_w_arr[2](i,j,k) = zero_d;
             }
         });
 
@@ -298,9 +298,9 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
     if (already_on_centroids) {
 
         ParallelFor(bxx, bxy, bxz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (u_vfrac(i,j,k)>zero) {
+            if (u_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
                 Real advectionSrc = ( (flx_u_arr[0](i+1, j  , k  ) - flx_u_arr[0](i, j, k)) * dxInv * mfsq
@@ -308,12 +308,12 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                                     + (flx_u_arr[2](i  , j  , k+1) - flx_u_arr[2](i, j, k)) * dzInv ) / u_vfrac(i,j,k);
                 rho_u_rhs(i, j, k) = -advectionSrc;
             } else {
-                rho_u_rhs(i, j, k) = zero;
+                rho_u_rhs(i, j, k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (v_vfrac(i,j,k)>zero) {
+            if (v_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
                 Real advectionSrc = ( (flx_v_arr[0](i+1, j  , k  ) - flx_v_arr[0](i, j, k)) * dxInv * mfsq
@@ -321,12 +321,12 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                                     + (flx_v_arr[2](i  , j  , k+1) - flx_v_arr[2](i, j, k)) * dzInv ) / v_vfrac(i,j,k);
                 rho_v_rhs(i, j, k) = -advectionSrc;
             } else {
-                rho_v_rhs(i, j, k) = zero;
+                rho_v_rhs(i, j, k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (w_vfrac(i,j,k)>zero) {
+            if (w_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
                 rho_w_rhs(i, j, k) = - ( (w_afrac_x(i+1, j  , k  ) * flx_w_arr[0](i+1, j  , k  ) - w_afrac_x(i, j, k) * flx_w_arr[0](i, j, k)) * dxInv * mfsq
@@ -345,14 +345,14 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
         Array4<const int> w_mask = physbnd_mask[IntVars::zmom].const_array(mfi);
 
         ParallelFor(bxx, bxy, bxz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (u_vfrac(i,j,k)>zero) {
+            if (u_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
                 if (u_cflag(i,j,k).isCovered())
                 {
-                    rho_u_rhs(i, j, k) = zero;
+                    rho_u_rhs(i, j, k) = zero_d;
                 }
                 else if (u_cflag(i,j,k).isRegular())
                 {
@@ -364,74 +364,74 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                 {
                     // Bilinear interpolation
                     Real fxm = flx_u_arr[0](i,j,k);
-                    if (u_afrac_x(i,j,k) != zero && u_afrac_x(i,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one, u_fcx(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one, u_fcx(i,j,k,1)));
-                        Real fracy = (u_mask(i-1,jj,k) || u_mask(i,jj,k)) ? std::abs(u_fcx(i,j,k,0)) : zero;
-                        Real fracz = (u_mask(i-1,j,kk) || u_mask(i,j,kk)) ? std::abs(u_fcx(i,j,k,1)) : zero;
-                        fxm = (one-fracy)*(one-fracz)*fxm
-                            +      fracy *(one-fracz)*flx_u_arr[0](i,jj,k )
-                            +      fracz *(one-fracy)*flx_u_arr[0](i,j ,kk)
+                    if (u_afrac_x(i,j,k) != zero_d && u_afrac_x(i,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d, u_fcx(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d, u_fcx(i,j,k,1)));
+                        Real fracy = (u_mask(i-1,jj,k) || u_mask(i,jj,k)) ? std::abs(u_fcx(i,j,k,0)) : zero_d;
+                        Real fracz = (u_mask(i-1,j,kk) || u_mask(i,j,kk)) ? std::abs(u_fcx(i,j,k,1)) : zero_d;
+                        fxm = (one_d-fracy)*(one_d-fracz)*fxm
+                            +      fracy *(one_d-fracz)*flx_u_arr[0](i,jj,k )
+                            +      fracz *(one_d-fracy)*flx_u_arr[0](i,j ,kk)
                             +      fracy *           fracz *flx_u_arr[0](i,jj,kk);
                     }
 
                     Real fxp = flx_u_arr[0](i+1,j,k);
-                    if (u_afrac_x(i+1,j,k) != zero && u_afrac_x(i+1,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one,u_fcx(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,u_fcx(i+1,j,k,1)));
-                        Real fracy = (u_mask(i,jj,k) || u_mask(i+1,jj,k)) ? std::abs(u_fcx(i+1,j,k,0)) : zero;
-                        Real fracz = (u_mask(i,j,kk) || u_mask(i+1,j,kk)) ? std::abs(u_fcx(i+1,j,k,1)) : zero;
-                        fxp = (one-fracy)*(one-fracz)*fxp
-                            +      fracy *(one-fracz)*flx_u_arr[0](i+1,jj,k )
-                            +      fracz *(one-fracy)*flx_u_arr[0](i+1,j ,kk)
+                    if (u_afrac_x(i+1,j,k) != zero_d && u_afrac_x(i+1,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d,u_fcx(i+1,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,u_fcx(i+1,j,k,1)));
+                        Real fracy = (u_mask(i,jj,k) || u_mask(i+1,jj,k)) ? std::abs(u_fcx(i+1,j,k,0)) : zero_d;
+                        Real fracz = (u_mask(i,j,kk) || u_mask(i+1,j,kk)) ? std::abs(u_fcx(i+1,j,k,1)) : zero_d;
+                        fxp = (one_d-fracy)*(one_d-fracz)*fxp
+                            +      fracy *(one_d-fracz)*flx_u_arr[0](i+1,jj,k )
+                            +      fracz *(one_d-fracy)*flx_u_arr[0](i+1,j ,kk)
                             +      fracy *     fracz *flx_u_arr[0](i+1,jj,kk);
                     }
 
                     Real fym = flx_u_arr[1](i,j,k);
-                    if (u_afrac_y(i,j,k) != zero && u_afrac_y(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,u_fcy(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,u_fcy(i,j,k,1)));
-                        Real fracx = (u_mask(ii,j-1,k) || u_mask(ii,j,k)) ? std::abs(u_fcy(i,j,k,0)) : zero;
-                        Real fracz = (u_mask(i,j-1,kk) || u_mask(i,j,kk)) ? std::abs(u_fcy(i,j,k,1)) : zero;
-                        fym = (one-fracx)*(one-fracz)*fym
-                            +      fracx *(one-fracz)*flx_u_arr[1](ii,j,k )
-                            +      fracz *(one-fracx)*flx_u_arr[1](i ,j,kk)
+                    if (u_afrac_y(i,j,k) != zero_d && u_afrac_y(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,u_fcy(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,u_fcy(i,j,k,1)));
+                        Real fracx = (u_mask(ii,j-1,k) || u_mask(ii,j,k)) ? std::abs(u_fcy(i,j,k,0)) : zero_d;
+                        Real fracz = (u_mask(i,j-1,kk) || u_mask(i,j,kk)) ? std::abs(u_fcy(i,j,k,1)) : zero_d;
+                        fym = (one_d-fracx)*(one_d-fracz)*fym
+                            +      fracx *(one_d-fracz)*flx_u_arr[1](ii,j,k )
+                            +      fracz *(one_d-fracx)*flx_u_arr[1](i ,j,kk)
                             +      fracx *     fracz *flx_u_arr[1](ii,j,kk);
                     }
 
                     Real fyp = flx_u_arr[1](i,j+1,k);
-                    if (u_afrac_y(i,j+1,k) != zero && u_afrac_y(i,j+1,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,u_fcy(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,u_fcy(i,j+1,k,1)));
-                        Real fracx = (u_mask(ii,j,k) || u_mask(ii,j+1,k)) ? std::abs(u_fcy(i,j+1,k,0)) : zero;
-                        Real fracz = (u_mask(i,j,kk) || u_mask(i,j+1,kk)) ? std::abs(u_fcy(i,j+1,k,1)) : zero;
-                        fyp = (one-fracx)*(one-fracz)*fyp
-                            +      fracx *(one-fracz)*flx_u_arr[1](ii,j+1,k )
-                            +      fracz *(one-fracx)*flx_u_arr[1](i ,j+1,kk)
+                    if (u_afrac_y(i,j+1,k) != zero_d && u_afrac_y(i,j+1,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,u_fcy(i,j+1,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,u_fcy(i,j+1,k,1)));
+                        Real fracx = (u_mask(ii,j,k) || u_mask(ii,j+1,k)) ? std::abs(u_fcy(i,j+1,k,0)) : zero_d;
+                        Real fracz = (u_mask(i,j,kk) || u_mask(i,j+1,kk)) ? std::abs(u_fcy(i,j+1,k,1)) : zero_d;
+                        fyp = (one_d-fracx)*(one_d-fracz)*fyp
+                            +      fracx *(one_d-fracz)*flx_u_arr[1](ii,j+1,k )
+                            +      fracz *(one_d-fracx)*flx_u_arr[1](i ,j+1,kk)
                             +      fracx *     fracz *flx_u_arr[1](ii,j+1,kk);
                     }
 
                     Real fzm = flx_u_arr[2](i,j,k);
-                    if (u_afrac_z(i,j,k) != zero && u_afrac_z(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,u_fcz(i,j,k,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,u_fcz(i,j,k,1)));
-                        Real fracx = (u_mask(ii,j,k-1) || u_mask(ii,j,k)) ? std::abs(u_fcz(i,j,k,0)) : zero;
-                        Real fracy = (u_mask(i,jj,k-1) || u_mask(i,jj,k)) ? std::abs(u_fcz(i,j,k,1)) : zero;
-                        fzm = (one-fracx)*(one-fracy)*fzm
-                            +      fracx *(one-fracy)*flx_u_arr[2](ii,j ,k)
-                            +      fracy *(one-fracx)*flx_u_arr[2](i ,jj,k)
+                    if (u_afrac_z(i,j,k) != zero_d && u_afrac_z(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,u_fcz(i,j,k,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,u_fcz(i,j,k,1)));
+                        Real fracx = (u_mask(ii,j,k-1) || u_mask(ii,j,k)) ? std::abs(u_fcz(i,j,k,0)) : zero_d;
+                        Real fracy = (u_mask(i,jj,k-1) || u_mask(i,jj,k)) ? std::abs(u_fcz(i,j,k,1)) : zero_d;
+                        fzm = (one_d-fracx)*(one_d-fracy)*fzm
+                            +      fracx *(one_d-fracy)*flx_u_arr[2](ii,j ,k)
+                            +      fracy *(one_d-fracx)*flx_u_arr[2](i ,jj,k)
                             +      fracx *     fracy *flx_u_arr[2](ii,jj,k);
                     }
 
                     Real fzp = flx_u_arr[2](i,j,k+1);
-                    if (u_afrac_z(i,j,k+1) != zero && u_afrac_z(i,j,k+1) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,u_fcz(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,u_fcz(i,j,k+1,1)));
-                        Real fracx = (u_mask(ii,j,k) || u_mask(ii,j,k+1)) ? std::abs(u_fcz(i,j,k+1,0)) : zero;
-                        Real fracy = (u_mask(i,jj,k) || u_mask(i,jj,k+1)) ? std::abs(u_fcz(i,j,k+1,1)) : zero;
-                        fzp = (one-fracx)*(one-fracy)*fzp
-                            +      fracx *(one-fracy)*flx_u_arr[2](ii,j ,k+1)
-                            +      fracy *(one-fracx)*flx_u_arr[2](i ,jj,k+1)
+                    if (u_afrac_z(i,j,k+1) != zero_d && u_afrac_z(i,j,k+1) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,u_fcz(i,j,k+1,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,u_fcz(i,j,k+1,1)));
+                        Real fracx = (u_mask(ii,j,k) || u_mask(ii,j,k+1)) ? std::abs(u_fcz(i,j,k+1,0)) : zero_d;
+                        Real fracy = (u_mask(i,jj,k) || u_mask(i,jj,k+1)) ? std::abs(u_fcz(i,j,k+1,1)) : zero_d;
+                        fzp = (one_d-fracx)*(one_d-fracy)*fzp
+                            +      fracx *(one_d-fracy)*flx_u_arr[2](ii,j ,k+1)
+                            +      fracy *(one_d-fracx)*flx_u_arr[2](i ,jj,k+1)
                             +      fracx *     fracy *flx_u_arr[2](ii,jj,k+1);
                     }
 
@@ -441,17 +441,17 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                 }
 
             } else {
-                rho_u_rhs(i, j, k) = zero;
+                rho_u_rhs(i, j, k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (v_vfrac(i,j,k)>zero) {
+            if (v_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
                 if (v_cflag(i,j,k).isCovered())
                 {
-                    rho_v_rhs(i, j, k) = zero;
+                    rho_v_rhs(i, j, k) = zero_d;
                 }
                 else if (v_cflag(i,j,k).isRegular())
                 {
@@ -463,74 +463,74 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                 {
                     // Bilinear interpolation
                     Real fxm = flx_v_arr[0](i,j,k);
-                    if (v_afrac_x(i,j,k) != zero && v_afrac_x(i,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one, v_fcx(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one, v_fcx(i,j,k,1)));
-                        Real fracy = (v_mask(i-1,jj,k) || v_mask(i,jj,k)) ? std::abs(v_fcx(i,j,k,0)) : zero;
-                        Real fracz = (v_mask(i-1,j,kk) || v_mask(i,j,kk)) ? std::abs(v_fcx(i,j,k,1)) : zero;
-                        fxm = (one-fracy)*(one-fracz)*fxm
-                            +      fracy *(one-fracz)*flx_v_arr[0](i,jj,k )
-                            +      fracz *(one-fracy)*flx_v_arr[0](i,j ,kk)
+                    if (v_afrac_x(i,j,k) != zero_d && v_afrac_x(i,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d, v_fcx(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d, v_fcx(i,j,k,1)));
+                        Real fracy = (v_mask(i-1,jj,k) || v_mask(i,jj,k)) ? std::abs(v_fcx(i,j,k,0)) : zero_d;
+                        Real fracz = (v_mask(i-1,j,kk) || v_mask(i,j,kk)) ? std::abs(v_fcx(i,j,k,1)) : zero_d;
+                        fxm = (one_d-fracy)*(one_d-fracz)*fxm
+                            +      fracy *(one_d-fracz)*flx_v_arr[0](i,jj,k )
+                            +      fracz *(one_d-fracy)*flx_v_arr[0](i,j ,kk)
                             +      fracy *     fracz *flx_v_arr[0](i,jj,kk);
                     }
 
                     Real fxp = flx_v_arr[0](i+1,j,k);
-                    if (v_afrac_x(i+1,j,k) != zero && v_afrac_x(i+1,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one,v_fcx(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,v_fcx(i+1,j,k,1)));
-                        Real fracy = (v_mask(i,jj,k) || v_mask(i+1,jj,k)) ? std::abs(v_fcx(i+1,j,k,0)) : zero;
-                        Real fracz = (v_mask(i,j,kk) || v_mask(i+1,j,kk)) ? std::abs(v_fcx(i+1,j,k,1)) : zero;
-                        fxp = (one-fracy)*(one-fracz)*fxp
-                            +      fracy *(one-fracz)*flx_v_arr[0](i+1,jj,k )
-                            +      fracz *(one-fracy)*flx_v_arr[0](i+1,j ,kk)
+                    if (v_afrac_x(i+1,j,k) != zero_d && v_afrac_x(i+1,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d,v_fcx(i+1,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,v_fcx(i+1,j,k,1)));
+                        Real fracy = (v_mask(i,jj,k) || v_mask(i+1,jj,k)) ? std::abs(v_fcx(i+1,j,k,0)) : zero_d;
+                        Real fracz = (v_mask(i,j,kk) || v_mask(i+1,j,kk)) ? std::abs(v_fcx(i+1,j,k,1)) : zero_d;
+                        fxp = (one_d-fracy)*(one_d-fracz)*fxp
+                            +      fracy *(one_d-fracz)*flx_v_arr[0](i+1,jj,k )
+                            +      fracz *(one_d-fracy)*flx_v_arr[0](i+1,j ,kk)
                             +      fracy *     fracz *flx_v_arr[0](i+1,jj,kk);
                     }
 
                     Real fym = flx_v_arr[1](i,j,k);
-                    if (v_afrac_y(i,j,k) != zero && v_afrac_y(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,v_fcy(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,v_fcy(i,j,k,1)));
-                        Real fracx = (v_mask(ii,j-1,k) || v_mask(ii,j,k)) ? std::abs(v_fcy(i,j,k,0)) : zero;
-                        Real fracz = (v_mask(i,j-1,kk) || v_mask(i,j,kk)) ? std::abs(v_fcy(i,j,k,1)) : zero;
-                        fym = (one-fracx)*(one-fracz)*fym
-                            +      fracx *(one-fracz)*flx_v_arr[1](ii,j,k )
-                            +      fracz *(one-fracx)*flx_v_arr[1](i ,j,kk)
+                    if (v_afrac_y(i,j,k) != zero_d && v_afrac_y(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,v_fcy(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,v_fcy(i,j,k,1)));
+                        Real fracx = (v_mask(ii,j-1,k) || v_mask(ii,j,k)) ? std::abs(v_fcy(i,j,k,0)) : zero_d;
+                        Real fracz = (v_mask(i,j-1,kk) || v_mask(i,j,kk)) ? std::abs(v_fcy(i,j,k,1)) : zero_d;
+                        fym = (one_d-fracx)*(one_d-fracz)*fym
+                            +      fracx *(one_d-fracz)*flx_v_arr[1](ii,j,k )
+                            +      fracz *(one_d-fracx)*flx_v_arr[1](i ,j,kk)
                             +      fracx *           fracz *flx_v_arr[1](ii,j,kk);
                     }
 
                     Real fyp = flx_v_arr[1](i,j+1,k);
-                    if (v_afrac_y(i,j+1,k) != zero && v_afrac_y(i,j+1,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,v_fcy(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,v_fcy(i,j+1,k,1)));
-                        Real fracx = (v_mask(ii,j,k) || v_mask(ii,j+1,k)) ? std::abs(v_fcy(i,j+1,k,0)) : zero;
-                        Real fracz = (v_mask(i,j,kk) || v_mask(i,j+1,kk)) ? std::abs(v_fcy(i,j+1,k,1)) : zero;
-                        fyp = (one-fracx)*(one-fracz)*fyp
-                            +      fracx *(one-fracz)*flx_v_arr[1](ii,j+1,k )
-                            +      fracz *(one-fracx)*flx_v_arr[1](i ,j+1,kk)
+                    if (v_afrac_y(i,j+1,k) != zero_d && v_afrac_y(i,j+1,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,v_fcy(i,j+1,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,v_fcy(i,j+1,k,1)));
+                        Real fracx = (v_mask(ii,j,k) || v_mask(ii,j+1,k)) ? std::abs(v_fcy(i,j+1,k,0)) : zero_d;
+                        Real fracz = (v_mask(i,j,kk) || v_mask(i,j+1,kk)) ? std::abs(v_fcy(i,j+1,k,1)) : zero_d;
+                        fyp = (one_d-fracx)*(one_d-fracz)*fyp
+                            +      fracx *(one_d-fracz)*flx_v_arr[1](ii,j+1,k )
+                            +      fracz *(one_d-fracx)*flx_v_arr[1](i ,j+1,kk)
                             +      fracx *     fracz *flx_v_arr[1](ii,j+1,kk);
                     }
 
                     Real fzm = flx_v_arr[2](i,j,k);
-                    if (v_afrac_z(i,j,k) != zero && v_afrac_z(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,v_fcz(i,j,k,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,v_fcz(i,j,k,1)));
-                        Real fracx = (v_mask(ii,j,k-1) || v_mask(ii,j,k)) ? std::abs(v_fcz(i,j,k,0)) : zero;
-                        Real fracy = (v_mask(i,jj,k-1) || v_mask(i,jj,k)) ? std::abs(v_fcz(i,j,k,1)) : zero;
-                        fzm = (one-fracx)*(one-fracy)*fzm
-                            +      fracx *(one-fracy)*flx_v_arr[2](ii,j ,k)
-                            +      fracy *(one-fracx)*flx_v_arr[2](i ,jj,k)
+                    if (v_afrac_z(i,j,k) != zero_d && v_afrac_z(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,v_fcz(i,j,k,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,v_fcz(i,j,k,1)));
+                        Real fracx = (v_mask(ii,j,k-1) || v_mask(ii,j,k)) ? std::abs(v_fcz(i,j,k,0)) : zero_d;
+                        Real fracy = (v_mask(i,jj,k-1) || v_mask(i,jj,k)) ? std::abs(v_fcz(i,j,k,1)) : zero_d;
+                        fzm = (one_d-fracx)*(one_d-fracy)*fzm
+                            +      fracx *(one_d-fracy)*flx_v_arr[2](ii,j ,k)
+                            +      fracy *(one_d-fracx)*flx_v_arr[2](i ,jj,k)
                             +      fracx *     fracy *flx_v_arr[2](ii,jj,k);
                     }
 
                     Real fzp = flx_v_arr[2](i,j,k+1);
-                    if (v_afrac_z(i,j,k+1) != zero && v_afrac_z(i,j,k+1) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,v_fcz(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,v_fcz(i,j,k+1,1)));
-                        Real fracx = (v_mask(ii,j,k) || v_mask(ii,j,k+1)) ? std::abs(v_fcz(i,j,k+1,0)) : zero;
-                        Real fracy = (v_mask(i,jj,k) || v_mask(i,jj,k+1)) ? std::abs(v_fcz(i,j,k+1,1)) : zero;
-                        fzp = (one-fracx)*(one-fracy)*fzp
-                            +      fracx *(one-fracy)*flx_v_arr[2](ii,j ,k+1)
-                            +      fracy *(one-fracx)*flx_v_arr[2](i ,jj,k+1)
+                    if (v_afrac_z(i,j,k+1) != zero_d && v_afrac_z(i,j,k+1) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,v_fcz(i,j,k+1,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,v_fcz(i,j,k+1,1)));
+                        Real fracx = (v_mask(ii,j,k) || v_mask(ii,j,k+1)) ? std::abs(v_fcz(i,j,k+1,0)) : zero_d;
+                        Real fracy = (v_mask(i,jj,k) || v_mask(i,jj,k+1)) ? std::abs(v_fcz(i,j,k+1,1)) : zero_d;
+                        fzp = (one_d-fracx)*(one_d-fracy)*fzp
+                            +      fracx *(one_d-fracy)*flx_v_arr[2](ii,j ,k+1)
+                            +      fracy *(one_d-fracx)*flx_v_arr[2](i ,jj,k+1)
                             +      fracx *     fracy *flx_v_arr[2](ii,jj,k+1);
                     }
 
@@ -540,17 +540,17 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                 }
 
             } else {
-                rho_v_rhs(i, j, k) = zero;
+                rho_v_rhs(i, j, k) = zero_d;
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (w_vfrac(i,j,k)>zero) {
+            if (w_vfrac(i,j,k)>zero_d) {
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
                 if (w_cflag(i,j,k).isCovered())
                 {
-                    rho_w_rhs(i, j, k) = zero;
+                    rho_w_rhs(i, j, k) = zero_d;
                 }
                 else if (w_cflag(i,j,k).isRegular())
                 {
@@ -562,74 +562,74 @@ AdvectionSrcForMom_EB ( const MFIter& mfi,
                 {
                     // Bilinear interpolation
                     Real fxm = flx_w_arr[0](i,j,k);
-                    if (w_afrac_x(i,j,k) != zero && w_afrac_x(i,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one, w_fcx(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one, w_fcx(i,j,k,1)));
-                        Real fracy = (w_mask(i-1,jj,k) || w_mask(i,jj,k)) ? std::abs(w_fcx(i,j,k,0)) : zero;
-                        Real fracz = (w_mask(i-1,j,kk) || w_mask(i,j,kk)) ? std::abs(w_fcx(i,j,k,1)) : zero;
-                        fxm = (one-fracy)*(one-fracz)*fxm
-                            +      fracy *(one-fracz)*flx_w_arr[0](i,jj,k )
-                            +      fracz *(one-fracy)*flx_w_arr[0](i,j ,kk)
+                    if (w_afrac_x(i,j,k) != zero_d && w_afrac_x(i,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d, w_fcx(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d, w_fcx(i,j,k,1)));
+                        Real fracy = (w_mask(i-1,jj,k) || w_mask(i,jj,k)) ? std::abs(w_fcx(i,j,k,0)) : zero_d;
+                        Real fracz = (w_mask(i-1,j,kk) || w_mask(i,j,kk)) ? std::abs(w_fcx(i,j,k,1)) : zero_d;
+                        fxm = (one_d-fracy)*(one_d-fracz)*fxm
+                            +      fracy *(one_d-fracz)*flx_w_arr[0](i,jj,k )
+                            +      fracz *(one_d-fracy)*flx_w_arr[0](i,j ,kk)
                             +      fracy *     fracz *flx_w_arr[0](i,jj,kk);
                     }
 
                     Real fxp = flx_w_arr[0](i+1,j,k);
-                    if (w_afrac_x(i+1,j,k) != zero && w_afrac_x(i+1,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one,w_fcx(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,w_fcx(i+1,j,k,1)));
-                        Real fracy = (w_mask(i,jj,k) || w_mask(i+1,jj,k)) ? std::abs(w_fcx(i+1,j,k,0)) : zero;
-                        Real fracz = (w_mask(i,j,kk) || w_mask(i+1,j,kk)) ? std::abs(w_fcx(i+1,j,k,1)) : zero;
-                        fxp = (one-fracy)*(one-fracz)*fxp
-                            +      fracy *(one-fracz)*flx_w_arr[0](i+1,jj,k )
-                            +      fracz *(one-fracy)*flx_w_arr[0](i+1,j ,kk)
+                    if (w_afrac_x(i+1,j,k) != zero_d && w_afrac_x(i+1,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d,w_fcx(i+1,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,w_fcx(i+1,j,k,1)));
+                        Real fracy = (w_mask(i,jj,k) || w_mask(i+1,jj,k)) ? std::abs(w_fcx(i+1,j,k,0)) : zero_d;
+                        Real fracz = (w_mask(i,j,kk) || w_mask(i+1,j,kk)) ? std::abs(w_fcx(i+1,j,k,1)) : zero_d;
+                        fxp = (one_d-fracy)*(one_d-fracz)*fxp
+                            +      fracy *(one_d-fracz)*flx_w_arr[0](i+1,jj,k )
+                            +      fracz *(one_d-fracy)*flx_w_arr[0](i+1,j ,kk)
                             +      fracy *     fracz *flx_w_arr[0](i+1,jj,kk);
                     }
 
                     Real fym = flx_w_arr[1](i,j,k);
-                    if (w_afrac_y(i,j,k) != zero && w_afrac_y(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,w_fcy(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,w_fcy(i,j,k,1)));
-                        Real fracx = (w_mask(ii,j-1,k) || w_mask(ii,j,k)) ? std::abs(w_fcy(i,j,k,0)) : zero;
-                        Real fracz = (w_mask(i,j-1,kk) || w_mask(i,j,kk)) ? std::abs(w_fcy(i,j,k,1)) : zero;
-                        fym = (one-fracx)*(one-fracz)*fym
-                            +      fracx *(one-fracz)*flx_w_arr[1](ii,j,k )
-                            +      fracz *(one-fracx)*flx_w_arr[1](i ,j,kk)
+                    if (w_afrac_y(i,j,k) != zero_d && w_afrac_y(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,w_fcy(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,w_fcy(i,j,k,1)));
+                        Real fracx = (w_mask(ii,j-1,k) || w_mask(ii,j,k)) ? std::abs(w_fcy(i,j,k,0)) : zero_d;
+                        Real fracz = (w_mask(i,j-1,kk) || w_mask(i,j,kk)) ? std::abs(w_fcy(i,j,k,1)) : zero_d;
+                        fym = (one_d-fracx)*(one_d-fracz)*fym
+                            +      fracx *(one_d-fracz)*flx_w_arr[1](ii,j,k )
+                            +      fracz *(one_d-fracx)*flx_w_arr[1](i ,j,kk)
                             +      fracx *     fracz *flx_w_arr[1](ii,j,kk);
                     }
 
                     Real fyp = flx_w_arr[1](i,j+1,k);
-                    if (w_afrac_y(i,j+1,k) != zero && w_afrac_y(i,j+1,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,w_fcy(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,w_fcy(i,j+1,k,1)));
-                        Real fracx = (w_mask(ii,j,k) || w_mask(ii,j+1,k)) ? std::abs(w_fcy(i,j+1,k,0)) : zero;
-                        Real fracz = (w_mask(i,j,kk) || w_mask(i,j+1,kk)) ? std::abs(w_fcy(i,j+1,k,1)) : zero;
-                        fyp = (one-fracx)*(one-fracz)*fyp
-                            +      fracx *(one-fracz)*flx_w_arr[1](ii,j+1,k )
-                            +      fracz *(one-fracx)*flx_w_arr[1](i ,j+1,kk)
+                    if (w_afrac_y(i,j+1,k) != zero_d && w_afrac_y(i,j+1,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,w_fcy(i,j+1,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,w_fcy(i,j+1,k,1)));
+                        Real fracx = (w_mask(ii,j,k) || w_mask(ii,j+1,k)) ? std::abs(w_fcy(i,j+1,k,0)) : zero_d;
+                        Real fracz = (w_mask(i,j,kk) || w_mask(i,j+1,kk)) ? std::abs(w_fcy(i,j+1,k,1)) : zero_d;
+                        fyp = (one_d-fracx)*(one_d-fracz)*fyp
+                            +      fracx *(one_d-fracz)*flx_w_arr[1](ii,j+1,k )
+                            +      fracz *(one_d-fracx)*flx_w_arr[1](i ,j+1,kk)
                             +      fracx *     fracz *flx_w_arr[1](ii,j+1,kk);
                     }
 
                     Real fzm = flx_w_arr[2](i,j,k);
-                    if (w_afrac_z(i,j,k) != zero && w_afrac_z(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,w_fcz(i,j,k,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,w_fcz(i,j,k,1)));
-                        Real fracx = (w_mask(ii,j,k-1) || w_mask(ii,j,k)) ? std::abs(w_fcz(i,j,k,0)) : zero;
-                        Real fracy = (w_mask(i,jj,k-1) || w_mask(i,jj,k)) ? std::abs(w_fcz(i,j,k,1)) : zero;
-                        fzm = (one-fracx)*(one-fracy)*fzm
-                            +      fracx *(one-fracy)*flx_w_arr[2](ii,j ,k)
-                            +      fracy *(one-fracx)*flx_w_arr[2](i ,jj,k)
+                    if (w_afrac_z(i,j,k) != zero_d && w_afrac_z(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,w_fcz(i,j,k,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,w_fcz(i,j,k,1)));
+                        Real fracx = (w_mask(ii,j,k-1) || w_mask(ii,j,k)) ? std::abs(w_fcz(i,j,k,0)) : zero_d;
+                        Real fracy = (w_mask(i,jj,k-1) || w_mask(i,jj,k)) ? std::abs(w_fcz(i,j,k,1)) : zero_d;
+                        fzm = (one_d-fracx)*(one_d-fracy)*fzm
+                            +      fracx *(one_d-fracy)*flx_w_arr[2](ii,j ,k)
+                            +      fracy *(one_d-fracx)*flx_w_arr[2](i ,jj,k)
                             +      fracx *     fracy *flx_w_arr[2](ii,jj,k);
                     }
 
                     Real fzp = flx_w_arr[2](i,j,k+1);
-                    if (w_afrac_z(i,j,k+1) != zero && w_afrac_z(i,j,k+1) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,w_fcz(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,w_fcz(i,j,k+1,1)));
-                        Real fracx = (w_mask(ii,j,k) || w_mask(ii,j,k+1)) ? std::abs(w_fcz(i,j,k+1,0)) : zero;
-                        Real fracy = (w_mask(i,jj,k) || w_mask(i,jj,k+1)) ? std::abs(w_fcz(i,j,k+1,1)) : zero;
-                        fzp = (one-fracx)*(one-fracy)*fzp
-                            +      fracx *(one-fracy)*flx_w_arr[2](ii,j ,k+1)
-                            +      fracy *(one-fracx)*flx_w_arr[2](i ,jj,k+1)
+                    if (w_afrac_z(i,j,k+1) != zero_d && w_afrac_z(i,j,k+1) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,w_fcz(i,j,k+1,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,w_fcz(i,j,k+1,1)));
+                        Real fracx = (w_mask(ii,j,k) || w_mask(ii,j,k+1)) ? std::abs(w_fcz(i,j,k+1,0)) : zero_d;
+                        Real fracy = (w_mask(i,jj,k) || w_mask(i,jj,k+1)) ? std::abs(w_fcz(i,j,k+1,1)) : zero_d;
+                        fzp = (one_d-fracx)*(one_d-fracy)*fzp
+                            +      fracx *(one_d-fracy)*flx_w_arr[2](ii,j ,k+1)
+                            +      fracy *(one_d-fracx)*flx_w_arr[2](i ,jj,k+1)
                             +      fracx *     fracy *flx_w_arr[2](ii,jj,k+1);
                     }
 

--- a/Source/Advection/ERF_AdvectionSrcForMom_N.H
+++ b/Source/Advection/ERF_AdvectionSrcForMom_N.H
@@ -306,9 +306,9 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
     auto dz_ptr = stretched_dz_d.data();
 
     amrex::ParallelFor(bxx,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        auto dzInv = one/dz_ptr[k];
+        auto dzInv = one_d/dz_ptr[k];
         rho_u_rhs(i, j, k) = -AdvectionSrcForXMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_u_h, interp_u_v,
                                                     mf_ux_inv, mf_uy_inv, mf_vx_inv,
@@ -316,9 +316,9 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
     });
 
     amrex::ParallelFor(bxy,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        auto dzInv = one/dz_ptr[k];
+        auto dzInv = one_d/dz_ptr[k];
         rho_v_rhs(i, j, k) = -AdvectionSrcForYMom_N(i, j, k, rho_u, rho_v, rho_w,
                                                     interp_v_h, interp_v_v,
                                                     mf_uy_inv, mf_vx_inv, mf_vy_inv,
@@ -326,9 +326,9 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
     });
 
     amrex::ParallelFor(bxz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        auto dzInv = (k == 0) ? one / dz_ptr[k] : two/(dz_ptr[k] + dz_ptr[k-1]);
+        auto dzInv = (k == 0) ? one_d / dz_ptr[k] : two_d/(dz_ptr[k] + dz_ptr[k-1]);
         rho_w_rhs(i, j, k) = -AdvectionSrcForZMom_N(i, j, k, rho_u, rho_v, rho_w, w,
                                                     interp_w_h, interp_w_v, interp_w_wall,
                                                     mf_mx, mf_my, mf_uy_inv, mf_vx_inv,

--- a/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
@@ -74,15 +74,15 @@ AdvectionSrcForMom_StretchedDz (const Box& bxx, const Box& bxy, const Box& bxz,
     const Array4<Real>& mf_vy_inv = mf_vy_invFAB.array();
 
     ParallelFor(box2d_u, box2d_v,
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_ux_inv(i,j,0) = one / mf_ux(i,j,0);
-        mf_uy_inv(i,j,0) = one / mf_uy(i,j,0);
+        mf_ux_inv(i,j,0) = one_d / mf_ux(i,j,0);
+        mf_uy_inv(i,j,0) = one_d / mf_uy(i,j,0);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_vx_inv(i,j,0) = one / mf_vx(i,j,0);
-        mf_vy_inv(i,j,0) = one / mf_vy(i,j,0);
+        mf_vx_inv(i,j,0) = one_d / mf_vx(i,j,0);
+        mf_vy_inv(i,j,0) = one_d / mf_vy(i,j,0);
     });
 
     auto dz_ptr = stretched_dz_d.data();
@@ -91,62 +91,62 @@ AdvectionSrcForMom_StretchedDz (const Box& bxx, const Box& bxy, const Box& bxz,
     if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
     {
             ParallelFor(bxx, bxy, bxz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real xflux_hi = fourth * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i+1, j  , k) * mf_uy_inv(i+1,j,0)) * (u(i+1,j,k) + u(i,j,k));
-                Real xflux_lo = fourth * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i-1, j  , k) * mf_uy_inv(i-1,j,0)) * (u(i-1,j,k) + u(i,j,k));
+                Real xflux_hi = fourth_d * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i+1, j  , k) * mf_uy_inv(i+1,j,0)) * (u(i+1,j,k) + u(i,j,k));
+                Real xflux_lo = fourth_d * (rho_u(i, j  , k) * mf_uy_inv(i,j,0) + rho_u(i-1, j  , k) * mf_uy_inv(i-1,j,0)) * (u(i-1,j,k) + u(i,j,k));
 
-                Real yflux_hi = fourth * (rho_v(i, j+1, k) * mf_vx_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_vx_inv(i-1,j+1,0)) * (u(i,j+1,k) + u(i,j,k));
-                Real yflux_lo = fourth * (rho_v(i, j  , k) * mf_vx_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_vx_inv(i-1,j  ,0)) * (u(i,j-1,k) + u(i,j,k));
+                Real yflux_hi = fourth_d * (rho_v(i, j+1, k) * mf_vx_inv(i,j+1,0) + rho_v(i-1, j+1, k) * mf_vx_inv(i-1,j+1,0)) * (u(i,j+1,k) + u(i,j,k));
+                Real yflux_lo = fourth_d * (rho_v(i, j  , k) * mf_vx_inv(i,j  ,0) + rho_v(i-1, j  , k) * mf_vx_inv(i-1,j  ,0)) * (u(i,j-1,k) + u(i,j,k));
 
-                Real zflux_hi = fourth * (omega(i, j, k+1) + omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
-                Real zflux_lo = fourth * (omega(i, j, k  ) + omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
+                Real zflux_hi = fourth_d * (omega(i, j, k+1) + omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k));
+                Real zflux_lo = fourth_d * (omega(i, j, k  ) + omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k));
 
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
-                Real dzInv = one/dz_ptr[k];
+                Real dzInv = one_d/dz_ptr[k];
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
                 rho_u_rhs(i, j, k) = -advectionSrc;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-                Real xflux_hi = fourth * (rho_u(i+1, j, k) * mf_uy_inv(i+1,j,0) + rho_u(i+1, j-1, k) * mf_uy_inv(i+1,j-1,0)) * (v(i+1,j,k) + v(i,j,k));
-                Real xflux_lo = fourth * (rho_u(i  , j, k) * mf_uy_inv(i  ,j,0) + rho_u(i  , j-1, k) * mf_uy_inv(i  ,j-1,0)) * (v(i-1,j,k) + v(i,j,k));
+                Real xflux_hi = fourth_d * (rho_u(i+1, j, k) * mf_uy_inv(i+1,j,0) + rho_u(i+1, j-1, k) * mf_uy_inv(i+1,j-1,0)) * (v(i+1,j,k) + v(i,j,k));
+                Real xflux_lo = fourth_d * (rho_u(i  , j, k) * mf_uy_inv(i  ,j,0) + rho_u(i  , j-1, k) * mf_uy_inv(i  ,j-1,0)) * (v(i-1,j,k) + v(i,j,k));
 
-                Real yflux_hi = fourth * (rho_v(i  ,j+1,k) * mf_vx_inv(i,j+1,0) + rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0)) * (v(i,j+1,k) + v(i,j,k));
-                Real yflux_lo = fourth * (rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0) + rho_v(i  ,j-1,k) * mf_vx_inv(i,j-1,0)) * (v(i,j-1,k) + v(i,j,k));
+                Real yflux_hi = fourth_d * (rho_v(i  ,j+1,k) * mf_vx_inv(i,j+1,0) + rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0)) * (v(i,j+1,k) + v(i,j,k));
+                Real yflux_lo = fourth_d * (rho_v(i  ,j  ,k) * mf_vx_inv(i,j  ,0) + rho_v(i  ,j-1,k) * mf_vx_inv(i,j-1,0)) * (v(i,j-1,k) + v(i,j,k));
 
-                Real zflux_hi = fourth * (omega(i, j, k+1) + omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
-                Real zflux_lo = fourth * (omega(i, j, k  ) + omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
+                Real zflux_hi = fourth_d * (omega(i, j, k+1) + omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k));
+                Real zflux_lo = fourth_d * (omega(i, j, k  ) + omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k));
 
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
-                Real dzInv = one/dz_ptr[k];
+                Real dzInv = one_d/dz_ptr[k];
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
                 rho_v_rhs(i, j, k) = -advectionSrc;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-                Real xflux_hi = fourth*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * mf_uy_inv(i+1,j  ,0) * (w(i+1,j,k) + w(i,j,k));
-                Real xflux_lo = fourth*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * mf_uy_inv(i  ,j  ,0) * (w(i-1,j,k) + w(i,j,k));
+                Real xflux_hi = fourth_d*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * mf_uy_inv(i+1,j  ,0) * (w(i+1,j,k) + w(i,j,k));
+                Real xflux_lo = fourth_d*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * mf_uy_inv(i  ,j  ,0) * (w(i-1,j,k) + w(i,j,k));
 
-                Real yflux_hi = fourth*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * mf_vx_inv(i  ,j+1,0) * (w(i,j+1,k) + w(i,j,k));
-                Real yflux_lo = fourth*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * mf_vx_inv(i  ,j  ,0) * (w(i,j-1,k) + w(i,j,k));
+                Real yflux_hi = fourth_d*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * mf_vx_inv(i  ,j+1,0) * (w(i,j+1,k) + w(i,j,k));
+                Real yflux_lo = fourth_d*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * mf_vx_inv(i  ,j  ,0) * (w(i,j-1,k) + w(i,j,k));
 
-                Real zflux_lo = fourth * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
+                Real zflux_lo = fourth_d * (omega(i,j,k) + omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
 
                 Real zflux_hi = (k == hi_z_face) ? omega(i,j,k) * w(i,j,k) :
-                    fourth * (omega(i,j,k) + omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1));
+                    fourth_d * (omega(i,j,k) + omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1));
 
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
-                Real dzInv = (k == 0) ? one / dz_ptr[k] : two/(dz_ptr[k] + dz_ptr[k-1]);
+                Real dzInv = (k == 0) ? one_d / dz_ptr[k] : two_d/(dz_ptr[k] + dz_ptr[k-1]);
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq

--- a/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
@@ -84,108 +84,108 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
     const Array4<Real>& mf_vy_inv = mf_vy_invFAB.array();
 
     ParallelFor(box2d_u, box2d_v,
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_ux_inv(i,j,0) = one / mf_ux(i,j,0);
-        mf_uy_inv(i,j,0) = one / mf_uy(i,j,0);
+        mf_ux_inv(i,j,0) = one_d / mf_ux(i,j,0);
+        mf_uy_inv(i,j,0) = one_d / mf_uy(i,j,0);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
-        mf_vx_inv(i,j,0) = one / mf_vx(i,j,0);
-        mf_vy_inv(i,j,0) = one / mf_vy(i,j,0);
+        mf_vx_inv(i,j,0) = one_d / mf_vx(i,j,0);
+        mf_vy_inv(i,j,0) = one_d / mf_vy(i,j,0);
     });
 
     // Inline with 2nd order for efficiency
     if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
     {
             ParallelFor(bxx, bxy, bxz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real xflux_hi = fourth * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i+1,j,k) * mf_uy_inv(i+1,j,0)) *
-                                       (u(i+1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i+1,j,k));
+                Real xflux_hi = fourth_d * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i+1,j,k) * mf_uy_inv(i+1,j,0)) *
+                                       (u(i+1,j,k) + u(i,j,k)) * myhalf_d * (ax(i,j,k) + ax(i+1,j,k));
 
-                Real xflux_lo = fourth * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i-1,j,k) * mf_uy_inv(i-1,j,0)) *
-                                       (u(i-1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i-1,j,k));
+                Real xflux_lo = fourth_d * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i-1,j,k) * mf_uy_inv(i-1,j,0)) *
+                                       (u(i-1,j,k) + u(i,j,k)) * myhalf_d * (ax(i,j,k) + ax(i-1,j,k));
 
                 Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterK(i,j+1,k,cellSizeInv,z_nd);
-                Real yflux_hi = fourth * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i-1,j+1,k)*mf_vx_inv(i-1,j+1,0)) *
+                Real yflux_hi = fourth_d * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i-1,j+1,k)*mf_vx_inv(i-1,j+1,0)) *
                                        (u(i,j+1,k) + u(i,j,k)) * met_h_zeta_yhi;
 
                 Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterK(i,j  ,k,cellSizeInv,z_nd);
-                Real yflux_lo = fourth * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i-1,j  ,k)*mf_vx_inv(i-1,j  ,0)) *
+                Real yflux_lo = fourth_d * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i-1,j  ,k)*mf_vx_inv(i-1,j  ,0)) *
                                        (u(i,j-1,k) + u(i,j,k)) * met_h_zeta_ylo;
 
-                Real zflux_hi = fourth * (Omega(i,j,k+1) + Omega(i-1,j,k+1)) * (u(i,j,k+1) + u(i,j,k)) *
-                                        myhalf * (az(i,j,k+1) + az(i-1,j,k+1));
-                Real zflux_lo = fourth * (Omega(i,j,k  ) + Omega(i-1,j,k  )) * (u(i,j,k-1) + u(i,j,k)) *
-                                        myhalf * (az(i,j,k  ) + az(i-1,j,k  ));
+                Real zflux_hi = fourth_d * (Omega(i,j,k+1) + Omega(i-1,j,k+1)) * (u(i,j,k+1) + u(i,j,k)) *
+                                        myhalf_d * (az(i,j,k+1) + az(i-1,j,k+1));
+                Real zflux_lo = fourth_d * (Omega(i,j,k  ) + Omega(i-1,j,k  )) * (u(i,j,k-1) + u(i,j,k)) *
+                                        myhalf_d * (az(i,j,k  ) + az(i-1,j,k  ));
 
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-                rho_u_rhs(i, j, k) = -advectionSrc / (myhalf * (detJ(i,j,k) + detJ(i-1,j,k)));
+                rho_u_rhs(i, j, k) = -advectionSrc / (myhalf_d * (detJ(i,j,k) + detJ(i-1,j,k)));
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
 
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterK(i+1,j,k,cellSizeInv,z_nd);
-                Real xflux_hi = fourth * (rho_u(i+1,j,k)*mf_uy_inv(i+1,j,0) + rho_u(i+1,j-1,k)*mf_uy_inv(i+1,j-1,0)) *
+                Real xflux_hi = fourth_d * (rho_u(i+1,j,k)*mf_uy_inv(i+1,j,0) + rho_u(i+1,j-1,k)*mf_uy_inv(i+1,j-1,0)) *
                                        (v(i+1,j,k) + v(i,j,k)) * met_h_zeta_xhi;
 
                 Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterK(i  ,j,k,cellSizeInv,z_nd);
-                Real xflux_lo = fourth * (rho_u(i, j, k)*mf_uy_inv(i  ,j,0) + rho_u(i  ,j-1,k)*mf_uy_inv(i  ,j-1,0)) *
+                Real xflux_lo = fourth_d * (rho_u(i, j, k)*mf_uy_inv(i  ,j,0) + rho_u(i  ,j-1,k)*mf_uy_inv(i  ,j-1,0)) *
                                        (v(i-1,j,k) + v(i,j,k)) * met_h_zeta_xlo;
 
-                Real yflux_hi = fourth * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i,j  ,k) * mf_vx_inv(i,j  ,0)) *
-                                       (v(i,j+1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j+1,k));
+                Real yflux_hi = fourth_d * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i,j  ,k) * mf_vx_inv(i,j  ,0)) *
+                                       (v(i,j+1,k) + v(i,j,k)) * myhalf_d * (ay(i,j,k) + ay(i,j+1,k));
 
-                Real yflux_lo = fourth * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i,j-1,k) * mf_vx_inv(i,j-1,0)) *
-                                       (v(i,j-1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j-1,k));
+                Real yflux_lo = fourth_d * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i,j-1,k) * mf_vx_inv(i,j-1,0)) *
+                                       (v(i,j-1,k) + v(i,j,k)) * myhalf_d * (ay(i,j,k) + ay(i,j-1,k));
 
-                Real zflux_hi = fourth * (Omega(i,j,k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)) *
-                                        myhalf * (az(i,j,k+1) + az(i,j-1,k+1));
-                Real zflux_lo = fourth * (Omega(i,j,k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)) *
-                                        myhalf * (az(i,j,k  ) + az(i,j-1,k  ));
+                Real zflux_hi = fourth_d * (Omega(i,j,k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)) *
+                                        myhalf_d * (az(i,j,k+1) + az(i,j-1,k+1));
+                Real zflux_lo = fourth_d * (Omega(i,j,k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)) *
+                                        myhalf_d * (az(i,j,k  ) + az(i,j-1,k  ));
 
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-                rho_v_rhs(i, j, k) = -advectionSrc / (myhalf * (detJ(i,j,k) + detJ(i,j-1,k)));
+                rho_v_rhs(i, j, k) = -advectionSrc / (myhalf_d * (detJ(i,j,k) + detJ(i,j-1,k)));
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
-                Real xflux_hi = fourth*(rho_u(i+1,j  ,k) + rho_u(i+1,j,k-1)) * mf_uy_inv(i+1,j,0) *
+                Real xflux_hi = fourth_d*(rho_u(i+1,j  ,k) + rho_u(i+1,j,k-1)) * mf_uy_inv(i+1,j,0) *
                                      (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi;
 
                 Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd);
-                Real xflux_lo = fourth*(rho_u(i  ,j  ,k) + rho_u(i  ,j,k-1)) * mf_uy_inv(i  ,j,0) *
+                Real xflux_lo = fourth_d*(rho_u(i  ,j  ,k) + rho_u(i  ,j,k-1)) * mf_uy_inv(i  ,j,0) *
                                      (w(i-1,j,k) + w(i,j,k)) * met_h_zeta_xlo;
 
                 Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd);
-                Real yflux_hi = fourth*(rho_v(i,j+1,k) + rho_v(i,j+1,k-1)) * mf_vx_inv(i,j+1,0) *
+                Real yflux_hi = fourth_d*(rho_v(i,j+1,k) + rho_v(i,j+1,k-1)) * mf_vx_inv(i,j+1,0) *
                                      (w(i,j+1,k) + w(i,j,k)) * met_h_zeta_yhi;
 
                 Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd);
-                Real yflux_lo = fourth*(rho_v(i,j  ,k) + rho_v(i,j  ,k-1)) * mf_vx_inv(i,j  ,0) *
+                Real yflux_lo = fourth_d*(rho_v(i,j  ,k) + rho_v(i,j  ,k-1)) * mf_vx_inv(i,j  ,0) *
                                      (w(i,j-1,k) + w(i,j,k)) * met_h_zeta_ylo;
 
-                Real zflux_lo = fourth * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
+                Real zflux_lo = fourth_d * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
 
                 Real zflux_hi = (k == hi_z_face) ? Omega(i,j,k) * w(i,j,k)  * az(i,j,k):
-                    fourth * (Omega(i,j,k) + Omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1)) *
-                    myhalf  * (az(i,j,k) + az(i,j,k+1));
+                    fourth_d * (Omega(i,j,k) + Omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1)) *
+                    myhalf_d  * (az(i,j,k) + az(i,j,k+1));
 
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
                 Real advectionSrc = (xflux_hi - xflux_lo) * dxInv * mfsq
                                   + (yflux_hi - yflux_lo) * dyInv * mfsq
                                   + (zflux_hi - zflux_lo) * dzInv;
-                rho_w_rhs(i, j, k) = -advectionSrc / (myhalf*(detJ(i,j,k) + detJ(i,j,k-1)));
+                rho_w_rhs(i, j, k) = -advectionSrc / (myhalf_d*(detJ(i,j,k) + detJ(i,j,k-1)));
             });
 
     // Template higher order methods

--- a/Source/Advection/ERF_AdvectionSrcForOpenBC.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForOpenBC.cpp
@@ -19,7 +19,7 @@ AdvectionSrcForOpenBC_Normal (const Box& bx,
     // NOTE: Indices (i,j,k) correspond to data that is ON the open bdy.
     int sgn = 1; if (do_lo) sgn = -1;
     Real c_o_star = Real(sgn)*Real(30.0);
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         IntVect ivu1(i,j,k); if ( do_lo) ivu1[dir] -= sgn; // Vel indexed into domain for do_lo
         IntVect ivu2(i,j,k); if (!do_lo) ivu2[dir] -= sgn; // Vel indexed into domain for do_hi
@@ -27,8 +27,8 @@ AdvectionSrcForOpenBC_Normal (const Box& bx,
         IntVect ivr1(i,j,k); if (!do_lo) ivr1[dir] -= sgn; // Rho indexed into domain for do_hi
         IntVect ivr2(i,j,k); if ( do_lo) ivr2[dir] += sgn; // Rho indexed out  domain for do_lo
 
-        Real rho_face  = myhalf * ( cell_data_arr(ivr1,Rho_comp) + cell_data_arr(ivr2,Rho_comp) );
-        Real mom_star  = rho_face * Real(sgn) * max( Real(sgn)*(vel_norm_arr(ivu1) + c_o_star), zero );
+        Real rho_face  = myhalf_d * ( cell_data_arr(ivr1,Rho_comp) + cell_data_arr(ivr2,Rho_comp) );
+        Real mom_star  = rho_face * Real(sgn) * max( Real(sgn)*(vel_norm_arr(ivu1) + c_o_star), zero_d );
         Real vel_grad  =  ( vel_norm_arr(ivu1) - vel_norm_arr(ivu2) ) * dxInv[dir];
         Real flux      = -( mom_star * vel_grad );
         rhs_arr(i,j,k) = flux;
@@ -54,23 +54,23 @@ AdvectionSrcForOpenBC_Tangent_Xmom (const Box& bxx,
 
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    ParallelFor(bxx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bxx,[=,zero_d=zero,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if (ax(i,j,k) > zero) {
-            Real xflux_hi = fourth * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i+1,j,k));
-            Real xflux_lo = fourth * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i-1,j,k));
+        if (ax(i,j,k) > zero_d) {
+            Real xflux_hi = fourth_d * (rho_u(i, j  , k) + rho_u(i+1, j  , k)) * (u(i+1,j,k) + u(i,j,k)) * myhalf_d * (ax(i,j,k) + ax(i+1,j,k));
+            Real xflux_lo = fourth_d * (rho_u(i, j  , k) + rho_u(i-1, j  , k)) * (u(i-1,j,k) + u(i,j,k)) * myhalf_d * (ax(i,j,k) + ax(i-1,j,k));
 
-            Real zflux_hi = fourth * (Omega(i, j, k+1) + Omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k)) * az(i,j,k+1);
-            Real zflux_lo = fourth * (Omega(i, j, k  ) + Omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k)) * az(i,j,k  );
+            Real zflux_hi = fourth_d * (Omega(i, j, k+1) + Omega(i-1, j, k+1)) * (u(i,j,k+1) + u(i,j,k)) * az(i,j,k+1);
+            Real zflux_lo = fourth_d * (Omega(i, j, k  ) + Omega(i-1, j, k  )) * (u(i,j,k-1) + u(i,j,k)) * az(i,j,k  );
 
             Real x_src = (xflux_hi - xflux_lo) * dxInv;
             Real y_src = AdvectionSrcForOpenBC_Tangent(i, j, k, 0, dir, u, rho_v, dyInv, do_lo);
             Real z_src = (zflux_hi - zflux_lo) * dzInv;
             Real advectionSrc = x_src + y_src + z_src;
 
-            rho_u_rhs(i, j, k) = -advectionSrc / (myhalf * (detJ(i,j,k) + detJ(i-1,j,k)));
+            rho_u_rhs(i, j, k) = -advectionSrc / (myhalf_d * (detJ(i,j,k) + detJ(i-1,j,k)));
         } else {
-            rho_u_rhs(i, j, k) = zero;
+            rho_u_rhs(i, j, k) = zero_d;
         }
     });
 }
@@ -94,23 +94,23 @@ AdvectionSrcForOpenBC_Tangent_Ymom (const Box& bxy,
 
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    ParallelFor(bxy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bxy,[=,zero_d=zero,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if (ay(i,j,k) > zero) {
-            Real yflux_hi = fourth * (rho_v(i  ,j+1,k) + rho_v(i  ,j  ,k)) * (v(i,j+1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j+1,k));
-            Real yflux_lo = fourth * (rho_v(i  ,j  ,k) + rho_v(i  ,j-1,k)) * (v(i,j-1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j-1,k));
+        if (ay(i,j,k) > zero_d) {
+            Real yflux_hi = fourth_d * (rho_v(i  ,j+1,k) + rho_v(i  ,j  ,k)) * (v(i,j+1,k) + v(i,j,k)) * myhalf_d * (ay(i,j,k) + ay(i,j+1,k));
+            Real yflux_lo = fourth_d * (rho_v(i  ,j  ,k) + rho_v(i  ,j-1,k)) * (v(i,j-1,k) + v(i,j,k)) * myhalf_d * (ay(i,j,k) + ay(i,j-1,k));
 
-            Real zflux_hi = fourth * (Omega(i, j, k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)) * az(i,j,k+1);
-            Real zflux_lo = fourth * (Omega(i, j, k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)) * az(i,j,k  );
+            Real zflux_hi = fourth_d * (Omega(i, j, k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)) * az(i,j,k+1);
+            Real zflux_lo = fourth_d * (Omega(i, j, k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)) * az(i,j,k  );
 
             Real x_src = AdvectionSrcForOpenBC_Tangent(i, j, k, 0, dir, v, rho_u, dxInv, do_lo);
             Real y_src = (yflux_hi - yflux_lo) * dyInv;
             Real z_src = (zflux_hi - zflux_lo) * dzInv;
             Real advectionSrc = x_src + y_src + z_src;
 
-            rho_v_rhs(i, j, k) = -advectionSrc / (myhalf * (detJ(i,j,k) + detJ(i,j-1,k)));
+            rho_v_rhs(i, j, k) = -advectionSrc / (myhalf_d * (detJ(i,j,k) + detJ(i,j-1,k)));
         } else {
-            rho_v_rhs(i, j, k) = zero;
+            rho_v_rhs(i, j, k) = zero_d;
         }
     });
 }
@@ -139,27 +139,27 @@ AdvectionSrcForOpenBC_Tangent_Zmom (const Box& bxz,
 
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    ParallelFor(bxz, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bxz, [=,zero_d=zero,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if (az(i,j,k) > zero) {
-            Real xflux_hi = fourth*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) *
-                            myhalf *(ax(i+1,j,k) + ax(i+1,j,k-1));
+        if (az(i,j,k) > zero_d) {
+            Real xflux_hi = fourth_d*(rho_u(i+1,j  ,k) + rho_u(i+1, j, k-1)) * (w(i+1,j,k) + w(i,j,k)) *
+                            myhalf_d *(ax(i+1,j,k) + ax(i+1,j,k-1));
 
-            Real xflux_lo = fourth*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) *
-                            myhalf *(ax(i,j,k) + ax(i,j,k-1));
+            Real xflux_lo = fourth_d*(rho_u(i  ,j  ,k) + rho_u(i  , j, k-1)) * (w(i-1,j,k) + w(i,j,k)) *
+                            myhalf_d *(ax(i,j,k) + ax(i,j,k-1));
 
-            Real yflux_hi = fourth*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) *
-                            myhalf *(ay(i,j+1,k) + ay(i,j+1,k-1));
+            Real yflux_hi = fourth_d*(rho_v(i  ,j+1,k) + rho_v(i, j+1, k-1)) * (w(i,j+1,k) + w(i,j,k)) *
+                            myhalf_d *(ay(i,j+1,k) + ay(i,j+1,k-1));
 
-            Real yflux_lo = fourth*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) *
-                            myhalf *(ay(i,j,k) + ay(i,j,k-1));
+            Real yflux_lo = fourth_d*(rho_v(i  ,j  ,k) + rho_v(i, j  , k-1)) * (w(i,j-1,k) + w(i,j,k)) *
+                            myhalf_d *(ay(i,j,k) + ay(i,j,k-1));
 
-            Real zflux_lo = fourth * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1)) *
-                            myhalf *(az(i,j,k) + az(i,j,k-1));
+            Real zflux_lo = fourth_d * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1)) *
+                            myhalf_d *(az(i,j,k) + az(i,j,k-1));
 
             Real zflux_hi = (k == domhi_z+1) ? Omega(i,j,k) * w(i,j,k) * az(i,j,k):
-                                               fourth * (Omega(i,j,k) + Omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1)) *
-                                               myhalf  * (az(i,j,k) + az(i,j,k+1));
+                                               fourth_d * (Omega(i,j,k) + Omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1)) *
+                                               myhalf_d  * (az(i,j,k) + az(i,j,k+1));
 
             Real x_src = (xopen) ? AdvectionSrcForOpenBC_Tangent(i, j, k, 0, dir, w, rho_u, dxInv, do_lo) :
                                    (xflux_hi - xflux_lo) * dxInv;
@@ -168,9 +168,9 @@ AdvectionSrcForOpenBC_Tangent_Zmom (const Box& bxz,
             Real z_src = (zflux_hi - zflux_lo) * dzInv;
             Real advectionSrc = x_src + y_src + z_src;
 
-            rho_w_rhs(i, j, k) = -advectionSrc / (myhalf*(detJ(i,j,k) + detJ(i,j,k-1)));
+            rho_w_rhs(i, j, k) = -advectionSrc / (myhalf_d*(detJ(i,j,k) + detJ(i,j,k-1)));
         } else {
-            rho_w_rhs(i, j, k) = zero;
+            rho_w_rhs(i, j, k) = zero_d;
         }
     });
 }
@@ -197,23 +197,23 @@ AdvectionSrcForOpenBC_Tangent_Cons (const Box& bx,
 
     auto dxInv = cellSizeInv[0], dyInv = cellSizeInv[1], dzInv = cellSizeInv[2];
 
-    ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    ParallelFor(bx, ncomp, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
-        if (detJ(i,j,k) > zero) {
+        if (detJ(i,j,k) > zero_d) {
             const int cons_index = icomp + n;
             const int prim_index = cons_index - 1;
-            Real prim_xlo = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
-            Real prim_xhi = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i+1,j,k,prim_index));
+            Real prim_xlo = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
+            Real prim_xhi = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i+1,j,k,prim_index));
             Real xflux_lo = avg_xmom(i  ,j,k) * prim_xlo;
             Real xflux_hi = avg_xmom(i+1,j,k) * prim_xhi;
 
-            Real prim_ylo = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
-            Real prim_yhi = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j+1,k,prim_index));
+            Real prim_ylo = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
+            Real prim_yhi = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j+1,k,prim_index));
             Real yflux_lo = avg_ymom(i,j  ,k) * prim_ylo;
             Real yflux_hi = avg_ymom(i,j+1,k) * prim_yhi;
 
-            Real prim_zlo = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
-            Real prim_zhi = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k+1,prim_index));
+            Real prim_zlo = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
+            Real prim_zhi = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k+1,prim_index));
             Real zflux_lo = avg_zmom(i,j,k  ) * prim_zlo;
             Real zflux_hi = avg_zmom(i,j,k+1) * prim_zhi;
 

--- a/Source/Advection/ERF_AdvectionSrcForScalars.H
+++ b/Source/Advection/ERF_AdvectionSrcForScalars.H
@@ -24,24 +24,24 @@ AdvectionSrcForScalarsWrapper (const amrex::Box& bx,
     const amrex::Box ybx = amrex::surroundingNodes(bx,1);
     const amrex::Box zbx = amrex::surroundingNodes(bx,2);
 
-    amrex::ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    amrex::ParallelFor(xbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         const int prim_index = cons_index - 1;
-        amrex::Real interpx(zero);
+        amrex::Real interpx(zero_d);
         interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i  ,j  ,k  ));
         (flx_arr[0])(i,j,k) = avg_xmom(i,j,k) * interpx;
     });
-    amrex::ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    amrex::ParallelFor(ybx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         const int prim_index = cons_index - 1;
-        amrex::Real interpy(zero);
+        amrex::Real interpy(zero_d);
         interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i  ,j  ,k  ));
         (flx_arr[1])(i,j,k) = avg_ymom(i,j,k) * interpy;
     });
-    amrex::ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    amrex::ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         const int prim_index = cons_index - 1;
-        amrex::Real interpz(zero);
+        amrex::Real interpz(zero_d);
         interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i  ,j  ,k  ));
         (flx_arr[2])(i,j,k) = avg_zmom(i,j,k) * interpz;
     });

--- a/Source/Advection/ERF_AdvectionSrcForState.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForState.cpp
@@ -72,22 +72,22 @@ AdvectionSrcForRho (const Box& bx,
     });
 
     if (fixed_rho) {
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            advectionSrc(i,j,k,0) = zero;
+            advectionSrc(i,j,k,0) = zero_d;
         });
     } else
     {
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (detJ(i,j,k) > zero) {
+            if (detJ(i,j,k) > zero_d) {
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
                 advectionSrc(i,j,k,0) = - mfsq / detJ(i,j,k) * (
                   ( (flx_arr[0])(i+1,j,k,0) - (flx_arr[0])(i  ,j,k,0) ) * dxInv +
                   ( (flx_arr[1])(i,j+1,k,0) - (flx_arr[1])(i,j  ,k,0) ) * dyInv +
                   ( (flx_arr[2])(i,j,k+1,0) - (flx_arr[2])(i,j,k  ,0) ) * dzInv );
             } else {
-                advectionSrc(i,j,k,0) = zero;
+                advectionSrc(i,j,k,0) = zero_d;
             }
         });
     }
@@ -174,22 +174,22 @@ AdvectionSrcForScalars (const Box& bx,
         //       because that was done when they were constructed in AdvectionSrcForRhoAndTheta
         if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
         {
-            ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 const int prim_index = cons_index - 1;
-                const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
+                const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
                 (flx_arr[0])(i,j,k) = avg_xmom(i,j,k) * prim_on_face;
             });
-            ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 const int prim_index = cons_index - 1;
-                const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
+                const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
                 (flx_arr[1])(i,j,k) = avg_ymom(i,j,k) * prim_on_face;
             });
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(zbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 const int prim_index = cons_index - 1;
-                const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
+                const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
                 (flx_arr[2])(i,j,k) = avg_zmom(i,j,k) * prim_on_face;
             });
 
@@ -266,11 +266,11 @@ AdvectionSrcForScalars (const Box& bx,
             }
         }
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (detJ(i,j,k) > zero)
+            if (detJ(i,j,k) > zero_d)
             {
-                Real invdetJ = one / detJ(i,j,k);
+                Real invdetJ = one_d / detJ(i,j,k);
                 Real mfsq    = mf_mx(i,j,0) * mf_my(i,j,0);
 
                 advectionSrc(i,j,k,cons_index) = - invdetJ * mfsq * (
@@ -278,7 +278,7 @@ AdvectionSrcForScalars (const Box& bx,
                   ( (flx_arr[1])(i,j+1,k) - (flx_arr[1])(i,j,k) ) * dyInv +
                   ( (flx_arr[2])(i,j,k+1) - (flx_arr[2])(i,j,k) ) * dzInv );
             } else {
-                advectionSrc(i,j,k,cons_index) = zero;
+                advectionSrc(i,j,k,cons_index) = zero_d;
             }
         });
 

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
@@ -154,7 +154,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
         if (bx_xhi.smallEnd(2) != domain.smallEnd(2)) bx_xhi.growLo(2,nghost[2]);
         if (bx_xhi.bigEnd(2)   != domain.bigEnd(2))   bx_xhi.growHi(2,nghost[2]);
         ParallelFor(
-            bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xlo, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = n;
                 int l_bc_type = bc_ptr[n].lo(0);
@@ -169,10 +169,10 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
                     Real delta_i = static_cast<Real>(dom_lo.x - i);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp) ;
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp) ;
                 }
             },
-            bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xhi, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = n;
                 int h_bc_type = bc_ptr[n].hi(0);
@@ -187,7 +187,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
                     Real delta_i = static_cast<Real>(i - dom_hi.x);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp) ;
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp) ;
                 }
             }
         );
@@ -203,7 +203,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
         if (bx_yhi.smallEnd(2) != domain.smallEnd(2)) bx_yhi.growLo(2,nghost[2]);
         if (bx_yhi.bigEnd(2)   != domain.bigEnd(2))   bx_yhi.growHi(2,nghost[2]);
         ParallelFor(
-            bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_ylo, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = n;
                 int l_bc_type = bc_ptr[n].lo(1);
@@ -218,11 +218,11 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
                     Real delta_j = static_cast<Real>(dom_lo.y - j);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp) ;
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp) ;
                 }
 
             },
-            bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_yhi, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = n;
                 int h_bc_type = bc_ptr[n].hi(1);
@@ -237,7 +237,7 @@ void ERFPhysBCFunct_base::impose_lateral_basestate_bcs (const Array4<Real>& dest
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
                     Real delta_j = static_cast<Real>(j - dom_hi.y);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
                 }
             }
         );

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
@@ -83,7 +83,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         bx_xlo.grow(2,ng[2]);
         bx_xhi.grow(2,ng[2]);
         ParallelFor(
-            bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xlo, ncomp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -92,7 +92,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 int l_bc_type = bc_ptr[n].lo(0);
 
                 if ( (l_bc_type == ERFBCType::ext_dir) ||
-                     (l_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) )
+                     (l_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero_d) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
                         dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
@@ -108,7 +108,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     }
                 }
             },
-            bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xhi, ncomp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -117,7 +117,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 int h_bc_type = bc_ptr[n].hi(0);
 
                 if ( (h_bc_type == ERFBCType::ext_dir) ||
-                     (h_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) )
+                     (h_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero_d) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
                         dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
@@ -149,7 +149,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         bx_yhi.grow(2,ng[2]);
 
         ParallelFor(
-            bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_ylo, ncomp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -157,7 +157,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int l_bc_type = bc_ptr[n].lo(1);
                 if ( (l_bc_type == ERFBCType::ext_dir) ||
-                     (l_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) )
+                     (l_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero_d) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
                         dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
@@ -173,7 +173,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     }
                 }
             },
-            bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_yhi, ncomp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -181,7 +181,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
                 int h_bc_type = bc_ptr[n].hi(1);
                 if ( (h_bc_type == ERFBCType::ext_dir) ||
-                     (h_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) )
+                     (h_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero_d) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
                         dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
@@ -212,7 +212,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         if (bx_xhi.smallEnd(2) != domain.smallEnd(2)) bx_xhi.growLo(2,ng[2]);
         if (bx_xhi.bigEnd(2)   != domain.bigEnd(2))   bx_xhi.growHi(2,ng[2]);
         ParallelFor(
-            bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xlo, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int l_bc_type = bc_ptr[n].lo(0);
@@ -227,10 +227,10 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
                     Real delta_i = static_cast<Real>(dom_lo.x - i);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_i)*dest_arr(dom_lo.x,j,k,dest_comp) - delta_i*dest_arr(dom_lo.x+1,j,k,dest_comp);
                 }
             },
-            bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_xhi, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int h_bc_type = bc_ptr[n].hi(0);
@@ -245,7 +245,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k,dest_comp) = -dest_arr(iflip,j,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
                     Real delta_i = static_cast<Real>(i - dom_hi.x);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_i)*dest_arr(dom_hi.x,j,k,dest_comp) - delta_i*dest_arr(dom_hi.x-1,j,k,dest_comp);
                 }
             }
         );
@@ -261,7 +261,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
         if (bx_yhi.smallEnd(2) != domain.smallEnd(2)) bx_yhi.growLo(2,ng[2]);
         if (bx_yhi.bigEnd(2)   != domain.bigEnd(2))   bx_yhi.growHi(2,ng[2]);
         ParallelFor(
-            bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_ylo, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int l_bc_type = bc_ptr[n].lo(1);
@@ -276,11 +276,11 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (l_bc_type == ERFBCType::hoextrap) {
                     Real delta_j = static_cast<Real>(dom_lo.y - j);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_j)*dest_arr(i,dom_lo.y,k,dest_comp) - delta_j*dest_arr(i,dom_lo.y+1,k,dest_comp);
                 }
 
             },
-            bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_yhi, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int h_bc_type = bc_ptr[n].hi(1);
@@ -295,7 +295,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k,dest_comp) = -dest_arr(i,jflip,k,dest_comp);
                 } else if (h_bc_type == ERFBCType::hoextrap) {
                     Real delta_j = static_cast<Real>(j - dom_hi.y);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_j)*dest_arr(i,dom_hi.y,k,dest_comp) - delta_j*dest_arr(i,dom_hi.y-1,k,dest_comp);
                 }
             }
         );
@@ -418,7 +418,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
         Box bx_zhi(bx);  bx_zhi.setSmall(2,dom_hi.z+1);
         // Populate ghost cells on lo-z and hi-z domain boundaries
         ParallelFor(
-            bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_zlo, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -446,11 +446,11 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                     }
                 } else if (l_bc_type == ERFBCType::hoextrap) {
                     Real delta_k = static_cast<Real>(dom_lo.z - k);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_k) * dest_arr(i,j,dom_lo.z  ,dest_comp) -
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_k) * dest_arr(i,j,dom_lo.z  ,dest_comp) -
                                                        delta_k  * dest_arr(i,j,dom_lo.z+1,dest_comp);
                 }
             },
-            bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+            bx_zhi, ncomp, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
@@ -478,7 +478,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                     }
                 } else if (h_bc_type == ERFBCType::hoextrap){
                     Real delta_k = static_cast<Real>(k - dom_hi.z);
-                    dest_arr(i,j,k,dest_comp) = (one + delta_k)*dest_arr(i,j,dom_hi.z,dest_comp) - delta_k*dest_arr(i,j,dom_hi.z-1,dest_comp);
+                    dest_arr(i,j,k,dest_comp) = (one_d + delta_k)*dest_arr(i,j,dom_hi.z,dest_comp) - delta_k*dest_arr(i,j,dom_hi.z-1,dest_comp);
                 }
             }
         );
@@ -512,7 +512,7 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                     Real dz = geomdata.CellSize(2);
 
                     // Fill all the Neumann srcs with terrain
-                    ParallelFor(xybx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    ParallelFor(xybx, [=,zero_d=zero,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         // Clip indices for ghost-cells
                         int ii = amrex::min(amrex::max(i,perdom_lo.x),perdom_hi.x);
@@ -527,29 +527,29 @@ void ERFPhysBCFunct_cons::impose_vertical_cons_bcs (const Array4<Real>& dest_arr
                         // used foextrap for cell-centered quantities outside the domain to define the gradient as zero
                         Real GradVarx, GradVary;
                         if (i < dom_lo.x-1 || i > dom_hi.x+1 || (i+1 > bx_hi.x && i-1 < bx_lo.x) ) {
-                            GradVarx = zero;
+                            GradVarx = zero_d;
                         } else if (i+1 > bx_hi.x) {
                             GradVarx =       dxInv[0] * (dest_arr(i  ,j,k0,dest_comp) - dest_arr(i-1,j,k0,dest_comp));
                         } else if (i-1 < bx_lo.x) {
                             GradVarx =       dxInv[0] * (dest_arr(i+1,j,k0,dest_comp) - dest_arr(i  ,j,k0,dest_comp));
                         } else {
-                            GradVarx = myhalf * dxInv[0] * (dest_arr(i+1,j,k0,dest_comp) - dest_arr(i-1,j,k0,dest_comp));
+                            GradVarx = myhalf_d * dxInv[0] * (dest_arr(i+1,j,k0,dest_comp) - dest_arr(i-1,j,k0,dest_comp));
                         }
 
                         // GradY at IJK location inside domain -- this relies on the assumption that we have
                         // used foextrap for cell-centered quantities outside the domain to define the gradient as zero
                         if (j < dom_lo.y-1 || j > dom_hi.y+1 || (j+1 > bx_hi.y && j-1 < bx_lo.y) ) {
-                            GradVary = zero;
+                            GradVary = zero_d;
                         } else if (j+1 > bx_hi.y) {
                             GradVary =       dxInv[1] * (dest_arr(i,j  ,k0,dest_comp) - dest_arr(i,j-1,k0,dest_comp));
                         } else if (j-1 < bx_lo.y) {
                             GradVary =       dxInv[1] * (dest_arr(i,j+1,k0,dest_comp) - dest_arr(i,j  ,k0,dest_comp));
                         } else {
-                            GradVary = myhalf * dxInv[1] * (dest_arr(i,j+1,k0,dest_comp) - dest_arr(i,j-1,k0,dest_comp));
+                            GradVary = myhalf_d * dxInv[1] * (dest_arr(i,j+1,k0,dest_comp) - dest_arr(i,j-1,k0,dest_comp));
                         }
 
                         // Prefactor
-                        Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one );
+                        Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one_d );
 
                         // Accumulate in bottom ghost cell (EXTRAP already populated)
                         dest_arr(i,j,k,dest_comp) -= dz * met_fac * ( met_h_xi * GradVarx + met_h_eta * GradVary );

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsXvel.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsXvel.cpp
@@ -58,12 +58,12 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
         Box bx_xlo_face(bx); bx_xlo_face.setSmall(0,dom_lo.x  ); bx_xlo_face.setBig(0,dom_lo.x  );
         Box bx_xhi_face(bx); bx_xhi_face.setSmall(0,dom_hi.x+1); bx_xhi_face.setBig(0,dom_hi.x+1);
         ParallelFor(bx_xlo, bx_xlo_face,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 int iflip = dom_lo.x - i;
                 if (bc_ptr[0].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
-                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) {
+                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero_d) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
                 } else if (bc_ptr[0].lo(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(dom_lo.x,j,k);
@@ -74,31 +74,31 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
                 } else if (bc_ptr[0].lo(0) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k) = -dest_arr(iflip,j,k);
                 } else if (bc_ptr[0].lo(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/three_d;
                 } else if (bc_ptr[0].lo(0) == ERFBCType::hoextrap) {
                     Real delta_i = (dom_lo.x - i);
-                    dest_arr(i,j,k) = (one + delta_i)*dest_arr(dom_lo.x,j,k) - delta_i*dest_arr(dom_lo.x+1,j,k);
+                    dest_arr(i,j,k) = (one_d + delta_i)*dest_arr(dom_lo.x,j,k) - delta_i*dest_arr(dom_lo.x+1,j,k);
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR or neumann_int
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 if (bc_ptr[0].lo(0) == ERFBCType::ext_dir) {
                       dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
-                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) {
+                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero_d) {
                       dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
                 } else if (bc_ptr[0].lo(0) == ERFBCType::neumann_int) {
-                      dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/three;
+                      dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_lo.x+1,j,k) - dest_arr(dom_lo.x+2,j,k))/three_d;
                 }
             }
         );
         ParallelFor(bx_xhi, bx_xhi_face,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 int iflip =  2*(dom_hi.x + 1) - i;
                 if (bc_ptr[0].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
-                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) {
+                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero_d) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
                 } else if (bc_ptr[0].hi(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(dom_hi.x+1,j,k);
@@ -109,21 +109,21 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
                 } else if (bc_ptr[0].hi(0) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k) = -dest_arr(iflip,j,k);
                 } else if (bc_ptr[0].hi(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/three_d;
                 } else if (bc_ptr[0].hi(0) == ERFBCType::hoextrap) {
                     Real delta_i = (i - dom_hi.x - 1);
-                    dest_arr(i,j,k) = (one + delta_i)*dest_arr(dom_hi.x+1,j,k) - delta_i*dest_arr(dom_hi.x,j,k);
+                    dest_arr(i,j,k) = (one_d + delta_i)*dest_arr(dom_hi.x+1,j,k) - delta_i*dest_arr(dom_hi.x,j,k);
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR or neumann_int
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 if (bc_ptr[0].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
-                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) {
+                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero_d) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
                 } else if (bc_ptr[0].hi(0) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(dom_hi.x,j,k) - dest_arr(dom_hi.x-1,j,k))/three_d;
                 }
             }
         );
@@ -136,11 +136,11 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
         ParallelFor(bx_ylo, bx_yhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int jflip = dom_lo.y - 1 - j;
                 if (bc_ptr[0].lo(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
-                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) {
+                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero_d) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
                 } else if (bc_ptr[0].lo(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(i,dom_lo.y,k);
@@ -152,14 +152,14 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,jflip,k);
                 } else if (bc_ptr[0].lo(1) == ERFBCType::hoextrap) {
                     Real delta_j = (dom_lo.y - j);
-                    dest_arr(i,j,k) = (one + delta_j)*dest_arr(i,dom_lo.y,k) - delta_j*dest_arr(i,dom_lo.y+1,k);
+                    dest_arr(i,j,k) = (one_d + delta_j)*dest_arr(i,dom_lo.y,k) - delta_j*dest_arr(i,dom_lo.y+1,k);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int jflip =  2*dom_hi.y + 1 - j;
                 if (bc_ptr[0].hi(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
-                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) {
+                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero_d) {
                     dest_arr(i,j,k) = (xvel_bc_ptr) ? xvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
                 } else if (bc_ptr[0].hi(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(i,dom_hi.y,k);
@@ -171,7 +171,7 @@ void ERFPhysBCFunct_u::impose_lateral_xvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,jflip,k);
                 } else if (bc_ptr[0].hi(1) == ERFBCType::hoextrap) {
                     Real delta_j = (j - dom_hi.y);
-                    dest_arr(i,j,k) = (one + delta_j)*dest_arr(i,dom_hi.y,k) - delta_j*dest_arr(i,dom_hi.y-1,k);
+                    dest_arr(i,j,k) = (one_d + delta_j)*dest_arr(i,dom_hi.y,k) - delta_j*dest_arr(i,dom_hi.y-1,k);
                 }
             }
         );
@@ -235,7 +235,7 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
         Box bx_zlo(bx);  bx_zlo.setBig  (2,dom_lo.z-1);
         Box bx_zhi(bx);  bx_zhi.setSmall(2,dom_hi.z+1);
         ParallelFor(bx_zlo, bx_zhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int kflip = dom_lo.z - 1 - k;
                 if (bc_ptr[0].lo(2) == ERFBCType::ext_dir) {
                     #ifdef ERF_USE_TERRAIN_VELOCITY
@@ -253,10 +253,10 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,j,kflip);
                 } else if (bc_ptr[0].lo(2) == ERFBCType::hoextrap) {
                     Real delta_k = (dom_lo.z - k);
-                    dest_arr(i,j,k) = (one + delta_k)*dest_arr(i,j,dom_lo.z) - delta_k*dest_arr(i,j,dom_lo.z+1);
+                    dest_arr(i,j,k) = (one_d + delta_k)*dest_arr(i,j,dom_lo.z) - delta_k*dest_arr(i,j,dom_lo.z+1);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int kflip =  2*dom_hi.z + 1 - k;
                 if (bc_ptr[0].hi(2) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[0][5];
@@ -270,7 +270,7 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,j,kflip);
                 } else if (bc_ptr[0].hi(2) == ERFBCType::hoextrap){
                     Real delta_k = (k - dom_hi.z);
-                    dest_arr(i,j,k) = (one + delta_k)*dest_arr(i,j,dom_hi.z) - delta_k*dest_arr(i,j,dom_hi.z-1);
+                    dest_arr(i,j,k) = (one_d + delta_k)*dest_arr(i,j,dom_hi.z) - delta_k*dest_arr(i,j,dom_hi.z-1);
                 }
             }
         );
@@ -300,7 +300,7 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
             Real dz = geomdata.CellSize(2);
 
             // Fill all the Neumann srcs with terrain
-            ParallelFor(xybx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(xybx, [=,zero_d=zero,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,perdom_lo.x),perdom_hi.x);
@@ -317,29 +317,29 @@ void ERFPhysBCFunct_u::impose_vertical_xvel_bcs (const Array4<Real>& dest_arr,
                 // used foextrap for quantities outside the domain to define the gradient as zero
                 Real GradVarx, GradVary;
                 if ( i < dom_lo.x-1 || i > dom_hi.x+1 || (i+1 > bx_hi.x && i-1 < bx_lo.x) ) {
-                    GradVarx = zero;
+                    GradVarx = zero_d;
                 } else if (i+1 > bx_hi.x) {
                     GradVarx =       dxInv[0] * (dest_arr(i  ,j,k0) - dest_arr(i-1,j,k0));
                 } else if (i-1 < bx_lo.x) {
                     GradVarx =       dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i  ,j,k0));
                 } else {
-                    GradVarx = myhalf * dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i-1,j,k0));
+                    GradVarx = myhalf_d * dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i-1,j,k0));
                 }
 
                 // GradY at IJK location inside domain -- this relies on the assumption that we have
                 // used foextrap for quantities outside the domain to define the gradient as zero
                 if ( j < dom_lo.y-1 || j > dom_hi.y+1 || (j+1 > bx_hi.y && j-1 < bx_lo.y) ) {
-                    GradVary = zero;
+                    GradVary = zero_d;
                 } else if (j+1 > bx_hi.y) {
                     GradVary =       dxInv[1] * (dest_arr(i,j  ,k0) - dest_arr(i,j-1,k0));
                 } else if (j-1 < bx_lo.y) {
                     GradVary =       dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j  ,k0));
                 } else {
-                    GradVary = myhalf * dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j-1,k0));
+                    GradVary = myhalf_d * dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j-1,k0));
                 }
 
                 // Prefactor
-                Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one );
+                Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one_d );
 
                 // Accumulate in bottom ghost cell (EXTRAP already populated)
                 dest_arr(i,j,k) -= dz * met_fac * ( met_h_xi * GradVarx + met_h_eta * GradVary );

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsYvel.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsYvel.cpp
@@ -56,11 +56,11 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
         Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
         ParallelFor(bx_xlo, bx_xhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int iflip = dom_lo.x - 1- i;
                 if (bc_ptr[0].lo(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
-                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) {
+                } else if (bc_ptr[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
                 } else if (bc_ptr[0].lo(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(dom_lo.x,j,k);
@@ -72,14 +72,14 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(iflip,j,k);
                 } else if (bc_ptr[0].lo(0) == ERFBCType::hoextrap) {
                     Real delta_i = (dom_lo.x - i);
-                    dest_arr(i,j,k) = (one + delta_i)*dest_arr(dom_lo.x,j,k) - delta_i*dest_arr(dom_lo.x+1,j,k);
+                    dest_arr(i,j,k) = (one_d + delta_i)*dest_arr(dom_lo.x,j,k) - delta_i*dest_arr(dom_lo.x+1,j,k);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int iflip =  2*dom_hi.x + 1 - i;
                 if (bc_ptr[0].hi(0) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
-                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) {
+                } else if (bc_ptr[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
                 } else if (bc_ptr[0].hi(0) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(dom_hi.x,j,k);
@@ -91,7 +91,7 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(iflip,j,k);
                 } else if (bc_ptr[0].hi(0) == ERFBCType::hoextrap) {
                     Real delta_i = (i - dom_hi.x);
-                    dest_arr(i,j,k) = (one + delta_i)*dest_arr(dom_hi.x,j,k) - delta_i*dest_arr(dom_hi.x-1,j,k);
+                    dest_arr(i,j,k) = (one_d + delta_i)*dest_arr(dom_hi.x,j,k) - delta_i*dest_arr(dom_hi.x-1,j,k);
                 }
             }
         );
@@ -106,12 +106,12 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
         Box bx_ylo_face(bx); bx_ylo_face.setSmall(1,dom_lo.y  ); bx_ylo_face.setBig(1,dom_lo.y  );
         Box bx_yhi_face(bx); bx_yhi_face.setSmall(1,dom_hi.y+1); bx_yhi_face.setBig(1,dom_hi.y+1);
         ParallelFor(bx_ylo, bx_ylo_face,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 int jflip = dom_lo.y-j;
                 if (bc_ptr[0].lo(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
-                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) {
+                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
                 } else if (bc_ptr[0].lo(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(i,dom_lo.y,k);
@@ -122,31 +122,31 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
                 } else if (bc_ptr[0].lo(1) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k) = -dest_arr(i,jflip,k);
                 } else if (bc_ptr[0].lo(1) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_lo.y+1,k) - dest_arr(i,dom_lo.y+2,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_lo.y+1,k) - dest_arr(i,dom_lo.y+2,k))/three_d;
                 } else if (bc_ptr[0].lo(1) == ERFBCType::hoextrap) {
                     Real delta_j = (dom_lo.y - j);
-                    dest_arr(i,j,k) = (one + delta_j)*dest_arr(i,dom_lo.y,k) - delta_j*dest_arr(i,dom_lo.y+1,k);
+                    dest_arr(i,j,k) = (one_d + delta_j)*dest_arr(i,dom_lo.y,k) - delta_j*dest_arr(i,dom_lo.y+1,k);
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR or neumann_int
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 if (bc_ptr[0].lo(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
-                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) {
+                } else if (bc_ptr[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
                 } else if (bc_ptr[0].lo(1) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_lo.y+1,k) - dest_arr(i,dom_lo.y+2,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_lo.y+1,k) - dest_arr(i,dom_lo.y+2,k))/three_d;
                 }
             }
         );
         ParallelFor(bx_yhi, bx_yhi_face,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 int jflip =  2*(dom_hi.y + 1) - j;
                 if (bc_ptr[0].hi(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
-                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) {
+                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
                 } else if (bc_ptr[0].hi(1) == ERFBCType::foextrap) {
                     dest_arr(i,j,k) =  dest_arr(i,dom_hi.y+1,k);
@@ -157,21 +157,21 @@ void ERFPhysBCFunct_v::impose_lateral_yvel_bcs (const Array4<Real>& dest_arr,
                 } else if (bc_ptr[0].hi(1) == ERFBCType::reflect_odd) {
                     dest_arr(i,j,k) = -dest_arr(i,jflip,k);
                 } else if (bc_ptr[0].hi(1) == ERFBCType::neumann_int) {
-                   dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_hi.y,k) - dest_arr(i,dom_hi.y-1,k))/three;
+                   dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_hi.y,k) - dest_arr(i,dom_hi.y-1,k))/three_d;
                 } else if (bc_ptr[0].hi(1) == ERFBCType::hoextrap) {
                     Real delta_j = (j - dom_hi.y - 1);
-                    dest_arr(i,j,k) = (one + delta_j)*dest_arr(i,dom_hi.y+1,k) - delta_j*dest_arr(i,dom_hi.y,k);
+                    dest_arr(i,j,k) = (one_d + delta_j)*dest_arr(i,dom_hi.y+1,k) - delta_j*dest_arr(i,dom_hi.y,k);
                 }
             },
             // We only set the values on the domain faces themselves if EXT_DIR or neumann_int
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 if (bc_ptr[0].hi(1) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
-                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) {
+                } else if (bc_ptr[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero_d) {
                     dest_arr(i,j,k) = (yvel_bc_ptr) ? yvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
                 } else if (bc_ptr[0].hi(1) == ERFBCType::neumann_int) {
-                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_hi.y,k) - dest_arr(i,dom_hi.y-1,k))/three;
+                    dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,dom_hi.y,k) - dest_arr(i,dom_hi.y-1,k))/three_d;
                 }
             }
         );
@@ -237,7 +237,7 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
         Box bx_zlo(bx);  bx_zlo.setBig  (2,dom_lo.z-1);
         Box bx_zhi(bx);  bx_zhi.setSmall(2,dom_hi.z+1);
         ParallelFor(bx_zlo, bx_zhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int kflip = dom_lo.z - 1 - k;
                 if (bc_ptr[0].lo(2) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[0][2];
@@ -251,10 +251,10 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,j,kflip);
                 } else if (bc_ptr[0].lo(2) == ERFBCType::hoextrap) {
                     Real delta_k = (dom_lo.z - k);
-                    dest_arr(i,j,k) = (one + delta_k)*dest_arr(i,j,dom_lo.z) - delta_k*dest_arr(i,j,dom_lo.z+1);
+                    dest_arr(i,j,k) = (one_d + delta_k)*dest_arr(i,j,dom_lo.z) - delta_k*dest_arr(i,j,dom_lo.z+1);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int kflip =  2*dom_hi.z + 1 - k;
                 if (bc_ptr[0].hi(2) == ERFBCType::ext_dir) {
                     dest_arr(i,j,k) = l_bc_extdir_vals_d[0][5];
@@ -268,7 +268,7 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
                     dest_arr(i,j,k) = -dest_arr(i,j,kflip);
                 } else if (bc_ptr[0].hi(2) == ERFBCType::hoextrap){
                     Real delta_k = (k - dom_hi.z);
-                    dest_arr(i,j,k) = (one + delta_k)*dest_arr(i,j,dom_hi.z) - delta_k*dest_arr(i,j,dom_hi.z-1);
+                    dest_arr(i,j,k) = (one_d + delta_k)*dest_arr(i,j,dom_hi.z) - delta_k*dest_arr(i,j,dom_hi.z-1);
                 }
             }
         );
@@ -299,7 +299,7 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
             Real dz = geomdata.CellSize(2);
 
             // Fill all the Neumann srcs with terrain
-            ParallelFor(xybx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(xybx, [=,zero_d=zero,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,perdom_lo.x),perdom_hi.x);
@@ -316,29 +316,29 @@ void ERFPhysBCFunct_v::impose_vertical_yvel_bcs (const Array4<Real>& dest_arr,
                 // used foextrap for cell-centered quantities outside the domain to define the gradient as zero
                 Real GradVarx, GradVary;
                 if ( i < dom_lo.x-1 || i > dom_hi.x+1 || (i+1 > bx_hi.x && i-1 < bx_lo.x) ) {
-                    GradVarx = zero;
+                    GradVarx = zero_d;
                 } else if (i+1 > bx_hi.x) {
                     GradVarx =       dxInv[0] * (dest_arr(i  ,j,k0) - dest_arr(i-1,j,k0));
                 } else if (i-1 < bx_lo.x) {
                     GradVarx =       dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i  ,j,k0));
                 } else {
-                    GradVarx = myhalf * dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i-1,j,k0));
+                    GradVarx = myhalf_d * dxInv[0] * (dest_arr(i+1,j,k0) - dest_arr(i-1,j,k0));
                 }
 
                 // GradY at IJK location inside domain -- this relies on the assumption that we have
                 // used foextrap for cell-centered quantities outside the domain to define the gradient as zero
                  if ( j < dom_lo.y-1 || j > dom_hi.y+1 || (j+1 > bx_hi.y && j-1 < bx_lo.y) ) {
-                    GradVary = zero;
+                    GradVary = zero_d;
                 } else if (j+1 > bx_hi.y) {
                     GradVary =       dxInv[1] * (dest_arr(i,j  ,k0) - dest_arr(i,j-1,k0));
                 } else if (j-1 < bx_lo.y) {
                     GradVary =       dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j  ,k0));
                 } else {
-                    GradVary = myhalf * dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j-1,k0));
+                    GradVary = myhalf_d * dxInv[1] * (dest_arr(i,j+1,k0) - dest_arr(i,j-1,k0));
                 }
 
                 // Prefactor
-                Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one );
+                Real met_fac =  met_h_zeta / ( met_h_xi*met_h_xi + met_h_eta*met_h_eta + one_d );
 
                 // Accumulate in bottom ghost cell (EXTRAP already populated)
                 dest_arr(i,j,k) -= dz * met_fac * ( met_h_xi * GradVarx + met_h_eta * GradVary );

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsZvel.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsZvel.cpp
@@ -67,10 +67,10 @@ void ERFPhysBCFunct_w::impose_lateral_zvel_bcs (const Array4<Real      >& dest_a
         Box bx_xlo(bx);  bx_xlo.setBig  (0,dom_lo.x-1);
         Box bx_xhi(bx);  bx_xhi.setSmall(0,dom_hi.x+1);
         ParallelFor(bx_xlo, bx_xhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int iflip = dom_lo.x - 1 - i;
                 if ( (bc_ptr_w[0].lo(0) == ERFBCType::ext_dir) ||
-                     (bc_ptr_w[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) )
+                     (bc_ptr_w[0].lo(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero_d) )
                 {
                     dest_arr(i,j,k) = (zvel_bc_ptr) ? zvel_bc_ptr[k] : l_bc_extdir_vals_d[0][0];
                     if (l_use_terrain_fitted_coords) {
@@ -88,10 +88,10 @@ void ERFPhysBCFunct_w::impose_lateral_zvel_bcs (const Array4<Real      >& dest_a
                     dest_arr(i,j,k) = -dest_arr(iflip,j,k);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int iflip = 2*dom_hi.x + 1 - i;
                 if ( (bc_ptr_w[0].hi(0) == ERFBCType::ext_dir) ||
-                     (bc_ptr_w[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) )
+                     (bc_ptr_w[0].hi(0) == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero_d) )
                 {
                     dest_arr(i,j,k) = (zvel_bc_ptr) ? zvel_bc_ptr[k] : l_bc_extdir_vals_d[0][3];
                     if (l_use_terrain_fitted_coords) {
@@ -119,10 +119,10 @@ void ERFPhysBCFunct_w::impose_lateral_zvel_bcs (const Array4<Real      >& dest_a
         Box bx_ylo(bx);  bx_ylo.setBig  (1,dom_lo.y-1);
         Box bx_yhi(bx);  bx_yhi.setSmall(1,dom_hi.y+1);
         ParallelFor(bx_ylo, bx_yhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int jflip = dom_lo.y - 1 - j;
                 if ( (bc_ptr_w[0].lo(1) == ERFBCType::ext_dir) ||
-                     (bc_ptr_w[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) )
+                     (bc_ptr_w[0].lo(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero_d) )
                 {
                     dest_arr(i,j,k) = (zvel_bc_ptr) ? zvel_bc_ptr[k] : l_bc_extdir_vals_d[0][1];
                     if (l_use_terrain_fitted_coords) {
@@ -140,10 +140,10 @@ void ERFPhysBCFunct_w::impose_lateral_zvel_bcs (const Array4<Real      >& dest_a
                     dest_arr(i,j,k) = -dest_arr(i,jflip,k);
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 int jflip =  2*dom_hi.y + 1 - j;
                 if ( (bc_ptr_w[0].hi(1) == ERFBCType::ext_dir) ||
-                     (bc_ptr_w[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) )
+                     (bc_ptr_w[0].hi(1) == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero_d) )
                 {
                     dest_arr(i,j,k) = (zvel_bc_ptr) ? zvel_bc_ptr[k] : l_bc_extdir_vals_d[0][4];
                     if (l_use_terrain_fitted_coords) {
@@ -286,9 +286,9 @@ void ERFPhysBCFunct_w::impose_vertical_zvel_bcs (const Array4<Real>& dest_arr,
                 }
             });
         } else if (bc_ptr_w_h[0].hi(2) == ERFBCType::neumann_int) {
-            ParallelFor(makeSlab(bx,2,dom_hi.z+1), [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(makeSlab(bx,2,dom_hi.z+1), [=,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,j,dom_hi.z) - dest_arr(i,j,dom_hi.z-1))/three;
+                dest_arr(i,j,k) = (Real(4.0)*dest_arr(i,j,dom_hi.z) - dest_arr(i,j,dom_hi.z-1))/three_d;
             });
         }
     }

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -1374,7 +1374,7 @@ MOSTAverage::compute_region_averages (const int& lev)
                 auto x_pos_arr = x_pos->array(mfi);
                 auto y_pos_arr = y_pos->array(mfi);
                 auto z_pos_arr = z_pos->array(mfi);
-                ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(pbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
                     ma_arr(i,j,0) *= d_fact_old;
 

--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -326,21 +326,21 @@ MOSTAverage::set_rotated_fields (const int& lev)
         const Array4<Real>& v_rot_arr = rot_fields[1]->array(mfi);
 
         // U rotated magnitude
-        ParallelFor(ubx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ubx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of first tangent vector
             Real met_h_xi    = Compute_h_xi_AtIface(i,j,k,dxInv,z_phys_arr);
             u_rot_arr(i,j,k) = (u_arr(i,j,k) + met_h_xi*w_arr(i,j,k))
-                             / std::sqrt(met_h_xi*met_h_xi + one);
+                             / std::sqrt(met_h_xi*met_h_xi + one_d);
         });
 
         // V rotated magnitude
-        ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(vbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of second tangent vector
             Real met_h_eta   = Compute_h_eta_AtJface(i,j,k,dxInv,z_phys_arr);
             v_rot_arr(i,j,k) = (v_arr(i,j,k) + met_h_eta*w_arr(i,j,k))
-                             / std::sqrt(met_h_eta*met_h_eta + one);
+                             / std::sqrt(met_h_eta*met_h_eta + one_d);
         });
     }
 
@@ -620,23 +620,23 @@ MOSTAverage::set_k_indices_T (const int& lev)
             const auto z_phys_arr = m_z_phys_nd[lev]->const_array(mfi);
             auto k_arr = m_k_indx[lev]->array(mfi);
             auto zref_arr = m_zref[lev]->array(mfi);
-            ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(npbx, [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 k_arr(i,j,k) = klo;
                 bool found = false;
-                Real z_bot_face  = fourth * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
+                Real z_bot_face  = fourth_d * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
                                           + z_phys_arr(i  ,j+1,k) + z_phys_arr(i+1,j+1,k) );
                 Real z_target    = z_bot_face + d_zref;
                 for (int lk(klo); lk<=kmax; ++lk) {
-                    Real z_lo = fourth * ( z_phys_arr(i,j  ,lk  ) + z_phys_arr(i+1,j  ,lk  )
+                    Real z_lo = fourth_d * ( z_phys_arr(i,j  ,lk  ) + z_phys_arr(i+1,j  ,lk  )
                                        + z_phys_arr(i,j+1,lk  ) + z_phys_arr(i+1,j+1,lk  ) );
-                    Real z_hi = fourth * ( z_phys_arr(i,j  ,lk+1) + z_phys_arr(i+1,j  ,lk+1)
+                    Real z_hi = fourth_d * ( z_phys_arr(i,j  ,lk+1) + z_phys_arr(i+1,j  ,lk+1)
                                        + z_phys_arr(i,j+1,lk+1) + z_phys_arr(i+1,j+1,lk+1) );
                     if (z_target > z_lo && z_target < z_hi){
                         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lk >= d_radius,
                                                          "K index must be larger than averaging radius!");
                         k_arr(i,j,0) = lk;
-                        zref_arr(i,j,0) = myhalf * (z_hi + z_lo) - z_bot_face;
+                        zref_arr(i,j,0) = myhalf_d * (z_hi + z_lo) - z_bot_face;
                         found = true;
                         break;
                     }
@@ -693,17 +693,17 @@ MOSTAverage::set_norm_indices_T (const int& lev)
         auto j_arr = m_j_indx[lev]->array(mfi);
         auto k_arr = m_k_indx[lev]->array(mfi);
         auto zref_arr = m_zref[lev]->array(mfi);
-        ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(npbx, [=,one_d=one,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of normal vector
             Real met_h_xi  = Compute_h_xi_AtCellCenter (i,j,k,dxInv,z_phys_arr);
             Real met_h_eta = Compute_h_eta_AtCellCenter(i,j,k,dxInv,z_phys_arr);
-            Real mag = std::sqrt(met_h_xi*met_h_xi + met_h_eta*met_h_eta + one);
+            Real mag = std::sqrt(met_h_xi*met_h_xi + met_h_eta*met_h_eta + one_d);
 
             // Unit-normal vector scaled by z_ref
             Real delta_x = -met_h_xi/mag  * d_zref;
             Real delta_y = -met_h_eta/mag * d_zref;
-            Real delta_z = one/mag * d_zref;
+            Real delta_z = one_d/mag * d_zref;
 
             // Compute i & j as displacements (no grid stretching)
             int delta_i  = static_cast<int>(std::round(delta_x*dxInv[0]));
@@ -714,24 +714,24 @@ MOSTAverage::set_norm_indices_T (const int& lev)
             j_arr(i,j,0) = j_new;
 
             // Search for k (grid is stretched in z)
-            Real z_bot_face  = fourth * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
+            Real z_bot_face  = fourth_d * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
                                       + z_phys_arr(i  ,j+1,k) + z_phys_arr(i+1,j+1,k) );
             Real z_target    = z_bot_face + delta_z;
             k_arr(i,j,0)     = klo;
-            zref_arr(i,j,0)  = myhalf * z_bot_face +
+            zref_arr(i,j,0)  = myhalf_d * z_bot_face +
                                Real(0.125) * ( z_phys_arr(i  ,j  ,k+1) + z_phys_arr(i+1,j  ,k+1)
                                        + z_phys_arr(i  ,j+1,k+1) + z_phys_arr(i+1,j+1,k+1) );
             for (int lk(klo); lk<=kmax; ++lk) {
-                Real z_lo = fourth * ( z_phys_arr(i_new,j_new  ,lk  ) + z_phys_arr(i_new+1,j_new  ,lk  )
+                Real z_lo = fourth_d * ( z_phys_arr(i_new,j_new  ,lk  ) + z_phys_arr(i_new+1,j_new  ,lk  )
                                    + z_phys_arr(i_new,j_new+1,lk  ) + z_phys_arr(i_new+1,j_new+1,lk  ) );
-                Real z_hi = fourth * ( z_phys_arr(i_new,j_new  ,lk+1) + z_phys_arr(i_new+1,j_new  ,lk+1)
+                Real z_hi = fourth_d * ( z_phys_arr(i_new,j_new  ,lk+1) + z_phys_arr(i_new+1,j_new  ,lk+1)
                                    + z_phys_arr(i_new,j_new+1,lk+1) + z_phys_arr(i_new+1,j_new+1,lk+1) );
                 if (z_target > z_lo && z_target < z_hi){
                     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(lk >= d_radius,
                                                      "K index must be larger than averaging radius!");
                     amrex::ignore_unused(d_radius);
                     k_arr(i,j,0) = lk;
-                    zref_arr(i,j,0) = myhalf * (z_hi + z_lo) - z_bot_face;
+                    zref_arr(i,j,0) = myhalf_d * (z_hi + z_lo) - z_bot_face;
                     break;
                 }
             }
@@ -784,17 +784,17 @@ MOSTAverage::set_z_positions_T (const int& lev)
         auto x_pos_arr = m_x_pos[lev]->array(mfi);
         auto y_pos_arr = m_y_pos[lev]->array(mfi);
         auto z_pos_arr = m_z_pos[lev]->array(mfi);
-        ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(npbx, [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Final position at end of vector
-            x_pos_arr(i,j,0) = plo[0] + ((Real) i + myhalf) * dx[0];
-            y_pos_arr(i,j,0) = plo[1] + ((Real) j + myhalf) * dx[1];
-            Real z_bot_face  = fourth * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
+            x_pos_arr(i,j,0) = plo[0] + ((Real) i + myhalf_d) * dx[0];
+            y_pos_arr(i,j,0) = plo[1] + ((Real) j + myhalf_d) * dx[1];
+            Real z_bot_face  = fourth_d * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
                                       + z_phys_arr(i  ,j+1,k) + z_phys_arr(i+1,j+1,k) );
             z_pos_arr(i,j,0) = z_bot_face + d_zref;
 
             // Destination position must be contained on the current process!
-            Real pos[] = {x_pos_arr(i,j,0)-plo[0],y_pos_arr(i,j,0)-plo[1],myhalf*dx[2]};
+            Real pos[] = {x_pos_arr(i,j,0)-plo[0],y_pos_arr(i,j,0)-plo[1],myhalf_d*dx[2]};
             amrex::ignore_unused(pos);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grb.contains(&pos[0]),
                                              "Query point outside of proc domain!");
@@ -846,12 +846,12 @@ MOSTAverage::set_norm_positions_T (const int& lev)
         auto y_pos_arr   = m_y_pos[lev]->array(mfi);
         auto z_pos_arr   = m_z_pos[lev]->array(mfi);
         auto zref_arr    = m_zref[lev]->array(mfi);
-        ParallelFor(npbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(npbx, [=,one_d=one,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Elements of normal vector
             Real met_h_xi  = Compute_h_xi_AtCellCenter (i,j,k,dxInv,z_phys_arr);
             Real met_h_eta = Compute_h_eta_AtCellCenter(i,j,k,dxInv,z_phys_arr);
-            Real imag = one / std::sqrt(met_h_xi*met_h_xi + met_h_eta*met_h_eta + one);
+            Real imag = one_d / std::sqrt(met_h_xi*met_h_xi + met_h_eta*met_h_eta + one_d);
 
             // Unit-normal vector scaled by z_ref
             Real delta_x = -met_h_xi  * imag * d_zref;
@@ -859,21 +859,21 @@ MOSTAverage::set_norm_positions_T (const int& lev)
             Real delta_z =              imag * d_zref;
 
             // Position of the current node (indx:0,0,1)
-            Real x0 = plo[0] + ((Real) i + myhalf) * dx[0];
-            Real y0 = plo[1] + ((Real) j + myhalf) * dx[1];
+            Real x0 = plo[0] + ((Real) i + myhalf_d) * dx[0];
+            Real y0 = plo[1] + ((Real) j + myhalf_d) * dx[1];
 
             // Final position at end of vector
             x_pos_arr(i,j,0) = x0 + delta_x;
             y_pos_arr(i,j,0) = y0 + delta_y;
-            Real z_bot_face  = fourth * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
+            Real z_bot_face  = fourth_d * ( z_phys_arr(i  ,j  ,k) + z_phys_arr(i+1,j  ,k)
                                       + z_phys_arr(i  ,j+1,k) + z_phys_arr(i+1,j+1,k) );
             z_pos_arr(i,j,0) = z_bot_face + delta_z;
 
             // NOTE: Normal vector end point can be below the surface for concave regions.
             //       Here we protect against that by augmenting the normal if needed.
-            int i_new = (int) ((x_pos_arr(i,j,0) - plo[0]) / dx[0] - myhalf);
-            int j_new = (int) ((y_pos_arr(i,j,0) - plo[1]) / dx[1] - myhalf);
-            Real z_new_bot_face = fourth * ( z_phys_arr(i_new,j_new  ,k) + z_phys_arr(i_new+1,j_new  ,k)
+            int i_new = (int) ((x_pos_arr(i,j,0) - plo[0]) / dx[0] - myhalf_d);
+            int j_new = (int) ((y_pos_arr(i,j,0) - plo[1]) / dx[1] - myhalf_d);
+            Real z_new_bot_face = fourth_d * ( z_phys_arr(i_new,j_new  ,k) + z_phys_arr(i_new+1,j_new  ,k)
                                          + z_phys_arr(i_new,j_new+1,k) + z_phys_arr(i_new+1,j_new+1,k) );
             if (z_pos_arr(i,j,0) < z_new_bot_face) {
                 z_pos_arr(i,j,0) = z_new_bot_face + delta_z;
@@ -882,7 +882,7 @@ MOSTAverage::set_norm_positions_T (const int& lev)
             zref_arr(i,j,0) = delta_z;
 
             // Destination position must be contained on the current process!
-            Real pos[] = {x_pos_arr(i,j,0)-plo[0],y_pos_arr(i,j,0)-plo[1],myhalf*dx[2]};
+            Real pos[] = {x_pos_arr(i,j,0)-plo[0],y_pos_arr(i,j,0)-plo[1],myhalf_d*dx[2]};
             amrex::ignore_unused(pos);
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(grb.contains(&pos[0]),
                                               "Query point outside of proc domain!");
@@ -1082,7 +1082,7 @@ MOSTAverage::compute_plane_averages (const int& lev)
                 auto x_pos_arr = x_pos->array(mfi);
                 auto y_pos_arr = y_pos->array(mfi);
                 auto z_pos_arr = z_pos->array(mfi);
-                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=]
+                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=,one_d=one]
                 AMREX_GPU_DEVICE(int i, int j, int , Gpu::Handler const& handler) noexcept
                 {
                     Real T_interp{0};
@@ -1097,9 +1097,9 @@ MOSTAverage::compute_plane_averages (const int& lev)
                         Real qr_interp{0};
                         trilinear_interp_T(x_pos_arr(i,j,0), y_pos_arr(i,j,0), z_pos_arr(i,j,0),
                                            &qr_interp, qr_mf_arr, z_phys_arr, plo, dxInv, 1);
-                        vfac = one + Real(0.61)*qv_interp - qr_interp;
+                        vfac = one_d + Real(0.61)*qv_interp - qr_interp;
                     } else {
-                        vfac = one + Real(0.61)*qv_interp;
+                        vfac = one_d + Real(0.61)*qv_interp;
                     }
                     const Real val = T_interp * vfac;
                     Gpu::deviceReduceSum(&plane_avg[iavg], val, handler);
@@ -1108,7 +1108,7 @@ MOSTAverage::compute_plane_averages (const int& lev)
                 auto k_arr = k_indx->const_array(mfi);
                 auto j_arr = j_indx ? j_indx->const_array(mfi) : Array4<const int> {};
                 auto i_arr = i_indx ? i_indx->const_array(mfi) : Array4<const int> {};
-                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=]
+                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=,one_d=one]
                 AMREX_GPU_DEVICE(int i, int j, int , Gpu::Handler const& handler) noexcept
                 {
                     int mk = k_arr(i,j,0);
@@ -1117,9 +1117,9 @@ MOSTAverage::compute_plane_averages (const int& lev)
                     Real vfac;
                     if (qr_mf_arr) {
                         // We also have liquid water
-                        vfac = one + Real(0.61)*qv_mf_arr(mi,mj,mk) - qr_mf_arr(mi,mj,mk);
+                        vfac = one_d + Real(0.61)*qv_mf_arr(mi,mj,mk) - qr_mf_arr(mi,mj,mk);
                     } else {
-                        vfac = one + Real(0.61)*qv_mf_arr(mi,mj,mk);
+                        vfac = one_d + Real(0.61)*qv_mf_arr(mi,mj,mk);
                     }
                     const Real val = T_mf_arr(mi,mj,mk) * vfac;
                     Gpu::deviceReduceSum(&plane_avg[iavg], val, handler);
@@ -1191,14 +1191,14 @@ MOSTAverage::compute_plane_averages (const int& lev)
                 auto k_arr = k_indx->const_array(mfi);
                 auto j_arr = j_indx ? j_indx->const_array(mfi) : Array4<const int> {};
                 auto i_arr = i_indx ? i_indx->const_array(mfi) : Array4<const int> {};
-                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=]
+                ParallelFor(Gpu::KernelInfo().setReduction(true), pbx, [=,myhalf_d=myhalf]
                 AMREX_GPU_DEVICE(int i, int j, int , Gpu::Handler const& handler) noexcept
                 {
                     int mk = k_arr(i,j,0);
                     int mj = j_arr ? j_arr(i,j,0) : j;
                     int mi = i_arr ? i_arr(i,j,0) : i;
-                    const Real u_val = myhalf * (u_mf_arr(mi,mj,mk) + u_mf_arr(mi+1,mj  ,mk));
-                    const Real v_val = myhalf * (v_mf_arr(mi,mj,mk) + v_mf_arr(mi  ,mj+1,mk));
+                    const Real u_val = myhalf_d * (u_mf_arr(mi,mj,mk) + u_mf_arr(mi+1,mj  ,mk));
+                    const Real v_val = myhalf_d * (v_mf_arr(mi,mj,mk) + v_mf_arr(mi  ,mj+1,mk));
                     const Real val = std::sqrt(u_val*u_val + v_val*v_val + Vsg*Vsg);
                     Gpu::deviceReduceSum(&plane_avg[iavg], val, handler);
                 });
@@ -1293,7 +1293,7 @@ MOSTAverage::compute_region_averages (const int& lev)
                 auto x_pos_arr = x_pos->array(mfi);
                 auto y_pos_arr = y_pos->array(mfi);
                 auto z_pos_arr = z_pos->array(mfi);
-                ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(pbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
                     ma_arr(i,j,0) *= d_fact_old;
 
@@ -1395,9 +1395,9 @@ MOSTAverage::compute_region_averages (const int& lev)
                                 Real qr_interp{0};
                                 trilinear_interp_T(x_pos_arr(i,j,0), y_pos_arr(i,j,0), z_pos_arr(i,j,0),
                                                    &qr_interp, qr_mf_arr, z_phys_arr, plo, dxInv, 1);
-                                vfac = one + Real(0.61)*qv_interp - qr_interp;
+                                vfac = one_d + Real(0.61)*qv_interp - qr_interp;
                             } else {
-                                vfac = one + Real(0.61)*qv_interp;
+                                vfac = one_d + Real(0.61)*qv_interp;
                             }
                             const Real mag = T_interp * vfac;
                             const Real val = denom * mag * d_fact_new;
@@ -1410,7 +1410,7 @@ MOSTAverage::compute_region_averages (const int& lev)
                 auto k_arr = k_indx->const_array(mfi);
                 auto j_arr = j_indx ? j_indx->const_array(mfi) : Array4<const int> {};
                 auto i_arr = i_indx ? i_indx->const_array(mfi) : Array4<const int> {};
-                ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
+                ParallelFor(pbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
                 {
                     ma_arr(i,j,0) *= d_fact_old;
 
@@ -1423,9 +1423,9 @@ MOSTAverage::compute_region_averages (const int& lev)
                             Real vfac;
                             if (qr_mf_arr) {
                                 // We also have liquid water
-                                vfac = one + Real(0.61)*qv_mf_arr(li,lj,lk) - qr_mf_arr(li,lj,lk);
+                                vfac = one_d + Real(0.61)*qv_mf_arr(li,lj,lk) - qr_mf_arr(li,lj,lk);
                             } else {
-                                vfac = one + Real(0.61)*qv_mf_arr(li,lj,lk);
+                                vfac = one_d + Real(0.61)*qv_mf_arr(li,lj,lk);
                             }
                             const Real mag = T_mf_arr(li,lj,lk) * vfac;
                             const Real val = denom * mag * d_fact_new;
@@ -1511,7 +1511,7 @@ MOSTAverage::compute_region_averages (const int& lev)
                 auto k_arr = k_indx->const_array(mfi);
                 auto j_arr = j_indx ? j_indx->const_array(mfi) : Array4<const int> {};
                 auto i_arr = i_indx ? i_indx->const_array(mfi) : Array4<const int> {};
-                ParallelFor(pbx, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
+                ParallelFor(pbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
                 {
                     ma_arr(i,j,0) *= d_fact_old;
 
@@ -1521,8 +1521,8 @@ MOSTAverage::compute_region_averages (const int& lev)
                     for (int lk(mk-d_radius); lk <= (mk+d_radius); ++lk) {
                       for (int lj(mj-d_radius); lj <= (mj+d_radius); ++lj) {
                         for (int li(mi-d_radius); li <= (mi+d_radius); ++li) {
-                            const Real u_val = myhalf * (u_mf_arr(li,lj,lk) + u_mf_arr(li+1,lj  ,lk));
-                            const Real v_val = myhalf * (v_mf_arr(li,lj,lk) + v_mf_arr(li  ,lj+1,lk));
+                            const Real u_val = myhalf_d * (u_mf_arr(li,lj,lk) + u_mf_arr(li+1,lj  ,lk));
+                            const Real v_val = myhalf_d * (v_mf_arr(li,lj,lk) + v_mf_arr(li  ,lj+1,lk));
                             const Real mag   = std::sqrt(u_val*u_val + v_val*v_val + Vsg*Vsg);
                             Real val = denom * mag * d_fact_new;
                             ma_arr(i,j,0) += val;
@@ -1686,7 +1686,7 @@ MOSTAverage::compute_eb_averages (const int& lev)
             auto const v_arr = fields[1]->const_array(mfi);
             auto const w_arr = fields[5]->const_array(mfi);
 
-            ParallelFor(Gpu::KernelInfo().setReduction(true), bx, [=]
+            ParallelFor(Gpu::KernelInfo().setReduction(true), bx, [=,zero_d=zero]
             AMREX_GPU_DEVICE(int i, int j, int k, Gpu::Handler const& handler) noexcept
             {
                 // Area-weighted averaging over cut cells at any k
@@ -1709,17 +1709,17 @@ MOSTAverage::compute_eb_averages (const int& lev)
                     Real vf_u_lo = u_vf_arr(i,j,k);
                     Real vf_u_hi = u_vf_arr(i+1,j,k);
                     Real sum_vf_u = vf_u_lo + vf_u_hi;
-                    Real u_cc = (sum_vf_u > zero) ? (u_arr(i,j,k)*vf_u_lo + u_arr(i+1,j,k)*vf_u_hi) / sum_vf_u : zero;
+                    Real u_cc = (sum_vf_u > zero_d) ? (u_arr(i,j,k)*vf_u_lo + u_arr(i+1,j,k)*vf_u_hi) / sum_vf_u : zero_d;
 
                     Real vf_v_lo = v_vf_arr(i,j,k);
                     Real vf_v_hi = v_vf_arr(i,j+1,k);
                     Real sum_vf_v = vf_v_lo + vf_v_hi;
-                    Real v_cc = (sum_vf_v > zero) ? (v_arr(i,j,k)*vf_v_lo + v_arr(i,j+1,k)*vf_v_hi) / sum_vf_v : zero;
+                    Real v_cc = (sum_vf_v > zero_d) ? (v_arr(i,j,k)*vf_v_lo + v_arr(i,j+1,k)*vf_v_hi) / sum_vf_v : zero_d;
 
                     Real vf_w_lo = w_vf_arr(i,j,k);
                     Real vf_w_hi = w_vf_arr(i,j,k+1);
                     Real sum_vf_w = vf_w_lo + vf_w_hi;
-                    Real w_cc = (sum_vf_w > zero) ? (w_arr(i,j,k)*vf_w_lo + w_arr(i,j,k+1)*vf_w_hi) / sum_vf_w : zero;
+                    Real w_cc = (sum_vf_w > zero_d) ? (w_arr(i,j,k)*vf_w_lo + w_arr(i,j,k+1)*vf_w_hi) / sum_vf_w : zero_d;
 
                     // Get normal vector components
                     Real nx = bnorm_arr(i,j,k,0);
@@ -1832,7 +1832,7 @@ MOSTAverage::compute_eb_averages (const int& lev)
             const Array4<Real const> qr_mf_arr = (fields[4]) ? fields[4]->const_array(mfi) :
                                                                 Array4<const Real> {};
 
-            ParallelFor(Gpu::KernelInfo().setReduction(true), bx, [=]
+            ParallelFor(Gpu::KernelInfo().setReduction(true), bx, [=,one_d=one]
             AMREX_GPU_DEVICE(int i, int j, int k, Gpu::Handler const& handler) noexcept
             {
                 if (flag_arr(i,j,k).isSingleValued()) {
@@ -1853,9 +1853,9 @@ MOSTAverage::compute_eb_averages (const int& lev)
                     Real vfac;
                     if (qr_mf_arr) {
                         // We also have liquid water
-                        vfac = one + Real(0.61)*qv_mf_arr(i,j,k) - qr_mf_arr(i,j,k);
+                        vfac = one_d + Real(0.61)*qv_mf_arr(i,j,k) - qr_mf_arr(i,j,k);
                     } else {
-                        vfac = one + Real(0.61)*qv_mf_arr(i,j,k);
+                        vfac = one_d + Real(0.61)*qv_mf_arr(i,j,k);
                     }
                     const Real val = T_mf_arr(i,j,k) * vfac * area;
                     Gpu::deviceReduceSum(&plane_avg[iavg], val, handler);

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -231,13 +231,13 @@ SurfaceLayer::update_fluxes (const int& lev,
             const auto& t_star_arr = t_star[lev]->const_array(mfi);
             const auto& dist_arr   = walldist->const_array(mfi);
 
-            ParallelFor(gpbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(gpbx, [=,CONST_GRAV_d=CONST_GRAV,KAPPA_d=KAPPA,two_d=two,three_d=three] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real rho = cons_arr(i,j,k,Rho_comp);
                 if (t_star_arr(i,j,0) < -1e-8) {
                     // Only destabilizing buoyancy flux affects the boundary k
                     // tstar < 0 ==> B > 0
-                    Real B = -CONST_GRAV * l_inv_theta0 * u_star_arr(i,j,0) * t_star_arr(i,j,0);
+                    Real B = -CONST_GRAV_d * l_inv_theta0 * u_star_arr(i,j,0) * t_star_arr(i,j,0);
                     if (!use_ref_theta) {
                         B *= cons_arr(i,j,k,Rho_comp) /
                              cons_arr(i,j,k,RhoTheta_comp);
@@ -247,8 +247,8 @@ SurfaceLayer::update_fluxes (const int& lev,
                     cons_arr(i,j,k,RhoKE_comp) = rho * l_inv_Cmu2 *
                         std::pow(
                             u_star_arr(i,j,0) * u_star_arr(i,j,0) * u_star_arr(i,j,0)
-                            + KAPPA * B * dist_arr(i,j,k),
-                        two/three);
+                            + KAPPA_d * B * dist_arr(i,j,k),
+                        two_d/three_d);
                 } else {
                     cons_arr(i,j,k,RhoKE_comp) = rho * l_inv_Cmu2 * u_star_arr(i,j,0) * u_star_arr(i,j,0);
                 }
@@ -572,14 +572,14 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         Box bx = mfi.tilebox();
         if (bx.smallEnd(2) != klo) { continue; }
         bx.makeSlab(2,klo);
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx, [=,lsm_undefined_d=lsm_undefined] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Valid theta flux from LSM and over land. The LSM writes the
             // lsm_undefined sentinel for cells it did not process (sea-ice /
             // open water); fall back to MOST there instead of applying garbage.
             Real Tflux;
             int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
-            const bool lsm_flux_is_valid = (lsm_t_flux_arr) ? (lsm_t_flux_arr(i,j,0) < lsm_undefined) :
+            const bool lsm_flux_is_valid = (lsm_t_flux_arr) ? (lsm_t_flux_arr(i,j,0) < lsm_undefined_d) :
                                                               false;
             const bool has_land_and_flux = (static_cast<bool>(is_land) && lsm_flux_is_valid);
             if (lsm_t_flux_arr && has_land_and_flux) {
@@ -613,12 +613,12 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         // Rho*Qv flux
         //============================================================================
         if (use_moisture) {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bx, [=,lsm_undefined_d=lsm_undefined] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Valid qv flux from LSM and over land (sentinel -> fall back to MOST)
                 Real Qflux;
                 int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
-                const bool lsm_flux_is_valid = (lsm_q_flux_arr) ? (lsm_q_flux_arr(i,j,0) < lsm_undefined) :
+                const bool lsm_flux_is_valid = (lsm_q_flux_arr) ? (lsm_q_flux_arr(i,j,0) < lsm_undefined_d) :
                                                                   false;
                 const bool has_land_and_flux = (static_cast<bool>(is_land) && lsm_flux_is_valid);
                 if (lsm_q_flux_arr && has_land_and_flux) {
@@ -649,7 +649,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             // Rho*u flux
             //============================================================================
             Box bxx = surroundingNodes(bx,0);
-            ParallelFor(bxx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bxx, [=,zero_d=zero,lsm_undefined_d=lsm_undefined] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Valid tau13 from LSM and over land. A side that is land but
                 // whose LSM flux is the sentinel (sea-ice / open water) is treated
@@ -659,10 +659,10 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 int is_land_lo = (lmask_arr) ? lmask_arr(i-1,j,0) : 1;
                 const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
                     static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_hi),
-                    lsm_tau13_arr ? lsm_tau13_arr(i  ,j,0) : zero, lsm_undefined);
+                    lsm_tau13_arr ? lsm_tau13_arr(i  ,j,0) : zero_d, lsm_undefined_d);
                 const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
                     static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_lo),
-                    lsm_tau13_arr ? lsm_tau13_arr(i-1,j,0) : zero, lsm_undefined);
+                    lsm_tau13_arr ? lsm_tau13_arr(i-1,j,0) : zero_d, lsm_undefined_d);
                 const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
                 const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
                 if (lsm_tau13_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
@@ -671,7 +671,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                     const Real most_stress = (!has_land_and_flux_hi || !has_land_and_flux_lo) ?
                         flux_comp.compute_u_flux(i, j, k,
                                                  cons_arr, velx_arr, vely_arr,
-                                                 umm_arr, um_arr, u_star_arr) : zero;
+                                                 umm_arr, um_arr, u_star_arr) : zero_d;
                     const auto result = surface_layer_stress::combine_lsm_and_most_stress(
                         rho_lo, rho_hi, lsm_tau13_arr(i-1,j,0), lsm_tau13_arr(i,j,0),
                         has_land_and_flux_lo, has_land_and_flux_hi, most_stress);
@@ -700,7 +700,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             // Rho*v flux
             //============================================================================
             Box bxy = surroundingNodes(bx,1);
-            ParallelFor(bxy, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bxy, [=,zero_d=zero,lsm_undefined_d=lsm_undefined] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Valid tau23 from LSM and over land (sentinel side -> MOST stress)
                 Real stressy;
@@ -708,10 +708,10 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 int is_land_lo = (lmask_arr) ? lmask_arr(i,j-1,0) : 1;
                 const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
                     static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_hi),
-                    lsm_tau23_arr ? lsm_tau23_arr(i,j  ,0) : zero, lsm_undefined);
+                    lsm_tau23_arr ? lsm_tau23_arr(i,j  ,0) : zero_d, lsm_undefined_d);
                 const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
                     static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_lo),
-                    lsm_tau23_arr ? lsm_tau23_arr(i,j-1,0) : zero, lsm_undefined);
+                    lsm_tau23_arr ? lsm_tau23_arr(i,j-1,0) : zero_d, lsm_undefined_d);
                 const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
                 const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
                 if (lsm_tau23_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
@@ -720,7 +720,7 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                     const Real most_stress = (!has_land_and_flux_hi || !has_land_and_flux_lo) ?
                         flux_comp.compute_v_flux(i, j, k,
                                                  cons_arr, velx_arr, vely_arr,
-                                                 umm_arr, vm_arr, u_star_arr) : zero;
+                                                 umm_arr, vm_arr, u_star_arr) : zero_d;
                     const auto result = surface_layer_stress::combine_lsm_and_most_stress(
                         rho_lo, rho_hi, lsm_tau23_arr(i,j-1,0), lsm_tau23_arr(i,j,0),
                         has_land_and_flux_lo, has_land_and_flux_hi, most_stress);
@@ -1009,30 +1009,30 @@ SurfaceLayer::compute_sfc_params_from_lsm_fluxes (const int& lev,
             if (toLower(m_lsm_flux_name[n]) == "tau23")  { lsm_tau23_arr  = m_lsm_flux_lev[lev][n]->array(mfi); }
         }
 
-        ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+        ParallelFor(vbx, [=,lsm_undefined_d=lsm_undefined,zero_d=zero,one_d=one,R_v_d=R_v,R_d_d=R_d,KAPPA_d=KAPPA,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
             // Skip cells the LSM did not have a valid flux (lsm_undefined).
-            if (is_land && lsm_t_flux_arr && lsm_t_flux_arr(i,j,0) < lsm_undefined) {
+            if (is_land && lsm_t_flux_arr && lsm_t_flux_arr(i,j,0) < lsm_undefined_d) {
                 Real rho = cons_arr(i,j,klo,Rho_comp);
                 Real Thd = cons_arr(i,j,klo,RhoTheta_comp) / rho;
-                Real qv  = (has_moisture) ? cons_arr(i,j,klo,RhoQ1_comp) / rho : zero;
-                Real Thv = Thd * (one + (R_v/R_d - one)*qv);
+                Real qv  = (has_moisture) ? cons_arr(i,j,klo,RhoQ1_comp) / rho : zero_d;
+                Real Thv = Thd * (one_d + (R_v_d/R_d_d - one_d)*qv);
                 Real tau = std::sqrt( lsm_tau13_arr(i,j,0)*lsm_tau13_arr(i,j,0)
                                     + lsm_tau23_arr(i,j,0)*lsm_tau23_arr(i,j,0) );
                 u_star_arr(i,j,0) = amrex::max(std::sqrt(tau),eps);
-                if (lsm_t_flux_arr(i,j,0)>=zero) {
+                if (lsm_t_flux_arr(i,j,0)>=zero_d) {
                     t_star_arr(i,j,0) = amrex::min(-lsm_t_flux_arr(i,j,0) / u_star_arr(i,j,0),-eps);
                 } else {
                     t_star_arr(i,j,0) = amrex::max(-lsm_t_flux_arr(i,j,0) / u_star_arr(i,j,0),eps);
                 }
-                if (lsm_q_flux_arr(i,j,0)>=zero) {
+                if (lsm_q_flux_arr(i,j,0)>=zero_d) {
                     q_star_arr(i,j,0) = amrex::min(-lsm_q_flux_arr(i,j,0) / u_star_arr(i,j,0),-eps);
                 } else {
                     q_star_arr(i,j,0) = amrex::max(-lsm_q_flux_arr(i,j,0) / u_star_arr(i,j,0),eps);
                 }
                 olen_arr(i,j,0)   = ( u_star_arr(i,j,0) * u_star_arr(i,j,0) * Thv ) /
-                                    ( KAPPA * CONST_GRAV * t_star_arr(i,j,0) );
+                                    ( KAPPA_d * CONST_GRAV_d * t_star_arr(i,j,0) );
             }
         });
     } // mfi
@@ -1149,17 +1149,17 @@ SurfaceLayer::fill_qsurf_with_qsat (const int& lev,
         const auto z_arr    = (z_phys_nd) ? z_phys_nd->const_array(mfi) :
                                             Array4<const Real> {};
 
-        ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(gtbx, [=,myhalf_d=myhalf,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             int is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
             if (!is_land) {
                 auto deltaZ = (z_arr) ? Compute_Zrel_AtCellCenter(i,j,k,z_arr) :
-                                        myhalf*dz;
+                                        myhalf_d*dz;
                 auto Rho  = cons_arr(i,j,k,Rho_comp);
                 auto RTh  = cons_arr(i,j,k,RhoTheta_comp);
                 auto Qv   = cons_arr(i,j,k,RhoQ1_comp) / Rho;
                 auto P_cc = getPgivenRTh(RTh, Qv);
-                P_cc += Rho*CONST_GRAV*deltaZ;
+                P_cc += Rho*CONST_GRAV_d*deltaZ;
                 P_cc *= Real(0.01);
                 erf_qsatw(t_surf_arr(i,j,k), P_cc, q_surf_arr(i,j,k));
             }
@@ -1263,10 +1263,10 @@ SurfaceLayer::init_tke_from_ustar (const int& lev,
         auto const& z_phys_arr = z_phys_nd->const_array(mfi);
         auto        z_surf_all = z_surf_lo.array();
 
-        ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
+        ParallelFor(vbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
         {
             u_star_all(i,j,0) = u_star_arr(i,j,0);
-            z_surf_all(i,j,0) = fourth * ( z_phys_arr(i  ,j  ,klo) + z_phys_arr(i+1,j  ,klo)
+            z_surf_all(i,j,0) = fourth_d * ( z_phys_arr(i  ,j  ,klo) + z_phys_arr(i+1,j  ,klo)
                                        + z_phys_arr(i  ,j+1,klo) + z_phys_arr(i+1,j+1,klo) );
         });
     }
@@ -1366,7 +1366,7 @@ SurfaceLayer::read_custom_roughness (const int& lev,
             int jhi = m_geom[lev].Domain().bigEnd(1);
 
             Array4<Real> const& z0_arr = z_0[lev].array(mfi);
-            ParallelFor(gtbx, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
+            ParallelFor(gtbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int /*k*/)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,ilo),ihi);
@@ -1380,7 +1380,7 @@ SurfaceLayer::read_custom_roughness (const int& lev,
                     z0_arr(i,j,klo) = z0p[inode];
                 } else {
                     // Unexpected list order, do brute force search
-                    Real z0loc = zero;
+                    Real z0loc = zero_d;
                     bool found = false;
                     for (int n=0; n<nnode; ++n) {
                         Real delta=std::sqrt(amrex::Math::powi<2>(x-xp[n])+amrex::Math::powi<2>(y-yp[n]));

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -429,9 +429,9 @@ struct TurbulentPerturbation {
                         pert_cell(i,j,k) = rand_number_const * amp_copy;
                     });
                 } else {
-                    ParallelForRNG(ubx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+                    ParallelForRNG(ubx, [=,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
                         amrex::Real rand_double = amrex::Random(engine);
-                        pert_cell(i,j,k) = (rand_double*two - one) * amp_copy;
+                        pert_cell(i,j,k) = (rand_double*two_d - one_d) * amp_copy;
                     });
                 }
 
@@ -451,8 +451,8 @@ struct TurbulentPerturbation {
             amrex::Box ubx = pbx & vbx;
             if (ubx.ok()) {
                 const amrex::Array4<amrex::Real>& pert_cell = pb_cell[lev].array(mfi);
-                ParallelFor(ubx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    pert_cell(i,j,k) = zero;
+                ParallelFor(ubx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    pert_cell(i,j,k) = zero_d;
                 });
             }
         }

--- a/Source/Diffusion/ERF_AddTKESources.H
+++ b/Source/Diffusion/ERF_AddTKESources.H
@@ -12,7 +12,7 @@
     //       each RK stage, but that does not change the buoyancy production term here.
     if (l_use_keqn && (start_comp <= RhoKE_comp) && (end_comp >= RhoKE_comp)) {
         int qty_index = RhoKE_comp;
-        ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx,[=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Add Buoyancy Source
             // where the SGS buoyancy flux tau_{theta,i} = -KH * dtheta/dx_i,
@@ -35,7 +35,7 @@
             //   P = -tau_ij * S_ij = 2 * mu_turb * S_ij * S_ij
             // Note: This assumes that the horizontal and vertical diffusivities
             // of momentum are equal
-            cell_rhs(i,j,k,qty_index) += two*mu_turb(i,j,k,EddyDiff::Mom_v) * SmnSmn_a(i,j,k);
+            cell_rhs(i,j,k,qty_index) += two_d*mu_turb(i,j,k,EddyDiff::Mom_v) * SmnSmn_a(i,j,k);
 
             // TKE dissipation
             cell_rhs(i,j,k,qty_index) -= diss(i,j,k);

--- a/Source/Diffusion/ERF_ComputeStrain_EB.cpp
+++ b/Source/Diffusion/ERF_ComputeStrain_EB.cpp
@@ -122,12 +122,12 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxy.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
-                                     + (-(Real(8.)/three) * v(i-1,j,k) + three * v(i,j,k) - third * v(i+1,j,k))*dxInv[0] );
+        ParallelFor(planexy,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
+                                     + (-(Real(8.)/three_d) * v(i-1,j,k) + three_d * v(i,j,k) - third_d * v(i+1,j,k))*dxInv[0] );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
                                        (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             }
         });
@@ -138,12 +138,12 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxy.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
-                                     - (-(Real(8.)/three) * v(i,j,k) + three * v(i-1,j,k) - third * v(i-2,j,k))*dxInv[0] );
+        ParallelFor(planexy,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
+                                     - (-(Real(8.)/three_d) * v(i,j,k) + three_d * v(i-1,j,k) - third_d * v(i-2,j,k))*dxInv[0] );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1] +
                                        (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             }
         });
@@ -154,17 +154,17 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxz.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     + (-(Real(8.)/three) * w(i-1,j,k) + three * w(i,j,k) - third * w(i+1,j,k))*dxInv[0] );
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     + (-(Real(8.)/three_d) * w(i-1,j,k) + three_d * w(i,j,k) - third_d * w(i+1,j,k))*dxInv[0] );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
             }
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (xh_w_dir) {
@@ -173,17 +173,17 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxz.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     - (-(Real(8.)/three) * w(i,j,k) + three * w(i-1,j,k) - third * w(i-2,j,k))*dxInv[0] );
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     - (-(Real(8.)/three_d) * w(i,j,k) + three_d * w(i-1,j,k) - third_d * w(i-2,j,k))*dxInv[0] );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
             }
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -195,12 +195,12 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxy.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (-(Real(8.)/three) * u(i,j-1,k) + three * u(i,j,k) - third * u(i,j+1,k))*dxInv[1]
+        ParallelFor(planexy,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (-(Real(8.)/three_d) * u(i,j-1,k) + three_d * u(i,j,k) - third_d * u(i,j+1,k))*dxInv[1]
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             }
         });
@@ -211,12 +211,12 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxxy.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( -(-(Real(8.)/three) * u(i,j,k) + three * u(i,j-1,k) - third * u(i,j-2,k))*dxInv[1]
+        ParallelFor(planexy,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( -(-(Real(8.)/three_d) * u(i,j,k) + three_d * u(i,j-1,k) - third_d * u(i,j-2,k))*dxInv[1]
                                       + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0] );
             }
         });
@@ -227,17 +227,17 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxyz.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     + (-(Real(8.)/three) * w(i,j-1,k) + three * w(i,j  ,k) - third * w(i,j+1,k))*dxInv[1] );
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     + (-(Real(8.)/three_d) * w(i,j-1,k) + three_d * w(i,j  ,k) - third_d * w(i,j+1,k))*dxInv[1] );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
             }
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (yh_w_dir) {
@@ -246,17 +246,17 @@ ComputeStrain_EB (const MFIter& mfi,
         tbxyz.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,zero_d=zero,myhalf_d=myhalf,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     - (-(Real(8.)/three) * w(i,j  ,k) + three * w(i,j-1,k) - third * w(i,j-2,k))*dxInv[1] );
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     - (-(Real(8.)/three_d) * w(i,j  ,k) + three_d * w(i,j-1,k) - third_d * w(i,j-2,k))*dxInv[1] );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
             }
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -267,12 +267,12 @@ ComputeStrain_EB (const MFIter& mfi,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real du_dz = (-(Real(8.)/three) * u(i,j,k-1) + three * u(i,j,k) - third * u(i,j,k+1))*dxInv[2];
-            tau13(i,j,k) = myhalf * ( du_dz
+        ParallelFor(planexz,[=,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real du_dz = (-(Real(8.)/three_d) * u(i,j,k-1) + three_d * u(i,j,k) - third_d * u(i,j,k+1))*dxInv[2];
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (zh_u_dir) {
@@ -280,12 +280,12 @@ ComputeStrain_EB (const MFIter& mfi,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real du_dz = -(-(Real(8.)/three) * u(i,j,k) + three * u(i,j,k-1) - third * u(i,j,k-2))*dxInv[2];
-            tau13(i,j,k) = myhalf * ( du_dz
+        ParallelFor(planexz,[=,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real du_dz = -(-(Real(8.)/three_d) * u(i,j,k) + three_d * u(i,j,k-1) - third_d * u(i,j,k-2))*dxInv[2];
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  +  (w(i, j, k) - w(i-1, j, k))*dxInv[0] );
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -293,12 +293,12 @@ ComputeStrain_EB (const MFIter& mfi,
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dv_dz = (-(Real(8.)/three) * v(i,j,k-1) + three * v(i,j,k  ) - third * v(i,j,k+1))*dxInv[2];
-            tau23(i,j,k) = myhalf * ( dv_dz
+        ParallelFor(planeyz,[=,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dv_dz = (-(Real(8.)/three_d) * v(i,j,k-1) + three_d * v(i,j,k  ) - third_d * v(i,j,k+1))*dxInv[2];
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (zh_v_dir) {
@@ -306,49 +306,49 @@ ComputeStrain_EB (const MFIter& mfi,
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dv_dz = -(-(Real(8.)/three) * v(i,j,k  ) + three * v(i,j,k-1) - third * v(i,j,k-2))*dxInv[2];
-            tau23(i,j,k) = myhalf * ( dv_dz
+        ParallelFor(planeyz,[=,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dv_dz = -(-(Real(8.)/three_d) * v(i,j,k  ) + three_d * v(i,j,k-1) - third_d * v(i,j,k-2))*dxInv[2];
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  +  (w(i, j, k) - w(i, j-1, k))*dxInv[1] );
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
     // Fill the remaining cells
     //***********************************************************************************
     // Cell centered strains
-    ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    ParallelFor(bxcc, [=,zero_d=zero,two_d=two,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
 
-        Real du_dx{zero};
+        Real du_dx{zero_d};
         bool can_lo_x = (i-2 >= dom_lo.x);
         bool can_hi_x = (i+3 <= dom_hi.x+1);
         if (can_lo_x && u_cflag(i+1,j,k).isCovered() && u_cflag(i,j,k).isSingleValued()) {
-            du_dx = ( two*u(i, j, k) - three*u(i-1, j, k) + u(i-2, j, k))*dxInv[0];
+            du_dx = ( two_d*u(i, j, k) - three_d*u(i-1, j, k) + u(i-2, j, k))*dxInv[0];
         } else if (can_hi_x && u_cflag(i,j,k).isCovered() && u_cflag(i+1,j,k).isSingleValued()) {
-            du_dx = (- two*u(i+1, j, k) + three*u(i+2, j, k) - u(i+3, j, k))*dxInv[0];
+            du_dx = (- two_d*u(i+1, j, k) + three_d*u(i+2, j, k) - u(i+3, j, k))*dxInv[0];
         } else {
             du_dx = (u(i+1, j, k) - u(i, j, k))*dxInv[0];
         }
 
-        Real dv_dy{zero};
+        Real dv_dy{zero_d};
         bool can_lo_y = (j-2 >= dom_lo.y);
         bool can_hi_y = (j+3 <= dom_hi.y+1);
         if (can_lo_y && v_cflag(i,j+1,k).isCovered() && v_cflag(i,j,k).isSingleValued()) {
-            dv_dy = ( two*v(i, j, k) - three*v(i, j-1, k) + v(i, j-2, k))*dxInv[1];
+            dv_dy = ( two_d*v(i, j, k) - three_d*v(i, j-1, k) + v(i, j-2, k))*dxInv[1];
         } else if (can_hi_y && v_cflag(i,j,k).isCovered() && v_cflag(i,j+1,k).isSingleValued()) {
-            dv_dy = (- two*v(i, j+1, k) + three*v(i, j+2, k) - v(i, j+3, k))*dxInv[1];
+            dv_dy = (- two_d*v(i, j+1, k) + three_d*v(i, j+2, k) - v(i, j+3, k))*dxInv[1];
         } else {
             dv_dy = (v(i, j+1, k) - v(i, j, k))*dxInv[1];
         }
 
-        Real dw_dz{zero};
+        Real dw_dz{zero_d};
         bool can_lo_z = (k-2 >= dom_lo.z);
         bool can_hi_z = (k+3 <= dom_hi.z+1);
         if (can_lo_z && w_cflag(i,j,k+1).isCovered() && w_cflag(i,j,k).isSingleValued()) {
-            dw_dz = ( two*w(i, j, k) - three*w(i, j, k-1) + w(i, j, k-2))*dxInv[2];
+            dw_dz = ( two_d*w(i, j, k) - three_d*w(i, j, k-1) + w(i, j, k-2))*dxInv[2];
         } else if (can_hi_z && w_cflag(i,j,k).isCovered() && w_cflag(i,j,k+1).isSingleValued()) {
-            dw_dz = (- two*w(i, j, k+1) + three*w(i, j, k+2) - w(i, j, k+3))*dxInv[2];
+            dw_dz = (- two_d*w(i, j, k+1) + three_d*w(i, j, k+2) - w(i, j, k+3))*dxInv[2];
         } else {
             dw_dz = (w(i, j, k+1) - w(i, j, k))*dxInv[2];
         }
@@ -360,87 +360,87 @@ ComputeStrain_EB (const MFIter& mfi,
 
     // Off-diagonal strains
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,zero_d=zero,two_d=two,three_d=three,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
 
-        Real du_dy{zero};
+        Real du_dy{zero_d};
         bool can_lo_y_du = (j-3 >= dom_lo.y);
         bool can_hi_y_du = (j+2 <= dom_hi.y);
         if (can_lo_y_du && u_cflag(i,j,k).isCovered() && u_cflag(i,j-1,k).isSingleValued()) {
-            du_dy = ( two*u(i, j-1, k) - three*u(i, j-2, k) + u(i, j-3, k))*dxInv[1];
+            du_dy = ( two_d*u(i, j-1, k) - three_d*u(i, j-2, k) + u(i, j-3, k))*dxInv[1];
         } else if (can_hi_y_du && u_cflag(i,j-1,k).isCovered() && u_cflag(i,j,k).isSingleValued()) {
-            du_dy = (- two*u(i, j, k) + three*u(i, j+1, k) - u(i, j+2, k))*dxInv[1];
+            du_dy = (- two_d*u(i, j, k) + three_d*u(i, j+1, k) - u(i, j+2, k))*dxInv[1];
         } else {
             du_dy = (u(i, j, k) - u(i, j-1, k))*dxInv[1];
         }
 
-        Real dv_dx{zero};
+        Real dv_dx{zero_d};
         bool can_lo_x_dv = (i-3 >= dom_lo.x);
         bool can_hi_x_dv = (i+2 <= dom_hi.x);
         if (can_lo_x_dv && v_cflag(i,j,k).isCovered() && v_cflag(i-1,j,k).isSingleValued()) {
-            dv_dx = ( two*v(i-1, j, k) - three*v(i-2, j, k) + v(i-3, j, k))*dxInv[0];
+            dv_dx = ( two_d*v(i-1, j, k) - three_d*v(i-2, j, k) + v(i-3, j, k))*dxInv[0];
         } else if (can_hi_x_dv && v_cflag(i-1,j,k).isCovered() && v_cflag(i,j,k).isSingleValued()) {
-            dv_dx = (- two*v(i, j, k) + three*v(i+1, j, k) - v(i+2, j, k))*dxInv[0];
+            dv_dx = (- two_d*v(i, j, k) + three_d*v(i+1, j, k) - v(i+2, j, k))*dxInv[0];
         } else {
             dv_dx = (v(i, j, k) - v(i-1, j, k))*dxInv[0];
         }
 
-        tau12(i,j,k) = myhalf * ( du_dy + dv_dx );
+        tau12(i,j,k) = myhalf_d * ( du_dy + dv_dx );
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,zero_d=zero,two_d=two,three_d=three,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
 
-        Real du_dz{zero};
+        Real du_dz{zero_d};
         bool can_lo_z_du = (k-3 >= dom_lo.z);
         bool can_hi_z_du = (k+2 <= dom_hi.z);
         if (can_lo_z_du && u_cflag(i,j,k).isCovered() && u_cflag(i,j,k-1).isSingleValued()) {
-            du_dz = ( two*u(i, j, k-1) - three*u(i, j, k-2) + u(i, j, k-3))*dxInv[2];
+            du_dz = ( two_d*u(i, j, k-1) - three_d*u(i, j, k-2) + u(i, j, k-3))*dxInv[2];
         } else if (can_hi_z_du && u_cflag(i,j,k-1).isCovered() && u_cflag(i,j,k).isSingleValued()) {
-            du_dz = (- two*u(i, j, k) + three*u(i, j, k+1) - u(i, j, k+2))*dxInv[2];
+            du_dz = (- two_d*u(i, j, k) + three_d*u(i, j, k+1) - u(i, j, k+2))*dxInv[2];
         } else {
             du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
         }
 
-        Real dw_dx{zero};
+        Real dw_dx{zero_d};
         bool can_lo_x_dw = (i-3 >= dom_lo.x);
         bool can_hi_x_dw = (i+2 <= dom_hi.x);
         if (can_lo_x_dw && w_cflag(i,j,k).isCovered() && w_cflag(i-1,j,k).isSingleValued()) {
-            dw_dx = ( two*w(i-1, j, k) - three*w(i-2, j, k) + w(i-3, j, k))*dxInv[0];
+            dw_dx = ( two_d*w(i-1, j, k) - three_d*w(i-2, j, k) + w(i-3, j, k))*dxInv[0];
         } else if (can_hi_x_dw && w_cflag(i-1,j,k).isCovered() && w_cflag(i,j,k).isSingleValued()) {
-            dw_dx = (- two*w(i, j, k) + three*w(i+1, j, k) - w(i+2, j, k))*dxInv[0];
+            dw_dx = (- two_d*w(i, j, k) + three_d*w(i+1, j, k) - w(i+2, j, k))*dxInv[0];
         } else {
             dw_dx = (w(i, j, k) - w(i-1, j, k))*dxInv[0];
         }
 
-        tau13(i,j,k) = myhalf * ( du_dz + dw_dx );
+        tau13(i,j,k) = myhalf_d * ( du_dz + dw_dx );
 
-        if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+        if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,zero_d=zero,two_d=two,three_d=three,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
 
-        Real dv_dz{zero};
+        Real dv_dz{zero_d};
         bool can_lo_z_dv = (k-3 >= dom_lo.z);
         bool can_hi_z_dv = (k+2 <= dom_hi.z);
         if (can_lo_z_dv && v_cflag(i,j,k).isCovered() && v_cflag(i,j,k-1).isSingleValued()) {
-            dv_dz = ( two*v(i, j, k-1) - three*v(i, j, k-2) + v(i, j, k-3))*dxInv[2];
+            dv_dz = ( two_d*v(i, j, k-1) - three_d*v(i, j, k-2) + v(i, j, k-3))*dxInv[2];
         } else if (can_hi_z_dv && v_cflag(i,j,k-1).isCovered() && v_cflag(i,j,k).isSingleValued()) {
-            dv_dz = (- two*v(i, j, k) + three*v(i, j, k+1) - v(i, j, k+2))*dxInv[2];
+            dv_dz = (- two_d*v(i, j, k) + three_d*v(i, j, k+1) - v(i, j, k+2))*dxInv[2];
         } else {
             dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
         }
 
-        Real dw_dy{zero};
+        Real dw_dy{zero_d};
         bool can_lo_y_dw = (j-3 >= dom_lo.y);
         bool can_hi_y_dw = (j+2 <= dom_hi.y);
         if (can_lo_y_dw && w_cflag(i,j,k).isCovered() && w_cflag(i,j-1,k).isSingleValued()) {
-            dw_dy = ( two*w(i, j-1, k) - three*w(i, j-2, k) + w(i, j-3, k))*dxInv[1];
+            dw_dy = ( two_d*w(i, j-1, k) - three_d*w(i, j-2, k) + w(i, j-3, k))*dxInv[1];
         } else if (can_hi_y_dw && w_cflag(i,j-1,k).isCovered() && w_cflag(i,j,k).isSingleValued()) {
-            dw_dy = (- two*w(i, j, k) + three*w(i, j+1, k) - w(i, j+2, k))*dxInv[1];
+            dw_dy = (- two_d*w(i, j, k) + three_d*w(i, j+1, k) - w(i, j+2, k))*dxInv[1];
         } else {
             dw_dy = (w(i, j, k) - w(i, j-1, k))*dxInv[1];
         }
 
 
-        tau23(i,j,k) = myhalf * ( dv_dz + dw_dy );
+        tau23(i,j,k) = myhalf_d * ( dv_dz + dw_dy );
 
-        if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+        if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
     });
 }

--- a/Source/Diffusion/ERF_ComputeStrain_N.cpp
+++ b/Source/Diffusion/ERF_ComputeStrain_N.cpp
@@ -123,14 +123,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
-                                     + (-eightthirds * v(i-1,j,k) + three * v(i,j,k) - third * v(i+1,j,k))*dxInv[0]*mfx );
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
+                                     + (-eightthirds_d * v(i-1,j,k) + three_d * v(i,j,k) - third_d * v(i+1,j,k))*dxInv[0]*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy +
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy +
                                        (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             }
         });
@@ -141,14 +141,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
-                                     - (-eightthirds * v(i,j,k) + three * v(i-1,j,k) - third * v(i-2,j,k))*dxInv[0]*mfx );
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
+                                     - (-eightthirds_d * v(i,j,k) + three_d * v(i-1,j,k) - third_d * v(i-2,j,k))*dxInv[0]*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy +
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy +
                                        (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             }
         });
@@ -159,19 +159,19 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,zero_d=zero,myhalf_d=myhalf,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     + (-eightthirds * w(i-1,j,k) + three * w(i,j,k) - third * w(i+1,j,k))*dxInv[0]*mfx );
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     + (-eightthirds_d * w(i-1,j,k) + three_d * w(i,j,k) - third_d * w(i+1,j,k))*dxInv[0]*mfx );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
             }
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (xh_w_dir) {
@@ -180,18 +180,18 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,zero_d=zero,myhalf_d=myhalf,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     - (-eightthirds * w(i,j,k) + three * w(i-1,j,k) - third * w(i-2,j,k))*dxInv[0]*mfx );
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     - (-eightthirds_d * w(i,j,k) + three_d * w(i-1,j,k) - third_d * w(i-2,j,k))*dxInv[0]*mfx );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
             }
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -203,14 +203,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (-eightthirds * u(i,j-1,k) + three * u(i,j,k) - third * u(i,j+1,k))*dxInv[1]*mfy
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (-eightthirds_d * u(i,j-1,k) + three_d * u(i,j,k) - third_d * u(i,j+1,k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             }
         });
@@ -221,14 +221,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( -(-eightthirds * u(i,j,k) + three * u(i,j-1,k) - third * u(i,j-2,k))*dxInv[1]*mfy
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( -(-eightthirds_d * u(i,j,k) + three_d * u(i,j-1,k) - third_d * u(i,j-2,k))*dxInv[1]*mfy
                                       + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
             }
         });
@@ -239,19 +239,19 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,zero_d=zero,myhalf_d=myhalf,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     + (-eightthirds * w(i,j-1,k) + three * w(i,j  ,k) - third * w(i,j+1,k))*dxInv[1]*mfy );
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     + (-eightthirds_d * w(i,j-1,k) + three_d * w(i,j  ,k) - third_d * w(i,j+1,k))*dxInv[1]*mfy );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
             }
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (yh_w_dir) {
@@ -260,19 +260,19 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,zero_d=zero,myhalf_d=myhalf,eightthirds_d=eightthirds,three_d=three,third_d=third] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     - (-eightthirds * w(i,j  ,k) + three * w(i,j-1,k) - third * w(i,j-2,k))*dxInv[1]*mfy );
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     - (-eightthirds_d * w(i,j  ,k) + three_d * w(i,j-1,k) - third_d * w(i,j-2,k))*dxInv[1]*mfy );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
             }
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -283,14 +283,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,eightthirds_d=eightthirds,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real du_dz = (-eightthirds * u(i,j,k-1) + three * u(i,j,k) - third * u(i,j,k+1))*dxInv[2];
-            tau13(i,j,k) = myhalf * ( du_dz
+            Real du_dz = (-eightthirds_d * u(i,j,k-1) + three_d * u(i,j,k) - third_d * u(i,j,k+1))*dxInv[2];
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (zh_u_dir) {
@@ -298,14 +298,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,eightthirds_d=eightthirds,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real du_dz = -(-eightthirds * u(i,j,k) + three * u(i,j,k-1) - third * u(i,j,k-2))*dxInv[2];
-            tau13(i,j,k) = myhalf * ( du_dz
+            Real du_dz = -(-eightthirds_d * u(i,j,k) + three_d * u(i,j,k-1) - third_d * u(i,j,k-2))*dxInv[2];
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  +  (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -313,14 +313,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,eightthirds_d=eightthirds,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dv_dz = (-eightthirds * v(i,j,k-1) + three * v(i,j,k  ) - third * v(i,j,k+1))*dxInv[2];
-            tau23(i,j,k) = myhalf * ( dv_dz
+            Real dv_dz = (-eightthirds_d * v(i,j,k-1) + three_d * v(i,j,k  ) - third_d * v(i,j,k+1))*dxInv[2];
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (zh_v_dir) {
@@ -328,14 +328,14 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,eightthirds_d=eightthirds,three_d=three,third_d=third,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dv_dz = -(-eightthirds * v(i,j,k  ) + three * v(i,j,k-1) - third * v(i,j,k-2))*dxInv[2];
-            tau23(i,j,k) = myhalf * ( dv_dz
+            Real dv_dz = -(-eightthirds_d * v(i,j,k  ) + three_d * v(i,j,k-1) - third_d * v(i,j,k-2))*dxInv[2];
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  +  (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -352,28 +352,28 @@ ComputeStrain_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
 
     // Off-diagonal strains
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-        Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
-        tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
+    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+        Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k))*dxInv[1]*mfy
                              + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx );
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real mfx = mf_ux(i,j,0);
 
         Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2];
-        tau13(i,j,k) = myhalf * ( du_dz
+        tau13(i,j,k) = myhalf_d * ( du_dz
                              + (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
 
-        if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+        if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real mfy = mf_vy(i,j,0);
 
         Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2];
-        tau23(i,j,k) = myhalf * ( dv_dz
+        tau23(i,j,k) = myhalf_d * ( dv_dz
                              + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
 
-        if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+        if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
     });
 }

--- a/Source/Diffusion/ERF_ComputeStrain_S.cpp
+++ b/Source/Diffusion/ERF_ComputeStrain_S.cpp
@@ -134,15 +134,15 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
-                                   + (-(Real(8.)/three) * v(i-1,j,k) + three * v(i,j,k) - (one/three) * v(i+1,j,k))*dxInv[0]*mfx);
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
+                                   + (-(Real(8.)/three_d) * v(i-1,j,k) + three_d * v(i,j,k) - (one_d/three_d) * v(i+1,j,k))*dxInv[0]*mfx);
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
             }
             tau21(i,j,k) = tau12(i,j,k);
@@ -153,15 +153,15 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
-                                   - (-(Real(8.)/three) * v(i,j,k) + three * v(i-1,j,k) - (one/three) * v(i-2,j,k))*dxInv[0]*mfx);
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
+                                   - (-(Real(8.)/three_d) * v(i,j,k) + three_d * v(i-1,j,k) - (one_d/three_d) * v(i-2,j,k))*dxInv[0]*mfx);
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
             }
             tau21(i,j,k) = tau12(i,j,k);
@@ -174,22 +174,22 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dz_inv;
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     + (-(Real(8.)/three) * w(i-1,j,k) + three * w(i,j,k) - (one/three) * w(i+1,j,k))*dxInv[0] * mfx );
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     + (-(Real(8.)/three_d) * w(i-1,j,k) + three_d * w(i,j,k) - (one_d/three_d) * w(i+1,j,k))*dxInv[0] * mfx );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0] * mfx );
             }
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -199,22 +199,22 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dz_inv;
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     - (-(Real(8.)/three) * w(i,j,k) + three * w(i-1,j,k) - (one/three) * w(i-2,j,k))*dxInv[0] * mfx );
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     - (-(Real(8.)/three_d) * w(i,j,k) + three_d * w(i-1,j,k) - (one_d/three_d) * w(i-2,j,k))*dxInv[0] * mfx );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0] * mfx );
             }
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -226,15 +226,15 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (-(Real(8.)/three) * u(i,j-1,k) + three * u(i,j,k) - (one/three) * u(i,j+1,k))*dxInv[1]*mfy
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (-(Real(8.)/three_d) * u(i,j-1,k) + three_d * u(i,j,k) - (one_d/three_d) * u(i,j+1,k))*dxInv[1]*mfy
                                    + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx);
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
             }
             tau21(i,j,k) = tau12(i,j,k);
@@ -245,15 +245,15 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        ParallelFor(planexy,[=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( -(-(Real(8.)/three) * u(i,j,k) + three * u(i,j-1,k) - (one/three) * u(i,j-2,k))*dxInv[1]*mfy +
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( -(-(Real(8.)/three_d) * u(i,j,k) + three_d * u(i,j-1,k) - (one_d/three_d) * u(i,j-2,k))*dxInv[1]*mfy +
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx);
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
             }
             tau21(i,j,k) = tau12(i,j,k);
@@ -266,22 +266,22 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dz_inv;
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     + (-(Real(8.)/three) * w(i,j-1,k) + three * w(i,j  ,k) - (one/three) * w(i,j+1,k))*dxInv[1] * mfy );
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     + (-(Real(8.)/three_d) * w(i,j-1,k) + three_d * w(i,j  ,k) - (one_d/three_d) * w(i,j+1,k))*dxInv[1] * mfy );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1] * mfy );
             }
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (yh_w_dir) {
@@ -290,22 +290,22 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dz_inv;
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     - (-(Real(8.)/three) * w(i,j  ,k) + three * w(i,j-1,k) - (one/three) * w(i,j-2,k))*dxInv[1] * mfy );
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     - (-(Real(8.)/three_d) * w(i,j  ,k) + three_d * w(i,j-1,k) - (one_d/three_d) * w(i,j-2,k))*dxInv[1] * mfy );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1] * mfy );
             }
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -316,25 +316,25 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
             Real dz0  = dz_ptr[k];
             Real dz1  = dz_ptr[k+1];
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfx = mf_ux(i,j,0);
 
             Real du_dz = (c1 * u(i,j,k-1) + c2 * u(i,j,k) + c3 * u(i,j,k+1))*idz0;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k))*dxInv[0] * mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (zh_u_dir) {
@@ -342,25 +342,25 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
             Real dz0  = dz_ptr[k-1];
             Real dz1  = dz_ptr[k-2];
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfx = mf_ux(i,j,0);
 
             Real du_dz = -(c1 * u(i,j,k) + c2 * u(i,j,k-1) + c3 * u(i,j,k-2))*idz0;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -368,25 +368,25 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
             Real dz0  = dz_ptr[k];
             Real dz1  = dz_ptr[k+1];
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfy = mf_vy(i,j,0);
 
             Real dv_dz = (c1 * v(i,j,k-1) + c2 * v(i,j,k  ) + c3 * v(i,j,k+1))*idz0;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k))*dxInv[1] * mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (zh_v_dir && (tbxyz.bigEnd(2) == domain_yz.bigEnd(2))) {
@@ -394,25 +394,25 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
             Real dz0  = dz_ptr[k-1];
             Real dz1  = dz_ptr[k-2];
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfy = mf_vy(i,j,0);
 
             Real dv_dz = -(c1 * v(i,j,k  ) + c2 * v(i,j,k-1) + c3 * v(i,j,k-2))*idz0;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -421,9 +421,9 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planecc = bxcc; planecc.setBig(2, planecc.smallEnd(2) );
         bxcc.growLo(2,-1);
 
-        ParallelFor(planecc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planecc, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real dz0  = dz_ptr[k];
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
             Real mfx = mf_mx(i,j,0);
             Real mfy = mf_my(i,j,0);
@@ -436,11 +436,11 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexy = tbxxy; planexy.setBig(2, planexy.smallEnd(2) );
         tbxxy.growLo(2,-1);
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        ParallelFor(planexy,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-            tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+            tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                  + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
             tau21(i,j,k) = tau12(i,j,k);
         });
@@ -453,34 +453,34 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2));
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dz_inv;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0] * mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (!zl_v_dir && (tbxyz.smallEnd(2) == domain_yz.smallEnd(2))) {
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dz_inv;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1] * mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -491,34 +491,34 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dz_inv;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]*mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (!zh_v_dir && (tbxyz.bigEnd(2) == domain_yz.bigEnd(2))) {
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
-            Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dz_inv;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]*mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -526,11 +526,11 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
     // Fill the interior cells
     //***********************************************************************************
     // Cell centered strains
-    ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    ParallelFor(bxcc, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real mfx = mf_mx(i,j,0);
         Real mfy = mf_my(i,j,0);
 
-        Real dz_inv = one / dz_ptr[k];
+        Real dz_inv = one_d / dz_ptr[k];
 
         tau11(i,j,k) = (u(i+1, j, k) - u(i, j, k))*dxInv[0] * mfx;
         tau22(i,j,k) = (v(i, j+1, k) - v(i, j, k))*dxInv[1] * mfy;
@@ -539,36 +539,36 @@ ComputeStrain_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
 
     // Off-diagonal strains
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-        Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+        Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
-        tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+        tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                              + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx);
         tau21(i,j,k) = tau12(i,j,k);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real mfx = mf_ux(i,j,0);
 
-        Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+        Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
         Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dz_inv;
-        tau13(i,j,k) = myhalf * ( du_dz
+        tau13(i,j,k) = myhalf_d * ( du_dz
                              + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0] * mfx );
         tau31(i,j,k) = tau13(i,j,k);
 
-        if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+        if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real mfy = mf_vy(i,j,0);
 
-        Real dz_inv = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
+        Real dz_inv = (k == 0) ? one_d / dz_ptr[k] : two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
         Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dz_inv;
-        tau23(i,j,k) = myhalf * ( dv_dz
+        tau23(i,j,k) = myhalf_d * ( dv_dz
                              + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1] * mfy );
         tau32(i,j,k) = tau23(i,j,k);
 
-        if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+        if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
     });
 }

--- a/Source/Diffusion/ERF_ComputeStrain_T.cpp
+++ b/Source/Diffusion/ERF_ComputeStrain_T.cpp
@@ -133,9 +133,9 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real inv_dist = (k == 0) ? two / (z_nd(i,j,k+2) - z_nd(i,j,k  )) :
-                                       two / (z_nd(i,j,k+2) + z_nd(i,j,k+1) - z_nd(i,j,k) - z_nd(i,j,k-1));
+        ParallelFor(planexy,[=,two_d=two,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real inv_dist = (k == 0) ? two_d / (z_nd(i,j,k+2) - z_nd(i,j,k  )) :
+                                       two_d / (z_nd(i,j,k+2) + z_nd(i,j,k+1) - z_nd(i,j,k) - z_nd(i,j,k-1));
 
             Real GradUz = (k == 0) ?
                             inv_dist * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
@@ -148,15 +148,15 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
                             inv_dist * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k-1) - v(i-1,j  ,k-1) );
 
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
             Real met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
             Real met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
-                                   + (-(Real(8.)/three) * v(i-1,j,k) + three * v(i,j,k) - (one/three) * v(i+1,j,k))*dxInv[0]*mfx
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
+                                   + (-(Real(8.)/three_d) * v(i-1,j,k) + three_d * v(i,j,k) - (one_d/three_d) * v(i+1,j,k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
                 // Note:
@@ -168,7 +168,7 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
                  // where ξ and η are in computational space, corresponding to
                  // x and y in physical space
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
@@ -181,9 +181,9 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::yvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real inv_dist = (k == 0) ? two / (z_nd(i,j,k+2) - z_nd(i,j,k  )) :
-                                       two / (z_nd(i,j,k+2) + z_nd(i,j,k+1) - z_nd(i,j,k) - z_nd(i,j,k-1));
+        ParallelFor(planexy,[=,two_d=two,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real inv_dist = (k == 0) ? two_d / (z_nd(i,j,k+2) - z_nd(i,j,k  )) :
+                                       two_d / (z_nd(i,j,k+2) + z_nd(i,j,k+1) - z_nd(i,j,k) - z_nd(i,j,k-1));
 
             Real GradUz = (k == 0) ?
                             inv_dist * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
@@ -196,19 +196,19 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
                             inv_dist * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k-1) - v(i-1,j  ,k-1) );
 
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
             Real met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
             Real met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
-                                   - (-(Real(8.)/three) * v(i,j,k) + three * v(i-1,j,k) - (one/three) * v(i-2,j,k))*dxInv[0]*mfx
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i, j-1, k) )*dxInv[1]*mfy
+                                   - (-(Real(8.)/three_d) * v(i,j,k) + three_d * v(i-1,j,k) - (one_d/three_d) * v(i-2,j,k))*dxInv[0]*mfx
                                    - (met_h_eta)*GradUz*mfy
                                    - (met_h_xi )*GradVz*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
@@ -223,12 +223,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growLo(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
+        ParallelFor(planexz,[=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
                               - z_nd(i,j,k-1) - z_nd(i,j+1,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
-            Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
+            Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
                                        - w(i  ,j  ,k-1) - w(i-1,j  ,k-1) );
             Real mfx = mf_ux(i,j,0);
 
@@ -236,9 +236,9 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             Real met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2]/met_h_zeta;
-            if (!need_to_test || u(dom_lo.x,j,k) >= zero) {
-                 tau13(i,j,k) = myhalf * ( du_dz
-                                      + ( (-(Real(8.)/three) * w(i-1,j,k) + three * w(i,j,k) - (one/three) * w(i+1,j,k))*dxInv[0]
+            if (!need_to_test || u(dom_lo.x,j,k) >= zero_d) {
+                 tau13(i,j,k) = myhalf_d * ( du_dz
+                                      + ( (-(Real(8.)/three_d) * w(i-1,j,k) + three_d * w(i,j,k) - (one_d/three_d) * w(i+1,j,k))*dxInv[0]
                                         - (met_h_xi)*GradWz ) * mfx );
                  // Note:
                  //   tau13 ~ (du/dζ) / (dz/dζ)
@@ -248,13 +248,13 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
                  // where ξ and ζ are in computational space, corresponding to
                  // x and z in physical space
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + ( (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]
                                        - (met_h_xi)*GradWz ) * mfx );
             }
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -264,12 +264,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxz.growHi(0,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(0) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
+        ParallelFor(planexz,[=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
                               - z_nd(i,j,k-1) - z_nd(i,j+1,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
-            Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
+            Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
                                        - w(i  ,j  ,k-1) - w(i-1,j  ,k-1) );
 
             Real mfx = mf_ux(i,j,0);
@@ -278,18 +278,18 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             Real met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
             Real du_dz = (u(i, j, k) - u(i, j, k-1))*dxInv[2]/met_h_zeta;
-            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero) {
-                tau13(i,j,k) = myhalf * ( du_dz
-                                     - ( (-(Real(8.)/three) * w(i,j,k) + three * w(i-1,j,k) - (one/three) * w(i-2,j,k))*dxInv[0]
+            if (!need_to_test || u(dom_hi.x+1,j,k) <= zero_d) {
+                tau13(i,j,k) = myhalf_d * ( du_dz
+                                     - ( (-(Real(8.)/three_d) * w(i,j,k) + three_d * w(i-1,j,k) - (one_d/three_d) * w(i-2,j,k))*dxInv[0]
                                        - (met_h_xi)*GradWz ) * mfx );
             } else {
-                tau13(i,j,k) = myhalf * ( du_dz
+                tau13(i,j,k) = myhalf_d * ( du_dz
                                      + ( (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]
                                        - (met_h_xi)*GradWz ) * mfx );
             }
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -301,34 +301,34 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexy,[=,one_d=one,myhalf_d=myhalf,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real dz0  = ( z_nd(i,j,k+1) - z_nd(i,j,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
             Real GradUz = (k == 0) ?
                                 idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                        - u(i  ,j  ,k  ) - u(i  ,j-1,k  ) ) :
-                       myhalf * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
+                       myhalf_d * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                        - u(i  ,j  ,k-1) - u(i  ,j-1,k-1) );
             Real GradVz = (k == 0) ?
                                 idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k  ) - v(i-1,j  ,k  ) ) :
-                       myhalf * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
+                       myhalf_d * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k-1) - v(i-1,j  ,k-1) );
 
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
             Real met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
             Real met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau12(i,j,k) = myhalf * ( (-(Real(8.)/three) * u(i,j-1,k) + three * u(i,j,k) - (one/three) * u(i,j+1,k))*dxInv[1]*mfy
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( (-(Real(8.)/three_d) * u(i,j-1,k) + three_d * u(i,j,k) - (one_d/three_d) * u(i,j+1,k))*dxInv[1]*mfy
                                    + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx
                                    - (met_h_eta)*GradUz*mfy
                                    - (met_h_xi )*GradVz*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
@@ -341,34 +341,34 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxxy.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::xvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexy,[=,one_d=one,myhalf_d=myhalf,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real dz0  = ( z_nd(i,j,k+1) - z_nd(i,j,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
             Real GradUz = (k == 0) ?
                                 idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                        - u(i  ,j  ,k  ) - u(i  ,j-1,k  ) ) :
-                       myhalf * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
+                       myhalf_d * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                        - u(i  ,j  ,k-1) - u(i  ,j-1,k-1) );
             Real GradVz = (k == 0) ?
                                 idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k  ) - v(i-1,j  ,k  ) ) :
-                       myhalf * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
+                       myhalf_d * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                        - v(i  ,j  ,k-1) - v(i-1,j  ,k-1) );
 
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
             Real met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
             Real met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau12(i,j,k) = myhalf * ( -(-(Real(8.)/three) * u(i,j,k) + three * u(i,j-1,k) - (one/three) * u(i,j-2,k))*dxInv[1]*mfy +
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau12(i,j,k) = myhalf_d * ( -(-(Real(8.)/three_d) * u(i,j,k) + three_d * u(i,j-1,k) - (one_d/three_d) * u(i,j-2,k))*dxInv[1]*mfy +
                                      + (v(i, j, k) - v(i-1, j, k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
             } else {
-                tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+                tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                      + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                      - (met_h_eta)*GradUz*mfy
                                      - (met_h_xi )*GradVz*mfx );
@@ -383,12 +383,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growLo(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].lo(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
                                  - z_nd(i,j,k-1) - z_nd(i+1,j,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
-            Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+            Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
                                           - w(i  ,j  ,k-1) - w(i  ,j-1,k-1) );
 
             Real mfy = mf_vy(i,j,0);
@@ -397,9 +397,9 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             Real met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2]/met_h_zeta;
-            if (!need_to_test || v(i,dom_lo.y,k) >= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     + ( (-(Real(8.)/three) * w(i,j-1,k) + three * w(i,j  ,k) - (one/three) * w(i,j+1,k))*dxInv[1]
+            if (!need_to_test || v(i,dom_lo.y,k) >= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     + ( (-(Real(8.)/three_d) * w(i,j-1,k) + three_d * w(i,j  ,k) - (one_d/three_d) * w(i,j+1,k))*dxInv[1]
                                        - (met_h_eta)*GradWz ) * mfy );
                 // Note:
                 //   tau23 ~ (dv/dζ) / (dz/dζ)
@@ -409,13 +409,13 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
                  // where η and ζ are in computational space, corresponding to
                  // y and z in physical space
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + ( (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]
                                        - (met_h_eta)*GradWz ) * mfy );
             }
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (yh_w_dir) {
@@ -424,12 +424,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         tbxyz.growHi(1,-1);
         bool need_to_test = (bc_ptr[BCVars::zvel_bc].hi(1) == ERFBCType::ext_dir_upwind) ? true : false;
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
                                  - z_nd(i,j,k-1) - z_nd(i+1,j,k-1) );
-            Real idz0 = one / dz0;
+            Real idz0 = one_d / dz0;
 
-            Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+            Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
                                        - w(i  ,j  ,k-1) - w(i  ,j-1,k-1) );
 
             Real mfy = mf_vy(i,j,0);
@@ -438,18 +438,18 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             Real met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
             Real dv_dz = (v(i, j, k) - v(i, j, k-1))*dxInv[2]/met_h_zeta;
-            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero) {
-                tau23(i,j,k) = myhalf * ( dv_dz
-                                     - ( (-(Real(8.)/three) * w(i,j  ,k) + three * w(i,j-1,k) - (one/three) * w(i,j-2,k))*dxInv[1]
+            if (!need_to_test || v(i,dom_hi.y+1,k) <= zero_d) {
+                tau23(i,j,k) = myhalf_d * ( dv_dz
+                                     - ( (-(Real(8.)/three_d) * w(i,j  ,k) + three_d * w(i,j-1,k) - (one_d/three_d) * w(i,j-2,k))*dxInv[1]
                                        - (met_h_eta)*GradWz ) * mfy );
             } else {
-                tau23(i,j,k) = myhalf * ( dv_dz
+                tau23(i,j,k) = myhalf_d * ( dv_dz
                                      + ( (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]
                                        - (met_h_eta)*GradWz ) * mfy );
             }
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -460,20 +460,20 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,myhalf_d=myhalf,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
                                  - z_nd(i,j,k  ) - z_nd(i,j+1,k  ) );
-            Real dz1  = myhalf * ( z_nd(i,j,k+2) + z_nd(i,j+1,k+2)
+            Real dz1  = myhalf_d * ( z_nd(i,j,k+2) + z_nd(i,j+1,k+2)
                                  - z_nd(i,j,k+1) - z_nd(i,j+1,k+1) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
-            Real GradWz = myhalf  * idz0 * ( w(i,j,k+1) + w(i-1,j,k+1)
+            Real GradWz = myhalf_d  * idz0 * ( w(i,j,k+1) + w(i-1,j,k+1)
                                         - w(i,j,k  ) - w(i-1,j,k  ) );
 
             Real mfx = mf_ux(i,j,0);
@@ -483,12 +483,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             // Note: u(i,j,k) and u(i,j,k+1) are located at cell centers
             //       whereas u(i,j,k-1) is the value on the boundary
             Real du_dz = (c1 * u(i,j,k-1) + c2 * u(i,j,k) + c3 * u(i,j,k+1))*idz0;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + ( (w(i, j, k) - w(i-1, j, k))*dxInv[0]
                                    - (met_h_xi)*GradWz ) * mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (zh_u_dir) {
@@ -496,27 +496,27 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,myhalf_d=myhalf,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
-            Real dz0  = myhalf * ( z_nd(i,j,k  ) + z_nd(i,j+1,k  )
+            Real dz0  = myhalf_d * ( z_nd(i,j,k  ) + z_nd(i,j+1,k  )
                                  - z_nd(i,j,k-1) - z_nd(i,j+1,k-1) );
-            Real dz1  = myhalf * ( z_nd(i,j,k-1) + z_nd(i,j+1,k-1)
+            Real dz1  = myhalf_d * ( z_nd(i,j,k-1) + z_nd(i,j+1,k-1)
                                  - z_nd(i,j,k-2) - z_nd(i,j+1,k-2) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfx = mf_ux(i,j,0);
 
             Real du_dz = -(c1 * u(i,j,k) + c2 * u(i,j,k-1) + c3 * u(i,j,k-2))*idz0;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  +  (w(i, j, k) - w(i-1, j, k))*dxInv[0]*mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
 
@@ -524,20 +524,20 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
-            Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
+            Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
                                  - z_nd(i,j,k  ) - z_nd(i+1,j,k  ) );
-            Real dz1  = myhalf * ( z_nd(i,j,k+2) + z_nd(i+1,j,k+2)
+            Real dz1  = myhalf_d * ( z_nd(i,j,k+2) + z_nd(i+1,j,k+2)
                                  - z_nd(i,j,k+1) - z_nd(i+1,j,k+1) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
-            Real GradWz = myhalf  * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+            Real GradWz = myhalf_d  * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
                                         - w(i  ,j  ,k  ) - w(i  ,j-1,k  ) );
 
             Real mfy = mf_vy(i,j,0);
@@ -548,12 +548,12 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
             // Note: v(i,j,k) and v(i,j,k+1) are located at cell centers
             //       whereas v(i,j,k-1) is the value on the boundary
             Real dv_dz = (c1 * v(i,j,k-1) + c2 * v(i,j,k  ) + c3 * v(i,j,k+1))*idz0;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + ( (w(i, j, k) - w(i, j-1, k))*dxInv[1]
                                    - (met_h_eta)*GradWz ) * mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
     if (zh_v_dir && (tbxyz.bigEnd(2) == domain_yz.bigEnd(2))) {
@@ -561,27 +561,27 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
-            Real dz0  = myhalf * ( z_nd(i,j,k  ) + z_nd(i+1,j,k  )
+            Real dz0  = myhalf_d * ( z_nd(i,j,k  ) + z_nd(i+1,j,k  )
                               - z_nd(i,j,k-1) - z_nd(i+1,j,k-1) );
-            Real dz1  = myhalf * ( z_nd(i,j,k-1) + z_nd(i+1,j,k-1)
+            Real dz1  = myhalf_d * ( z_nd(i,j,k-1) + z_nd(i+1,j,k-1)
                               - z_nd(i,j,k-2) - z_nd(i+1,j,k-2) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
             Real mfy = mf_vy(i,j,0);
 
             Real dv_dz = -(c1 * v(i,j,k  ) + c2 * v(i,j,k-1) + c3 * v(i,j,k-2))*idz0;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k))*dxInv[1]*mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -590,22 +590,22 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planecc = bxcc; planecc.setBig(2, planecc.smallEnd(2) );
         bxcc.growLo(2,-1);
 
-        ParallelFor(planecc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planecc, [=,fourth_d=fourth,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
-            Real dz0  = fourth * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1) + z_nd(i+1,j,k+1) + z_nd(i+1,j+1,k+1)
+            Real dz0  = fourth_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1) + z_nd(i+1,j,k+1) + z_nd(i+1,j+1,k+1)
                                - z_nd(i,j,k  ) - z_nd(i,j+1,k  ) - z_nd(i+1,j,k  ) - z_nd(i+1,j+1,k  ) );
-            Real dz1  = fourth * ( z_nd(i,j,k+2) + z_nd(i,j+1,k+2) + z_nd(i+1,j,k+2) + z_nd(i+1,j+1,k+2)
+            Real dz1  = fourth_d * ( z_nd(i,j,k+2) + z_nd(i,j+1,k+2) + z_nd(i+1,j,k+2) + z_nd(i+1,j+1,k+2)
                                - z_nd(i,j,k+1) - z_nd(i,j+1,k+1) - z_nd(i+1,j,k+1) - z_nd(i+1,j+1,k+1) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
-            Real GradUz = myhalf * idz0 * ( (c1 * u(i  ,j,k-1) + c2 * u(i  ,j,k) + c3 * u(i  ,j,k+1))
+            Real GradUz = myhalf_d * idz0 * ( (c1 * u(i  ,j,k-1) + c2 * u(i  ,j,k) + c3 * u(i  ,j,k+1))
                                           + (c1 * u(i-1,j,k-1) + c2 * u(i-1,j,k) + c3 * u(i-1,j,k+1)) );
-            Real GradVz = myhalf * idz0 * ( (c1 * v(i,j  ,k-1) + c2 * v(i,j  ,k) + c3 * v(i,j  ,k+1))
+            Real GradVz = myhalf_d * idz0 * ( (c1 * v(i,j  ,k-1) + c2 * v(i,j  ,k) + c3 * v(i,j  ,k+1))
                                           + (c1 * v(i,j-1,k-1) + c2 * v(i,j-1,k) + c3 * v(i,j-1,k+1)) );
 
             Real mfx = mf_mx(i,j,0);
@@ -626,30 +626,30 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexy = tbxxy; planexy.setBig(2, planexy.smallEnd(2) );
         tbxxy.growLo(2,-1);
 
-        ParallelFor(planexy,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexy,[=,one_d=one,two_d=two,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             // Third order stencil with variable dz
             Real dz0  = ( z_nd(i,j,k+1) - z_nd(i,j,k  ) );
             Real dz1  = ( z_nd(i,j,k+2) - z_nd(i,j,k+1) );
-            Real idz0 = one / dz0;
-            Real f    = (dz1 / dz0) + two;
+            Real idz0 = one_d / dz0;
+            Real f    = (dz1 / dz0) + two_d;
             Real f2   = f*f;
-            Real c3   = two / (f - f2);
+            Real c3   = two_d / (f - f2);
             Real c2   = -f2*c3;
-            Real c1   = -(one-f2)*c3;
+            Real c1   = -(one_d-f2)*c3;
 
-            Real GradUz = myhalf * idz0 * ( (c1 * u(i,j  ,k-1) + c2 * u(i,j  ,k) + c3 * u(i,j  ,k+1))
+            Real GradUz = myhalf_d * idz0 * ( (c1 * u(i,j  ,k-1) + c2 * u(i,j  ,k) + c3 * u(i,j  ,k+1))
                                           + (c1 * u(i,j-1,k-1) + c2 * u(i,j-1,k) + c3 * u(i,j-1,k+1)) );
-            Real GradVz = myhalf * idz0 * ( (c1 * v(i  ,j,k-1) + c2 * v(i  ,j,k) + c3 * v(i  ,j,k+1))
+            Real GradVz = myhalf_d * idz0 * ( (c1 * v(i  ,j,k-1) + c2 * v(i  ,j,k) + c3 * v(i  ,j,k+1))
                                           + (c1 * v(i-1,j,k-1) + c2 * v(i-1,j,k) + c3 * v(i-1,j,k+1)) );
 
-            Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-            Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+            Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+            Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
             Real met_h_xi,met_h_eta;
             met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
             met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-            tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+            tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                  + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                  - (met_h_eta)*GradUz*mfy
                                  - (met_h_xi )*GradVz*mfx );
@@ -664,48 +664,48 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2));
         tbxxz.growLo(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
             Real met_h_xi,met_h_zeta;
             met_h_xi   = Compute_h_xi_AtEdgeCenterJ  (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-            Real GradWz = myhalf  * dxInv[2] * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
+            Real GradWz = myhalf_d  * dxInv[2] * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
                                                - w(i  ,j  ,k  ) - w(i-1,j  ,k  ) );
             GradWz /= met_h_zeta;
 
             Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dxInv[2]/met_h_zeta;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + ( (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]
                                    - (met_h_xi)*GradWz ) * mfx);
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (!zl_v_dir && (tbxyz.smallEnd(2) == domain_yz.smallEnd(2))) {
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
             Real met_h_eta,met_h_zeta;
             met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-            Real GradWz = myhalf  * dxInv[2] * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+            Real GradWz = myhalf_d  * dxInv[2] * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
                                                - w(i  ,j  ,k  ) - w(i  ,j-1,k  ) );
             GradWz /= met_h_zeta;
 
             Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dxInv[2]/met_h_zeta;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + ( (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]
                                    - (met_h_eta)*GradWz ) * mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -716,36 +716,36 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
 
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planexz,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfx = mf_ux(i,j,0);
 
             Real met_h_zeta;
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
             Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dxInv[2]/met_h_zeta;
-            tau13(i,j,k) = myhalf * ( du_dz
+            tau13(i,j,k) = myhalf_d * ( du_dz
                                  + (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]*mfx );
             tau31(i,j,k) = tau13(i,j,k);
 
-            if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+            if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
         });
     }
     if (!zh_v_dir && (tbxyz.bigEnd(2) == domain_yz.bigEnd(2))) {
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
 
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(planeyz,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real mfy = mf_vy(i,j,0);
 
             Real met_h_zeta;
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
             Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dxInv[2]/met_h_zeta;
-            tau23(i,j,k) = myhalf * ( dv_dz
+            tau23(i,j,k) = myhalf_d * ( dv_dz
                                  + (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]*mfy );
             tau32(i,j,k) = tau23(i,j,k);
 
-            if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+            if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
         });
     }
 
@@ -753,20 +753,20 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
     // Fill the interior cells
     //***********************************************************************************
     // Cell centered strains
-    ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        Real dz0  = fourth * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1) + z_nd(i+1,j,k+1) + z_nd(i+1,j+1,k+1)
+    ParallelFor(bxcc, [=,fourth_d=fourth,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real dz0  = fourth_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1) + z_nd(i+1,j,k+1) + z_nd(i+1,j+1,k+1)
                            - z_nd(i,j,k-1) - z_nd(i,j+1,k-1) - z_nd(i+1,j,k-1) - z_nd(i+1,j+1,k-1) );
-        Real idz0 = one / dz0;
+        Real idz0 = one_d / dz0;
 
         Real GradUz = (k == 0) ?
                             idz0 * ( u(i  ,j  ,k+1) + u(i-1,j  ,k+1)
                                    - u(i  ,j  ,k  ) - u(i-1,j  ,k  ) ) :
-                   myhalf * idz0 * ( u(i  ,j  ,k+1) + u(i-1,j  ,k+1)
+                   myhalf_d * idz0 * ( u(i  ,j  ,k+1) + u(i-1,j  ,k+1)
                                    - u(i  ,j  ,k-1) - u(i-1,j  ,k-1) );
         Real GradVz = (k == 0) ?
                             idz0 * ( v(i  ,j  ,k+1) + v(i  ,j-1,k+1)
                                    - v(i  ,j  ,k  ) - v(i  ,j-1,k  ) ) :
-                   myhalf * idz0 * ( v(i  ,j  ,k+1) + v(i  ,j-1,k+1)
+                   myhalf_d * idz0 * ( v(i  ,j  ,k+1) + v(i  ,j-1,k+1)
                                    - v(i  ,j  ,k-1) - v(i  ,j-1,k-1) );
 
         Real mfx = mf_mx(i,j,0);
@@ -784,40 +784,40 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
 
     // Off-diagonal strains
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         Real dz0  = ( z_nd(i,j,k+1) - z_nd(i,j,k-1) );
-        Real idz0 = one / dz0;
+        Real idz0 = one_d / dz0;
 
         Real GradUz = (k == 0) ?
                             idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                    - u(i  ,j  ,k  ) - u(i  ,j-1,k  ) ) :
-                   myhalf * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
+                   myhalf_d * idz0 * ( u(i  ,j  ,k+1) + u(i  ,j-1,k+1)
                                    - u(i  ,j  ,k-1) - u(i  ,j-1,k-1) );
         Real GradVz = (k == 0) ?
                             idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                    - v(i  ,j  ,k  ) - v(i-1,j  ,k  ) ) :
-                   myhalf * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
+                   myhalf_d * idz0 * ( v(i  ,j  ,k+1) + v(i-1,j  ,k+1)
                                    - v(i  ,j  ,k-1) - v(i-1,j  ,k-1) );
 
-        Real mfy = myhalf * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
-        Real mfx = myhalf * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
+        Real mfy = myhalf_d * (mf_uy(i,j,0) + mf_uy(i  ,j-1,0));
+        Real mfx = myhalf_d * (mf_vx(i,j,0) + mf_vx(i-1,j  ,0));
 
         Real met_h_xi,met_h_eta;
         met_h_xi   = Compute_h_xi_AtEdgeCenterK  (i,j,k,dxInv,z_nd);
         met_h_eta  = Compute_h_eta_AtEdgeCenterK (i,j,k,dxInv,z_nd);
 
-        tau12(i,j,k) = myhalf * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
+        tau12(i,j,k) = myhalf_d * ( (u(i, j, k) - u(i  , j-1, k))*dxInv[1]*mfy
                                 + (v(i, j, k) - v(i-1, j  , k))*dxInv[0]*mfx
                                 - (met_h_eta)*GradUz*mfy
                                 - (met_h_xi )*GradVz*mfx );
         tau21(i,j,k) = tau12(i,j,k);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
+    [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i,j+1,k+1)
                              - z_nd(i,j,k-1) - z_nd(i,j+1,k-1) );
-        Real idz0 = one / dz0;
+        Real idz0 = one_d / dz0;
 
-        Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
+        Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i-1,j  ,k+1)
                                       - w(i  ,j  ,k-1) - w(i-1,j  ,k-1) );
 
         Real mfx = mf_ux(i,j,0);
@@ -827,19 +827,19 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
         Real du_dz = (u(i, j, k) - u(i  , j, k-1))*dxInv[2]/met_h_zeta;
-        tau13(i,j,k) = myhalf * ( du_dz
+        tau13(i,j,k) = myhalf_d * ( du_dz
                              + ( (w(i, j, k) - w(i-1, j, k  ))*dxInv[0]
                                - (met_h_xi)*GradWz ) * mfx );
         tau31(i,j,k) = tau13(i,j,k);
 
-        if (tau13i) tau13i(i,j,k) = myhalf * du_dz;
+        if (tau13i) tau13i(i,j,k) = myhalf_d * du_dz;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        Real dz0  = myhalf * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
+    [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        Real dz0  = myhalf_d * ( z_nd(i,j,k+1) + z_nd(i+1,j,k+1)
                              - z_nd(i,j,k-1) - z_nd(i+1,j,k-1) );
-        Real idz0 = one / dz0;
+        Real idz0 = one_d / dz0;
 
-        Real GradWz = myhalf * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
+        Real GradWz = myhalf_d * idz0 * ( w(i  ,j  ,k+1) + w(i  ,j-1,k+1)
                                       - w(i  ,j  ,k-1) - w(i  ,j-1,k-1) );
 
         Real mfy = mf_vy(i,j,0);
@@ -849,11 +849,11 @@ ComputeStrain_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Box domain,
         met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
         Real dv_dz = (v(i, j, k) - v(i, j  , k-1))*dxInv[2]/met_h_zeta;
-        tau23(i,j,k) = myhalf * ( dv_dz
+        tau23(i,j,k) = myhalf_d * ( dv_dz
                              + ( (w(i, j, k) - w(i, j-1, k  ))*dxInv[1]
                                - (met_h_eta)*GradWz ) * mfy );
         tau32(i,j,k) = tau23(i,j,k);
 
-        if (tau23i) tau23i(i,j,k) = myhalf * dv_dz;
+        if (tau23i) tau23i(i,j,k) = myhalf_d * dv_dz;
     });
 }

--- a/Source/Diffusion/ERF_ComputeStress_EB.cpp
+++ b/Source/Diffusion/ERF_ComputeStress_EB.cpp
@@ -52,46 +52,46 @@ ComputeStressConsVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff
 
         // Off-diagonal strains
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j-1,k) + vfrac(i-1,j-1,k);
-            Real rho_bar = zero;
+            Real rho_bar = zero_d;
             if (vol_sum > Real(1.e-16)) {
                 rho_bar = ( vfrac(i-1,j,k) * cell_data(i-1, j  , k, Rho_comp)
                             + vfrac(i,j,k) * cell_data(i, j  , k, Rho_comp)
                             + vfrac(i-1,j-1,k) * cell_data(i-1, j-1, k, Rho_comp)
                             + vfrac(i,j-1,k) * cell_data(i, j-1, k, Rho_comp) ) / vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
+                rho_bar = fourth_d*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
                                + cell_data(i-1, j-1, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             }
             tau12(i,j,k) *= -rho_bar * mu_eff;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j,k-1) + vfrac(i-1,j,k-1);
-            Real rho_bar = zero;
+            Real rho_bar = zero_d;
             if (vol_sum > Real(1.e-16)) {
                 rho_bar = ( vfrac(i-1,j,k) * cell_data(i-1, j, k  , Rho_comp)
                             + vfrac(i,j,k) * cell_data(i, j, k  , Rho_comp)
                             + vfrac(i-1,j,k-1) * cell_data(i-1, j, k-1, Rho_comp)
                             + vfrac(i,j,k-1) * cell_data(i, j, k-1, Rho_comp) )/ vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+                rho_bar = fourth_d*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i-1, j, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             }
             tau13(i,j,k) *= -rho_bar * mu_eff;
 
             if (tau13i) tau13i(i,j,k) *= -rho_bar * mu_eff;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i,j-1,k) + vfrac(i,j,k-1) + vfrac(i,j-1,k-1);
-            Real rho_bar = zero;
+            Real rho_bar = zero_d;
             if (vol_sum > Real(1.e-16)) {
                 rho_bar = ( vfrac(i,j-1,k) * cell_data(i, j-1, k  , Rho_comp)
                             + vfrac(i,j,k) * cell_data(i, j, k  , Rho_comp)
                             + vfrac(i,j-1,k-1) * cell_data(i, j-1, k-1, Rho_comp)
                             + vfrac(i,j,k-1) * cell_data(i, j, k-1, Rho_comp) ) / vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+                rho_bar = fourth_d*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i, j-1, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             }
             tau23(i,j,k) *= -rho_bar * mu_eff;
@@ -173,27 +173,27 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // constant alpha (stored in mu_eff)
     {
         // Cell centered strains (no EB correction needed — cell-centered quantities)
-        ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (vfrac(i,j,k) > zero) {
+        ParallelFor(bxcc, [=,zero_d=zero,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (vfrac(i,j,k) > zero_d) {
                 Real rhoAlpha = cell_data(i, j, k, Rho_comp) * mu_eff;
-                Real mu_11 = rhoAlpha + two * mu_turb(i, j, k, EddyDiff::Mom_h);
+                Real mu_11 = rhoAlpha + two_d * mu_turb(i, j, k, EddyDiff::Mom_h);
                 Real mu_22 = mu_11;
-                Real mu_33 = rhoAlpha + two * mu_turb(i, j, k, EddyDiff::Mom_v);
+                Real mu_33 = rhoAlpha + two_d * mu_turb(i, j, k, EddyDiff::Mom_v);
                 if (tau33i) tau33i(i,j,k) = -mu_33 * tau33(i,j,k);
                 tau11(i,j,k) = -mu_11 * ( tau11(i,j,k) - OneThird*er_arr(i,j,k) );
                 tau22(i,j,k) = -mu_22 * ( tau22(i,j,k) - OneThird*er_arr(i,j,k) );
                 tau33(i,j,k) = -mu_33 * ( tau33(i,j,k) - OneThird*er_arr(i,j,k) );
             } else {
-                if (tau33i) tau33i(i,j,k) = zero;
-                tau11(i,j,k) = zero;
-                tau22(i,j,k) = zero;
-                tau33(i,j,k) = zero;
+                if (tau33i) tau33i(i,j,k) = zero_d;
+                tau11(i,j,k) = zero_d;
+                tau22(i,j,k) = zero_d;
+                tau33(i,j,k) = zero_d;
             }
         });
 
         // Off-diagonal strains: vfrac-weighted rho_bar and mu_bar
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j-1,k) + vfrac(i-1,j-1,k);
             Real rho_bar, mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -206,15 +206,15 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                           + vfrac(i-1,j-1,k) * mu_turb(i-1, j-1, k, EddyDiff::Mom_h)
                           + vfrac(i  ,j-1,k) * mu_turb(i  , j-1, k, EddyDiff::Mom_h) ) / vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i  , j  , k, Rho_comp)
+                rho_bar = fourth_d*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i  , j  , k, Rho_comp)
                                + cell_data(i-1, j-1, k, Rho_comp) + cell_data(i  , j-1, k, Rho_comp) );
-                mu_bar  = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i  , j  , k, EddyDiff::Mom_h)
+                mu_bar  = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i  , j  , k, EddyDiff::Mom_h)
                                + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i  , j-1, k, EddyDiff::Mom_h) );
             }
-            Real mu_12 = rho_bar*mu_eff + two*mu_bar;
+            Real mu_12 = rho_bar*mu_eff + two_d*mu_bar;
             tau12(i,j,k) *= -mu_12;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j,k-1) + vfrac(i-1,j,k-1);
             Real rho_bar, mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -227,16 +227,16 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                           + vfrac(i-1,j,k-1) * mu_turb(i-1, j, k-1, EddyDiff::Mom_v)
                           + vfrac(i  ,j,k-1) * mu_turb(i  , j, k-1, EddyDiff::Mom_v) ) / vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i  , j, k  , Rho_comp)
+                rho_bar = fourth_d*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i  , j, k  , Rho_comp)
                                  + cell_data(i-1, j, k-1, Rho_comp) + cell_data(i  , j, k-1, Rho_comp) );
-                mu_bar  = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i  , j, k  , EddyDiff::Mom_v)
+                mu_bar  = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i  , j, k  , EddyDiff::Mom_v)
                                  + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i  , j, k-1, EddyDiff::Mom_v) );
             }
-            Real mu_13 = rho_bar*mu_eff + two*mu_bar;
+            Real mu_13 = rho_bar*mu_eff + two_d*mu_bar;
             tau13(i,j,k) *= -mu_13;
             if (tau13i) tau13i(i,j,k) *= -mu_13;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i,j-1,k) + vfrac(i,j,k-1) + vfrac(i,j-1,k-1);
             Real rho_bar, mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -249,12 +249,12 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                           + vfrac(i,j-1,k-1) * mu_turb(i, j-1, k-1, EddyDiff::Mom_v)
                           + vfrac(i,j  ,k-1) * mu_turb(i, j  , k-1, EddyDiff::Mom_v) ) / vol_sum;
             } else {
-                rho_bar = fourth*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j  , k  , Rho_comp)
+                rho_bar = fourth_d*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j  , k  , Rho_comp)
                                  + cell_data(i, j-1, k-1, Rho_comp) + cell_data(i, j  , k-1, Rho_comp) );
-                mu_bar  = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j  , k  , EddyDiff::Mom_v)
+                mu_bar  = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j  , k  , EddyDiff::Mom_v)
                                  + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j  , k-1, EddyDiff::Mom_v) );
             }
-            Real mu_23 = rho_bar*mu_eff + two*mu_bar;
+            Real mu_23 = rho_bar*mu_eff + two_d*mu_bar;
             tau23(i,j,k) *= -mu_23;
             if (tau23i) tau23i(i,j,k) *= -mu_23;
         });
@@ -263,26 +263,26 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // constant mu_eff
     {
         // Cell centered strains
-        ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            if (vfrac(i,j,k) > zero) {
-                Real mu_11 = mu_eff + two * mu_turb(i, j, k, EddyDiff::Mom_h);
+        ParallelFor(bxcc, [=,zero_d=zero,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            if (vfrac(i,j,k) > zero_d) {
+                Real mu_11 = mu_eff + two_d * mu_turb(i, j, k, EddyDiff::Mom_h);
                 Real mu_22 = mu_11;
-                Real mu_33 = mu_eff + two * mu_turb(i, j, k, EddyDiff::Mom_v);
+                Real mu_33 = mu_eff + two_d * mu_turb(i, j, k, EddyDiff::Mom_v);
                 if (tau33i) tau33i(i,j,k) = -mu_33 * tau33(i,j,k);
                 tau11(i,j,k) = -mu_11 * ( tau11(i,j,k) - OneThird*er_arr(i,j,k) );
                 tau22(i,j,k) = -mu_22 * ( tau22(i,j,k) - OneThird*er_arr(i,j,k) );
                 tau33(i,j,k) = -mu_33 * ( tau33(i,j,k) - OneThird*er_arr(i,j,k) );
             } else {
-                if (tau33i) tau33i(i,j,k) = zero;
-                tau11(i,j,k) = zero;
-                tau22(i,j,k) = zero;
-                tau33(i,j,k) = zero;
+                if (tau33i) tau33i(i,j,k) = zero_d;
+                tau11(i,j,k) = zero_d;
+                tau22(i,j,k) = zero_d;
+                tau33(i,j,k) = zero_d;
             }
         });
 
         // Off-diagonal strains: vfrac-weighted mu_bar
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j-1,k) + vfrac(i-1,j-1,k);
             Real mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -291,13 +291,13 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                          + vfrac(i-1,j-1,k) * mu_turb(i-1, j-1, k, EddyDiff::Mom_h)
                          + vfrac(i  ,j-1,k) * mu_turb(i  , j-1, k, EddyDiff::Mom_h) ) / vol_sum;
             } else {
-                mu_bar = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i  , j  , k, EddyDiff::Mom_h)
+                mu_bar = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i  , j  , k, EddyDiff::Mom_h)
                                 + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i  , j-1, k, EddyDiff::Mom_h) );
             }
-            Real mu_12 = mu_eff + two*mu_bar;
+            Real mu_12 = mu_eff + two_d*mu_bar;
             tau12(i,j,k) *= -mu_12;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i-1,j,k) + vfrac(i,j,k-1) + vfrac(i-1,j,k-1);
             Real mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -306,14 +306,14 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                          + vfrac(i-1,j,k-1) * mu_turb(i-1, j, k-1, EddyDiff::Mom_v)
                          + vfrac(i  ,j,k-1) * mu_turb(i  , j, k-1, EddyDiff::Mom_v) ) / vol_sum;
             } else {
-                mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i  , j, k  , EddyDiff::Mom_v)
+                mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i  , j, k  , EddyDiff::Mom_v)
                                 + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i  , j, k-1, EddyDiff::Mom_v) );
             }
-            Real mu_13 = mu_eff + two*mu_bar;
+            Real mu_13 = mu_eff + two_d*mu_bar;
             tau13(i,j,k) *= -mu_13;
             if (tau13i) tau13i(i,j,k) *= -mu_13;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real vol_sum = vfrac(i,j,k) + vfrac(i,j-1,k) + vfrac(i,j,k-1) + vfrac(i,j-1,k-1);
             Real mu_bar;
             if (vol_sum > Real(1.e-16)) {
@@ -322,10 +322,10 @@ ComputeStressVarVisc_EB (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
                          + vfrac(i,j-1,k-1) * mu_turb(i, j-1, k-1, EddyDiff::Mom_v)
                          + vfrac(i,j  ,k-1) * mu_turb(i, j  , k-1, EddyDiff::Mom_v) ) / vol_sum;
             } else {
-                mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j  , k  , EddyDiff::Mom_v)
+                mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j  , k  , EddyDiff::Mom_v)
                                 + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j  , k-1, EddyDiff::Mom_v) );
             }
-            Real mu_23 = mu_eff + two*mu_bar;
+            Real mu_23 = mu_eff + two_d*mu_bar;
             tau23(i,j,k) *= -mu_23;
             if (tau23i) tau23i(i,j,k) *= -mu_23;
         });

--- a/Source/Diffusion/ERF_ComputeStress_N.cpp
+++ b/Source/Diffusion/ERF_ComputeStress_N.cpp
@@ -51,20 +51,20 @@ ComputeStressConsVisc_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         // Off-diagonal strains
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
+        [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
                                 + cell_data(i-1, j-1, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             tau12(i,j,k) *= -rho_bar * mu_eff;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+        [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i-1, j, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             tau13(i,j,k) *= -rho_bar * mu_eff;
 
             if (tau13i) tau13i(i,j,k) *= -rho_bar * mu_eff;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+        [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i, j-1, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             tau23(i,j,k) *= -rho_bar * mu_eff;
 
@@ -141,11 +141,11 @@ ComputeStressVarVisc_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // constant alpha (stored in mu_eff)
     {
         // Cell centered strains
-        ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(bxcc, [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real rhoAlpha = cell_data(i, j, k, Rho_comp) * mu_eff;
-            Real mu_11 = rhoAlpha + two * mu_turb(i, j, k, EddyDiff::Mom_h);
+            Real mu_11 = rhoAlpha + two_d * mu_turb(i, j, k, EddyDiff::Mom_h);
             Real mu_22 = mu_11;
-            Real mu_33 = rhoAlpha + two * mu_turb(i, j, k, EddyDiff::Mom_v);
+            Real mu_33 = rhoAlpha + two_d * mu_turb(i, j, k, EddyDiff::Mom_v);
             if (tau33i) tau33i(i,j,k) = -mu_33 * tau33(i,j,k);
             tau11(i,j,k) = -mu_11 * ( tau11(i,j,k) - OneThird*er_arr(i,j,k) );
             tau22(i,j,k) = -mu_22 * ( tau22(i,j,k) - OneThird*er_arr(i,j,k) );
@@ -154,30 +154,30 @@ ComputeStressVarVisc_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         // Off-diagonal strains
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i-1, j  , k, Rho_comp) + cell_data(i, j  , k, Rho_comp)
                                 + cell_data(i-1, j-1, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
-            Real mu_bar = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
+            Real mu_bar = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
                                + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i, j-1, k, EddyDiff::Mom_h) );
-            Real mu_12  = rho_bar*mu_eff + two*mu_bar;
+            Real mu_12  = rho_bar*mu_eff + two_d*mu_bar;
             tau12(i,j,k) *= -mu_12;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i-1, j, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i-1, j, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
-            Real mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real mu_13  = rho_bar*mu_eff + two*mu_bar;
+            Real mu_13  = rho_bar*mu_eff + two_d*mu_bar;
             tau13(i,j,k) *= -mu_13;
 
             if (tau13i) tau13i(i,j,k) *= -mu_13;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real rho_bar = fourth*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real rho_bar = fourth_d*( cell_data(i, j-1, k  , Rho_comp) + cell_data(i, j, k  , Rho_comp)
                                 + cell_data(i, j-1, k-1, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
-            Real mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real mu_23  = rho_bar*mu_eff + two*mu_bar;
+            Real mu_23  = rho_bar*mu_eff + two_d*mu_bar;
             tau23(i,j,k) *= -mu_23;
 
             if (tau23i) tau23i(i,j,k) *= -mu_23;
@@ -187,10 +187,10 @@ ComputeStressVarVisc_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // constant mu_eff
     {
         // Cell centered strains
-        ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mu_11 = mu_eff + two * mu_turb(i, j, k, EddyDiff::Mom_h);
+        ParallelFor(bxcc, [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_11 = mu_eff + two_d * mu_turb(i, j, k, EddyDiff::Mom_h);
             Real mu_22 = mu_11;
-            Real mu_33 = mu_eff + two * mu_turb(i, j, k, EddyDiff::Mom_v);
+            Real mu_33 = mu_eff + two_d * mu_turb(i, j, k, EddyDiff::Mom_v);
             if (tau33i) tau33i(i,j,k) = -mu_33 * tau33(i,j,k);
             tau11(i,j,k) = -mu_11 * ( tau11(i,j,k) - OneThird*er_arr(i,j,k) );
             tau22(i,j,k) = -mu_22 * ( tau22(i,j,k) - OneThird*er_arr(i,j,k) );
@@ -199,24 +199,24 @@ ComputeStressVarVisc_N (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         // Off-diagonal strains
         ParallelFor(tbxxy,tbxxz,tbxyz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mu_bar = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_bar = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
                                + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i, j-1, k, EddyDiff::Mom_h) );
-            Real mu_12  = mu_eff + two*mu_bar;
+            Real mu_12  = mu_eff + two_d*mu_bar;
             tau12(i,j,k) *= -mu_12;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real mu_13  = mu_eff + two*mu_bar;
+            Real mu_13  = mu_eff + two_d*mu_bar;
             tau13(i,j,k) *= -mu_13;
 
             if (tau13i) tau13i(i,j,k) *= -mu_13;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+        [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real mu_23  = mu_eff + two*mu_bar;
+            Real mu_23  = mu_eff + two_d*mu_bar;
             tau23(i,j,k) *= -mu_23;
 
             if (tau23i) tau23i(i,j,k) *= -mu_23;

--- a/Source/Diffusion/ERF_ComputeStress_S.cpp
+++ b/Source/Diffusion/ERF_ComputeStress_S.cpp
@@ -95,22 +95,22 @@ ComputeStressConsVisc_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Second block: off diagonal stresses
     //***********************************************************************************
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real mfx = myhalf * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
-        Real mfy = myhalf * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
+        Real mfx = myhalf_d * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
+        Real mfy = myhalf_d * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
 
-        Real mu_tot = fourth*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
+        Real mu_tot = fourth_d*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
                            + rhoAlpha(i-1, j-1, k) + rhoAlpha(i, j-1, k) );
 
         tau12(i,j,k) *= -mu_tot / mfx;
         tau21(i,j,k) *= -mu_tot / mfy;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfy = mf_uy(i,j,0);
 
-        Real mu_tot = fourth * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
+        Real mu_tot = fourth_d * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
                              + rhoAlpha(i-1, j  , k-1) + rhoAlpha(i  , j  , k-1) );
 
         tau13(i,j,k) *= -mu_tot;
@@ -118,11 +118,11 @@ ComputeStressConsVisc_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         if (tau13i) tau13i(i,j,k) *= -mu_tot;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_vx(i,j,0);
 
-        Real mu_tot = fourth * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
+        Real mu_tot = fourth_d * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
                              + rhoAlpha(i  , j-1, k-1) + rhoAlpha(i  , j  , k-1) );
 
         tau23(i,j,k) *= -mu_tot;
@@ -209,14 +209,14 @@ ComputeStressVarVisc_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // First block: cell centered stresses
     //***********************************************************************************
     Real OneThird   = (one/three);
-    ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bxcc, [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_mx(i,j,0);
         Real mfy = mf_my(i,j,0);
 
-        Real mu_11 = rhoAlpha(i,j,k) + two * mu_turb(i, j, k, EddyDiff::Mom_h);
+        Real mu_11 = rhoAlpha(i,j,k) + two_d * mu_turb(i, j, k, EddyDiff::Mom_h);
         Real mu_22 = mu_11;
-        Real mu_33 = rhoAlpha(i,j,k) + two * mu_turb(i, j, k, EddyDiff::Mom_v);
+        Real mu_33 = rhoAlpha(i,j,k) + two_d * mu_turb(i, j, k, EddyDiff::Mom_v);
 
         if (tau33i) tau33i(i,j,k) = -mu_33 * tau33(i,j,k);
 
@@ -228,44 +228,44 @@ ComputeStressVarVisc_S (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Second block: off diagonal stresses
     //***********************************************************************************
     ParallelFor(tbxxy,tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real mfx = myhalf * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
-        Real mfy = myhalf * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
+        Real mfx = myhalf_d * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
+        Real mfy = myhalf_d * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
 
-        Real mu_bar = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
+        Real mu_bar = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
                            + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i, j-1, k, EddyDiff::Mom_h) );
-        Real rhoAlpha_bar = fourth*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
+        Real rhoAlpha_bar = fourth_d*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
                                  + rhoAlpha(i-1, j-1, k) + rhoAlpha(i, j-1, k) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau12(i,j,k) *= -mu_tot / mfx;
         tau21(i,j,k) *= -mu_tot / mfy;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfy = mf_uy(i,j,0);
 
-        Real mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+        Real mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                            + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-        Real rhoAlpha_bar = fourth*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
+        Real rhoAlpha_bar = fourth_d*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
                                  + rhoAlpha(i-1, j, k-1) + rhoAlpha(i, j, k-1) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau13(i,j,k) *= -mu_tot;
         tau31(i,j,k) *= -mu_tot / mfy;
 
         if (tau13i) tau13i(i,j,k) *= -mu_tot;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_vx(i,j,0);
 
-        Real mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+        Real mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                            + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-        Real rhoAlpha_bar = fourth*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
+        Real rhoAlpha_bar = fourth_d*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
                                  + rhoAlpha(i, j-1, k-1) + rhoAlpha(i, j, k-1) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau23(i,j,k) *= -mu_tot;
         tau32(i,j,k) *= -mu_tot / mfx;

--- a/Source/Diffusion/ERF_ComputeStress_T.cpp
+++ b/Source/Diffusion/ERF_ComputeStress_T.cpp
@@ -102,7 +102,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Fill tau33 first (no linear combination extrapolation)
     //-----------------------------------------------------------------------------------
     ParallelFor(bxcc2,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_mx(i,j,0);
         Real mfy = mf_my(i,j,0);
@@ -111,9 +111,9 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_xi   = Compute_h_xi_AtCellCenter  (i,j,k,dxInv,z_nd);
         met_h_eta  = Compute_h_eta_AtCellCenter (i,j,k,dxInv,z_nd);
 
-        Real tau31bar = fourth * ( tau31(i  , j  , k  ) + tau31(i+1, j  , k  )
+        Real tau31bar = fourth_d * ( tau31(i  , j  , k  ) + tau31(i+1, j  , k  )
                                  + tau31(i  , j  , k+1) + tau31(i+1, j  , k+1) );
-        Real tau32bar = fourth * ( tau32(i  , j  , k  ) + tau32(i  , j+1, k  )
+        Real tau32bar = fourth_d * ( tau32(i  , j  , k  ) + tau32(i  , j+1, k  )
                                  + tau32(i  , j  , k+1) + tau32(i  , j+1, k+1) );
         Real mu_tot   = rhoAlpha(i,j,k);
 
@@ -131,7 +131,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     {
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planexz,[=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_ux(i,j,0);
             Real mfy = mf_uy(i,j,0);
@@ -141,15 +141,15 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-            Real tau11lo  = myhalf * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  ) );
-            Real tau11hi  = myhalf * ( tau11(i  , j  , k+1) + tau11(i-1, j  , k+1) );
-            Real tau11bar = Real(1.5)*tau11lo - myhalf*tau11hi;
+            Real tau11lo  = myhalf_d * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  ) );
+            Real tau11hi  = myhalf_d * ( tau11(i  , j  , k+1) + tau11(i-1, j  , k+1) );
+            Real tau11bar = Real(1.5)*tau11lo - myhalf_d*tau11hi;
 
-            Real tau12lo  = myhalf * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  ) );
-            Real tau12hi  = myhalf * ( tau12(i  , j  , k+1) + tau12(i  , j+1, k+1) );
-            Real tau12bar = Real(1.5)*tau12lo - myhalf*tau12hi;
+            Real tau12lo  = myhalf_d * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  ) );
+            Real tau12hi  = myhalf_d * ( tau12(i  , j  , k+1) + tau12(i  , j+1, k+1) );
+            Real tau12bar = Real(1.5)*tau12lo - myhalf_d*tau12hi;
 
-            Real mu_tot = fourth*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
+            Real mu_tot = fourth_d*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
                                + rhoAlpha(i-1, j, k-1) + rhoAlpha(i, j, k-1) );
 
             tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
@@ -161,7 +161,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_vx(i,j,0);
             Real mfy = mf_vy(i,j,0);
@@ -171,15 +171,15 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-            Real tau21lo  = myhalf * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  ) );
-            Real tau21hi  = myhalf * ( tau21(i  , j  , k+1) + tau21(i+1, j  , k+1) );
-            Real tau21bar = Real(1.5)*tau21lo - myhalf*tau21hi;
+            Real tau21lo  = myhalf_d * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  ) );
+            Real tau21hi  = myhalf_d * ( tau21(i  , j  , k+1) + tau21(i+1, j  , k+1) );
+            Real tau21bar = Real(1.5)*tau21lo - myhalf_d*tau21hi;
 
-            Real tau22lo  = myhalf * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  ) );
-            Real tau22hi  = myhalf * ( tau22(i  , j  , k+1) + tau22(i  , j-1, k+1) );
-            Real tau22bar = Real(1.5)*tau22lo - myhalf*tau22hi;
+            Real tau22lo  = myhalf_d * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  ) );
+            Real tau22hi  = myhalf_d * ( tau22(i  , j  , k+1) + tau22(i  , j-1, k+1) );
+            Real tau22bar = Real(1.5)*tau22lo - myhalf_d*tau22hi;
 
-            Real mu_tot = fourth*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
+            Real mu_tot = fourth_d*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
                                + rhoAlpha(i, j-1, k-1) + rhoAlpha(i, j, k-1) );
 
             tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
@@ -193,7 +193,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     {
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planexz,[=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_ux(i,j,0);
             Real mfy = mf_uy(i,j,0);
@@ -203,15 +203,15 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-            Real tau11lo  = myhalf * ( tau11(i  , j  , k-2) + tau11(i-1, j  , k-2) );
-            Real tau11hi  = myhalf * ( tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
-            Real tau11bar = Real(1.5)*tau11hi - myhalf*tau11lo;
+            Real tau11lo  = myhalf_d * ( tau11(i  , j  , k-2) + tau11(i-1, j  , k-2) );
+            Real tau11hi  = myhalf_d * ( tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
+            Real tau11bar = Real(1.5)*tau11hi - myhalf_d*tau11lo;
 
-            Real tau12lo  = myhalf * ( tau12(i  , j  , k-2) + tau12(i  , j+1, k-2) );
-            Real tau12hi  = myhalf * ( tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
-            Real tau12bar = Real(1.5)*tau12hi - myhalf*tau12lo;
+            Real tau12lo  = myhalf_d * ( tau12(i  , j  , k-2) + tau12(i  , j+1, k-2) );
+            Real tau12hi  = myhalf_d * ( tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
+            Real tau12bar = Real(1.5)*tau12hi - myhalf_d*tau12lo;
 
-            Real mu_tot = fourth*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
+            Real mu_tot = fourth_d*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
                                + rhoAlpha(i-1, j, k-1) + rhoAlpha(i, j, k-1) );
 
             tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
@@ -223,7 +223,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_vx(i,j,0);
             Real mfy = mf_vy(i,j,0);
@@ -233,15 +233,15 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-            Real tau21lo  = myhalf * ( tau21(i  , j  , k-2) + tau21(i+1, j  , k-2) );
-            Real tau21hi  = myhalf * ( tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
-            Real tau21bar = Real(1.5)*tau21hi - myhalf*tau21lo;
+            Real tau21lo  = myhalf_d * ( tau21(i  , j  , k-2) + tau21(i+1, j  , k-2) );
+            Real tau21hi  = myhalf_d * ( tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
+            Real tau21bar = Real(1.5)*tau21hi - myhalf_d*tau21lo;
 
-            Real tau22lo  = myhalf * ( tau22(i  , j  , k-2) + tau22(i  , j-1, k-2) );
-            Real tau22hi  = myhalf * ( tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
-            Real tau22bar = Real(1.5)*tau22hi - myhalf*tau22lo;
+            Real tau22lo  = myhalf_d * ( tau22(i  , j  , k-2) + tau22(i  , j-1, k-2) );
+            Real tau22hi  = myhalf_d * ( tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
+            Real tau22bar = Real(1.5)*tau22hi - myhalf_d*tau22lo;
 
-            Real mu_tot = fourth*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
+            Real mu_tot = fourth_d*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
                                + rhoAlpha(i, j-1, k-1) + rhoAlpha(i, j, k-1) );
 
             tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
@@ -257,7 +257,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Fill tau13, tau23 next (valid averaging region)
     //-----------------------------------------------------------------------------------
     ParallelFor(tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_ux(i,j,0);
         Real mfy = mf_uy(i,j,0);
@@ -267,11 +267,11 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
         met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-        Real tau11bar = fourth * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  )
+        Real tau11bar = fourth_d * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  )
                                + tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
-        Real tau12bar = fourth * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  )
+        Real tau12bar = fourth_d * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  )
                                + tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
-        Real mu_tot = fourth * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
+        Real mu_tot = fourth_d * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
                              + rhoAlpha(i-1, j  , k-1) + rhoAlpha(i  , j  , k-1) );
 
         tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
@@ -280,7 +280,7 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         tau31(i,j,k) *= -mu_tot*met_h_zeta/mfy;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_vx(i,j,0);
         Real mfy = mf_vy(i,j,0);
@@ -290,11 +290,11 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
         met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-        Real tau21bar = fourth * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  )
+        Real tau21bar = fourth_d * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  )
                                + tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
-        Real tau22bar = fourth * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  )
+        Real tau22bar = fourth_d * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  )
                                + tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
-        Real mu_tot = fourth * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
+        Real mu_tot = fourth_d * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
                              + rhoAlpha(i  , j-1, k-1) + rhoAlpha(i  , j  , k-1) );
 
         tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
@@ -318,14 +318,14 @@ ComputeStressConsVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         tau11(i,j,k) *= -mu_tot*met_h_zeta/mfy;
         tau22(i,j,k) *= -mu_tot*met_h_zeta/mfx;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real mfx = myhalf * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
-        Real mfy = myhalf * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
+        Real mfx = myhalf_d * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
+        Real mfy = myhalf_d * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
 
         Real met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i,j,k,dxInv,z_nd);
 
-        Real mu_tot = fourth*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
+        Real mu_tot = fourth_d*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
                            + rhoAlpha(i-1, j-1, k) + rhoAlpha(i, j-1, k) );
 
         tau12(i,j,k) *= -mu_tot*met_h_zeta/mfx;
@@ -434,7 +434,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Fill tau33 first (no linear combination extrapolation)
     //-----------------------------------------------------------------------------------
     ParallelFor(bxcc2,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_mx(i,j,0);
         Real mfy = mf_my(i,j,0);
@@ -443,12 +443,12 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_xi   = Compute_h_xi_AtCellCenter  (i,j,k,dxInv,z_nd);
         met_h_eta  = Compute_h_eta_AtCellCenter (i,j,k,dxInv,z_nd);
 
-        Real tau31bar = fourth * ( tau31(i  , j  , k  ) + tau31(i+1, j  , k  )
+        Real tau31bar = fourth_d * ( tau31(i  , j  , k  ) + tau31(i+1, j  , k  )
                                + tau31(i  , j  , k+1) + tau31(i+1, j  , k+1) );
-        Real tau32bar = fourth * ( tau32(i  , j  , k  ) + tau32(i  , j+1, k  )
+        Real tau32bar = fourth_d * ( tau32(i  , j  , k  ) + tau32(i  , j+1, k  )
                                + tau32(i  , j  , k+1) + tau32(i  , j+1, k+1) );
 
-        Real mu_tot   = rhoAlpha(i,j,k) + two*mu_turb(i, j, k, EddyDiff::Mom_v);
+        Real mu_tot   = rhoAlpha(i,j,k) + two_d*mu_turb(i, j, k, EddyDiff::Mom_v);
 
         tau33(i,j,k) -= met_h_xi*mfx*tau31bar + met_h_eta*mfy*tau32bar;
         tau33(i,j,k) *= -mu_tot;
@@ -464,7 +464,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     {
         Box planexz = tbxxz; planexz.setBig(2, planexz.smallEnd(2) );
         tbxxz.growLo(2,-1);
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planexz,[=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_ux(i,j,0);
             Real mfy = mf_uy(i,j,0);
@@ -474,19 +474,19 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-            Real tau11lo  = myhalf * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  ) );
-            Real tau11hi  = myhalf * ( tau11(i  , j  , k+1) + tau11(i-1, j  , k+1) );
-            Real tau11bar = Real(1.5)*tau11lo - myhalf*tau11hi;
+            Real tau11lo  = myhalf_d * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  ) );
+            Real tau11hi  = myhalf_d * ( tau11(i  , j  , k+1) + tau11(i-1, j  , k+1) );
+            Real tau11bar = Real(1.5)*tau11lo - myhalf_d*tau11hi;
 
-            Real tau12lo  = myhalf * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  ) );
-            Real tau12hi  = myhalf * ( tau12(i  , j  , k+1) + tau12(i  , j+1, k+1) );
-            Real tau12bar = Real(1.5)*tau12lo - myhalf*tau12hi;
+            Real tau12lo  = myhalf_d * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  ) );
+            Real tau12hi  = myhalf_d * ( tau12(i  , j  , k+1) + tau12(i  , j+1, k+1) );
+            Real tau12bar = Real(1.5)*tau12lo - myhalf_d*tau12hi;
 
-            Real mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                  + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real rhoAlpha_bar = fourth*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
+            Real rhoAlpha_bar = fourth_d*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
                                      + rhoAlpha(i-1, j, k-1) + rhoAlpha(i, j, k-1) );
-            Real mu_tot = rhoAlpha_bar + two*mu_bar;
+            Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
             tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
             tau13(i,j,k) *= -mu_tot;
@@ -497,7 +497,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         Box planeyz = tbxyz; planeyz.setBig(2, planeyz.smallEnd(2) );
         tbxyz.growLo(2,-1);
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_vx(i,j,0);
             Real mfy = mf_vy(i,j,0);
@@ -507,19 +507,19 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-            Real tau21lo  = myhalf * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  ) );
-            Real tau21hi  = myhalf * ( tau21(i  , j  , k+1) + tau21(i+1, j  , k+1) );
-            Real tau21bar = Real(1.5)*tau21lo - myhalf*tau21hi;
+            Real tau21lo  = myhalf_d * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  ) );
+            Real tau21hi  = myhalf_d * ( tau21(i  , j  , k+1) + tau21(i+1, j  , k+1) );
+            Real tau21bar = Real(1.5)*tau21lo - myhalf_d*tau21hi;
 
-            Real tau22lo  = myhalf * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  ) );
-            Real tau22hi  = myhalf * ( tau22(i  , j  , k+1) + tau22(i  , j-1, k+1) );
-            Real tau22bar = Real(1.5)*tau22lo - myhalf*tau22hi;
+            Real tau22lo  = myhalf_d * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  ) );
+            Real tau22hi  = myhalf_d * ( tau22(i  , j  , k+1) + tau22(i  , j-1, k+1) );
+            Real tau22bar = Real(1.5)*tau22lo - myhalf_d*tau22hi;
 
-            Real mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                  + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real rhoAlpha_bar = fourth*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
+            Real rhoAlpha_bar = fourth_d*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
                                        + rhoAlpha(i, j-1, k-1) + rhoAlpha(i, j, k-1) );
-            Real mu_tot = rhoAlpha_bar + two*mu_bar;
+            Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
             tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
             tau23(i,j,k) *= -mu_tot;
@@ -532,7 +532,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     {
         Box planexz = tbxxz; planexz.setSmall(2, planexz.bigEnd(2) );
         tbxxz.growHi(2,-1);
-        ParallelFor(planexz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planexz,[=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_ux(i,j,0);
             Real mfy = mf_uy(i,j,0);
@@ -542,19 +542,19 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-            Real tau11lo  = myhalf * ( tau11(i  , j  , k-2) + tau11(i-1, j  , k-2) );
-            Real tau11hi  = myhalf * ( tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
-            Real tau11bar = Real(1.5)*tau11hi - myhalf*tau11lo;
+            Real tau11lo  = myhalf_d * ( tau11(i  , j  , k-2) + tau11(i-1, j  , k-2) );
+            Real tau11hi  = myhalf_d * ( tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
+            Real tau11bar = Real(1.5)*tau11hi - myhalf_d*tau11lo;
 
-            Real tau12lo  = myhalf * ( tau12(i  , j  , k-2) + tau12(i  , j+1, k-2) );
-            Real tau12hi  = myhalf * ( tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
-            Real tau12bar = Real(1.5)*tau12hi - myhalf*tau12lo;
+            Real tau12lo  = myhalf_d * ( tau12(i  , j  , k-2) + tau12(i  , j+1, k-2) );
+            Real tau12hi  = myhalf_d * ( tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
+            Real tau12bar = Real(1.5)*tau12hi - myhalf_d*tau12lo;
 
-            Real mu_bar = fourth*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i-1, j, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                  + mu_turb(i-1, j, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real rhoAlpha_bar = fourth*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
+            Real rhoAlpha_bar = fourth_d*( rhoAlpha(i-1, j, k  ) + rhoAlpha(i, j, k  )
                                        + rhoAlpha(i-1, j, k-1) + rhoAlpha(i, j, k-1) );
-            Real mu_tot = rhoAlpha_bar + two*mu_bar;
+            Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
             tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
             tau13(i,j,k) *= -mu_tot;
@@ -565,7 +565,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         Box planeyz = tbxyz; planeyz.setSmall(2, planeyz.bigEnd(2) );
         tbxyz.growHi(2,-1);
-        ParallelFor(planeyz,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(planeyz,[=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real mfx = mf_vx(i,j,0);
             Real mfy = mf_vy(i,j,0);
@@ -575,19 +575,19 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
             met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
             met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-            Real tau21lo  = myhalf * ( tau21(i  , j  , k-2) + tau21(i+1, j  , k-2) );
-            Real tau21hi  = myhalf * ( tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
-            Real tau21bar = Real(1.5)*tau21hi - myhalf*tau21lo;
+            Real tau21lo  = myhalf_d * ( tau21(i  , j  , k-2) + tau21(i+1, j  , k-2) );
+            Real tau21hi  = myhalf_d * ( tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
+            Real tau21bar = Real(1.5)*tau21hi - myhalf_d*tau21lo;
 
-            Real tau22lo  = myhalf * ( tau22(i  , j  , k-2) + tau22(i  , j-1, k-2) );
-            Real tau22hi  = myhalf * ( tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
-            Real tau22bar = Real(1.5)*tau22hi - myhalf*tau22lo;
+            Real tau22lo  = myhalf_d * ( tau22(i  , j  , k-2) + tau22(i  , j-1, k-2) );
+            Real tau22hi  = myhalf_d * ( tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
+            Real tau22bar = Real(1.5)*tau22hi - myhalf_d*tau22lo;
 
-            Real mu_bar = fourth*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
+            Real mu_bar = fourth_d*( mu_turb(i, j-1, k  , EddyDiff::Mom_v) + mu_turb(i, j, k  , EddyDiff::Mom_v)
                                  + mu_turb(i, j-1, k-1, EddyDiff::Mom_v) + mu_turb(i, j, k-1, EddyDiff::Mom_v) );
-            Real rhoAlpha_bar = fourth*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
+            Real rhoAlpha_bar = fourth_d*( rhoAlpha(i, j-1, k  ) + rhoAlpha(i, j, k  )
                                        + rhoAlpha(i, j-1, k-1) + rhoAlpha(i, j, k-1) );
-            Real mu_tot = rhoAlpha_bar + two*mu_bar;
+            Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
             tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
             tau23(i,j,k) *= -mu_tot;
@@ -602,7 +602,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Fill tau13, tau23 next (valid averaging region)
     //-----------------------------------------------------------------------------------
     ParallelFor(tbxxz,tbxyz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_ux(i,j,0);
         Real mfy = mf_uy(i,j,0);
@@ -612,16 +612,16 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_eta  = Compute_h_eta_AtEdgeCenterJ (i,j,k,dxInv,z_nd);
         met_h_zeta = Compute_h_zeta_AtEdgeCenterJ(i,j,k,dxInv,z_nd);
 
-        Real tau11bar = fourth * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  )
+        Real tau11bar = fourth_d * ( tau11(i  , j  , k  ) + tau11(i-1, j  , k  )
                                + tau11(i  , j  , k-1) + tau11(i-1, j  , k-1) );
-        Real tau12bar = fourth * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  )
+        Real tau12bar = fourth_d * ( tau12(i  , j  , k  ) + tau12(i  , j+1, k  )
                                + tau12(i  , j  , k-1) + tau12(i  , j+1, k-1) );
 
-        Real mu_bar = fourth * ( mu_turb(i-1, j  , k  , EddyDiff::Mom_v) + mu_turb(i  , j  , k  , EddyDiff::Mom_v)
+        Real mu_bar = fourth_d * ( mu_turb(i-1, j  , k  , EddyDiff::Mom_v) + mu_turb(i  , j  , k  , EddyDiff::Mom_v)
                                + mu_turb(i-1, j  , k-1, EddyDiff::Mom_v) + mu_turb(i  , j  , k-1, EddyDiff::Mom_v) );
-        Real rhoAlpha_bar = fourth * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
+        Real rhoAlpha_bar = fourth_d * ( rhoAlpha(i-1, j  , k  ) + rhoAlpha(i  , j  , k  )
                                      + rhoAlpha(i-1, j  , k-1) + rhoAlpha(i  , j  , k-1) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau13(i,j,k) -= met_h_xi*mfx*tau11bar + met_h_eta*mfy*tau12bar;
         tau13(i,j,k) *= -mu_tot;
@@ -629,7 +629,7 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
 
         tau31(i,j,k) *= -mu_tot*met_h_zeta/mfy;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_vx(i,j,0);
         Real mfy = mf_vy(i,j,0);
@@ -639,16 +639,16 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
         met_h_eta  = Compute_h_eta_AtEdgeCenterI (i,j,k,dxInv,z_nd);
         met_h_zeta = Compute_h_zeta_AtEdgeCenterI(i,j,k,dxInv,z_nd);
 
-        Real tau21bar = fourth * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  )
+        Real tau21bar = fourth_d * ( tau21(i  , j  , k  ) + tau21(i+1, j  , k  )
                                + tau21(i  , j  , k-1) + tau21(i+1, j  , k-1) );
-        Real tau22bar = fourth * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  )
+        Real tau22bar = fourth_d * ( tau22(i  , j  , k  ) + tau22(i  , j-1, k  )
                                + tau22(i  , j  , k-1) + tau22(i  , j-1, k-1) );
 
-        Real mu_bar = fourth * ( mu_turb(i  , j-1, k  , EddyDiff::Mom_v) + mu_turb(i  , j  , k  , EddyDiff::Mom_v)
+        Real mu_bar = fourth_d * ( mu_turb(i  , j-1, k  , EddyDiff::Mom_v) + mu_turb(i  , j  , k  , EddyDiff::Mom_v)
                                + mu_turb(i  , j-1, k-1, EddyDiff::Mom_v) + mu_turb(i  , j  , k-1, EddyDiff::Mom_v) );
-        Real rhoAlpha_bar = fourth * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
+        Real rhoAlpha_bar = fourth_d * ( rhoAlpha(i  , j-1, k  ) + rhoAlpha(i  , j  , k  )
                                      + rhoAlpha(i  , j-1, k-1) + rhoAlpha(i  , j  , k-1) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau23(i,j,k) -= met_h_xi*mfx*tau21bar + met_h_eta*mfy*tau22bar;
         tau23(i,j,k) *= -mu_tot;
@@ -660,30 +660,30 @@ ComputeStressVarVisc_T (Box bxcc, Box tbxxy, Box tbxxz, Box tbxyz, Real mu_eff,
     // Fill the remaining components: tau11, tau22, tau12/21
     //-----------------------------------------------------------------------------------
     ParallelFor(bxcc,tbxxy,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfx = mf_mx(i,j,0);
         Real mfy = mf_my(i,j,0);
 
         Real met_h_zeta = detJ(i,j,k);
 
-        Real mu_tot = rhoAlpha(i,j,k) + two*mu_turb(i, j, k, EddyDiff::Mom_h);
+        Real mu_tot = rhoAlpha(i,j,k) + two_d*mu_turb(i, j, k, EddyDiff::Mom_h);
 
         tau11(i,j,k) *= -mu_tot*met_h_zeta/mfy;
         tau22(i,j,k) *= -mu_tot*met_h_zeta/mfx;
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real mfx = myhalf * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
-        Real mfy = myhalf * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
+        Real mfx = myhalf_d * (mf_ux(i,j,0) + mf_ux(i,j-1,0));
+        Real mfy = myhalf_d * (mf_vy(i,j,0) + mf_vy(i-1,j,0));
 
         Real met_h_zeta = Compute_h_zeta_AtEdgeCenterK(i,j,k,dxInv,z_nd);
 
-        Real mu_bar = fourth*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
+        Real mu_bar = fourth_d*( mu_turb(i-1, j  , k, EddyDiff::Mom_h) + mu_turb(i, j  , k, EddyDiff::Mom_h)
                              + mu_turb(i-1, j-1, k, EddyDiff::Mom_h) + mu_turb(i, j-1, k, EddyDiff::Mom_h) );
-        Real rhoAlpha_bar = fourth*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
+        Real rhoAlpha_bar = fourth_d*( rhoAlpha(i-1, j  , k) + rhoAlpha(i, j  , k)
                                    + rhoAlpha(i-1, j-1, k) + rhoAlpha(i, j-1, k) );
-        Real mu_tot = rhoAlpha_bar + two*mu_bar;
+        Real mu_tot = rhoAlpha_bar + two_d*mu_bar;
 
         tau12(i,j,k) *= -mu_tot*met_h_zeta/mfx;
         tau21(i,j,k) *= -mu_tot*met_h_zeta/mfy;

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -89,7 +89,7 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
             Array4<Real const> u_arr = (l_has_xvel) ? xvel->const_array(mfi) : Array4<Real const>{};
             Array4<Real const> v_arr = (l_has_yvel) ? yvel->const_array(mfi) : Array4<Real const>{};
 
-            ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bxcc, [=,two_d=two,one_d=one,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // =====================================================================
                 // one STRAIN RATE MAGNITUDE CALCULATION
@@ -100,7 +100,7 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 } else {
                     SmnSmn = ComputeSmnSmn(i,j,k,tau11,tau22,tau33,tau12,tau13,tau23);
                 }
-                Real strain_rate_magnitude = std::sqrt(two * SmnSmn);
+                Real strain_rate_magnitude = std::sqrt(two_d * SmnSmn);
 
                 // =====================================================================
                 // two GRID SCALE CALCULATION (filter width Δ)
@@ -115,12 +115,12 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 Real Delta;
                 Real DeltaH;
                 if (isotropic) {
-                    Real cellVolMsf = one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
+                    Real cellVolMsf = one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
                     Delta = std::cbrt(cellVolMsf);
                     DeltaH = Delta;
                 } else {
-                    Delta = one / dzInv;
-                    DeltaH = std::sqrt(one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
+                    Delta = one_d / dzInv;
+                    DeltaH = std::sqrt(one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
                 }
 
                 Real rho = cell_data(i, j, k, Rho_comp);
@@ -130,7 +130,7 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 Real nu_turb_base_h = CsDeltaSqr_h * strain_rate_magnitude;
                 Real nu_turb_base_v = CsDeltaSqr_v * strain_rate_magnitude;
 
-                Real stability_factor = one;
+                Real stability_factor = one_d;
 
                 if (l_use_Ri_corr && l_has_xvel && l_has_yvel) {
                     Real N2 = ComputeN2(i, j, k, dzInv, l_abs_g, cell_data, moisture_indices);
@@ -147,11 +147,11 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                     mu_turb(i, j, k, EddyDiff::Mom_v) = rho * nu_turb_base_v * stability_factor;
                 }
 
-                Real dtheta_dz = myhalf * ( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
+                Real dtheta_dz = myhalf_d * ( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
                                           - cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dzInv;
 
-                hfx_x(i,j,k) = zero;
-                hfx_y(i,j,k) = zero;
+                hfx_x(i,j,k) = zero_d;
+                hfx_y(i,j,k) = zero_d;
                 hfx_z(i,j,k) = -inv_Pr_t * mu_turb(i,j,k,EddyDiff::Mom_v) * dtheta_dz;
             });
         }
@@ -189,7 +189,7 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
 
             Array4<Real const> z_nd_arr = z_phys_nd->const_array(mfi);
 
-            ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bxcc, [=,one_d=one,myhalf_d=myhalf,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 Real dxInv = cellSizeInv[0];
                 Real dyInv = cellSizeInv[1];
@@ -200,21 +200,21 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 }
                 Real Delta;
                 if (isotropic) {
-                    Real cellVolMsf = one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
+                    Real cellVolMsf = one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
                     Delta = std::cbrt(cellVolMsf);
                 } else {
-                    Delta = one / dzInv;
+                    Delta = one_d / dzInv;
                 }
 
                 Real dtheta_dz;
                 if (use_thetav_grad) {
-                    dtheta_dz = myhalf * ( GetThetav(i, j, k+1, cell_data, moisture_indices)
+                    dtheta_dz = myhalf_d * ( GetThetav(i, j, k+1, cell_data, moisture_indices)
                                       - GetThetav(i, j, k-1, cell_data, moisture_indices) )*dzInv;
                 } else if (use_thetal_grad) {
-                    dtheta_dz = myhalf * ( GetThetal(i, j, k+1, cell_data, moisture_indices)
+                    dtheta_dz = myhalf_d * ( GetThetal(i, j, k+1, cell_data, moisture_indices)
                                       - GetThetal(i, j, k-1, cell_data, moisture_indices) )*dzInv;
                 } else {
-                    dtheta_dz = myhalf * ( cell_data(i, j, k+1, RhoTheta_comp) / cell_data(i, j, k+1, Rho_comp)
+                    dtheta_dz = myhalf_d * ( cell_data(i, j, k+1, RhoTheta_comp) / cell_data(i, j, k+1, Rho_comp)
                                       - cell_data(i, j, k-1, RhoTheta_comp) / cell_data(i, j, k-1, Rho_comp) )*dzInv;
                 }
 
@@ -241,9 +241,9 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                     length = amrex::max(length, Real(0.001) * Delta);
                 }
 
-                Real DeltaH = (isotropic) ? length : std::sqrt(one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
+                Real DeltaH = (isotropic) ? length : std::sqrt(one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
 
-                Real Pr_inv_v = (one + two*length/Delta);
+                Real Pr_inv_v = (one_d + two_d*length/Delta);
                 Real Pr_inv_h  = (isotropic) ? Pr_inv_v : inv_Pr_t;
 
                 // Calculate eddy diffusivities
@@ -269,8 +269,8 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
                 // - heat flux
                 //   (Note: If using SurfaceLayer, the value at k=0 will
                 //    be overwritten)
-                hfx_x(i,j,k) = zero;
-                hfx_y(i,j,k) = zero;
+                hfx_x(i,j,k) = zero_d;
+                hfx_y(i,j,k) = zero_d;
                 hfx_z(i,j,k) = -mu_turb(i,j,k,EddyDiff::Theta_v) * dtheta_dz; // (rho*w)' theta' [kg m^-2 s^-1 K]
             });
         }
@@ -404,19 +404,19 @@ void ComputeTurbulentViscosityLES_EB (Vector<std::unique_ptr<MultiFab>>& Tau_lev
             Array4<const Real      > u_vfrac = (ebfact.get_u_const_factory())->getVolFrac().const_array(mfi);
             Array4<const Real      > v_vfrac = (ebfact.get_v_const_factory())->getVolFrac().const_array(mfi);
 
-            ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bxcc, [=,zero_d=zero,two_d=two,one_d=one,three_d=three,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 if (!c_cflag(i,j,k).isCovered()) {
                     // =====================================================================
                     // 1. STRAIN RATE MAGNITUDE CALCULATION
                     // =====================================================================
-                    Real SmnSmn = zero;
+                    Real SmnSmn = zero_d;
                     if (c_cflag(i,j,k).isRegular()) {
                         SmnSmn = ComputeSmnSmn(i,j,k,tau11,tau22,tau33,tau12,tau13,tau23);
                     } else if (c_cflag(i,j,k).isSingleValued()) {
                         SmnSmn = ComputeSmnSmn_EB(i,j,k,tau11,tau22,tau33,tau12,tau13,tau23,c_cflag,u_cflag,v_cflag,w_cflag);
                     }
-                    Real strain_rate_magnitude = std::sqrt(two * SmnSmn);
+                    Real strain_rate_magnitude = std::sqrt(two_d * SmnSmn);
 
                     // =====================================================================
                     // 2. GRID SCALE CALCULATION (filter width Δ)
@@ -424,12 +424,12 @@ void ComputeTurbulentViscosityLES_EB (Vector<std::unique_ptr<MultiFab>>& Tau_lev
                     Real Delta;
                     Real DeltaH;
                     if (isotropic) {
-                        Real cellVolMsf = one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
+                        Real cellVolMsf = one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0) * dzInv);
                         Delta = std::cbrt(cellVolMsf);
                         DeltaH = Delta;
                     } else {
-                        Delta = one / dzInv;
-                        DeltaH = std::sqrt(one / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
+                        Delta = one_d / dzInv;
+                        DeltaH = std::sqrt(one_d / (dxInv * mf_u(i,j,0) * dyInv * mf_v(i,j,0)));
                     }
 
                     Real rho = cell_data(i, j, k, Rho_comp);
@@ -439,11 +439,11 @@ void ComputeTurbulentViscosityLES_EB (Vector<std::unique_ptr<MultiFab>>& Tau_lev
                     Real nu_turb_base_h = CsDeltaSqr_h * strain_rate_magnitude;
                     Real nu_turb_base_v = CsDeltaSqr_v * strain_rate_magnitude;
 
-                    Real stability_factor = one;
+                    Real stability_factor = one_d;
 
                     if (l_use_Ri_corr && l_has_xvel && l_has_yvel) {
-                        Real N2 = zero;
-                        Real S2_vert = zero;
+                        Real N2 = zero_d;
+                        Real S2_vert = zero_d;
                         if (c_cflag(i,j,k).isRegular()) {
                             N2 = ComputeN2(i, j, k, dzInv, l_abs_g, cell_data, moisture_indices);
                             S2_vert = ComputeVerticalShear2(i, j, k, dzInv, u_arr, v_arr);
@@ -463,33 +463,33 @@ void ComputeTurbulentViscosityLES_EB (Vector<std::unique_ptr<MultiFab>>& Tau_lev
                         mu_turb(i, j, k, EddyDiff::Mom_v) = rho * nu_turb_base_v * stability_factor;
                     }
 
-                    Real dtheta_dz = zero;
+                    Real dtheta_dz = zero_d;
 
                     if (c_cflag(i,j,k).isSingleValued() && c_cflag(i,j,k+1).isCovered()) {
                         amrex::Real theta    = cell_data(i, j, k,   RhoTheta_comp) / rho;
                         amrex::Real theta_km1 = cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp);
                         amrex::Real theta_km2 = cell_data(i,j,k-2,RhoTheta_comp)/cell_data(i,j,k-2,Rho_comp);
-                        dtheta_dz = (three*theta - Real(4.)*theta_km1 + theta_km2) * myhalf * dzInv;
+                        dtheta_dz = (three_d*theta - Real(4.)*theta_km1 + theta_km2) * myhalf_d * dzInv;
                     } else if (c_cflag(i,j,k).isSingleValued() && c_cflag(i,j,k-1).isCovered()) {
                         amrex::Real theta    = cell_data(i, j, k,   RhoTheta_comp) / rho;
                         amrex::Real theta_kp1 = cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp);
                         amrex::Real theta_kp2 = cell_data(i,j,k+2,RhoTheta_comp)/cell_data(i,j,k+2,Rho_comp);
-                        dtheta_dz = (-theta_kp2 + Real(4.)*theta_kp1 - three*theta) * myhalf * dzInv;
+                        dtheta_dz = (-theta_kp2 + Real(4.)*theta_kp1 - three_d*theta) * myhalf_d * dzInv;
                     } else if (!c_cflag(i,j,k).isCovered()) {
                         amrex::Real theta_km1 = cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp);
                         amrex::Real theta_kp1 = cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp);
-                        dtheta_dz = myhalf * (theta_kp1 - theta_km1) * dzInv;
+                        dtheta_dz = myhalf_d * (theta_kp1 - theta_km1) * dzInv;
                     }
 
-                    hfx_x(i,j,k) = zero;
-                    hfx_y(i,j,k) = zero;
+                    hfx_x(i,j,k) = zero_d;
+                    hfx_y(i,j,k) = zero_d;
                     hfx_z(i,j,k) = -inv_Pr_t * mu_turb(i,j,k,EddyDiff::Mom_v) * dtheta_dz;
 
                 } else {
 
-                    hfx_x(i,j,k) = zero;
-                    hfx_y(i,j,k) = zero;
-                    hfx_z(i,j,k) = zero;
+                    hfx_x(i,j,k) = zero_d;
+                    hfx_y(i,j,k) = zero_d;
+                    hfx_z(i,j,k) = zero_d;
                 }// End of if not covered
             });
         }
@@ -625,7 +625,7 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
 
             const Array4<Real const>& z_nd_arr = z_phys_nd->const_array(mfi);
 
-            ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bxcc, [=,myhalf_d=myhalf,KAPPA_d=KAPPA,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 Real eps = std::numeric_limits<Real>::epsilon();
                 Real tke = amrex::max(cell_data(i,j,k,RhoKE_comp)/cell_data(i,j,k,Rho_comp), eps);
@@ -636,7 +636,7 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                     // the terrain grid is only deformed in z for now
                     dzInv /= Compute_h_zeta_AtCellCenter(i,j,k, cellSizeInv, z_nd_arr);
                 }
-                Real dtheta_dz = myhalf * ( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
+                Real dtheta_dz = myhalf_d * ( cell_data(i,j,k+1,RhoTheta_comp)/cell_data(i,j,k+1,Rho_comp)
                                           - cell_data(i,j,k-1,RhoTheta_comp)/cell_data(i,j,k-1,Rho_comp) )*dzInv;
                 Real N2 = abs_g * inv_theta0 * dtheta_dz; // Brunt–Väisälä frequency squared
                 if (!use_ref_theta) {
@@ -646,8 +646,8 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                 }
 
                 // Geometric length scale (AL01, Eqn. 22)
-                Real l_g = (z0_arr) ? KAPPA * (d_arr(i, j, k) + z0_arr(i, j, 0))
-                                    : KAPPA * d_arr(i, j, k);
+                Real l_g = (z0_arr) ? KAPPA_d * (d_arr(i, j, k) + z0_arr(i, j, 0))
+                                    : KAPPA_d * d_arr(i, j, k);
 
                 // Enforce a maximum value
                 l_g = l_g_max * l_g / (l_g_max + l_g);
@@ -658,19 +658,19 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                     length = l_g;
                 } else if (N2 > eps) {
                     // Stable (AL01, Eqn. 26)
-                    length = std::sqrt(one /
-                            (one / (l_g * l_g) + inv_Cb_sq * N2 / tke));
+                    length = std::sqrt(one_d /
+                            (one_d / (l_g * l_g) + inv_Cb_sq * N2 / tke));
                 } else {
                     Real diss0 = Cmu0_pow3 * std::pow(tke,Real(1.5)) / l_g; // approx
                     Rt = tke*tke * N2 / (diss0*diss0);
 
                     // Unstable (AL01, Eqn. 28)
                     // - predict
-                    length = l_g * std::sqrt(one - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
+                    length = l_g * std::sqrt(one_d - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
                     // - correct
                     diss0 = Cmu0_pow3 * std::pow(tke,Real(1.5)) / length;
                     Rt = tke*tke * N2 / (diss0*diss0);
-                    length  = l_g * std::sqrt(one - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
+                    length  = l_g * std::sqrt(one_d - Cmu0_pow3*Cmu0_pow3 * inv_Cb_sq * Rt);
                 }
                 mu_turb(i, j, k, EddyDiff::Turb_lengthscale) = length;
 
@@ -687,7 +687,7 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
                 // Stability functions
                 // Note: These use the smoothed turbulent Richardson number
                 Real cmu = (Cmu0 + Real(0.108)*Rt)
-                         / (one + Real(0.308)*Rt + Real(0.00837)*Rt*Rt); // (AL01, Eqn. 31)
+                         / (one_d + Real(0.308)*Rt + Real(0.00837)*Rt*Rt); // (AL01, Eqn. 31)
                 Real cmu_prime = Cmu0 / (1 + Real(0.277)*Rt); // (AL01, Eqn. 32)
 
                 // Calculate eddy diffusivities
@@ -700,8 +700,8 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
 
                 // Calculate heat flux
                 // - If using SurfaceLayer, the value at k=0 will be overwritten
-                hfx_x(i, j, k) = zero;
-                hfx_y(i, j, k) = zero;
+                hfx_x(i, j, k) = zero_d;
+                hfx_y(i, j, k) = zero_d;
                 // Note: buoyant production = g/theta0 * hfx == -nut_prime * N^2 (c.f. AL01 Eqn. 15)
                 //                          = nut_prime * g/theta0 * dtheta/dz
                 //                  ==> hfx = nut_prime * dtheta/dz

--- a/Source/Diffusion/ERF_DiffusionSrcForMom.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom.cpp
@@ -55,7 +55,7 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
 
     if (l_variable_dz) { // Variable dz (i.e. terrain-fitted coordinates)
         ParallelFor(bxx, bxy, bxz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
@@ -63,10 +63,10 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
             Real diffContrib  = ( (tau11(i  , j  , k  ) - tau11(i-1, j  ,k  )) * dxinv * mfsq // Contribution to x-mom eqn from diffusive flux in x-dir
                                 + (tau12(i  , j+1, k  ) - tau12(i  , j  ,k  )) * dyinv * mfsq // Contribution to x-mom eqn from diffusive flux in y-dir
                                 + (tau13(i  , j  , k+1) - tau13(i  , j  ,k  )) * dzinv );     // Contribution to x-mom eqn from diffusive flux in z-dir;
-            diffContrib      /= myhalf*(detJ(i,j,k) + detJ(i-1,j,k));
+            diffContrib      /= myhalf_d*(detJ(i,j,k) + detJ(i-1,j,k));
             rho_u_rhs(i,j,k) -= diffContrib;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
@@ -74,10 +74,10 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
             Real diffContrib  = ( (tau21(i+1, j  , k  ) - tau21(i  , j  , k  )) * dxinv * mfsq // Contribution to y-mom eqn from diffusive flux in x-dir
                                 + (tau22(i  , j  , k  ) - tau22(i  , j-1, k  )) * dyinv * mfsq // Contribution to y-mom eqn from diffusive flux in y-dir
                                 + (tau23(i  , j  , k+1) - tau23(i  , j  , k  )) * dzinv );     // Contribution to y-mom eqn from diffusive flux in z-dir;
-            diffContrib      /= myhalf*(detJ(i,j,k) + detJ(i,j-1,k));
+            diffContrib      /= myhalf_d*(detJ(i,j,k) + detJ(i,j-1,k));
             rho_v_rhs(i,j,k) -= diffContrib;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
@@ -85,7 +85,7 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
             Real diffContrib  = ( (tau31(i+1, j  , k  ) - tau31(i  , j  , k  )) * dxinv * mfsq // Contribution to z-mom eqn from diffusive flux in x-dir
                                 + (tau32(i  , j+1, k  ) - tau32(i  , j  , k  )) * dyinv * mfsq // Contribution to z-mom eqn from diffusive flux in y-dir
                                 + (tau33(i  , j  , k  ) - tau33(i  , j  , k-1)) * dzinv );     // Contribution to z-mom eqn from diffusive flux in z-dir;
-            diffContrib      /= myhalf*(detJ(i,j,k) + detJ(i,j,k-1));
+            diffContrib      /= myhalf_d*(detJ(i,j,k) + detJ(i,j,k-1));
             rho_w_rhs(i,j,k) -= diffContrib;
         });
 
@@ -114,13 +114,13 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
 
             rho_v_rhs(i,j,k) -= diffContrib;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
             // Note: We don't compute a source term for z-momentum on the bottom or top domain boundary (from erf_slow_rhs_pre)
             //Real dzinv_loc = (k == 0) ? one / dz_ptr[k] : two / (dz_ptr[k] + dz_ptr[k-1]);
-            Real dzinv_loc = two / (dz_ptr[k] + dz_ptr[k-1]);
+            Real dzinv_loc = two_d / (dz_ptr[k] + dz_ptr[k-1]);
 
             Real diffContrib  = ( (tau31(i+1, j  , k  ) - tau31(i  , j  , k  )) * dxinv * mfsq // Contribution to z-mom eqn from diffusive flux in x-dir
                                 + (tau32(i  , j+1, k  ) - tau32(i  , j  , k  )) * dyinv * mfsq // Contribution to z-mom eqn from diffusive flux in y-dir
@@ -132,44 +132,44 @@ DiffusionSrcForMom (const Box& bxx, const Box& bxy , const Box& bxz,
     } else { // Constant Dz
 
         ParallelFor(bxx, bxy, bxz,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
             // Area corrections
-            Real Imfy_hi = one / mf_my(i  ,j,0);
-            Real Imfy_lo = one / mf_my(i-1,j,0);
-            Real Imfx_hi = one / (myhalf * (mf_vx(i,j+1,0) + mf_vx(i-1,j+1,0)));
-            Real Imfx_lo = one / (myhalf * (mf_vx(i,j  ,0) + mf_vx(i-1,j  ,0)));
+            Real Imfy_hi = one_d / mf_my(i  ,j,0);
+            Real Imfy_lo = one_d / mf_my(i-1,j,0);
+            Real Imfx_hi = one_d / (myhalf_d * (mf_vx(i,j+1,0) + mf_vx(i-1,j+1,0)));
+            Real Imfx_lo = one_d / (myhalf_d * (mf_vx(i,j  ,0) + mf_vx(i-1,j  ,0)));
             rho_u_rhs(i,j,k) -= ( (tau11(i  , j  , k  )*Imfy_hi - tau11(i-1, j  ,k  )*Imfy_lo) * dxinv * mfsq   // Contribution to x-mom eqn from diffusive flux in x-dir
                                 + (tau12(i  , j+1, k  )*Imfx_hi - tau12(i  , j  ,k  )*Imfx_lo) * dyinv * mfsq   // Contribution to x-mom eqn from diffusive flux in y-dir
                                 + (tau13(i  , j  , k+1)         - tau13(i  , j  ,k  )        ) * dzinv );       // Contribution to x-mom eqn from diffusive flux in z-dir;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
             // Area corrections
-            Real Imfy_hi = one / (myhalf * (mf_uy(i+1,j,0) + mf_uy(i+1,j-1,0)));
-            Real Imfy_lo = one / (myhalf * (mf_uy(i  ,j,0) + mf_uy(i  ,j-1,0)));
-            Real Imfx_hi = one / mf_mx(i  ,j,0);
-            Real Imfx_lo = one / mf_mx(i-1,j,0);
+            Real Imfy_hi = one_d / (myhalf_d * (mf_uy(i+1,j,0) + mf_uy(i+1,j-1,0)));
+            Real Imfy_lo = one_d / (myhalf_d * (mf_uy(i  ,j,0) + mf_uy(i  ,j-1,0)));
+            Real Imfx_hi = one_d / mf_mx(i  ,j,0);
+            Real Imfx_lo = one_d / mf_mx(i-1,j,0);
             rho_v_rhs(i,j,k) -= ( (tau12(i+1, j  , k  )*Imfy_hi - tau12(i  , j  , k  )*Imfy_lo) * dxinv * mfsq  // Contribution to y-mom eqn from diffusive flux in x-dir
                                 + (tau22(i  , j  , k  )*Imfx_hi - tau22(i  , j-1, k  )*Imfx_lo) * dyinv * mfsq  // Contribution to y-mom eqn from diffusive flux in y-dir
                                 + (tau23(i  , j  , k+1)         - tau23(i  , j  , k  )        ) * dzinv );      // Contribution to y-mom eqn from diffusive flux in z-dir;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Inv Jacobian
             Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 
             // Area corrections
-            Real Imfy_hi = one / mf_uy(i+1,j  ,0);
-            Real Imfy_lo = one / mf_uy(i  ,j  ,0);
-            Real Imfx_hi = one / mf_vx(i  ,j+1,0);
-            Real Imfx_lo = one / mf_vx(i  ,j  ,0);
+            Real Imfy_hi = one_d / mf_uy(i+1,j  ,0);
+            Real Imfy_lo = one_d / mf_uy(i  ,j  ,0);
+            Real Imfx_hi = one_d / mf_vx(i  ,j+1,0);
+            Real Imfx_lo = one_d / mf_vx(i  ,j  ,0);
             rho_w_rhs(i,j,k) -= ( (tau13(i+1, j  , k  )*Imfy_hi - tau13(i  , j  , k  )*Imfy_lo) * dxinv * mfsq  // Contribution to z-mom eqn from diffusive flux in x-dir
                                 + (tau23(i  , j+1, k  )*Imfx_hi - tau23(i  , j  , k  )*Imfx_lo) * dyinv * mfsq  // Contribution to z-mom eqn from diffusive flux in y-dir
                                 + (tau33(i  , j  , k  )         - tau33(i  , j  , k-1)        ) * dzinv );      // Contribution to z-mom eqn from diffusive flux in z-dir;

--- a/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom_EB.cpp
@@ -153,9 +153,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
     // x-momentum
     ParallelFor(bxx,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
+    [=,zero_d=zero,three_d=three,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        if (u_volfrac(i,j,k)>zero) {
+        if (u_volfrac(i,j,k)>zero_d) {
 
             // Inv Jacobian
             Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
@@ -185,15 +185,15 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
                 Real barea = std::sqrt(adx*adx + ady*ady + adz*adz);
 
-                Real dudn = zero;
+                Real dudn = zero_d;
 
                 if (l_no_slip || l_surface_layer) {
 
                     RealVect bcent_eb {u_bcent(i,j,k,0), u_bcent(i,j,k,1), u_bcent(i,j,k,2)};
 
-                    Real Dirichlet_u {zero};
-                    Real Dirichlet_v {zero};
-                    Real Dirichlet_w {zero};
+                    Real Dirichlet_u {zero_d};
+                    Real Dirichlet_v {zero_d};
+                    Real Dirichlet_w {zero_d};
 
                     Real nx = u_bnorm(i,j,k,0);
                     Real ny = u_bnorm(i,j,k,1);
@@ -236,9 +236,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                     Real dwdy = slopes_w[1];
                     Real dwdz = slopes_w[2];
 
-                    Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three );
-                    Real tau12_eb = myhalf * (dudy + dvdx);
-                    Real tau13_eb = myhalf * (dudz + dwdx);
+                    Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three_d );
+                    Real tau12_eb = myhalf_d * (dudy + dvdx);
+                    Real tau13_eb = myhalf_d * (dudz + dwdx);
 
                     if (l_no_slip) {
 
@@ -249,12 +249,12 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                         Real tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z;
                         compute_tangent_vectors(nx, ny, nz, tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z);
 
-                        Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three );
-                        Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three );
-                        Real tau23_eb = myhalf * (dvdz + dwdy);
+                        Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau23_eb = myhalf_d * (dvdz + dwdy);
 
                         Real tauzz = mu_eff * ( nx*nx*tau11_eb + ny*ny*tau22_eb + nz*nz*tau33_eb
-                                            + two * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
+                                            + two_d * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
 
                         dudn = - tbx_x * u_tau_eb13(i,j,k) - tby_x * u_tau_eb23(i,j,k) - nx * tauzz;
                     }
@@ -268,9 +268,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
     // y-momentum
     ParallelFor(bxy,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
+    [=,zero_d=zero,three_d=three,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        if (v_volfrac(i,j,k)>zero) {
+        if (v_volfrac(i,j,k)>zero_d) {
 
             // Inv Jacobian
             Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
@@ -306,9 +306,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
                     RealVect bcent_eb {v_bcent(i,j,k,0), v_bcent(i,j,k,1), v_bcent(i,j,k,2)};
 
-                    Real Dirichlet_u {zero};
-                    Real Dirichlet_v {zero};
-                    Real Dirichlet_w {zero};
+                    Real Dirichlet_u {zero_d};
+                    Real Dirichlet_v {zero_d};
+                    Real Dirichlet_w {zero_d};
 
                     Real nx = v_bnorm(i,j,k,0);
                     Real ny = v_bnorm(i,j,k,1);
@@ -350,9 +350,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                     Real dwdy = slopes_w[1];
                     Real dwdz = slopes_w[2];
 
-                    Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three );
-                    Real tau12_eb = myhalf * (dudy + dvdx);
-                    Real tau23_eb = myhalf * (dvdz + dwdy);
+                    Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three_d );
+                    Real tau12_eb = myhalf_d * (dudy + dvdx);
+                    Real tau23_eb = myhalf_d * (dvdz + dwdy);
 
                     if (l_no_slip) {
 
@@ -363,12 +363,12 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                         Real tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z;
                         compute_tangent_vectors(nx, ny, nz, tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z);
 
-                        Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three );
-                        Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three );
-                        Real tau13_eb = myhalf * (dudz + dwdx);
+                        Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau13_eb = myhalf_d * (dudz + dwdx);
 
                         Real tauzz = mu_eff * ( nx*nx*tau11_eb + ny*ny*tau22_eb + nz*nz*tau33_eb
-                                            + two * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
+                                            + two_d * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
 
                         dvdn = - tbx_y * v_tau_eb13(i,j,k) - tby_y * v_tau_eb23(i,j,k) - ny * tauzz;
                     }
@@ -381,9 +381,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
     // z-momentum
     ParallelFor(bxz,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k)
+    [=,zero_d=zero,three_d=three,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k)
     {
-        if (w_volfrac(i,j,k)>zero) {
+        if (w_volfrac(i,j,k)>zero_d) {
 
             // Inv Jacobian
             Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
@@ -412,15 +412,15 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
 
                 Real barea = std::sqrt(adx*adx + ady*ady + adz*adz);
 
-                Real dwdn = zero;
+                Real dwdn = zero_d;
 
                 if (l_no_slip || l_surface_layer) {
 
                     const RealVect bcent_eb {w_bcent(i,j,k,0), w_bcent(i,j,k,1), w_bcent(i,j,k,2)};
 
-                    Real Dirichlet_u {zero};
-                    Real Dirichlet_v {zero};
-                    Real Dirichlet_w {zero};
+                    Real Dirichlet_u {zero_d};
+                    Real Dirichlet_v {zero_d};
+                    Real Dirichlet_w {zero_d};
 
                     Real nx = w_bnorm(i,j,k,0);
                     Real ny = w_bnorm(i,j,k,1);
@@ -462,9 +462,9 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                     Real dwdy = slopes_w[1];
                     Real dwdz = slopes_w[2];
 
-                    Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three );
-                    Real tau13_eb = myhalf * (dudz + dwdx);
-                    Real tau23_eb = myhalf * (dvdz + dwdy);
+                    Real tau33_eb = ( dwdz - ( dudx + dvdy + dwdz ) / three_d );
+                    Real tau13_eb = myhalf_d * (dudz + dwdx);
+                    Real tau23_eb = myhalf_d * (dvdz + dwdy);
 
                     if (l_no_slip) {
 
@@ -475,12 +475,12 @@ DiffusionSrcForMom_EB (const MFIter& mfi,
                         Real tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z;
                         compute_tangent_vectors(nx, ny, nz, tbx_x, tbx_y, tbx_z, tby_x, tby_y, tby_z);
 
-                        Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three );
-                        Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three );
-                        Real tau12_eb = myhalf * (dudy + dvdx);
+                        Real tau11_eb = ( dudx - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau22_eb = ( dvdy - ( dudx + dvdy + dwdz ) / three_d );
+                        Real tau12_eb = myhalf_d * (dudy + dvdx);
 
                         Real tauzz = mu_eff * ( nx*nx*tau11_eb + ny*ny*tau22_eb + nz*nz*tau33_eb
-                                            + two * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
+                                            + two_d * (nx*ny*tau12_eb + ny*nz*tau23_eb + nx*nz*tau13_eb ));
 
                         dwdn = - tbx_z * w_tau_eb13(i,j,k) - tby_z * w_tau_eb23(i,j,k) - nz * tauzz;
 

--- a/Source/Diffusion/ERF_DiffusionSrcForState_EB.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_EB.cpp
@@ -86,96 +86,96 @@ DiffusionSrcForState_EB (const Box& bx, const Box& domain,
         const int  eddy_y    = d_eddy_diff_idy[eff_index];
         const int  eddy_z    = d_eddy_diff_idz[eff_index];
 
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real rhoFace  = l_consA ? myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) ) : one;
+            Real rhoFace  = l_consA ? myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) ) : one_d;
             Real rhoAlpha = rhoFace * alpha_mol;
             if (l_turb) {
-                rhoAlpha += myhalf * ( mu_turb(i  , j, k, eddy_x)
+                rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, eddy_x)
                                      + mu_turb(i-1, j, k, eddy_x) );
             }
 
             bool ext_dir_on_xlo = ( (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero_d) );
             ext_dir_on_xlo &= (i == dom_lo.x);
 
             bool ext_dir_on_xhi = ( (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero_d) );
             ext_dir_on_xhi &= (i == dom_hi.x+1);
 
             if (ext_dir_on_xlo) {
-                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i-1, j, k, prim_index)
-                                                 + three * cell_prim(i  , j, k, prim_index)
-                                            - (one/three) * cell_prim(i+1, j, k, prim_index) ) * dx_inv;
+                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i-1, j, k, prim_index)
+                                                 + three_d * cell_prim(i  , j, k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i+1, j, k, prim_index) ) * dx_inv;
             } else if (ext_dir_on_xhi) {
-                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i  , j, k, prim_index)
-                                                 - three * cell_prim(i-1, j, k, prim_index)
-                                            + (one/three) * cell_prim(i-2, j, k, prim_index) ) * dx_inv;
+                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i  , j, k, prim_index)
+                                                 - three_d * cell_prim(i-1, j, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i-2, j, k, prim_index) ) * dx_inv;
             } else {
                 if (cfg_arr(i,j,k).isCovered()) {
                     xflux(i,j,k) = -rhoAlpha * ( cell_prim(i-3, j, k, prim_index)
-                                            - three*cell_prim(i-2, j, k, prim_index)
-                                            + two*cell_prim(i-1, j, k, prim_index) ) * dx_inv;
+                                            - three_d*cell_prim(i-2, j, k, prim_index)
+                                            + two_d*cell_prim(i-1, j, k, prim_index) ) * dx_inv;
                 } else if (cfg_arr(i-1,j,k).isCovered()) {
-                    xflux(i,j,k) = -rhoAlpha * ( three*cell_prim(i+1, j, k, prim_index)
+                    xflux(i,j,k) = -rhoAlpha * ( three_d*cell_prim(i+1, j, k, prim_index)
                                             -    cell_prim(i+2, j, k, prim_index)
-                                            - two*cell_prim(i, j, k, prim_index) ) * dx_inv;
+                                            - two_d*cell_prim(i, j, k, prim_index) ) * dx_inv;
                 } else {
                     xflux(i,j,k) = -rhoAlpha * ( cell_prim(i  , j, k, prim_index)
                                                - cell_prim(i-1, j, k, prim_index) ) * dx_inv;
                 }
             }
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf,one_d=one,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real rhoFace  = l_consA ? myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) ) : one;
+            Real rhoFace  = l_consA ? myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) ) : one_d;
             Real rhoAlpha = rhoFace * alpha_mol;
             if (l_turb) {
-                rhoAlpha += myhalf * ( mu_turb(i, j  , k, eddy_y)
+                rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, eddy_y)
                                      + mu_turb(i, j-1, k, eddy_y) );
             }
 
             bool ext_dir_on_ylo = ( (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero_d) );
             ext_dir_on_ylo &= (j == dom_lo.y);
 
             bool ext_dir_on_yhi = ( (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero_d) );
             ext_dir_on_yhi &= (j == dom_hi.y+1);
 
             if (ext_dir_on_ylo) {
-                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j-1, k, prim_index)
-                                                 + three * cell_prim(i, j  , k, prim_index)
-                                            - (one/three) * cell_prim(i, j+1, k, prim_index) ) * dy_inv;
+                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j-1, k, prim_index)
+                                                 + three_d * cell_prim(i, j  , k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j+1, k, prim_index) ) * dy_inv;
             } else if (ext_dir_on_yhi) {
-                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j  , k, prim_index)
-                                                 - three * cell_prim(i, j-1, k, prim_index)
-                                            + (one/three) * cell_prim(i, j-2, k, prim_index) ) * dy_inv;
+                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j  , k, prim_index)
+                                                 - three_d * cell_prim(i, j-1, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j-2, k, prim_index) ) * dy_inv;
             } else {
                 if (cfg_arr(i,j,k).isCovered()) {
                     yflux(i,j,k) = -rhoAlpha * ( cell_prim(i, j-3, k, prim_index)
-                                            - three*cell_prim(i, j-2, k, prim_index)
-                                            + two*cell_prim(i, j-1, k, prim_index) ) * dy_inv;
+                                            - three_d*cell_prim(i, j-2, k, prim_index)
+                                            + two_d*cell_prim(i, j-1, k, prim_index) ) * dy_inv;
                 } else if (cfg_arr(i,j-1,k).isCovered()) {
-                    yflux(i,j,k) = -rhoAlpha * ( three*cell_prim(i, j+1, k, prim_index)
+                    yflux(i,j,k) = -rhoAlpha * ( three_d*cell_prim(i, j+1, k, prim_index)
                                             -    cell_prim(i, j+2, k, prim_index)
-                                            - two*cell_prim(i, j, k, prim_index) ) * dy_inv;
+                                            - two_d*cell_prim(i, j, k, prim_index) ) * dy_inv;
                 } else {
                     yflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index)
                                                - cell_prim(i, j-1, k, prim_index)) * dy_inv;
                 }
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real rhoFace  = l_consA ? myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) ) : one;
+            Real rhoFace  = l_consA ? myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) ) : one_d;
             Real rhoAlpha = rhoFace * alpha_mol;
             if (l_turb) {
-                rhoAlpha += myhalf * ( mu_turb(i, j, k  , eddy_z)
+                rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , eddy_z)
                                      + mu_turb(i, j, k-1, eddy_z) );
             }
 
@@ -188,13 +188,13 @@ DiffusionSrcForState_EB (const Box& bx, const Box& domain,
             bool SurfLayer_on_zlo = ( use_SurfLayer && k == dom_lo.z);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j, k-1, prim_index)
-                                                 + three * cell_prim(i, j, k  , prim_index)
-                                            - (one/three) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j, k-1, prim_index)
+                                                 + three_d * cell_prim(i, j, k  , prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j, k  , prim_index)
-                                                 - three * cell_prim(i, j, k-1, prim_index)
-                                            + (one/three) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j, k  , prim_index)
+                                                 - three_d * cell_prim(i, j, k-1, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (SurfLayer_on_zlo && (qty_index == RhoTheta_comp)) {
                 zflux(i,j,k) = hfx_z(i,j,0);
             } else if (SurfLayer_on_zlo && (qty_index == RhoQ1_comp)) {
@@ -202,12 +202,12 @@ DiffusionSrcForState_EB (const Box& bx, const Box& domain,
             } else {
                 if (cfg_arr(i,j,k).isCovered()) {
                     zflux(i,j,k) = -rhoAlpha * ( cell_prim(i, j, k-3, prim_index)
-                                            - three*cell_prim(i, j, k-2, prim_index)
-                                            + two*cell_prim(i, j, k-1, prim_index) ) * dz_inv;
+                                            - three_d*cell_prim(i, j, k-2, prim_index)
+                                            + two_d*cell_prim(i, j, k-1, prim_index) ) * dz_inv;
                 } else if (cfg_arr(i,j,k-1).isCovered()) {
-                    zflux(i,j,k) = -rhoAlpha * ( three*cell_prim(i, j, k+1, prim_index)
+                    zflux(i,j,k) = -rhoAlpha * ( three_d*cell_prim(i, j, k+1, prim_index)
                                             -    cell_prim(i, j, k+2, prim_index)
-                                            - two*cell_prim(i, j, k, prim_index) ) * dz_inv;
+                                            - two_d*cell_prim(i, j, k, prim_index) ) * dz_inv;
                 } else {
                     zflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index)
                                               - cell_prim(i, j, k-1, prim_index)) * dz_inv;

--- a/Source/Diffusion/ERF_DiffusionSrcForState_N.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_N.cpp
@@ -83,14 +83,14 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
     // Constant alpha & Turb model
     if (l_consA && l_turb) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_scal_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -99,35 +99,35 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_xlo = ( (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero_d) );
             ext_dir_on_xlo &= (i == dom_lo.x);
 
             bool ext_dir_on_xhi = ( (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero_d) );
             ext_dir_on_xlo &= (i == dom_hi.x+1);
 
             if (ext_dir_on_xlo) {
-                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i-1, j, k, prim_index)
-                                                 + three * cell_prim(i  , j, k, prim_index)
-                                            - (one/three) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i-1, j, k, prim_index)
+                                                 + three_d * cell_prim(i  , j, k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else if (ext_dir_on_xhi) {
-                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i  , j, k, prim_index)
-                                                 - three * cell_prim(i-1, j, k, prim_index)
-                                            + (one/three) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i  , j, k, prim_index)
+                                                 - three_d * cell_prim(i-1, j, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else {
                 xflux(i,j,k) = -rhoAlpha * (  cell_prim(i  , j, k, prim_index)
                                             - cell_prim(i-1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             }
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_scal_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -135,33 +135,33 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool ext_dir_on_ylo = ( (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero_d) );
             ext_dir_on_ylo &= (j == dom_lo.y);
             bool ext_dir_on_yhi = ( (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero_d) );
             ext_dir_on_yhi &= (j == dom_hi.y+1);
 
             if (ext_dir_on_ylo) {
-                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j-1, k, prim_index)
-                                                 + three * cell_prim(i, j  , k, prim_index)
-                                            - (one/three) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j-1, k, prim_index)
+                                                 + three_d * cell_prim(i, j  , k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else if (ext_dir_on_yhi) {
-                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j  , k, prim_index)
-                                                 - three * cell_prim(i, j-1, k, prim_index)
-                                            + (one/three) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j  , k, prim_index)
+                                                 - three_d * cell_prim(i, j-1, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else {
                 yflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,three_d=three,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_scal_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -177,20 +177,20 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             bool SurfLayer_on_zlo = ( use_SurfLayer && k==dom_lo.z);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j, k-1, prim_index)
-                                                 + three * cell_prim(i, j, k  , prim_index)
-                                            - (one/three) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j, k-1, prim_index)
+                                                 + three_d * cell_prim(i, j, k  , prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j, k  , prim_index)
-                                                 - three * cell_prim(i, j, k-1, prim_index)
-                                            + (one/three) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j, k  , prim_index)
+                                                 - three_d * cell_prim(i, j, k-1, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (SurfLayer_on_zlo) {
                 if (qty_index == RhoTheta_comp) {
                     zflux(i,j,k) = hfx_z(i,j,0);
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
@@ -210,12 +210,12 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
         });
     // Constant rho*alpha & Turb model
     } else if (l_turb) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -224,33 +224,33 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_xlo = ( (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero_d) );
             ext_dir_on_xlo &= (i == dom_lo.x);
 
             bool ext_dir_on_xhi = ( (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero_d) );
             ext_dir_on_xhi &= (i == dom_hi.x+1);
 
             if (ext_dir_on_xlo) {
-                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i-1, j, k, prim_index)
-                                                 + three * cell_prim(i  , j, k, prim_index)
-                                            - (one/three) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i-1, j, k, prim_index)
+                                                 + three_d * cell_prim(i  , j, k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else if (ext_dir_on_xhi) {
-                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i  , j, k, prim_index)
-                                                 - three * cell_prim(i-1, j, k, prim_index)
-                                            + (one/three) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i  , j, k, prim_index)
+                                                 - three_d * cell_prim(i-1, j, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else {
                 xflux(i,j,k) = -rhoAlpha * ( cell_prim(i  , j, k, prim_index)
                                            - cell_prim(i-1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             }
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -259,32 +259,32 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_ylo = ( (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero_d) );
             ext_dir_on_ylo &= (j == dom_lo.y);
 
             bool ext_dir_on_yhi = ( (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero_d) );
             ext_dir_on_yhi &= (j == dom_hi.y+1);
 
             if (ext_dir_on_ylo) {
-                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j-1, k, prim_index)
-                                                 + three * cell_prim(i, j  , k, prim_index)
-                                            - (one/three) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j-1, k, prim_index)
+                                                 + three_d * cell_prim(i, j  , k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else if (ext_dir_on_yhi) {
-                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j  , k, prim_index)
-                                                 - three * cell_prim(i, j-1, k, prim_index)
-                                            + (one/three) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j  , k, prim_index)
+                                                 - three_d * cell_prim(i, j-1, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else {
               yflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,three_d=three,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -299,20 +299,20 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             bool SurfLayer_on_zlo = ( use_SurfLayer && k == dom_lo.z);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j, k-1, prim_index)
-                                                 + three * cell_prim(i, j, k  , prim_index)
-                                            - (one/three) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j, k-1, prim_index)
+                                                 + three_d * cell_prim(i, j, k  , prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j, k  , prim_index)
-                                                 - three * cell_prim(i, j, k-1, prim_index)
-                                            + (one/three) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j, k  , prim_index)
+                                                 - three_d * cell_prim(i, j, k-1, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (SurfLayer_on_zlo) {
                 if (qty_index == RhoTheta_comp) {
                     zflux(i,j,k) = hfx_z(i,j,0);
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
@@ -332,11 +332,11 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
         });
     // Constant alpha & no LES/PBL model
     } else if(l_consA) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -345,32 +345,32 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_xlo = ( (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero_d) );
             ext_dir_on_xlo &= (i == dom_lo.x);
 
             bool ext_dir_on_xhi = ( (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero_d) );
             ext_dir_on_xhi &= (i == dom_hi.x+1);
 
             if (ext_dir_on_xlo) {
-                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i-1, j, k, prim_index)
-                                                 + three * cell_prim(i  , j, k, prim_index)
-                                            - (one/three) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i-1, j, k, prim_index)
+                                                 + three_d * cell_prim(i  , j, k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else if (ext_dir_on_xhi) {
-                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i  , j, k, prim_index)
-                                                 - three * cell_prim(i-1, j, k, prim_index)
-                                            + (one/three) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i  , j, k, prim_index)
+                                                 - three_d * cell_prim(i-1, j, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else {
                 xflux(i,j,k) = -rhoAlpha * ( cell_prim(i  , j, k, prim_index)
                                            - cell_prim(i-1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             }
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -379,31 +379,31 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_ylo = ( (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero_d) );
             ext_dir_on_ylo &= (j == dom_lo.y);
 
             bool ext_dir_on_yhi = ( (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero_d) );
             ext_dir_on_yhi &= (j == dom_hi.y+1);
 
             if (ext_dir_on_ylo) {
-                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j-1, k, prim_index)
-                                                 + three * cell_prim(i, j  , k, prim_index)
-                                            - (one/three) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j-1, k, prim_index)
+                                                 + three_d * cell_prim(i, j  , k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else if (ext_dir_on_yhi) {
-                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j  , k, prim_index)
-                                                 - three * cell_prim(i, j-1, k, prim_index)
-                                            + (one/three) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j  , k, prim_index)
+                                                 - three_d * cell_prim(i, j-1, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else {
               yflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,three_d=three,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -418,20 +418,20 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             bool SurfLayer_on_zlo = ( use_SurfLayer && k == dom_lo.z);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j, k-1, prim_index)
-                                                 + three * cell_prim(i, j, k  , prim_index)
-                                            - (one/three) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j, k-1, prim_index)
+                                                 + three_d * cell_prim(i, j, k  , prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j, k  , prim_index)
-                                                 - three * cell_prim(i, j, k-1, prim_index)
-                                            + (one/three) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j, k  , prim_index)
+                                                 - three_d * cell_prim(i, j, k-1, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (SurfLayer_on_zlo) {
                 if (qty_index == RhoTheta_comp) {
                     zflux(i,j,k) = hfx_z(i,j,0);
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;
@@ -451,7 +451,7 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
         });
     // Constant rho*alpha & no LES/PBL model
     } else {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -463,28 +463,28 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_xlo = ( (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(0) == ERFBCType::ext_dir_upwind && u(dom_lo.x,j,k) >= zero_d) );
             ext_dir_on_xlo &= (i == dom_lo.x);
 
             bool ext_dir_on_xhi = ( (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(0) == ERFBCType::ext_dir_upwind && u(dom_hi.x+1,j,k) <= zero_d) );
             ext_dir_on_xhi &= (i == dom_hi.x+1);
 
             if (ext_dir_on_xlo) {
-                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i-1, j, k, prim_index)
-                                                 + three * cell_prim(i  , j, k, prim_index)
-                                            - (one/three) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i-1, j, k, prim_index)
+                                                 + three_d * cell_prim(i  , j, k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i+1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else if (ext_dir_on_xhi) {
-                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i  , j, k, prim_index)
-                                                 - three * cell_prim(i-1, j, k, prim_index)
-                                            + (one/three) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
+                xflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i  , j, k, prim_index)
+                                                 - three_d * cell_prim(i-1, j, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i-2, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             } else {
                 xflux(i,j,k) = -rhoAlpha * ( cell_prim(i  , j, k, prim_index)
                                            - cell_prim(i-1, j, k, prim_index) ) * dx_inv * mf_ux(i,j,0)/mf_uy(i,j,0);
             }
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,zero_d=zero,three_d=three,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -496,27 +496,27 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
 
             bool ext_dir_on_ylo = ( (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero) );
+                                    (bc_ptr[bc_comp].lo(1) == ERFBCType::ext_dir_upwind && v(i,dom_lo.y,k) >= zero_d) );
             ext_dir_on_ylo &= (j == dom_lo.y);
 
             bool ext_dir_on_yhi = ( (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir)      ||
                                     (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_prim) ||
-                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero) );
+                                    (bc_ptr[bc_comp].hi(1) == ERFBCType::ext_dir_upwind && v(i,dom_hi.y+1,k) <= zero_d) );
             ext_dir_on_yhi &= (j == dom_hi.y+1);
 
             if (ext_dir_on_ylo) {
-                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j-1, k, prim_index)
-                                                 + three * cell_prim(i, j  , k, prim_index)
-                                            - (one/three) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j-1, k, prim_index)
+                                                 + three_d * cell_prim(i, j  , k, prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j+1, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else if (ext_dir_on_yhi) {
-                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j  , k, prim_index)
-                                                 - three * cell_prim(i, j-1, k, prim_index)
-                                            + (one/three) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
+                yflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j  , k, prim_index)
+                                                 - three_d * cell_prim(i, j-1, k, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j-2, k, prim_index) ) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             } else {
               yflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j-1, k, prim_index)) * dy_inv * mf_vy(i,j,0)/mf_vx(i,j,0);
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,three_d=three,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -534,20 +534,20 @@ DiffusionSrcForState_N (const Box& bx, const Box& domain,
             bool SurfLayer_on_zlo = ( use_SurfLayer && k == dom_lo.z);
 
             if (ext_dir_on_zlo) {
-                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three) * cell_prim(i, j, k-1, prim_index)
-                                                 + three * cell_prim(i, j, k  , prim_index)
-                                            - (one/three) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * ( -(Real(8.)/three_d) * cell_prim(i, j, k-1, prim_index)
+                                                 + three_d * cell_prim(i, j, k  , prim_index)
+                                            - (one_d/three_d) * cell_prim(i, j, k+1, prim_index) ) * dz_inv;
             } else if (ext_dir_on_zhi) {
-                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three) * cell_prim(i, j, k  , prim_index)
-                                                 - three * cell_prim(i, j, k-1, prim_index)
-                                            + (one/three) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
+                zflux(i,j,k) = -rhoAlpha * (  (Real(8.)/three_d) * cell_prim(i, j, k  , prim_index)
+                                                 - three_d * cell_prim(i, j, k-1, prim_index)
+                                            + (one_d/three_d) * cell_prim(i, j, k-2, prim_index) ) * dz_inv;
             } else if (SurfLayer_on_zlo) {
                 if (qty_index == RhoTheta_comp) {
                     zflux(i,j,k) = hfx_z(i,j,0);
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * (cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index)) * dz_inv;

--- a/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
@@ -86,14 +86,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
     // Constant alpha & Turb model
     if (l_consA && l_turb) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_scal_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -104,14 +104,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * GradCx;
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_scal_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -122,14 +122,14 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * GradCy;
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_scal_index]) );
 
             Real GradCz;
@@ -148,12 +148,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k];
                 Real dz1  = dz_ptr[k+1];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -161,23 +161,23 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k-1];
                 Real dz1  = dz_ptr[k-2];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
                 Real dzk_inv;
                 if (k==klo) {
-                    dzk_inv =  one / dz_ptr[k];
+                    dzk_inv =  one_d / dz_ptr[k];
                 } else if (k==(khi+1)) {
-                    dzk_inv =  one / dz_ptr[k-1];
+                    dzk_inv =  one_d / dz_ptr[k-1];
                 } else {
-                    dzk_inv =  two / (dz_ptr[k] + dz_ptr[k-1]);
+                    dzk_inv =  two_d / (dz_ptr[k] + dz_ptr[k-1]);
                 }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -188,7 +188,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -208,12 +208,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
         });
     // Constant rho*alpha & Turb model
     } else if (l_turb) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -224,12 +224,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * GradCx;
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_index]) );
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -240,12 +240,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * GradCy;
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
 
             Real GradCz;
@@ -263,12 +263,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k];
                 Real dz1  = dz_ptr[k+1];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -276,23 +276,23 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k-1];
                 Real dz1  = dz_ptr[k-2];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
                 Real dzk_inv;
                 if (k==klo) {
-                    dzk_inv =  one / dz_ptr[k];
+                    dzk_inv =  one_d / dz_ptr[k];
                 } else if (k==(khi+1)) {
-                    dzk_inv =  one / dz_ptr[k-1];
+                    dzk_inv =  one_d / dz_ptr[k-1];
                 } else {
-                    dzk_inv =  two / (dz_ptr[k] + dz_ptr[k-1]);
+                    dzk_inv =  two_d / (dz_ptr[k] + dz_ptr[k-1]);
                 }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -305,7 +305,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -325,11 +325,11 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
         });
     // Constant alpha & no LES/PBL model
     } else if(l_consA) {
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -340,11 +340,11 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * GradCx;
         });
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             int bc_comp = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ?
@@ -355,11 +355,11 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * GradCy;
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             Real GradCz;
@@ -377,12 +377,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k];
                 Real dz1  = dz_ptr[k+1];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -390,23 +390,23 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k-1];
                 Real dz1  = dz_ptr[k-2];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
                 Real dzk_inv;
                 if (k==klo) {
-                    dzk_inv =  one / dz_ptr[k];
+                    dzk_inv =  one_d / dz_ptr[k];
                 } else if (k==(khi+1)) {
-                    dzk_inv =  one / dz_ptr[k-1];
+                    dzk_inv =  one_d / dz_ptr[k-1];
                 } else {
-                    dzk_inv =  two / (dz_ptr[k] + dz_ptr[k-1]);
+                    dzk_inv =  two_d / (dz_ptr[k] + dz_ptr[k-1]);
                 }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -419,7 +419,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -467,7 +467,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
             yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * GradCy;
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -488,12 +488,12 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k];
                 Real dz1  = dz_ptr[k+1];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -501,23 +501,23 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 // Third order stencil with variable dz
                 Real dz0  = dz_ptr[k-1];
                 Real dz1  = dz_ptr[k-2];
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
             } else {
                 Real dzk_inv;
                 if (k==klo) {
-                    dzk_inv =  one / dz_ptr[k];
+                    dzk_inv =  one_d / dz_ptr[k];
                 } else if (k==(khi+1)) {
-                    dzk_inv =  one / dz_ptr[k-1];
+                    dzk_inv =  one_d / dz_ptr[k-1];
                 } else {
-                    dzk_inv =  two / (dz_ptr[k] + dz_ptr[k-1]);
+                    dzk_inv =  two_d / (dz_ptr[k] + dz_ptr[k-1]);
                 }
                 GradCz = dzk_inv * ( cell_prim(i, j, k, prim_index) - cell_prim(i, j, k-1, prim_index) );
             }
@@ -530,7 +530,7 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -571,10 +571,10 @@ DiffusionSrcForState_S (const Box& bx, const Box& domain,
 
     // Use fluxes to compute RHS
     //-----------------------------------------------------------------------------------
-    ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx,[=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
-        Real dzk_inv = one / dz_ptr[k];
+        Real dzk_inv = one_d / dz_ptr[k];
         Real stateContrib = (xflux(i+1,j  ,k  ) - xflux(i, j, k)) * dx_inv * mfsq  // Diffusive flux in x-dir
                            +(yflux(i  ,j+1,k  ) - yflux(i, j, k)) * dy_inv * mfsq  // Diffusive flux in y-dir
                            +(zflux(i  ,j  ,k+1) - zflux(i, j, k)) * dzk_inv;       // Diffusive flux in z-dir

--- a/Source/Diffusion/ERF_DiffusionSrcForState_T.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_T.cpp
@@ -105,14 +105,14 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
     // Constant alpha & Turb model
     if (l_consA && l_turb) {
-        ParallelFor(xbx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_scal_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_scal_index]) );
 
             Real met_h_xi   = Compute_h_xi_AtIface  (i,j,k,cellSizeInv,z_nd);
@@ -123,9 +123,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
 
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
-            Real idz_lo = one / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
+            Real idz_lo = one_d / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i-1, j, k-1, prim_index)*idz_lo );
             Real GradCx = dx_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i-1, j, k  , prim_index) );
 
@@ -137,14 +137,14 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * ( GradCx - met_h_xi*GradCz );
             }
         });
-        ParallelFor(ybx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_scal_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_scal_index]) );
 
             Real met_h_eta  = Compute_h_eta_AtJface (i,j,k,cellSizeInv,z_nd);
@@ -154,9 +154,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
-            Real idz_lo = one / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
+            Real idz_lo = one_d / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i, j-1, k-1, prim_index)*idz_lo );
             Real GradCy = dy_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i, j-1, k  , prim_index) );
 
@@ -168,14 +168,14 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * ( GradCy - met_h_eta*GradCz );
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
             const int prim_scal_index = (qty_index >= RhoScalar_comp && qty_index < RhoScalar_comp+NSCALARS) ? PrimScalar_comp : prim_index;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_scal_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_scal_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_scal_index]) );
 
             Real GradCz;
@@ -195,12 +195,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k+1,z_nd);
                 Real dz0  = zm - Compute_Z_AtWFace(i,j,k,z_nd);
                 Real dz1  = Compute_Z_AtWFace(i,j,k+2,z_nd) - zm;
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -209,12 +209,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k-1,z_nd);
                 Real dz0  = Compute_Z_AtWFace(i,j,k,z_nd) - zm;
                 Real dz1  = zm - Compute_Z_AtWFace(i,j,k-2,z_nd);
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
@@ -229,7 +229,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -249,12 +249,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
         });
     // Constant rho*alpha & Turb model
     } else if (l_turb) {
-        ParallelFor(xbx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i  , j, k, d_eddy_diff_idx[prim_index])
                                  + mu_turb(i-1, j, k, d_eddy_diff_idx[prim_index]) );
 
             Real met_h_xi   = Compute_h_xi_AtIface  (i,j,k,cellSizeInv,z_nd);
@@ -264,9 +264,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
-            Real idz_lo = one / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
+            Real idz_lo = one_d / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i-1, j, k-1, prim_index)*idz_lo );
             Real GradCx = dx_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i-1, j, k  , prim_index) );
 
@@ -278,12 +278,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * ( GradCx - met_h_xi*GradCz );
             }
         });
-        ParallelFor(ybx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j  , k, d_eddy_diff_idy[prim_index])
                                  + mu_turb(i, j-1, k, d_eddy_diff_idy[prim_index]) );
 
             Real met_h_eta  = Compute_h_eta_AtJface (i,j,k,cellSizeInv,z_nd);
@@ -293,9 +293,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
-            Real idz_lo = one / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
+            Real idz_lo = one_d / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i, j-1, k-1, prim_index)*idz_lo );
             Real GradCy = dy_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i, j-1, k  , prim_index) );
 
@@ -307,12 +307,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * ( GradCy - met_h_eta*GradCz );
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
             Real rhoAlpha = d_alpha_eff[prim_index];
-            rhoAlpha += myhalf * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
+            rhoAlpha += myhalf_d * ( mu_turb(i, j, k  , d_eddy_diff_idz[prim_index])
                                  + mu_turb(i, j, k-1, d_eddy_diff_idz[prim_index]) );
 
             Real GradCz;
@@ -332,12 +332,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k+1,z_nd);
                 Real dz0  = zm - Compute_Z_AtWFace(i,j,k,z_nd);
                 Real dz1  = Compute_Z_AtWFace(i,j,k+2,z_nd) - zm;
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -346,12 +346,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k-1,z_nd);
                 Real dz0  = Compute_Z_AtWFace(i,j,k,z_nd) - zm;
                 Real dz1  = zm - Compute_Z_AtWFace(i,j,k-2,z_nd);
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
@@ -366,7 +366,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -387,11 +387,11 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
         });
     // Constant alpha & no LES/PBL model
     } else if(l_consA) {
-        ParallelFor(xbx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i-1, j, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             Real met_h_xi   = Compute_h_xi_AtIface  (i,j,k,cellSizeInv,z_nd);
@@ -401,9 +401,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
-            Real idz_lo = one / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
+            Real idz_lo = one_d / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i-1, j, k-1, prim_index)*idz_lo );
             Real GradCx = dx_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i-1, j, k  , prim_index) );
 
@@ -415,11 +415,11 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * ( GradCx - met_h_xi*GradCz );
             }
         });
-        ParallelFor(ybx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx_g1, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j-1, k, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             Real met_h_eta  = Compute_h_eta_AtJface (i,j,k,cellSizeInv,z_nd);
@@ -429,9 +429,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
-            Real idz_lo = one / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
+            Real idz_lo = one_d / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i, j-1, k-1, prim_index)*idz_lo );
             Real GradCy = dy_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i, j-1, k  , prim_index) );
 
@@ -443,11 +443,11 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * ( GradCy - met_h_eta*GradCz );
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
-            Real rhoFace  = myhalf * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
+            Real rhoFace  = myhalf_d * ( cell_data(i, j, k, Rho_comp) + cell_data(i, j, k-1, Rho_comp) );
             Real rhoAlpha = rhoFace * d_alpha_eff[prim_index];
 
             Real GradCz;
@@ -467,12 +467,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k+1,z_nd);
                 Real dz0  = zm - Compute_Z_AtWFace(i,j,k,z_nd);
                 Real dz1  = Compute_Z_AtWFace(i,j,k+2,z_nd) - zm;
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -481,12 +481,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k-1,z_nd);
                 Real dz0  = Compute_Z_AtWFace(i,j,k,z_nd) - zm;
                 Real dz1  = zm - Compute_Z_AtWFace(i,j,k-2,z_nd);
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
@@ -501,7 +501,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -521,7 +521,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
         });
     // Constant rho*alpha & no LES/PBL model
     } else {
-        ParallelFor(xbx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(xbx_g1, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -534,9 +534,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
-            Real idz_lo = one / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i  ,j,k+1) - z_cc(i  ,j,k-1));
+            Real idz_lo = one_d / (z_cc(i-1,j,k+1) - z_cc(i-1,j,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i-1, j, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i-1, j, k-1, prim_index)*idz_lo );
             Real GradCx = dx_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i-1, j, k  , prim_index) );
 
@@ -548,7 +548,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 xflux(i,j,k) = -rhoAlpha * mf_ux(i,j,0) * ( GradCx - met_h_xi*GradCz );
             }
         });
-        ParallelFor(ybx_g1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(ybx_g1, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -561,9 +561,9 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
             if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
             bool SurfLayer_on_zlo = ( use_SurfLayer && rotate && k == dom_lo.z);
 
-            Real idz_hi = one / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
-            Real idz_lo = one / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
-            Real GradCz =    myhalf * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
+            Real idz_hi = one_d / (z_cc(i,j  ,k+1) - z_cc(i,j  ,k-1));
+            Real idz_lo = one_d / (z_cc(i,j-1,k+1) - z_cc(i,j-1,k-1));
+            Real GradCz =    myhalf_d * ( cell_prim(i, j, k+1, prim_index)*idz_hi + cell_prim(i, j-1, k+1, prim_index)*idz_lo
                                    - cell_prim(i, j, k-1, prim_index)*idz_hi - cell_prim(i, j-1, k-1, prim_index)*idz_lo );
             Real GradCy = dy_inv * ( cell_prim(i, j, k  , prim_index)        - cell_prim(i, j-1, k  , prim_index) );
 
@@ -575,7 +575,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 yflux(i,j,k) = -rhoAlpha * mf_vy(i,j,0) * ( GradCy - met_h_eta*GradCz );
             }
         });
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const int prim_index = qty_index - 1;
 
@@ -599,12 +599,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k+1,z_nd);
                 Real dz0  = zm - Compute_Z_AtWFace(i,j,k,z_nd);
                 Real dz1  = Compute_Z_AtWFace(i,j,k+2,z_nd) - zm;
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * ( c1 * cell_prim(i, j, k-1, prim_index)
                                 + c2 * cell_prim(i, j, k  , prim_index)
                                 + c3 * cell_prim(i, j, k+1, prim_index) );
@@ -613,12 +613,12 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 Real zm   = Compute_Z_AtWFace(i,j,k-1,z_nd);
                 Real dz0  = Compute_Z_AtWFace(i,j,k,z_nd) - zm;
                 Real dz1  = zm - Compute_Z_AtWFace(i,j,k-2,z_nd);
-                Real idz0 = one / dz0;
-                Real f    = (dz1 / dz0) + two;
+                Real idz0 = one_d / dz0;
+                Real f    = (dz1 / dz0) + two_d;
                 Real f2   = f*f;
-                Real c3   = two / (f - f2);
+                Real c3   = two_d / (f - f2);
                 Real c2   = -f2*c3;
-                Real c1   = -(one-f2)*c3;
+                Real c1   = -(one_d-f2)*c3;
                 GradCz = idz0 * (  -( c1 * cell_prim(i, j, k  , prim_index)
                                     + c2 * cell_prim(i, j, k-1, prim_index)
                                     + c3 * cell_prim(i, j, k-2, prim_index) ) );
@@ -633,7 +633,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
                 } else if (qty_index == RhoQ1_comp) {
                     zflux(i,j,k) = qfx1_z(i,j,0);
                 } else {
-                    zflux(i,j,k) = zero;
+                    zflux(i,j,k) = zero_d;
                 }
             } else {
                 zflux(i,j,k) = -rhoAlpha * GradCz;
@@ -670,23 +670,23 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
     // Note that we combine all of these operations in order to keep this section
     //      of the loop tiling-safe.
     //-----------------------------------------------------------------------------------
-    ParallelFor(bx,[=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx,[=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real xfluxbar_lo, yfluxbar_lo;
         Real met_h_xi_lo  = Compute_h_xi_AtKface (i,j,k  ,cellSizeInv,z_nd);
         Real met_h_eta_lo = Compute_h_eta_AtKface(i,j,k  ,cellSizeInv,z_nd);
         if (k == dom_lo.z) {
-            Real xfluxlo  = myhalf * ( xflux(i,j,k  ) + xflux(i+1,j,k  ) );
-            Real xfluxhi  = myhalf * ( xflux(i,j,k+1) + xflux(i+1,j,k+1) );
-            xfluxbar_lo = Real(1.5)*xfluxlo - myhalf*xfluxhi;
+            Real xfluxlo  = myhalf_d * ( xflux(i,j,k  ) + xflux(i+1,j,k  ) );
+            Real xfluxhi  = myhalf_d * ( xflux(i,j,k+1) + xflux(i+1,j,k+1) );
+            xfluxbar_lo = Real(1.5)*xfluxlo - myhalf_d*xfluxhi;
 
-            Real yfluxlo  = myhalf * ( yflux(i,j,k  ) + yflux(i,j+1,k  ) );
-            Real yfluxhi  = myhalf * ( yflux(i,j,k+1) + yflux(i,j+1,k+1) );
-            yfluxbar_lo = Real(1.5)*yfluxlo - myhalf*yfluxhi;
+            Real yfluxlo  = myhalf_d * ( yflux(i,j,k  ) + yflux(i,j+1,k  ) );
+            Real yfluxhi  = myhalf_d * ( yflux(i,j,k+1) + yflux(i,j+1,k+1) );
+            yfluxbar_lo = Real(1.5)*yfluxlo - myhalf_d*yfluxhi;
         } else {
-            xfluxbar_lo = fourth * ( xflux(i,j,k  ) + xflux(i+1,j  ,k  )
+            xfluxbar_lo = fourth_d * ( xflux(i,j,k  ) + xflux(i+1,j  ,k  )
                                    + xflux(i,j,k-1) + xflux(i+1,j  ,k-1) );
-            yfluxbar_lo = fourth * ( yflux(i,j,k  ) + yflux(i  ,j+1,k  )
+            yfluxbar_lo = fourth_d * ( yflux(i,j,k  ) + yflux(i  ,j+1,k  )
                                    + yflux(i,j,k-1) + yflux(i  ,j+1,k-1) );
         }
 
@@ -694,17 +694,17 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
         Real met_h_xi_hi  = Compute_h_xi_AtKface (i,j,k+1,cellSizeInv,z_nd);
         Real met_h_eta_hi = Compute_h_eta_AtKface(i,j,k+1,cellSizeInv,z_nd);
         if (k == dom_hi.z) {
-            Real xfluxlo  = myhalf * ( xflux(i,j,k-1) + xflux(i+1,j,k-1) );
-            Real xfluxhi  = myhalf * ( xflux(i,j,k  ) + xflux(i+1,j,k  ) );
-            xfluxbar_hi = Real(1.5)*xfluxhi - myhalf*xfluxlo;
+            Real xfluxlo  = myhalf_d * ( xflux(i,j,k-1) + xflux(i+1,j,k-1) );
+            Real xfluxhi  = myhalf_d * ( xflux(i,j,k  ) + xflux(i+1,j,k  ) );
+            xfluxbar_hi = Real(1.5)*xfluxhi - myhalf_d*xfluxlo;
 
-            Real yfluxlo  = myhalf * ( yflux(i,j,k-1) + yflux(i,j+1,k-1) );
-            Real yfluxhi  = myhalf * ( yflux(i,j,k  ) + yflux(i,j+1,k  ) );
-            yfluxbar_hi = Real(1.5)*yfluxhi - myhalf*yfluxlo;
+            Real yfluxlo  = myhalf_d * ( yflux(i,j,k-1) + yflux(i,j+1,k-1) );
+            Real yfluxhi  = myhalf_d * ( yflux(i,j,k  ) + yflux(i,j+1,k  ) );
+            yfluxbar_hi = Real(1.5)*yfluxhi - myhalf_d*yfluxlo;
         } else {
-            xfluxbar_hi = fourth * ( xflux(i,j,k+1) + xflux(i+1,j  ,k+1)
+            xfluxbar_hi = fourth_d * ( xflux(i,j,k+1) + xflux(i+1,j  ,k+1)
                                    + xflux(i,j,k  ) + xflux(i+1,j  ,k  ) );
-            yfluxbar_hi = fourth * ( yflux(i,j,k+1) + yflux(i  ,j+1,k+1)
+            yfluxbar_hi = fourth_d * ( yflux(i,j,k+1) + yflux(i  ,j+1,k+1)
                                    + yflux(i,j,k  ) + yflux(i  ,j+1,k  ) );
         }
 
@@ -714,7 +714,7 @@ DiffusionSrcForState_T (const Box& bx, const Box& domain,
              k == dom_lo.z &&
              qty_index != RhoTheta_comp &&
              qty_index != RhoQ1_comp ) {
-            zflux_lo = zero;
+            zflux_lo = zero_d;
         } else {
             zflux_lo = zflux(i,j,k  )
                      - met_h_xi_lo  * mf_mx(i,j,0) * xfluxbar_lo

--- a/Source/Diffusion/ERF_ImplicitDiff_N.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_N.cpp
@@ -95,6 +95,9 @@ ImplicitDiffForStateLU_N (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
         for (int i(ilo); i<=ihi; ++i) {
 #endif
@@ -304,6 +307,10 @@ ImplicitDiffForMomLU_N (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real two_d    = two;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
       for (int i(ilo); i<=ihi; ++i) {
 #endif

--- a/Source/Diffusion/ERF_ImplicitDiff_N.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_N.cpp
@@ -92,7 +92,7 @@ ImplicitDiffForStateLU_N (const Box& bx,
     Real Fact = implicit_fac * dt * dz_inv;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -107,10 +107,10 @@ ImplicitDiffForStateLU_N (const Box& bx,
                             cell_data, mu_turb, d_alpha_eff, d_eddy_diff_idz,
                             prim_index, prim_scal_index, l_consA, l_turb);
 
-                a_tmp      = zero;
+                a_tmp      = zero_d;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv;
                 b_tmp      = cell_data(i,j,klo,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one;
+                inv_b2_tmp = one_d;
 
                 RHS_a(i,j,klo) = cell_data(i,j,klo,n); // NOTE: this is rho*phi; solution is phi
                 if (use_SurfLayer && scalar_zflux) {
@@ -123,7 +123,7 @@ ImplicitDiffForStateLU_N (const Box& bx,
                 // Only upper face contributes (no flux below surface)
                 if (use_mrf_countergradient && (n == RhoTheta_comp || n == RhoQ1_comp)) {
                     const int gam_comp = (n == RhoTheta_comp) ? EddyDiff::HGAMT_v : EddyDiff::HGAMQ_v;
-                    const Real gam_hi = myhalf * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
+                    const Real gam_hi = myhalf_d * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
                     RHS_a(i,j,klo) -= Fact * rhoAlpha_hi * gam_hi;
                 }
 
@@ -141,7 +141,7 @@ ImplicitDiffForStateLU_N (const Box& bx,
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv;
                 b_tmp      = cell_data(i,j,k,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
                 RHS_a(i,j,k)    = cell_data(i,j,k,n); // NOTE: this is rho*phi; solution is phi
 
@@ -151,8 +151,8 @@ ImplicitDiffForStateLU_N (const Box& bx,
                     const Real gam_k   = mu_turb(i, j, k,   gam_comp);
                     const Real gam_km1 = mu_turb(i, j, k-1, gam_comp);
                     const Real gam_kp1 = mu_turb(i, j, k+1, gam_comp);
-                    const Real gam_hi  = myhalf * (gam_k + gam_kp1); // at k+½
-                    const Real gam_lo  = myhalf * (gam_k + gam_km1); // at k-½
+                    const Real gam_hi  = myhalf_d * (gam_k + gam_kp1); // at k+½
+                    const Real gam_lo  = myhalf_d * (gam_k + gam_km1); // at k-½
                     // Countergradient flux divergence (implicit contribution to RHS):
                     //   -Fact * [ρα_{k+½}·γ_{k+½} - ρα_{k-½}·γ_{k-½}]
                     RHS_a(i,j,k) -= Fact * (rhoAlpha_hi * gam_hi - rhoAlpha_lo * gam_lo);
@@ -170,9 +170,9 @@ ImplicitDiffForStateLU_N (const Box& bx,
                             prim_index, prim_scal_index, l_consA, l_turb);
 
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv;
-                c_tmp      = zero;
+                c_tmp      = zero_d;
                 b_tmp      = cell_data(i,j,khi,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
                 RHS_a(i,j,khi) = cell_data(i,j,khi,n); // NOTE: this is rho*phi; solution is phi
                 if (neumann_on_zhi) {
@@ -301,7 +301,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
     Real Fact = implicit_fac * dt * dz_inv;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -345,12 +345,12 @@ ImplicitDiffForMomLU_N (const Box& bx,
           Real rhoface, rhoAlpha_lo, rhoAlpha_hi;
           Real a_tmp, b_tmp, c_tmp, inv_b2_tmp;
           {
-              rhoface = myhalf * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
               getRhoAlphaForFaces(i, j, klo, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              a_tmp = zero;
+              a_tmp = zero_d;
               c_tmp = -Fact * gfac * rhoAlpha_hi * dz_inv;
 
               RHS_a(i,j,klo) = face_data(i,j,klo); // NOTE: this is momenta; solution is velocity
@@ -359,12 +359,12 @@ ImplicitDiffForMomLU_N (const Box& bx,
               if (ext_dir_on_zlo) {
                   RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau_corr(i,j,klo));
                   if (stagdir==2) {
-                      c_tmp = zero;
-                      RHS_a(i,j,klo) = zero;
+                      c_tmp = zero_d;
+                      RHS_a(i,j,klo) = zero_d;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      a_tmp = -two * Fact * rhoAlpha_lo * dz_inv;
-                      RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv;
+                      a_tmp = -two_d * Fact * rhoAlpha_lo * dz_inv;
+                      RHS_a(i,j,klo) += two_d * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv;
                   }
               } else if (use_SurfLayer) {
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
@@ -376,7 +376,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one;
+              inv_b2_tmp = one_d;
 
               RHS_a(i,j,klo)    /= b_tmp;         // NOTE: this is now "rho"
               coeffG_a(i,j,klo)  = c_tmp / b_tmp; // NOTE: this is now "gamma"
@@ -385,7 +385,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
           // Build the coefficients and RHS for L decomp
           //===================================================
           for (int k(klo+1); k < khi; k++) {
-              rhoface = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               getRhoAlphaForFaces(i, j, k, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
@@ -393,7 +393,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
               a_tmp      = -Fact * rhoAlpha_lo * dz_inv;
               c_tmp      = -Fact * rhoAlpha_hi * dz_inv;
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one/ (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+              inv_b2_tmp = one_d/ (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
               RHS_a(i,j,k)    = face_data(i,j,k); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,k)   += Fact * gfac * (tau_corr(i,j,k+1) - tau_corr(i,j,k));
@@ -405,13 +405,13 @@ ImplicitDiffForMomLU_N (const Box& bx,
           // Top boundary coefficients and RHS for L decomp
           //===================================================
           {
-              rhoface = myhalf * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
               getRhoAlphaForFaces(i, j, khi, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
               a_tmp = -Fact * gfac * rhoAlpha_lo * dz_inv;
-              c_tmp = zero;
+              c_tmp = zero_d;
 
               RHS_a(i,j,khi)  = face_data(i,j,khi); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,khi) += Fact * gfac * (tau_corr(i,j,khi+1) - tau_corr(i,j,khi));
@@ -419,17 +419,17 @@ ImplicitDiffForMomLU_N (const Box& bx,
               // BCs: Dirichlet (u_i = val), slip wall (w = 0)
               if (ext_dir_on_zhi) {
                   if (stagdir==2) {
-                      a_tmp = zero;
-                      RHS_a(i,j,khi) = zero;
+                      a_tmp = zero_d;
+                      RHS_a(i,j,khi) = zero_d;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      c_tmp = -two * Fact * rhoAlpha_hi * dz_inv;
-                      RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv;
+                      c_tmp = -two_d * Fact * rhoAlpha_hi * dz_inv;
+                      RHS_a(i,j,khi) += two_d * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv;
                   }
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one/ (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+              inv_b2_tmp = one_d/ (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
               // First solve
               soln_a(i,j,khi) = (RHS_a(i,j,khi) - a_tmp * RHS_a(i,j,khi-1)) * inv_b2_tmp;
@@ -444,7 +444,7 @@ ImplicitDiffForMomLU_N (const Box& bx,
           // Convert back to momenta
           //===================================================
           for (int k(klo); k<=khi; ++k) {
-              rhoface = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               face_data(i,j,k) = rhoface * soln_a(i,j,k);
           }
 

--- a/Source/Diffusion/ERF_ImplicitDiff_S.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_S.cpp
@@ -93,6 +93,10 @@ ImplicitDiffForStateLU_S (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real two_d    = two;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
         for (int i(ilo); i<=ihi; ++i) {
 #endif
@@ -313,6 +317,10 @@ ImplicitDiffForMomLU_S (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real two_d    = two;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
       for (int i(ilo); i<=ihi; ++i) {
 #endif

--- a/Source/Diffusion/ERF_ImplicitDiff_S.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_S.cpp
@@ -90,7 +90,7 @@ ImplicitDiffForStateLU_S (const Box& bx,
     Real Fact = implicit_fac * dt;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,one_d=one,two_d=two,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -106,14 +106,14 @@ ImplicitDiffForStateLU_S (const Box& bx,
                             cell_data, mu_turb, d_alpha_eff, d_eddy_diff_idz,
                             prim_index, prim_scal_index, l_consA, l_turb);
 
-                dz_inv    = one / dz_ptr[klo];
+                dz_inv    = one_d / dz_ptr[klo];
                 dz_inv_lo = dz_inv;
-                dz_inv_hi = two / (dz_ptr[klo] + dz_ptr[klo+1]);
+                dz_inv_hi = two_d / (dz_ptr[klo] + dz_ptr[klo+1]);
 
-                a_tmp      = zero;
+                a_tmp      = zero_d;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
                 b_tmp      = cell_data(i,j,klo,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one;
+                inv_b2_tmp = one_d;
 
                 RHS_a(i,j,klo) = cell_data(i,j,klo,n); // NOTE: this is rho*phi; solution is phi
                 if (use_SurfLayer && scalar_zflux) {
@@ -125,7 +125,7 @@ ImplicitDiffForStateLU_S (const Box& bx,
                 // Add countergradient correction to RHS at bottom boundary
                 if (use_mrf_countergradient && (n == RhoTheta_comp || n == RhoQ1_comp)) {
                     const int gam_comp = (n == RhoTheta_comp) ? EddyDiff::HGAMT_v : EddyDiff::HGAMQ_v;
-                    const Real gam_hi = myhalf * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
+                    const Real gam_hi = myhalf_d * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
                     RHS_a(i,j,klo) -= Fact * rhoAlpha_hi * gam_hi * dz_inv_hi;
                 }
 
@@ -140,14 +140,14 @@ ImplicitDiffForStateLU_S (const Box& bx,
                             cell_data, mu_turb, d_alpha_eff, d_eddy_diff_idz,
                             prim_index, prim_scal_index, l_consA, l_turb);
 
-                dz_inv    = one / dz_ptr[k];
-                dz_inv_lo = two / (dz_ptr[k] + dz_ptr[k-1]);
-                dz_inv_hi = two / (dz_ptr[k] + dz_ptr[k+1]);
+                dz_inv    = one_d / dz_ptr[k];
+                dz_inv_lo = two_d / (dz_ptr[k] + dz_ptr[k-1]);
+                dz_inv_hi = two_d / (dz_ptr[k] + dz_ptr[k+1]);
 
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
                 b_tmp      = cell_data(i,j,k,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
                 RHS_a(i,j,k)    = cell_data(i,j,k,n); // NOTE: this is rho*phi; solution is phi
 
@@ -157,8 +157,8 @@ ImplicitDiffForStateLU_S (const Box& bx,
                     const Real gam_k   = mu_turb(i, j, k,   gam_comp);
                     const Real gam_km1 = mu_turb(i, j, k-1, gam_comp);
                     const Real gam_kp1 = mu_turb(i, j, k+1, gam_comp);
-                    const Real gam_hi  = myhalf * (gam_k + gam_kp1); // at k+½
-                    const Real gam_lo  = myhalf * (gam_k + gam_km1); // at k-½
+                    const Real gam_hi  = myhalf_d * (gam_k + gam_kp1); // at k+½
+                    const Real gam_lo  = myhalf_d * (gam_k + gam_km1); // at k-½
                     // Countergradient flux divergence (implicit contribution to RHS):
                     //   -Fact * [ρα_{k+½}·γ_{k+½}·dz_inv_hi - ρα_{k-½}·γ_{k-½}·dz_inv_lo]
                     RHS_a(i,j,k) -= Fact * (rhoAlpha_hi * gam_hi * dz_inv_hi - rhoAlpha_lo * gam_lo * dz_inv_lo);
@@ -175,14 +175,14 @@ ImplicitDiffForStateLU_S (const Box& bx,
                             cell_data, mu_turb, d_alpha_eff, d_eddy_diff_idz,
                             prim_index, prim_scal_index, l_consA, l_turb);
 
-                dz_inv    = one / dz_ptr[khi];
-                dz_inv_lo = two / (dz_ptr[khi] + dz_ptr[khi-1]);
+                dz_inv    = one_d / dz_ptr[khi];
+                dz_inv_lo = two_d / (dz_ptr[khi] + dz_ptr[khi-1]);
                 dz_inv_hi = dz_inv;
 
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
-                c_tmp      = zero;
+                c_tmp      = zero_d;
                 b_tmp      = cell_data(i,j,khi,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
                 RHS_a(i,j,khi) = cell_data(i,j,khi,n); // NOTE: this is rho*phi; solution is phi
                 if (neumann_on_zhi) {
@@ -310,7 +310,7 @@ ImplicitDiffForMomLU_S (const Box& bx,
     Real Fact = implicit_fac * dt;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,one_d=one,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -355,16 +355,16 @@ ImplicitDiffForMomLU_S (const Box& bx,
           Real dz_inv, dz_inv_lo, dz_inv_hi;
           Real a_tmp, b_tmp, c_tmp, inv_b2_tmp;
           {
-              rhoface = myhalf * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
               getRhoAlphaForFaces(i, j, klo, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              dz_inv    = one / dz_ptr[klo];
+              dz_inv    = one_d / dz_ptr[klo];
               dz_inv_lo = dz_inv;
-              dz_inv_hi = two / (dz_ptr[klo] + dz_ptr[klo+1]);
+              dz_inv_hi = two_d / (dz_ptr[klo] + dz_ptr[klo+1]);
 
-              a_tmp = zero;
+              a_tmp = zero_d;
               c_tmp = -Fact * gfac * rhoAlpha_hi * dz_inv_hi * dz_inv;
 
               RHS_a(i,j,klo) = face_data(i,j,klo); // NOTE: this is momenta; solution is velocity
@@ -377,8 +377,8 @@ ImplicitDiffForMomLU_S (const Box& bx,
                       RHS_a(i,j,klo) = 0.;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      a_tmp = -two * Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
-                      RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv_lo * dz_inv;
+                      a_tmp = -two_d * Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
+                      RHS_a(i,j,klo) += two_d * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv_lo * dz_inv;
                   }
               } else if (use_SurfLayer) {
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
@@ -390,7 +390,7 @@ ImplicitDiffForMomLU_S (const Box& bx,
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one;
+              inv_b2_tmp = one_d;
 
               RHS_a(i,j,klo)    /= b_tmp;         // NOTE: this is now "rho"
               coeffG_a(i,j,klo)  = c_tmp / b_tmp; // NOTE: this is now "gamma"
@@ -399,19 +399,19 @@ ImplicitDiffForMomLU_S (const Box& bx,
           // Build the coefficients and RHS for L decomp
           //===================================================
           for (int k(klo+1); k < khi; k++) {
-              rhoface = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               getRhoAlphaForFaces(i, j, k, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              dz_inv    = one / dz_ptr[k];
-              dz_inv_lo = two / (dz_ptr[k] + dz_ptr[k-1]);
-              dz_inv_hi = two / (dz_ptr[k] + dz_ptr[k+1]);
+              dz_inv    = one_d / dz_ptr[k];
+              dz_inv_lo = two_d / (dz_ptr[k] + dz_ptr[k-1]);
+              dz_inv_hi = two_d / (dz_ptr[k] + dz_ptr[k+1]);
 
               a_tmp      = -Fact * rhoAlpha_lo * dz_inv_lo * dz_inv;
               c_tmp      = -Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+              inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
               RHS_a(i,j,k)    = face_data(i,j,k); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,k)   += Fact * gfac * (tau_corr(i,j,k+1) - tau_corr(i,j,k)) * dz_inv;
@@ -423,17 +423,17 @@ ImplicitDiffForMomLU_S (const Box& bx,
           // Top boundary coefficients and RHS for L decomp
           //===================================================
           {
-              rhoface = myhalf * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
               getRhoAlphaForFaces(i, j, khi, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              dz_inv    = one / dz_ptr[khi];
-              dz_inv_lo = two / (dz_ptr[khi] + dz_ptr[khi-1]);
+              dz_inv    = one_d / dz_ptr[khi];
+              dz_inv_lo = two_d / (dz_ptr[khi] + dz_ptr[khi-1]);
               dz_inv_hi = dz_inv;
 
               a_tmp = -Fact * gfac * rhoAlpha_lo * dz_inv_lo * dz_inv;
-              c_tmp = zero;
+              c_tmp = zero_d;
 
               RHS_a(i,j,khi)  = face_data(i,j,khi); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,khi) += Fact * gfac * (tau_corr(i,j,khi+1) - tau_corr(i,j,khi)) * dz_inv;
@@ -441,17 +441,17 @@ ImplicitDiffForMomLU_S (const Box& bx,
               // BCs: Dirichlet (u_i = val), slip wall (w = 0)
               if (ext_dir_on_zhi) {
                   if (stagdir==2) {
-                      a_tmp = zero;
-                      RHS_a(i,j,khi) = zero;
+                      a_tmp = zero_d;
+                      RHS_a(i,j,khi) = zero_d;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      c_tmp = -two * Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
-                      RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv_hi * dz_inv;
+                      c_tmp = -two_d * Fact * rhoAlpha_hi * dz_inv_hi * dz_inv;
+                      RHS_a(i,j,khi) += two_d * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv_hi * dz_inv;
                   }
               }
 
               b_tmp      = rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+              inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
               // First solve
               soln_a(i,j,khi) = (RHS_a(i,j,khi) - a_tmp * RHS_a(i,j,khi-1)) * inv_b2_tmp;
@@ -466,7 +466,7 @@ ImplicitDiffForMomLU_S (const Box& bx,
           // Convert back to momenta
           //===================================================
           for (int k(klo); k<=khi; ++k) {
-              rhoface = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               face_data(i,j,k) = rhoface * soln_a(i,j,k);
           }
 

--- a/Source/Diffusion/ERF_ImplicitDiff_T.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_T.cpp
@@ -94,7 +94,7 @@ ImplicitDiffForStateLU_T (const Box& bx,
     Real Fact = implicit_fac * dt * dz_inv;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -117,10 +117,10 @@ ImplicitDiffForStateLU_T (const Box& bx,
                 met_h_zeta_lo = Compute_h_zeta_AtKface(i,j,klo  ,cellSizeInv,z_nd);
                 met_h_zeta_hi = Compute_h_zeta_AtKface(i,j,klo+1,cellSizeInv,z_nd);
 
-                a_tmp      = zero;
+                a_tmp      = zero_d;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
                 b_tmp      = detJ(i,j,klo) * cell_data(i,j,klo,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one;
+                inv_b2_tmp = one_d;
 
                 RHS_a(i,j,klo) = detJ(i,j,klo) * cell_data(i,j,klo,n); // NOTE: this is rho*phi; solution is phi
                 if (use_SurfLayer && scalar_zflux) {
@@ -132,7 +132,7 @@ ImplicitDiffForStateLU_T (const Box& bx,
                 // Add countergradient correction to RHS at bottom boundary
                 if (use_mrf_countergradient && (n == RhoTheta_comp || n == RhoQ1_comp)) {
                     const int gam_comp = (n == RhoTheta_comp) ? EddyDiff::HGAMT_v : EddyDiff::HGAMQ_v;
-                    const Real gam_hi = myhalf * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
+                    const Real gam_hi = myhalf_d * (mu_turb(i, j, klo, gam_comp) + mu_turb(i, j, klo+1, gam_comp));
                     RHS_a(i,j,klo) -= Fact * rhoAlpha_hi * gam_hi / met_h_zeta_hi;
                 }
 
@@ -153,7 +153,7 @@ ImplicitDiffForStateLU_T (const Box& bx,
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
                 c_tmp      = -Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
                 b_tmp      = detJ(i,j,k) * cell_data(i,j,k,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
                 RHS_a(i,j,k)    = detJ(i,j,k) * cell_data(i,j,k,n); // NOTE: this is rho*phi; solution is phi
 
@@ -163,8 +163,8 @@ ImplicitDiffForStateLU_T (const Box& bx,
                     const Real gam_k   = mu_turb(i, j, k,   gam_comp);
                     const Real gam_km1 = mu_turb(i, j, k-1, gam_comp);
                     const Real gam_kp1 = mu_turb(i, j, k+1, gam_comp);
-                    const Real gam_hi  = myhalf * (gam_k + gam_kp1); // at k+½
-                    const Real gam_lo  = myhalf * (gam_k + gam_km1); // at k-½
+                    const Real gam_hi  = myhalf_d * (gam_k + gam_kp1); // at k+½
+                    const Real gam_lo  = myhalf_d * (gam_k + gam_km1); // at k-½
                     // Countergradient flux divergence (implicit contribution to RHS):
                     //   -Fact * [ρα_{k+½}·γ_{k+½} - ρα_{k-½}·γ_{k-½}] / h_ζ
                     RHS_a(i,j,k) -= Fact * (rhoAlpha_hi * gam_hi / met_h_zeta_hi - rhoAlpha_lo * gam_lo / met_h_zeta_lo);
@@ -185,9 +185,9 @@ ImplicitDiffForStateLU_T (const Box& bx,
                 met_h_zeta_hi = Compute_h_zeta_AtKface(i,j,khi+1,cellSizeInv,z_nd);
 
                 a_tmp      = -Fact * rhoAlpha_lo * dz_inv / met_h_zeta_hi;
-                c_tmp      = zero;
+                c_tmp      = zero_d;
                 b_tmp      = detJ(i,j,khi) * cell_data(i,j,khi,Rho_comp) - a_tmp - c_tmp;
-                inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+                inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
                 RHS_a(i,j,khi) = detJ(i,j,khi) * cell_data(i,j,khi,n); // NOTE: this is rho*phi; solution is phi
                 if (neumann_on_zhi) {
@@ -320,7 +320,7 @@ ImplicitDiffForMomLU_T (const Box& bx,
     Real Fact = implicit_fac * dt * dz_inv;
 
 #ifdef AMREX_USE_GPU
-    ParallelFor(makeSlab(bx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+    ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
     for (int j(jlo); j<=jhi; ++j) {
@@ -369,18 +369,18 @@ ImplicitDiffForMomLU_T (const Box& bx,
           Real detJface, met_h_zeta_lo, met_h_zeta_hi;
           Real a_tmp, b_tmp, c_tmp, inv_b2_tmp;
           {
-              detJface = myhalf * (detJ(i,j,klo) + detJ(i-ioff,j-joff,klo));
-              rhoface  = myhalf * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
+              detJface = myhalf_d * (detJ(i,j,klo) + detJ(i-ioff,j-joff,klo));
+              rhoface  = myhalf_d * (cell_data(i,j,klo,Rho_comp) + cell_data(i-ioff,j-joff,klo,Rho_comp));
               getRhoAlphaForFaces(i, j, klo, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              met_h_zeta_lo = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,klo  ,cellSizeInv,z_nd)
+              met_h_zeta_lo = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,klo  ,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,klo  ,cellSizeInv,z_nd) );
-              met_h_zeta_hi = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,klo+1,cellSizeInv,z_nd)
+              met_h_zeta_hi = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,klo+1,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,klo+1,cellSizeInv,z_nd) );
 
-              a_tmp = zero;
+              a_tmp = zero_d;
               c_tmp = -Fact * gfac * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
 
               RHS_a(i,j,klo) = detJface * face_data(i,j,klo); // NOTE: this is momenta; solution is velocity
@@ -389,12 +389,12 @@ ImplicitDiffForMomLU_T (const Box& bx,
               if (ext_dir_on_zlo) {
                   RHS_a(i,j,klo) += Fact * gfac * (tau_corr(i,j,klo+1) - tau_corr(i,j,klo));
                   if (stagdir==2) {
-                      c_tmp = zero;
-                      RHS_a(i,j,klo) = zero;
+                      c_tmp = zero_d;
+                      RHS_a(i,j,klo) = zero_d;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      a_tmp = -two * Fact * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
-                      RHS_a(i,j,klo) += two * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv / met_h_zeta_lo;
+                      a_tmp = -two_d * Fact * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
+                      RHS_a(i,j,klo) += two_d * rhoAlpha_lo * face_data(i,j,klo-1) * dz_inv * dz_inv / met_h_zeta_lo;
                   }
               } else if (use_SurfLayer) {
                   // NOTE: tau = -mu*d_z(u_i) w/ SL
@@ -406,7 +406,7 @@ ImplicitDiffForMomLU_T (const Box& bx,
               }
 
               b_tmp      = detJface * rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one;
+              inv_b2_tmp = one_d;
 
               RHS_a(i,j,klo)    /= b_tmp;         // NOTE: this is now "rho"
               coeffG_a(i,j,klo)  = c_tmp / b_tmp; // NOTE: this is now "gamma"
@@ -415,21 +415,21 @@ ImplicitDiffForMomLU_T (const Box& bx,
           // Build the coefficients and RHS for L decomp
           //===================================================
           for (int k(klo+1); k < khi; k++) {
-              detJface = myhalf * (detJ(i,j,k) + detJ(i-ioff,j-joff,k));
-              rhoface  = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              detJface = myhalf_d * (detJ(i,j,k) + detJ(i-ioff,j-joff,k));
+              rhoface  = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               getRhoAlphaForFaces(i, j, k, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              met_h_zeta_lo = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,k  ,cellSizeInv,z_nd)
+              met_h_zeta_lo = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,k  ,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,k  ,cellSizeInv,z_nd) );
-              met_h_zeta_hi = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,k+1,cellSizeInv,z_nd)
+              met_h_zeta_hi = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,k+1,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,k+1,cellSizeInv,z_nd) );
 
               a_tmp      = -Fact * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
               c_tmp      = -Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
               b_tmp      = detJface * rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
+              inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,k-1));
 
               RHS_a(i,j,k)    = detJface * face_data(i,j,k); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,k)   += Fact * gfac * (tau_corr(i,j,k+1) - tau_corr(i,j,k));
@@ -441,19 +441,19 @@ ImplicitDiffForMomLU_T (const Box& bx,
           // Top boundary coefficients and RHS for L decomp
           //===================================================
           {
-              detJface = myhalf * (detJ(i,j,khi) + detJ(i-ioff,j-joff,khi));
-              rhoface  = myhalf * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
+              detJface = myhalf_d * (detJ(i,j,khi) + detJ(i-ioff,j-joff,khi));
+              rhoface  = myhalf_d * (cell_data(i,j,khi,Rho_comp) + cell_data(i-ioff,j-joff,khi,Rho_comp));
               getRhoAlphaForFaces(i, j, khi, ioff, joff, rhoAlpha_lo, rhoAlpha_hi,
                                   cell_data, mu_turb, mu_eff,
                                   l_consA, l_turb);
 
-              met_h_zeta_lo = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,khi  ,cellSizeInv,z_nd)
+              met_h_zeta_lo = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,khi  ,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,khi  ,cellSizeInv,z_nd) );
-              met_h_zeta_hi = myhalf * ( Compute_h_zeta_AtKface(i     ,j     ,khi+1,cellSizeInv,z_nd)
+              met_h_zeta_hi = myhalf_d * ( Compute_h_zeta_AtKface(i     ,j     ,khi+1,cellSizeInv,z_nd)
                                        + Compute_h_zeta_AtKface(i-ioff,j-joff,khi+1,cellSizeInv,z_nd) );
 
               a_tmp = -Fact * gfac * rhoAlpha_lo * dz_inv / met_h_zeta_lo;
-              c_tmp = zero;
+              c_tmp = zero_d;
 
               RHS_a(i,j,khi)  = detJface * face_data(i,j,khi); // NOTE: this is momenta; solution is velocity
               RHS_a(i,j,khi) += Fact * gfac * (tau_corr(i,j,khi+1) - tau_corr(i,j,khi));
@@ -461,17 +461,17 @@ ImplicitDiffForMomLU_T (const Box& bx,
               // BCs: Dirichlet (u_i = val), slip wall (w = 0)
               if (ext_dir_on_zhi) {
                   if (stagdir==2) {
-                      a_tmp = zero;
-                      RHS_a(i,j,khi) = zero;
+                      a_tmp = zero_d;
+                      RHS_a(i,j,khi) = zero_d;
                   } else {
                       // NOTE: wall is 1/2 dz away (2 dz_inv)
-                      c_tmp = -two * Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
-                      RHS_a(i,j,khi) += two * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv / met_h_zeta_hi;
+                      c_tmp = -two_d * Fact * rhoAlpha_hi * dz_inv / met_h_zeta_hi;
+                      RHS_a(i,j,khi) += two_d * rhoAlpha_hi * face_data(i,j,khi+1) * dz_inv * dz_inv / met_h_zeta_hi;
                   }
               }
 
               b_tmp      = detJface * rhoface - a_tmp - c_tmp;
-              inv_b2_tmp = one / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
+              inv_b2_tmp = one_d / (b_tmp - a_tmp * coeffG_a(i,j,khi-1));
 
               // First solve
               soln_a(i,j,khi) = (RHS_a(i,j,khi) - a_tmp * RHS_a(i,j,khi-1)) * inv_b2_tmp;
@@ -486,7 +486,7 @@ ImplicitDiffForMomLU_T (const Box& bx,
           // Convert back to momenta
           //===================================================
           for (int k(klo); k<=khi; ++k) {
-              rhoface = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
+              rhoface = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i-ioff,j-joff,k,Rho_comp));
               face_data(i,j,k) = rhoface * soln_a(i,j,k);
           }
 

--- a/Source/Diffusion/ERF_ImplicitDiff_T.cpp
+++ b/Source/Diffusion/ERF_ImplicitDiff_T.cpp
@@ -97,6 +97,9 @@ ImplicitDiffForStateLU_T (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
         for (int i(ilo); i<=ihi; ++i) {
 #endif
@@ -323,6 +326,10 @@ ImplicitDiffForMomLU_T (const Box& bx,
     ParallelFor(makeSlab(bx,2,0), [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
     {
 #else
+    Real zero_d   = zero;
+    Real one_d    = one;
+    Real two_d    = two;
+    Real myhalf_d = myhalf;
     for (int j(jlo); j<=jhi; ++j) {
       for (int i(ilo); i<=ihi; ++i) {
 #endif

--- a/Source/EB/ERF_EB.cpp
+++ b/Source/EB/ERF_EB.cpp
@@ -102,21 +102,21 @@ eb_::set_connection_flags ()
         Array4<EBCellFlag> const& flag = cellflag.array(mfi);
         Array4<Real const> const& vfrac = volfrac.const_array(mfi);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             for(int kk(-1); kk<=1; kk++) {
             for(int jj(-1); jj<=1; jj++) {
             for(int ii(-1); ii<=1; ii++)
             {
-                if (vfrac(i+ii,j+jj,k+kk) == zero) {
+                if (vfrac(i+ii,j+jj,k+kk) == zero_d) {
                     flag(i,j,k).setDisconnected(ii,jj,kk);
                 }
             }}}
         });
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            if (vfrac(i,j,k)==zero) {
+            if (vfrac(i,j,k)==zero_d) {
                 flag(i,j,k).setCovered();
             }
         });

--- a/Source/EB/ERF_EBAdvectionSrcForMom.H
+++ b/Source/EB/ERF_EBAdvectionSrcForMom.H
@@ -67,15 +67,15 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
     amrex::ParallelFor(bxx_grown[0], bxx_grown[1], bxx_grown[2],
     // x-momentum: x-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( u_afrac_x(i,j,k) > zero )
+        if ( u_afrac_x(i,j,k) > zero_d )
         {
-            amrex::Real rho_u_avg = myhalf * (rho_u(i-1,j,k) * mf_ux_inv(i-1,j,0) + rho_u(i,j,k) * mf_ux_inv(i,j,0));
+            amrex::Real rho_u_avg = myhalf_d * (rho_u(i-1,j,k) * mf_ux_inv(i-1,j,0) + rho_u(i,j,k) * mf_ux_inv(i,j,0));
 
             int icell = 0;
 
-            if (rho_u_avg>zero)
+            if (rho_u_avg>zero_d)
             {
                 for (int ii=0; ii<ncells_u_horz; ++ii) {
                     if (u_cflag(i-ii-1,j,k).isCovered()) {
@@ -84,7 +84,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     icell++;
                 }
             }
-            else if (rho_u_avg<zero)
+            else if (rho_u_avg<zero_d)
             {
                 for (int ii=0; ii<ncells_u_horz; ++ii) {
                     if (u_cflag(i+ii,j,k).isCovered()) {
@@ -96,7 +96,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate u using the highest-order scheme
 
-            amrex::Real interpx = zero;
+            amrex::Real interpx = zero_d;
             if (icell==ncells_u_horz) {
                 interp_u_horz.InterpolateInX(i,j,k,0,interpx,rho_u_avg);
             } else {
@@ -110,19 +110,19 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_u_arr[0](i,j,k) = zero;
+            flx_u_arr[0](i,j,k) = zero_d;
         }
     },
     // x-momentum: y-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( u_afrac_y(i,j,k) > zero )
+        if ( u_afrac_y(i,j,k) > zero_d )
         {
-            amrex::Real rho_v_avg = myhalf * (rho_v(i,j,k) * mf_vx_inv(i,j,0) + rho_v(i-1,j,k) * mf_vx_inv(i-1,j,0));
+            amrex::Real rho_v_avg = myhalf_d * (rho_v(i,j,k) * mf_vx_inv(i,j,0) + rho_v(i-1,j,k) * mf_vx_inv(i-1,j,0));
 
             int jcell = 0;
 
-            if (rho_v_avg>zero)
+            if (rho_v_avg>zero_d)
             {
                 for (int jj=0; jj<ncells_u_horz; ++jj) {
                     if (u_cflag(i,j-jj-1,k).isCovered()) {
@@ -131,7 +131,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     jcell++;
                 }
             }
-            else if (rho_v_avg<zero)
+            else if (rho_v_avg<zero_d)
             {
                 for (int jj=0; jj<ncells_u_horz; ++jj) {
                     if (u_cflag(i,j+jj,k).isCovered()) {
@@ -143,7 +143,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate u using the highest-order scheme
 
-            amrex::Real interpy = zero;
+            amrex::Real interpy = zero_d;
             if (jcell==ncells_u_horz) {
                 interp_u_horz.InterpolateInY(i,j,k,0,interpy,rho_v_avg);
             } else {
@@ -157,19 +157,19 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_u_arr[1](i,j,k) = zero;
+            flx_u_arr[1](i,j,k) = zero_d;
         }
     },
     // x-momentum: z-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( u_afrac_z(i,j,k) > zero )
+        if ( u_afrac_z(i,j,k) > zero_d )
         {
-            amrex::Real rho_w_avg = myhalf * (rho_w(i,j,k) + rho_w(i-1,j,k));
+            amrex::Real rho_w_avg = myhalf_d * (rho_w(i,j,k) + rho_w(i-1,j,k));
 
             int kcell = 0;
 
-            if (rho_w_avg>zero)
+            if (rho_w_avg>zero_d)
             {
                 for (int kk=0; kk<ncells_u_vert; ++kk) {
                     if (u_cflag(i,j,k-kk-1).isCovered()) {
@@ -178,7 +178,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     kcell++;
                 }
             }
-            else if (rho_w_avg<zero)
+            else if (rho_w_avg<zero_d)
             {
                 for (int kk=0; kk<ncells_u_vert; ++kk) {
                     if (u_cflag(i,j,k+kk).isCovered()) {
@@ -190,7 +190,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate u using the highest-order scheme
 
-            amrex::Real interpz = zero;
+            amrex::Real interpz = zero_d;
             if (kcell==ncells_u_vert) {
                 interp_u_vert.InterpolateInZ(i,j,k,0,interpz,rho_w_avg);
             } else {
@@ -204,7 +204,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_u_arr[2](i,j,k) = zero;
+            flx_u_arr[2](i,j,k) = zero_d;
         }
     });
 
@@ -214,15 +214,15 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
     amrex::ParallelFor(bxy_grown[0], bxy_grown[1], bxy_grown[2],
     // y-momentum: x-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( v_afrac_x(i,j,k) > zero )
+        if ( v_afrac_x(i,j,k) > zero_d )
         {
-            amrex::Real rho_u_avg = myhalf * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i,j-1,k) * mf_uy_inv(i,j-1,0));
+            amrex::Real rho_u_avg = myhalf_d * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i,j-1,k) * mf_uy_inv(i,j-1,0));
 
             int icell = 0;
 
-            if (rho_u_avg>zero)
+            if (rho_u_avg>zero_d)
             {
                 for (int ii=0; ii<ncells_v_horz; ++ii) {
                     if (v_cflag(i-ii-1,j,k).isCovered()) {
@@ -231,7 +231,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     icell++;
                 }
             }
-            else if (rho_u_avg<zero)
+            else if (rho_u_avg<zero_d)
             {
                 for (int ii=0; ii<ncells_v_horz; ++ii) {
                     if (v_cflag(i+ii,j,k).isCovered()) {
@@ -243,7 +243,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate v using the highest-order scheme
 
-            amrex::Real interpx = zero;
+            amrex::Real interpx = zero_d;
             if (icell==ncells_v_horz) {
                 interp_v_horz.InterpolateInX(i,j,k,0,interpx,rho_u_avg);
             } else {
@@ -257,19 +257,19 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_v_arr[0](i,j,k) = zero;
+            flx_v_arr[0](i,j,k) = zero_d;
         }
     },
     // y-momentum: y-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( v_afrac_y(i,j,k) > zero )
+        if ( v_afrac_y(i,j,k) > zero_d )
         {
-            amrex::Real rho_v_avg = myhalf * (rho_v(i,j,k) * mf_vy_inv(i,j,0) + rho_v(i,j-1,k) * mf_vy_inv(i,j-1,0));
+            amrex::Real rho_v_avg = myhalf_d * (rho_v(i,j,k) * mf_vy_inv(i,j,0) + rho_v(i,j-1,k) * mf_vy_inv(i,j-1,0));
 
             int jcell = 0;
 
-            if (rho_v_avg>zero)
+            if (rho_v_avg>zero_d)
             {
                 for (int jj=0; jj<ncells_v_horz; ++jj) {
                     if (v_cflag(i,j-jj-1,k).isCovered()) {
@@ -278,7 +278,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     jcell++;
                 }
             }
-            else if (rho_v_avg<zero)
+            else if (rho_v_avg<zero_d)
             {
                 for (int jj=0; jj<ncells_v_horz; ++jj) {
                     if (v_cflag(i,j+jj,k).isCovered()) {
@@ -290,7 +290,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate v using the highest-order scheme
 
-            amrex::Real interpy = zero;
+            amrex::Real interpy = zero_d;
             if (jcell==ncells_v_horz) {
                 interp_v_horz.InterpolateInY(i,j,k,0,interpy,rho_v_avg);
             } else {
@@ -304,19 +304,19 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_v_arr[1](i,j,k) = zero;
+            flx_v_arr[1](i,j,k) = zero_d;
         }
     },
     // y-momentum: z-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( v_afrac_z(i,j,k) > zero )
+        if ( v_afrac_z(i,j,k) > zero_d )
         {
-            amrex::Real rho_w_avg = myhalf * (rho_w(i,j,k) + rho_w(i,j-1,k));
+            amrex::Real rho_w_avg = myhalf_d * (rho_w(i,j,k) + rho_w(i,j-1,k));
 
             int kcell = 0;
 
-            if (rho_w_avg>zero)
+            if (rho_w_avg>zero_d)
             {
                 for (int kk=0; kk<ncells_v_vert; ++kk) {
                     if (v_cflag(i,j,k-kk-1).isCovered()) {
@@ -325,7 +325,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     kcell++;
                 }
             }
-            else if (rho_w_avg<zero)
+            else if (rho_w_avg<zero_d)
             {
                 for (int kk=0; kk<ncells_v_vert; ++kk) {
                     if (v_cflag(i,j,k+kk).isCovered()) {
@@ -337,7 +337,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate v using the highest-order scheme
 
-            amrex::Real interpz = zero;
+            amrex::Real interpz = zero_d;
             if (kcell==ncells_v_vert) {
                 interp_v_vert.InterpolateInZ(i,j,k,0,interpz,rho_w_avg);
             } else {
@@ -351,7 +351,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_v_arr[2](i,j,k) = zero;
+            flx_v_arr[2](i,j,k) = zero_d;
         }
     });
 
@@ -361,15 +361,15 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
     amrex::ParallelFor(bxz_grown[0], bxz_grown[1], bxz_grown[2],
     // z-momentum: x-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( w_afrac_x(i,j,k) > zero )
+        if ( w_afrac_x(i,j,k) > zero_d )
         {
-            amrex::Real rho_u_avg = myhalf * (rho_u(i,j,k) + rho_u(i,j,k-1)) * mf_ux_inv(i,j,0);
+            amrex::Real rho_u_avg = myhalf_d * (rho_u(i,j,k) + rho_u(i,j,k-1)) * mf_ux_inv(i,j,0);
 
             int icell = 0;
 
-            if (rho_u_avg>zero)
+            if (rho_u_avg>zero_d)
             {
                 for (int ii=0; ii<ncells_w_horz; ++ii) {
                     if (w_cflag(i-ii-1,j,k).isCovered()) {
@@ -378,7 +378,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     icell++;
                 }
             }
-            else if (rho_u_avg<zero)
+            else if (rho_u_avg<zero_d)
             {
                 for (int ii=0; ii<ncells_w_horz; ++ii) {
                     if (w_cflag(i+ii,j,k).isCovered()) {
@@ -390,7 +390,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate w using the highest-order scheme
 
-            amrex::Real interpx = zero;
+            amrex::Real interpx = zero_d;
             if (icell==ncells_w_horz) {
                 interp_w_horz.InterpolateInX(i,j,k,0,interpx,rho_u_avg);
             } else {
@@ -404,19 +404,19 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_w_arr[0](i,j,k) = zero;
+            flx_w_arr[0](i,j,k) = zero_d;
         }
     },
     // z-momentum: y-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( w_afrac_y(i,j,k) > zero )
+        if ( w_afrac_y(i,j,k) > zero_d )
         {
-            amrex::Real rho_v_avg = myhalf * (rho_v(i,j,k) + rho_v(i,j,k-1)) * mf_vy_inv(i,j,0);
+            amrex::Real rho_v_avg = myhalf_d * (rho_v(i,j,k) + rho_v(i,j,k-1)) * mf_vy_inv(i,j,0);
 
             int jcell = 0;
 
-            if (rho_v_avg>zero)
+            if (rho_v_avg>zero_d)
             {
                 for (int jj=0; jj<ncells_w_horz; ++jj) {
                     if (w_cflag(i,j-jj-1,k).isCovered()) {
@@ -425,7 +425,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                     jcell++;
                 }
             }
-            else if (rho_v_avg<zero)
+            else if (rho_v_avg<zero_d)
             {
                 for (int jj=0; jj<ncells_w_horz; ++jj) {
                     if (w_cflag(i,j+jj,k).isCovered()) {
@@ -437,7 +437,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
             // Interpolate w using the highest-order scheme
 
-            amrex::Real interpy = zero;
+            amrex::Real interpy = zero_d;
             if (jcell==ncells_w_horz) {
                 interp_w_horz.InterpolateInY(i,j,k,0,interpy,rho_v_avg);
             } else {
@@ -451,24 +451,24 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_w_arr[1](i,j,k) = zero;
+            flx_w_arr[1](i,j,k) = zero_d;
         }
     },
     // z-momentum: z-face
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ( w_afrac_z(i,j,k) > zero )
+        if ( w_afrac_z(i,j,k) > zero_d )
         {
             if (k==lo_z_face || k==hi_z_face+1) {
 
                 flx_w_arr[2](i,j,k) = rho_w(i,j,k) * w(i,j,k);
 
             } else {
-                amrex::Real rho_w_avg = myhalf * (rho_w(i,j,k) + rho_w(i,j,k-1));
+                amrex::Real rho_w_avg = myhalf_d * (rho_w(i,j,k) + rho_w(i,j,k-1));
 
                 int kcell = 0;
 
-                if (rho_w_avg>zero)
+                if (rho_w_avg>zero_d)
                 {
                     for (int kk=0; kk<ncells_w_vert; ++kk) {
                         if (w_cflag(i,j,k-kk-1).isCovered()) {
@@ -477,7 +477,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
                         kcell++;
                     }
                 }
-                else if (rho_w_avg<zero)
+                else if (rho_w_avg<zero_d)
                 {
                     for (int kk=0; kk<ncells_w_vert; ++kk) {
                         if (w_cflag(i,j,k+kk).isCovered()) {
@@ -497,7 +497,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
 
                 // Interpolate w using the highest-order scheme
 
-                amrex::Real interpz = zero;
+                amrex::Real interpz = zero_d;
                 if (kcell==ncells_w_vert) {
                     interp_w_vert.InterpolateInZ(i,j,k,0,interpz,rho_w_avg);
                 } else {
@@ -512,7 +512,7 @@ EBAdvectionSrcForMomWrapper (const amrex::Vector<amrex::Box>& bxx_grown,
         }
         else
         {
-            flx_w_arr[2](i,j,k) = zero;
+            flx_w_arr[2](i,j,k) = zero_d;
         }
     });
 

--- a/Source/EB/ERF_EBAdvectionSrcForScalars.H
+++ b/Source/EB/ERF_EBAdvectionSrcForScalars.H
@@ -40,17 +40,17 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
     const amrex::Box ybx = amrex::surroundingNodes(bx,1).grow(amrex::IntVect(1, 0, 1));
     const amrex::Box zbx = amrex::surroundingNodes(bx,2).grow(amrex::IntVect(1, 1, 0));
 
-    amrex::ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(xbx, ncomp,[=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
         const int cons_index = icomp + n;
 
-        if ( ax_arr(i,j,k) > zero ) // Do we need a threshold value for the area fraction to avoid infinitesimal fractions?
+        if ( ax_arr(i,j,k) > zero_d ) // Do we need a threshold value for the area fraction to avoid infinitesimal fractions?
         {
             // Find the highest upwind order based on the cell flag
 
             int icell = 0;
 
-            if (avg_xmom(i,j,k)>zero)
+            if (avg_xmom(i,j,k)>zero_d)
             {
                 for (int ii=0; ii<ncells_h; ++ii) {
                     if (cellflag(i-ii-1,j,k).isCovered()) {
@@ -59,7 +59,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                     icell++;
                 }
             }
-            else if (avg_xmom(i,j,k)<zero)
+            else if (avg_xmom(i,j,k)<zero_d)
             {
                 for (int ii=0; ii<ncells_h; ++ii) {
                     if (cellflag(i+ii,j,k).isCovered()) {
@@ -72,7 +72,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             // Interpolate the scalar variable (cell_prim) using the highest-order scheme
 
             const int prim_index = cons_index - 1;
-            amrex::Real interpx(zero);
+            amrex::Real interpx(zero_d);
 
             if (icell==ncells_h) {
                 interp_prim_h.InterpolateInX(i,j,k,prim_index,interpx,avg_xmom(i,j,k));
@@ -87,21 +87,21 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         }
         else
         {
-            (flx_arr[0])(i,j,k,cons_index) = zero;
+            (flx_arr[0])(i,j,k,cons_index) = zero_d;
         }
     });
 
-    amrex::ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(ybx, ncomp,[=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
         const int cons_index = icomp + n;
 
-        if ( ay_arr(i,j,k) > zero )
+        if ( ay_arr(i,j,k) > zero_d )
         {
             // Find the highest upwind order based on the cell flag
 
             int jcell = 0;
 
-            if (avg_ymom(i,j,k)>zero)
+            if (avg_ymom(i,j,k)>zero_d)
             {
                 for (int jj=0; jj<ncells_h; ++jj) {
                     if (cellflag(i,j-jj-1,k).isCovered()) {
@@ -110,7 +110,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                     jcell++;
                 }
             }
-            else if (avg_ymom(i,j,k)<zero)
+            else if (avg_ymom(i,j,k)<zero_d)
             {
                 for (int jj=0; jj<ncells_h; ++jj) {
                     if (cellflag(i,j+jj,k).isCovered()) {
@@ -123,7 +123,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             // Interpolate the scalar variable (cell_prim) using the highest-order scheme
 
             const int prim_index = cons_index - 1;
-            amrex::Real interpy(zero);
+            amrex::Real interpy(zero_d);
 
             if (jcell==ncells_h) {
                 interp_prim_h.InterpolateInY(i,j,k,prim_index,interpy,avg_ymom(i,j,k));
@@ -138,23 +138,23 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         }
         else
         {
-            (flx_arr[1])(i,j,k,cons_index) = zero;
+            (flx_arr[1])(i,j,k,cons_index) = zero_d;
         }
     });
 
     interp_prim_UPW3.SetUpwinding(vert_upw_frac);
 
-    amrex::ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+    amrex::ParallelFor(zbx, ncomp,[=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
     {
         const int cons_index = icomp + n;
 
-        if ( az_arr(i,j,k) > zero )
+        if ( az_arr(i,j,k) > zero_d )
         {
             // Find the highest upwind order based on the cell flag
 
             int kcell = 0;
 
-            if (avg_zmom(i,j,k)>zero)
+            if (avg_zmom(i,j,k)>zero_d)
             {
                 for (int kk=0; kk<ncells_v; ++kk) {
                     if (cellflag(i,j,k-kk-1).isCovered()) {
@@ -163,7 +163,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
                     kcell++;
                 }
             }
-            else if (avg_zmom(i,j,k)<zero)
+            else if (avg_zmom(i,j,k)<zero_d)
             {
                 for (int kk=0; kk<ncells_v; ++kk) {
                     if (cellflag(i,j,k+kk).isCovered()) {
@@ -176,7 +176,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
             // Interpolate the scalar variable (cell_prim) using the highest-order scheme
 
             const int prim_index = cons_index - 1;
-            amrex::Real interpz(zero);
+            amrex::Real interpz(zero_d);
 
             if (kcell==ncells_v) {
                 interp_prim_v.InterpolateInZ(i,j,k,prim_index,interpz,avg_zmom(i,j,k));
@@ -191,7 +191,7 @@ EBAdvectionSrcForScalarsWrapper (const amrex::Box& bx,
         }
         else
         {
-            (flx_arr[2])(i,j,k,cons_index) = zero;
+            (flx_arr[2])(i,j,k,cons_index) = zero_d;
         }
     });
 }
@@ -258,4 +258,3 @@ EBAdvectionSrcForScalarsVert (const amrex::Box& bx,
         AMREX_ASSERT_WITH_MESSAGE(false, "Unknown vertical advection scheme!");
     }
 }
-

--- a/Source/EB/ERF_EBAdvectionSrcForState.cpp
+++ b/Source/EB/ERF_EBAdvectionSrcForState.cpp
@@ -80,36 +80,36 @@ EBAdvectionSrcForRho (const Box& bx,
     });
 
     if (fixed_rho) {
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            advectionSrc(i,j,k,0) = zero;
+            advectionSrc(i,j,k,0) = zero_d;
         });
     } else
     {
         if (already_on_centroids) {
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                if (detJ(i,j,k) > zero) {
+                if (detJ(i,j,k) > zero_d) {
                     Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
                     advectionSrc(i,j,k,0) = - mfsq / detJ(i,j,k) * (
                                             ( ax_arr(i+1,j,k) * flx_arr[0](i+1,j,k,0) - ax_arr(i,j,k) * flx_arr[0](i,j,k,0) ) * dxInv +
                                             ( ay_arr(i,j+1,k) * flx_arr[1](i,j+1,k,0) - ay_arr(i,j,k) * flx_arr[1](i,j,k,0) ) * dyInv +
                                             ( az_arr(i,j,k+1) * flx_arr[2](i,j,k+1,0) - az_arr(i,j,k) * flx_arr[2](i,j,k,0) ) * dzInv );
                 } else {
-                    advectionSrc(i,j,k,0) = zero;
+                    advectionSrc(i,j,k,0) = zero_d;
                 }
             });
 
         } else {
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                if (detJ(i,j,k) > zero) {
+                if (detJ(i,j,k) > zero_d) {
                     Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
                     if (cfg_arr(i,j,k).isCovered())
                     {
-                        advectionSrc(i,j,k,0) = zero;
+                        advectionSrc(i,j,k,0) = zero_d;
                     }
                     else if (cfg_arr(i,j,k).isRegular())
                     {
@@ -122,74 +122,74 @@ EBAdvectionSrcForRho (const Box& bx,
                     {
                     // Bilinear interpolation
                     Real fxm = flx_arr[0](i,j,k,0);
-                    if (ax_arr(i,j,k) != zero && ax_arr(i,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one, fcx_arr(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one, fcx_arr(i,j,k,1)));
-                        Real fracy = (mask_arr(i-1,jj,k) || mask_arr(i,jj,k)) ? std::abs(fcx_arr(i,j,k,0)) : zero;
-                        Real fracz = (mask_arr(i-1,j,kk) || mask_arr(i,j,kk)) ? std::abs(fcx_arr(i,j,k,1)) : zero;
-                        fxm = (one-fracy)*(one-fracz)*fxm
-                            +      fracy *(one-fracz)*flx_arr[0](i,jj,k ,0)
-                            +      fracz *(one-fracy)*flx_arr[0](i,j ,kk,0)
+                    if (ax_arr(i,j,k) != zero_d && ax_arr(i,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d, fcx_arr(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d, fcx_arr(i,j,k,1)));
+                        Real fracy = (mask_arr(i-1,jj,k) || mask_arr(i,jj,k)) ? std::abs(fcx_arr(i,j,k,0)) : zero_d;
+                        Real fracz = (mask_arr(i-1,j,kk) || mask_arr(i,j,kk)) ? std::abs(fcx_arr(i,j,k,1)) : zero_d;
+                        fxm = (one_d-fracy)*(one_d-fracz)*fxm
+                            +      fracy *(one_d-fracz)*flx_arr[0](i,jj,k ,0)
+                            +      fracz *(one_d-fracy)*flx_arr[0](i,j ,kk,0)
                             +      fracy *     fracz *flx_arr[0](i,jj,kk,0);
                     }
 
                     Real fxp = flx_arr[0](i+1,j,k,0);
-                    if (ax_arr(i+1,j,k) != zero && ax_arr(i+1,j,k) != one) {
-                        int jj = j + static_cast<int>(std::copysign(one,fcx_arr(i+1,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,fcx_arr(i+1,j,k,1)));
-                        Real fracy = (mask_arr(i,jj,k) || mask_arr(i+1,jj,k)) ? std::abs(fcx_arr(i+1,j,k,0)) : zero;
-                        Real fracz = (mask_arr(i,j,kk) || mask_arr(i+1,j,kk)) ? std::abs(fcx_arr(i+1,j,k,1)) : zero;
-                        fxp = (one-fracy)*(one-fracz)*fxp
-                            +      fracy *(one-fracz)*flx_arr[0](i+1,jj,k ,0)
-                            +      fracz *(one-fracy)*flx_arr[0](i+1,j ,kk,0)
+                    if (ax_arr(i+1,j,k) != zero_d && ax_arr(i+1,j,k) != one_d) {
+                        int jj = j + static_cast<int>(std::copysign(one_d,fcx_arr(i+1,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,fcx_arr(i+1,j,k,1)));
+                        Real fracy = (mask_arr(i,jj,k) || mask_arr(i+1,jj,k)) ? std::abs(fcx_arr(i+1,j,k,0)) : zero_d;
+                        Real fracz = (mask_arr(i,j,kk) || mask_arr(i+1,j,kk)) ? std::abs(fcx_arr(i+1,j,k,1)) : zero_d;
+                        fxp = (one_d-fracy)*(one_d-fracz)*fxp
+                            +      fracy *(one_d-fracz)*flx_arr[0](i+1,jj,k ,0)
+                            +      fracz *(one_d-fracy)*flx_arr[0](i+1,j ,kk,0)
                             +      fracy *     fracz *flx_arr[0](i+1,jj,kk,0);
                     }
 
                     Real fym = flx_arr[1](i,j,k,0);
-                    if (ay_arr(i,j,k) != zero && ay_arr(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,fcy_arr(i,j,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,fcy_arr(i,j,k,1)));
-                        Real fracx = (mask_arr(ii,j-1,k) || mask_arr(ii,j,k)) ? std::abs(fcy_arr(i,j,k,0)) : zero;
-                        Real fracz = (mask_arr(i,j-1,kk) || mask_arr(i,j,kk)) ? std::abs(fcy_arr(i,j,k,1)) : zero;
-                        fym = (one-fracx)*(one-fracz)*fym
-                            +      fracx *(one-fracz)*flx_arr[1](ii,j,k ,0)
-                            +      fracz *(one-fracx)*flx_arr[1](i ,j,kk,0)
+                    if (ay_arr(i,j,k) != zero_d && ay_arr(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,fcy_arr(i,j,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,fcy_arr(i,j,k,1)));
+                        Real fracx = (mask_arr(ii,j-1,k) || mask_arr(ii,j,k)) ? std::abs(fcy_arr(i,j,k,0)) : zero_d;
+                        Real fracz = (mask_arr(i,j-1,kk) || mask_arr(i,j,kk)) ? std::abs(fcy_arr(i,j,k,1)) : zero_d;
+                        fym = (one_d-fracx)*(one_d-fracz)*fym
+                            +      fracx *(one_d-fracz)*flx_arr[1](ii,j,k ,0)
+                            +      fracz *(one_d-fracx)*flx_arr[1](i ,j,kk,0)
                             +      fracx *     fracz *flx_arr[1](ii,j,kk,0);
                     }
 
                     Real fyp = flx_arr[1](i,j+1,k,0);
-                    if (ay_arr(i,j+1,k) != zero && ay_arr(i,j+1,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,fcy_arr(i,j+1,k,0)));
-                        int kk = k + static_cast<int>(std::copysign(one,fcy_arr(i,j+1,k,1)));
-                        Real fracx = (mask_arr(ii,j,k) || mask_arr(ii,j+1,k)) ? std::abs(fcy_arr(i,j+1,k,0)) : zero;
-                        Real fracz = (mask_arr(i,j,kk) || mask_arr(i,j+1,kk)) ? std::abs(fcy_arr(i,j+1,k,1)) : zero;
-                        fyp = (one-fracx)*(one-fracz)*fyp
-                            +      fracx *(one-fracz)*flx_arr[1](ii,j+1,k ,0)
-                            +      fracz *(one-fracx)*flx_arr[1](i ,j+1,kk,0)
+                    if (ay_arr(i,j+1,k) != zero_d && ay_arr(i,j+1,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,fcy_arr(i,j+1,k,0)));
+                        int kk = k + static_cast<int>(std::copysign(one_d,fcy_arr(i,j+1,k,1)));
+                        Real fracx = (mask_arr(ii,j,k) || mask_arr(ii,j+1,k)) ? std::abs(fcy_arr(i,j+1,k,0)) : zero_d;
+                        Real fracz = (mask_arr(i,j,kk) || mask_arr(i,j+1,kk)) ? std::abs(fcy_arr(i,j+1,k,1)) : zero_d;
+                        fyp = (one_d-fracx)*(one_d-fracz)*fyp
+                            +      fracx *(one_d-fracz)*flx_arr[1](ii,j+1,k ,0)
+                            +      fracz *(one_d-fracx)*flx_arr[1](i ,j+1,kk,0)
                             +      fracx *     fracz *flx_arr[1](ii,j+1,kk,0);
                     }
 
                     Real fzm = flx_arr[2](i,j,k,0);
-                    if (az_arr(i,j,k) != zero && az_arr(i,j,k) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,fcz_arr(i,j,k,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,fcz_arr(i,j,k,1)));
-                        Real fracx = (mask_arr(ii,j,k-1) || mask_arr(ii,j,k)) ? std::abs(fcz_arr(i,j,k,0)) : zero;
-                        Real fracy = (mask_arr(i,jj,k-1) || mask_arr(i,jj,k)) ? std::abs(fcz_arr(i,j,k,1)) : zero;
-                        fzm = (one-fracx)*(one-fracy)*fzm
-                            +      fracx *(one-fracy)*flx_arr[2](ii,j ,k,0)
-                            +      fracy *(one-fracx)*flx_arr[2](i ,jj,k,0)
+                    if (az_arr(i,j,k) != zero_d && az_arr(i,j,k) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,fcz_arr(i,j,k,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,fcz_arr(i,j,k,1)));
+                        Real fracx = (mask_arr(ii,j,k-1) || mask_arr(ii,j,k)) ? std::abs(fcz_arr(i,j,k,0)) : zero_d;
+                        Real fracy = (mask_arr(i,jj,k-1) || mask_arr(i,jj,k)) ? std::abs(fcz_arr(i,j,k,1)) : zero_d;
+                        fzm = (one_d-fracx)*(one_d-fracy)*fzm
+                            +      fracx *(one_d-fracy)*flx_arr[2](ii,j ,k,0)
+                            +      fracy *(one_d-fracx)*flx_arr[2](i ,jj,k,0)
                             +      fracx *     fracy *flx_arr[2](ii,jj,k,0);
                     }
 
                     Real fzp = flx_arr[2](i,j,k+1,0);
-                    if (az_arr(i,j,k+1) != zero && az_arr(i,j,k+1) != one) {
-                        int ii = i + static_cast<int>(std::copysign(one,fcz_arr(i,j,k+1,0)));
-                        int jj = j + static_cast<int>(std::copysign(one,fcz_arr(i,j,k+1,1)));
-                        Real fracx = (mask_arr(ii,j,k) || mask_arr(ii,j,k+1)) ? std::abs(fcz_arr(i,j,k+1,0)) : zero;
-                        Real fracy = (mask_arr(i,jj,k) || mask_arr(i,jj,k+1)) ? std::abs(fcz_arr(i,j,k+1,1)) : zero;
-                        fzp = (one-fracx)*(one-fracy)*fzp
-                            +      fracx *(one-fracy)*flx_arr[2](ii,j ,k+1,0)
-                            +      fracy *(one-fracx)*flx_arr[2](i ,jj,k+1,0)
+                    if (az_arr(i,j,k+1) != zero_d && az_arr(i,j,k+1) != one_d) {
+                        int ii = i + static_cast<int>(std::copysign(one_d,fcz_arr(i,j,k+1,0)));
+                        int jj = j + static_cast<int>(std::copysign(one_d,fcz_arr(i,j,k+1,1)));
+                        Real fracx = (mask_arr(ii,j,k) || mask_arr(ii,j,k+1)) ? std::abs(fcz_arr(i,j,k+1,0)) : zero_d;
+                        Real fracy = (mask_arr(i,jj,k) || mask_arr(i,jj,k+1)) ? std::abs(fcz_arr(i,j,k+1,1)) : zero_d;
+                        fzp = (one_d-fracx)*(one_d-fracy)*fzp
+                            +      fracx *(one_d-fracy)*flx_arr[2](ii,j ,k+1,0)
+                            +      fracy *(one_d-fracx)*flx_arr[2](i ,jj,k+1,0)
                             +      fracx *     fracy *flx_arr[2](ii,jj,k+1,0);
                     }
 
@@ -199,7 +199,7 @@ EBAdvectionSrcForRho (const Box& bx,
                                 ( az_arr(i,j,k+1) * fzp - az_arr(i,j,k) * fzm ) * dzInv );
                     }
                 } else {
-                    advectionSrc(i,j,k,0) = zero;
+                    advectionSrc(i,j,k,0) = zero_d;
                 }
             });
 
@@ -299,25 +299,25 @@ EBAdvectionSrcForScalars (const Box& bx,
     //       The flux is weighted by area fraction after its interpolation.
     if (horiz_adv_type == AdvType::Centered_2nd && vert_adv_type == AdvType::Centered_2nd)
     {
-        ParallelFor(xbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        ParallelFor(xbx, ncomp,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int cons_index = icomp + n;
             const int prim_index = cons_index - 1;
-            const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
+            const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i-1,j,k,prim_index));
             flx_arr[0](i,j,k,cons_index) = avg_xmom(i,j,k) * prim_on_face;
         });
-        ParallelFor(ybx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        ParallelFor(ybx, ncomp,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int cons_index = icomp + n;
             const int prim_index = cons_index - 1;
-            const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
+            const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j-1,k,prim_index));
             flx_arr[1](i,j,k,cons_index) = avg_ymom(i,j,k) * prim_on_face;
         });
-        ParallelFor(zbx, ncomp,[=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        ParallelFor(zbx, ncomp,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int cons_index = icomp + n;
             const int prim_index = cons_index - 1;
-            const Real prim_on_face = myhalf * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
+            const Real prim_on_face = myhalf_d * (cell_prim(i,j,k,prim_index) + cell_prim(i,j,k-1,prim_index));
             flx_arr[2](i,j,k,cons_index) = avg_zmom(i,j,k) * prim_on_face;
         });
 
@@ -358,12 +358,12 @@ EBAdvectionSrcForScalars (const Box& bx,
 
     if (already_on_centroids) {
 
-        ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        ParallelFor(bx, ncomp, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
             const int cons_index = icomp + n;
-            if (detJ(i,j,k) > zero)
+            if (detJ(i,j,k) > zero_d)
             {
-                Real invdetJ = one / detJ(i,j,k);
+                Real invdetJ = one_d / detJ(i,j,k);
                 Real mfsq    = mf_mx(i,j,0) * mf_my(i,j,0);
 
                 advectionSrc(i,j,k,cons_index) = - invdetJ * mfsq * (
@@ -371,7 +371,7 @@ EBAdvectionSrcForScalars (const Box& bx,
                   ( ay_arr(i,j+1,k) * flx_arr[1](i,j+1,k,cons_index) - ay_arr(i,j,k) * flx_arr[1](i,j  ,k,cons_index) ) * dyInv +
                   ( az_arr(i,j,k+1) * flx_arr[2](i,j,k+1,cons_index) - az_arr(i,j,k) * flx_arr[2](i,j,k  ,cons_index) ) * dzInv );
             } else {
-                advectionSrc(i,j,k,cons_index) = zero;
+                advectionSrc(i,j,k,cons_index) = zero_d;
             }
         });
 

--- a/Source/EB/ERF_EBAux.cpp
+++ b/Source/EB/ERF_EBAux.cpp
@@ -114,28 +114,28 @@ define( [[maybe_unused]] int const& a_level,
 
     } else if (FlagFab[mfi].getType(bx) == FabType::regular ) {
 
-      ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(tbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         aux_flag(i,j,k).setRegular();
         aux_flag(i,j,k).setDisconnected();
-        aux_vfrac(i,j,k) = one;
-        aux_afrac_x(i,j,k) = one;
-        aux_afrac_y(i,j,k) = one;
-        aux_afrac_z(i,j,k) = one;
+        aux_vfrac(i,j,k) = one_d;
+        aux_afrac_x(i,j,k) = one_d;
+        aux_afrac_y(i,j,k) = one_d;
+        aux_afrac_z(i,j,k) = one_d;
         if (i==bx.bigEnd(0)) {
           aux_flag(i+1,j,k).setRegular();
-          aux_vfrac(i+1,j,k) = one;
-          aux_afrac_x(i+1,j,k) = one;
+          aux_vfrac(i+1,j,k) = one_d;
+          aux_afrac_x(i+1,j,k) = one_d;
         }
         if (j==bx.bigEnd(1)) {
           aux_flag(i,j+1,k).setRegular();
-          aux_vfrac(i,j+1,k) = one;
-          aux_afrac_y(i,j+1,k) = one;
+          aux_vfrac(i,j+1,k) = one_d;
+          aux_afrac_y(i,j+1,k) = one_d;
         }
         if (k==bx.bigEnd(2)) {
           aux_flag(i,j,k+1).setRegular();
-          aux_vfrac(i,j,k+1) = one;
-          aux_afrac_z(i,j,k+1) = one;
+          aux_vfrac(i,j,k+1) = one_d;
+          aux_afrac_z(i,j,k+1) = one_d;
         }
       });
 
@@ -186,7 +186,7 @@ define( [[maybe_unused]] int const& a_level,
       int const verbose=m_verbose;
 #endif
 
-      ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(bx, [=,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         // defaults to covered and disconnected.
         aux_flag(i,j,k).setCovered();
@@ -228,11 +228,11 @@ define( [[maybe_unused]] int const& a_level,
             lo_isRegular = true;
             lo_isSingleValued = false;
           } else if (hi_isSingleValued) {
-            if (almostEqual(afrac(i,j,k),zero)) {
+            if (almostEqual(afrac(i,j,k),zero_d)) {
               lo_isCovered = true;
               lo_isRegular = false;
               lo_isSingleValued = false;
-            } else if (almostEqual(afrac(i,j,k),one)) {
+            } else if (almostEqual(afrac(i,j,k),one_d)) {
               lo_isCovered = false;
               lo_isRegular = true;
               lo_isSingleValued = false;
@@ -257,11 +257,11 @@ define( [[maybe_unused]] int const& a_level,
             hi_isRegular = true;
             hi_isSingleValued = false;
           } else if (lo_isSingleValued) { // SingleValued
-            if (almostEqual(afrac(i,j,k),zero)) { //Covered
+            if (almostEqual(afrac(i,j,k),zero_d)) { //Covered
               hi_isCovered = true;
               hi_isRegular = false;
               hi_isSingleValued = false;
-            } else if (almostEqual(afrac(i,j,k),one)) { //Regular
+            } else if (almostEqual(afrac(i,j,k),one_d)) { //Regular
               hi_isCovered = false;
               hi_isRegular = true;
               hi_isSingleValued = false;
@@ -283,20 +283,20 @@ define( [[maybe_unused]] int const& a_level,
           aux_flag(i,j,k).setRegular();
           aux_flag(i,j,k).setConnected();
 
-          aux_vfrac(i,j,k) = one;
+          aux_vfrac(i,j,k) = one_d;
 
-          aux_afrac_x(i,j,k) = one;
-          aux_afrac_y(i,j,k) = one;
-          aux_afrac_z(i,j,k) = one;
+          aux_afrac_x(i,j,k) = one_d;
+          aux_afrac_y(i,j,k) = one_d;
+          aux_afrac_z(i,j,k) = one_d;
 
           if (i==bx.bigEnd(0)) {
-            aux_afrac_x(i+1,j,k) = one;
+            aux_afrac_x(i+1,j,k) = one_d;
           }
           if (j==bx.bigEnd(1)) {
-            aux_afrac_y(i,j+1,k) = one;
+            aux_afrac_y(i,j+1,k) = one_d;
           }
           if (k==bx.bigEnd(2)) {
-            aux_afrac_z(i,j,k+1) = one;
+            aux_afrac_z(i,j,k+1) = one_d;
           }
 
         } else {
@@ -304,8 +304,8 @@ define( [[maybe_unused]] int const& a_level,
 #ifndef AMREX_USE_GPU
           if (verbose) { Print() << "\ncell: " << amrex::IntVect(i,j,k) << "\n"; }
 #endif
-          Array<Real,AMREX_SPACEDIM> lo_arr = {-myhalf,-myhalf,-myhalf};
-          Array<Real,AMREX_SPACEDIM> hi_arr = { myhalf, myhalf, myhalf};
+          Array<Real,AMREX_SPACEDIM> lo_arr = {-myhalf_d,-myhalf_d,-myhalf_d};
+          Array<Real,AMREX_SPACEDIM> hi_arr = { myhalf_d, myhalf_d, myhalf_d};
 
           //-----------------------
           // Low EB cut cell
@@ -318,7 +318,7 @@ define( [[maybe_unused]] int const& a_level,
           RealVect lo_normal(bnorm(iv_lo,0), bnorm(iv_lo,1), bnorm(iv_lo,2));
 
           if (at_lo_boundary) { // At lower boundary
-            lo_point[a_idim] += one; // Move the boundary centroid upward in the a_idim direction.
+            lo_point[a_idim] += one_d; // Move the boundary centroid upward in the a_idim direction.
           }
 
           if (lo_isSingleValued ) {
@@ -334,8 +334,8 @@ define( [[maybe_unused]] int const& a_level,
           }
 
           // High side of low cell
-          lo_arr[a_idim] = zero;
-          hi_arr[a_idim] = myhalf;
+          lo_arr[a_idim] = zero_d;
+          hi_arr[a_idim] = myhalf_d;
           RealBox lo_rbx(lo_arr.data(), hi_arr.data());
 
           eb_cut_cell_ lo_eb_cc(flag(iv_lo), lo_rbx, lo_point, lo_normal);
@@ -353,7 +353,7 @@ define( [[maybe_unused]] int const& a_level,
           RealVect hi_normal(bnorm(iv_hi,0), bnorm(iv_hi,1), bnorm(iv_hi,2));
 
           if (at_hi_boundary) {
-            hi_point[a_idim] += -one; // Move the boundary centroid downward in the a_idim direction.
+            hi_point[a_idim] += -one_d; // Move the boundary centroid downward in the a_idim direction.
           }
 
           if (hi_isSingleValued ) {
@@ -369,8 +369,8 @@ define( [[maybe_unused]] int const& a_level,
           }
 
           // Low side of high cell
-          lo_arr[a_idim] = -myhalf;
-          hi_arr[a_idim] =  zero;
+          lo_arr[a_idim] = -myhalf_d;
+          hi_arr[a_idim] =  zero_d;
           RealBox hi_rbx(lo_arr.data(), hi_arr.data());
 
           eb_cut_cell_ hi_eb_cc(flag(iv_hi), hi_rbx, hi_point, hi_normal);
@@ -434,12 +434,12 @@ define( [[maybe_unused]] int const& a_level,
               Real const apnorm = std::sqrt(adx*adx + ady*ady + adz*adz);
 
               // EB normal
-              Real const apnorminv = one / apnorm;
+              Real const apnorminv = one_d / apnorm;
               RealVect const normal(adx*apnorminv, ady*apnorminv, adz*apnorminv);
               Real const dot_normals = normal.dotProduct(hi_normal);
 
 #ifndef AMREX_USE_GPU
-              if ( !amrex::almostEqual(dot_normals, one) ) {
+              if ( !amrex::almostEqual(dot_normals, one_d) ) {
                 Print() << "\nFail: check-1 dot_normals " << dot_normals
                         << '\n';
 
@@ -451,7 +451,7 @@ define( [[maybe_unused]] int const& a_level,
 
               }
 #endif
-              AMREX_ALWAYS_ASSERT( amrex::almostEqual(dot_normals, one) );
+              AMREX_ALWAYS_ASSERT( amrex::almostEqual(dot_normals, one_d) );
             }
 
             // The a_idim area of hi_eb_cc.areaHi() should equal hi_hi_eb_cc.areaLo()
@@ -532,27 +532,27 @@ define( [[maybe_unused]] int const& a_level,
             aux_flag(i,j,k).setRegular();
             aux_flag(i,j,k).setConnected();
 
-            aux_vfrac(i,j,k) = one;
+            aux_vfrac(i,j,k) = one_d;
 
-            aux_afrac_x(i,j,k) = one;
-            aux_afrac_y(i,j,k) = one;
-            aux_afrac_z(i,j,k) = one;
+            aux_afrac_x(i,j,k) = one_d;
+            aux_afrac_y(i,j,k) = one_d;
+            aux_afrac_z(i,j,k) = one_d;
 
-            aux_fcent_x(i,j,k,0) = zero; aux_fcent_x(i,j,k,1) = zero;
-            aux_fcent_y(i,j,k,0) = zero; aux_fcent_y(i,j,k,1) = zero;
-            aux_fcent_z(i,j,k,0) = zero; aux_fcent_z(i,j,k,1) = zero;
+            aux_fcent_x(i,j,k,0) = zero_d; aux_fcent_x(i,j,k,1) = zero_d;
+            aux_fcent_y(i,j,k,0) = zero_d; aux_fcent_y(i,j,k,1) = zero_d;
+            aux_fcent_z(i,j,k,0) = zero_d; aux_fcent_z(i,j,k,1) = zero_d;
 
             if (i==bx.bigEnd(0)) {
-              aux_afrac_x(i+1,j,k) = one;
-              aux_fcent_x(i+1,j,k,0) = zero; aux_fcent_x(i+1,j,k,1) = zero;
+              aux_afrac_x(i+1,j,k) = one_d;
+              aux_fcent_x(i+1,j,k,0) = zero_d; aux_fcent_x(i+1,j,k,1) = zero_d;
             }
             if (j==bx.bigEnd(1)) {
-              aux_afrac_y(i,j+1,k) = one;
-              aux_fcent_y(i,j+1,k,0) = zero; aux_fcent_y(i,j+1,k,1) = zero;
+              aux_afrac_y(i,j+1,k) = one_d;
+              aux_fcent_y(i,j+1,k,0) = zero_d; aux_fcent_y(i,j+1,k,1) = zero_d;
             }
             if (k==bx.bigEnd(2)) {
-              aux_afrac_z(i,j,k+1) = one;
-              aux_fcent_z(i,j,k+1,0) = zero; aux_fcent_z(i,j,k+1,1) = zero;
+              aux_afrac_z(i,j,k+1) = one_d;
+              aux_fcent_z(i,j,k+1,0) = zero_d; aux_fcent_z(i,j,k+1,1) = zero_d;
             }
 
           } else if ( (lo_eb_cc.isRegular() && hi_eb_cc.isCovered())
@@ -571,8 +571,8 @@ define( [[maybe_unused]] int const& a_level,
 
             // one Volume Fraction
 
-            Real lo_vol {lo_eb_cc.volume()}; AMREX_ASSERT(lo_vol >= zero && lo_vol <= myhalf);
-            Real hi_vol {hi_eb_cc.volume()}; AMREX_ASSERT(hi_vol >= zero && hi_vol <= myhalf);
+            Real lo_vol {lo_eb_cc.volume()}; AMREX_ASSERT(lo_vol >= zero_d && lo_vol <= myhalf_d);
+            Real hi_vol {hi_eb_cc.volume()}; AMREX_ASSERT(hi_vol >= zero_d && hi_vol <= myhalf_d);
 
             aux_vfrac(i,j,k) = lo_vol + hi_vol;
 
@@ -589,8 +589,8 @@ define( [[maybe_unused]] int const& a_level,
             RealVect lo_vcent {lo_eb_cc.centVol()};
             RealVect hi_vcent {hi_eb_cc.centVol()};
 
-            lo_vcent[a_idim] = lo_vcent[a_idim] - myhalf;
-            hi_vcent[a_idim] = hi_vcent[a_idim] + myhalf;
+            lo_vcent[a_idim] = lo_vcent[a_idim] - myhalf_d;
+            hi_vcent[a_idim] = hi_vcent[a_idim] + myhalf_d;
 
             aux_vcent(i,j,k,0) = ( lo_vol * lo_vcent[0] + hi_vol * hi_vcent[0] ) / aux_vfrac(i,j,k);
             aux_vcent(i,j,k,1) = ( lo_vol * lo_vcent[1] + hi_vol * hi_vcent[1] ) / aux_vfrac(i,j,k);
@@ -647,58 +647,58 @@ define( [[maybe_unused]] int const& a_level,
             if (a_idim == 0) {
               aux_fcent_x(i,j,k,0) = lo_centLo_x[1];      // y
               aux_fcent_x(i,j,k,1) = lo_centLo_x[2];      // z
-              aux_fcent_y(i,j,k,0) = (aux_afrac_y(i,j,k) > zero)   // x (mapped)
-                                    ? ( lo_areaLo_y * (lo_centLo_y[0] - myhalf)
-                                      + hi_areaLo_y * (hi_centLo_y[0] + myhalf) ) / aux_afrac_y(i,j,k)
-                                    : zero;
-              aux_fcent_y(i,j,k,1) = (aux_afrac_y(i,j,k) > zero)   // z
+              aux_fcent_y(i,j,k,0) = (aux_afrac_y(i,j,k) > zero_d)   // x (mapped)
+                                    ? ( lo_areaLo_y * (lo_centLo_y[0] - myhalf_d)
+                                      + hi_areaLo_y * (hi_centLo_y[0] + myhalf_d) ) / aux_afrac_y(i,j,k)
+                                    : zero_d;
+              aux_fcent_y(i,j,k,1) = (aux_afrac_y(i,j,k) > zero_d)   // z
                                     ? ( lo_areaLo_y * lo_centLo_y[2]
                                       + hi_areaLo_y * hi_centLo_y[2] ) / aux_afrac_y(i,j,k)
-                                    : zero;
-              aux_fcent_z(i,j,k,0) = (aux_afrac_z(i,j,k) > zero)   // x (mapped)
-                                    ? ( lo_areaLo_z * (lo_centLo_z[0] - myhalf)
-                                      + hi_areaLo_z * (hi_centLo_z[0] + myhalf) ) / aux_afrac_z(i,j,k)
-                                    : zero;
-              aux_fcent_z(i,j,k,1) = (aux_afrac_z(i,j,k) > zero)   // y
+                                    : zero_d;
+              aux_fcent_z(i,j,k,0) = (aux_afrac_z(i,j,k) > zero_d)   // x (mapped)
+                                    ? ( lo_areaLo_z * (lo_centLo_z[0] - myhalf_d)
+                                      + hi_areaLo_z * (hi_centLo_z[0] + myhalf_d) ) / aux_afrac_z(i,j,k)
+                                    : zero_d;
+              aux_fcent_z(i,j,k,1) = (aux_afrac_z(i,j,k) > zero_d)   // y
                                     ? ( lo_areaLo_z * lo_centLo_z[1]
                                       + hi_areaLo_z * hi_centLo_z[1] ) / aux_afrac_z(i,j,k)
-                                    : zero;
+                                    : zero_d;
             } else if (a_idim == 1) {
-              aux_fcent_x(i,j,k,0) = (aux_afrac_x(i,j,k) > zero)   // y (mapped)
-                                    ? ( lo_areaLo_x * (lo_centLo_x[1] - myhalf)
-                                      + hi_areaLo_x * (hi_centLo_x[1] + myhalf) ) / aux_afrac_x(i,j,k)
-                                    : zero;
-              aux_fcent_x(i,j,k,1) = (aux_afrac_x(i,j,k) > zero)   // z
+              aux_fcent_x(i,j,k,0) = (aux_afrac_x(i,j,k) > zero_d)   // y (mapped)
+                                    ? ( lo_areaLo_x * (lo_centLo_x[1] - myhalf_d)
+                                      + hi_areaLo_x * (hi_centLo_x[1] + myhalf_d) ) / aux_afrac_x(i,j,k)
+                                    : zero_d;
+              aux_fcent_x(i,j,k,1) = (aux_afrac_x(i,j,k) > zero_d)   // z
                                     ? ( lo_areaLo_x * lo_centLo_x[2]
                                       + hi_areaLo_x * hi_centLo_x[2] ) / aux_afrac_x(i,j,k)
-                                    : zero;
+                                    : zero_d;
               aux_fcent_y(i,j,k,0) = lo_centLo_y[0];      // x
               aux_fcent_y(i,j,k,1) = lo_centLo_y[2];      // z
-              aux_fcent_z(i,j,k,0) = (aux_afrac_z(i,j,k) > zero)   // x
+              aux_fcent_z(i,j,k,0) = (aux_afrac_z(i,j,k) > zero_d)   // x
                                     ? ( lo_areaLo_z * lo_centLo_z[0]
                                       + hi_areaLo_z * hi_centLo_z[0] ) / aux_afrac_z(i,j,k)
-                                    : zero;
-              aux_fcent_z(i,j,k,1) = (aux_afrac_z(i,j,k) > zero)   // y (mapped)
-                                    ? ( lo_areaLo_z * (lo_centLo_z[1] - myhalf)
-                                      + hi_areaLo_z * (hi_centLo_z[1] + myhalf) ) / aux_afrac_z(i,j,k)
-                                    : zero;
+                                    : zero_d;
+              aux_fcent_z(i,j,k,1) = (aux_afrac_z(i,j,k) > zero_d)   // y (mapped)
+                                    ? ( lo_areaLo_z * (lo_centLo_z[1] - myhalf_d)
+                                      + hi_areaLo_z * (hi_centLo_z[1] + myhalf_d) ) / aux_afrac_z(i,j,k)
+                                    : zero_d;
             } else if (a_idim == 2) {
-              aux_fcent_x(i,j,k,0) = (aux_afrac_x(i,j,k) > zero)   // y
+              aux_fcent_x(i,j,k,0) = (aux_afrac_x(i,j,k) > zero_d)   // y
                                     ? ( lo_areaLo_x * lo_centLo_x[1]
                                       + hi_areaLo_x * hi_centLo_x[1] ) / aux_afrac_x(i,j,k)
-                                    : zero;
-              aux_fcent_x(i,j,k,1) = (aux_afrac_x(i,j,k) > zero)   // z (mapped)
-                                    ? ( lo_areaLo_x * (lo_centLo_x[2] - myhalf)
-                                      + hi_areaLo_x * (hi_centLo_x[2] + myhalf) ) / aux_afrac_x(i,j,k)
-                                    : zero;
-              aux_fcent_y(i,j,k,0) = (aux_afrac_y(i,j,k) > zero)   // x
+                                    : zero_d;
+              aux_fcent_x(i,j,k,1) = (aux_afrac_x(i,j,k) > zero_d)   // z (mapped)
+                                    ? ( lo_areaLo_x * (lo_centLo_x[2] - myhalf_d)
+                                      + hi_areaLo_x * (hi_centLo_x[2] + myhalf_d) ) / aux_afrac_x(i,j,k)
+                                    : zero_d;
+              aux_fcent_y(i,j,k,0) = (aux_afrac_y(i,j,k) > zero_d)   // x
                                     ? ( lo_areaLo_y * lo_centLo_y[0]
                                       + hi_areaLo_y * hi_centLo_y[0] ) / aux_afrac_y(i,j,k)
-                                    : zero;
-              aux_fcent_y(i,j,k,1) = (aux_afrac_y(i,j,k) > zero)   // z (mapped)
-                                    ? ( lo_areaLo_y * (lo_centLo_y[2] - myhalf)
-                                      + hi_areaLo_y * (hi_centLo_y[2] + myhalf) ) / aux_afrac_y(i,j,k)
-                                    : zero;
+                                    : zero_d;
+              aux_fcent_y(i,j,k,1) = (aux_afrac_y(i,j,k) > zero_d)   // z (mapped)
+                                    ? ( lo_areaLo_y * (lo_centLo_y[2] - myhalf_d)
+                                      + hi_areaLo_y * (hi_centLo_y[2] + myhalf_d) ) / aux_afrac_y(i,j,k)
+                                    : zero_d;
               aux_fcent_z(i,j,k,0) = lo_centLo_z[0];      // x
               aux_fcent_z(i,j,k,1) = lo_centLo_z[1];      // y
             }
@@ -712,23 +712,23 @@ define( [[maybe_unused]] int const& a_level,
                 aux_fcent_x(i+1,j,k,0) = hi_centHi_x[1];      // y
                 aux_fcent_x(i+1,j,k,1) = hi_centHi_x[2];      // z
               } else if (a_idim == 1) {
-                aux_fcent_x(i+1,j,k,0) = (aux_afrac_x(i+1,j,k) > zero)   // y (mapped)
-                                      ? ( lo_areaHi_x * (lo_centHi_x[1] - myhalf)
-                                        + hi_areaHi_x * (hi_centHi_x[1] + myhalf) ) / aux_afrac_x(i+1,j,k)
-                                      : zero;
-                aux_fcent_x(i+1,j,k,1) = (aux_afrac_x(i+1,j,k) > zero)   // z
+                aux_fcent_x(i+1,j,k,0) = (aux_afrac_x(i+1,j,k) > zero_d)   // y (mapped)
+                                      ? ( lo_areaHi_x * (lo_centHi_x[1] - myhalf_d)
+                                        + hi_areaHi_x * (hi_centHi_x[1] + myhalf_d) ) / aux_afrac_x(i+1,j,k)
+                                      : zero_d;
+                aux_fcent_x(i+1,j,k,1) = (aux_afrac_x(i+1,j,k) > zero_d)   // z
                                       ? ( lo_areaHi_x * lo_centHi_x[2]
                                         + hi_areaHi_x * hi_centHi_x[2] ) / aux_afrac_x(i+1,j,k)
-                                      : zero;
+                                      : zero_d;
               } else if (a_idim == 2) {
-                aux_fcent_x(i+1,j,k,0) = (aux_afrac_x(i+1,j,k) > zero)   // y
+                aux_fcent_x(i+1,j,k,0) = (aux_afrac_x(i+1,j,k) > zero_d)   // y
                                       ? ( lo_areaHi_x * lo_centHi_x[1]
                                         + hi_areaHi_x * hi_centHi_x[1] ) / aux_afrac_x(i+1,j,k)
-                                      : zero;
-                aux_fcent_x(i+1,j,k,1) = (aux_afrac_x(i+1,j,k) > zero)   // z (mapped)
-                                      ? ( lo_areaHi_x * (lo_centHi_x[2] - myhalf)
-                                        + hi_areaHi_x * (hi_centHi_x[2] + myhalf) ) / aux_afrac_x(i+1,j,k)
-                                      : zero;
+                                      : zero_d;
+                aux_fcent_x(i+1,j,k,1) = (aux_afrac_x(i+1,j,k) > zero_d)   // z (mapped)
+                                      ? ( lo_areaHi_x * (lo_centHi_x[2] - myhalf_d)
+                                        + hi_areaHi_x * (hi_centHi_x[2] + myhalf_d) ) / aux_afrac_x(i+1,j,k)
+                                      : zero_d;
               }
             }
             if (j==bx.bigEnd(1)) {
@@ -737,26 +737,26 @@ define( [[maybe_unused]] int const& a_level,
               RealVect lo_centHi_y {lo_eb_cc.centHi(1)};
               RealVect hi_centHi_y {hi_eb_cc.centHi(1)};
               if (a_idim == 0) {
-                aux_fcent_y(i,j+1,k,0) = (aux_afrac_y(i,j+1,k) > zero)   // x (mapped)
-                                      ? ( lo_areaHi_y * (lo_centHi_y[0] - myhalf)
-                                        + hi_areaHi_y * (hi_centHi_y[0] + myhalf) ) / aux_afrac_y(i,j+1,k)
-                                      : zero;
-                aux_fcent_y(i,j+1,k,1) = (aux_afrac_y(i,j+1,k) > zero)   // z
+                aux_fcent_y(i,j+1,k,0) = (aux_afrac_y(i,j+1,k) > zero_d)   // x (mapped)
+                                      ? ( lo_areaHi_y * (lo_centHi_y[0] - myhalf_d)
+                                        + hi_areaHi_y * (hi_centHi_y[0] + myhalf_d) ) / aux_afrac_y(i,j+1,k)
+                                      : zero_d;
+                aux_fcent_y(i,j+1,k,1) = (aux_afrac_y(i,j+1,k) > zero_d)   // z
                                       ? ( lo_areaHi_y * lo_centHi_y[2]
                                         + hi_areaHi_y * hi_centHi_y[2] ) / aux_afrac_y(i,j+1,k)
-                                      : zero;
+                                      : zero_d;
               } else if (a_idim == 1) {
                 aux_fcent_y(i,j+1,k,0) = lo_centHi_y[0];      // x
                 aux_fcent_y(i,j+1,k,1) = lo_centHi_y[2];      // z
               } else if (a_idim == 2) {
-                aux_fcent_y(i,j+1,k,0) = (aux_afrac_y(i,j+1,k) > zero)   // x
+                aux_fcent_y(i,j+1,k,0) = (aux_afrac_y(i,j+1,k) > zero_d)   // x
                                       ? ( lo_areaHi_y * lo_centHi_y[0]
                                         + hi_areaHi_y * hi_centHi_y[0] ) / aux_afrac_y(i,j+1,k)
-                                      : zero;
-                aux_fcent_y(i,j+1,k,1) = (aux_afrac_y(i,j+1,k) > zero)   // z (mapped)
-                                      ? ( lo_areaHi_y * (lo_centHi_y[2] - myhalf)
-                                        + hi_areaHi_y * (hi_centHi_y[2] + myhalf) ) / aux_afrac_y(i,j+1,k)
-                                      : zero;
+                                      : zero_d;
+                aux_fcent_y(i,j+1,k,1) = (aux_afrac_y(i,j+1,k) > zero_d)   // z (mapped)
+                                      ? ( lo_areaHi_y * (lo_centHi_y[2] - myhalf_d)
+                                        + hi_areaHi_y * (hi_centHi_y[2] + myhalf_d) ) / aux_afrac_y(i,j+1,k)
+                                      : zero_d;
               }
             }
             if (k==bx.bigEnd(2)) {
@@ -765,23 +765,23 @@ define( [[maybe_unused]] int const& a_level,
               RealVect lo_centHi_z {lo_eb_cc.centHi(2)};
               RealVect hi_centHi_z {hi_eb_cc.centHi(2)};
               if (a_idim == 0) {
-                aux_fcent_z(i,j,k+1,0) = (aux_afrac_z(i,j,k+1) > zero)   // x (mapped)
-                                      ? ( lo_areaHi_z * (lo_centHi_z[0] - myhalf)
-                                        + hi_areaHi_z * (hi_centHi_z[0] + myhalf) ) / aux_afrac_z(i,j,k+1)
-                                      : zero;
-                aux_fcent_z(i,j,k+1,1) = (aux_afrac_z(i,j,k+1) > zero)   // y
+                aux_fcent_z(i,j,k+1,0) = (aux_afrac_z(i,j,k+1) > zero_d)   // x (mapped)
+                                      ? ( lo_areaHi_z * (lo_centHi_z[0] - myhalf_d)
+                                        + hi_areaHi_z * (hi_centHi_z[0] + myhalf_d) ) / aux_afrac_z(i,j,k+1)
+                                      : zero_d;
+                aux_fcent_z(i,j,k+1,1) = (aux_afrac_z(i,j,k+1) > zero_d)   // y
                                       ? ( lo_areaHi_z * lo_centHi_z[1]
                                         + hi_areaHi_z * hi_centHi_z[1] ) / aux_afrac_z(i,j,k+1)
-                                      : zero;
+                                      : zero_d;
               } else if (a_idim == 1) {
-                aux_fcent_z(i,j,k+1,0) = (aux_afrac_z(i,j,k+1) > zero)   // x
+                aux_fcent_z(i,j,k+1,0) = (aux_afrac_z(i,j,k+1) > zero_d)   // x
                                       ? ( lo_areaHi_z * lo_centHi_z[0]
                                         + hi_areaHi_z * hi_centHi_z[0] ) / aux_afrac_z(i,j,k+1)
-                                      : zero;
-                aux_fcent_z(i,j,k+1,1) = (aux_afrac_z(i,j,k+1) > zero)   // y (mapped)
-                                      ? ( lo_areaHi_z * (lo_centHi_z[1] - myhalf)
-                                        + hi_areaHi_z * (hi_centHi_z[1] + myhalf) ) / aux_afrac_z(i,j,k+1)
-                                      : zero;
+                                      : zero_d;
+                aux_fcent_z(i,j,k+1,1) = (aux_afrac_z(i,j,k+1) > zero_d)   // y (mapped)
+                                      ? ( lo_areaHi_z * (lo_centHi_z[1] - myhalf_d)
+                                        + hi_areaHi_z * (hi_centHi_z[1] + myhalf_d) ) / aux_afrac_z(i,j,k+1)
+                                      : zero_d;
               } else if (a_idim == 2) {
                 aux_fcent_z(i,j,k+1,0) = lo_centHi_z[0];      // x
                 aux_fcent_z(i,j,k+1,1) = lo_centHi_z[1];      // y
@@ -801,17 +801,17 @@ define( [[maybe_unused]] int const& a_level,
             RealVect hi_centBoun {hi_eb_cc.centBoun()};
 
             if (a_idim == 0) {
-              aux_bcent(i,j,k,0) = ( lo_areaBoun * (lo_centBoun[0]-myhalf) + hi_areaBoun * (hi_centBoun[0]+myhalf) ) / aux_barea(i,j,k);  // x (mapped)
+              aux_bcent(i,j,k,0) = ( lo_areaBoun * (lo_centBoun[0]-myhalf_d) + hi_areaBoun * (hi_centBoun[0]+myhalf_d) ) / aux_barea(i,j,k);  // x (mapped)
               aux_bcent(i,j,k,1) = ( lo_areaBoun * lo_centBoun[1] + hi_areaBoun * hi_centBoun[1] ) / aux_barea(i,j,k);              // y
               aux_bcent(i,j,k,2) = ( lo_areaBoun * lo_centBoun[2] + hi_areaBoun * hi_centBoun[2] ) / aux_barea(i,j,k);              // z
             } else if (a_idim == 1) {
               aux_bcent(i,j,k,0) = ( lo_areaBoun * lo_centBoun[0] + hi_areaBoun * hi_centBoun[0] ) / aux_barea(i,j,k);              // x
-              aux_bcent(i,j,k,1) = ( lo_areaBoun * (lo_centBoun[1]-myhalf) + hi_areaBoun * (hi_centBoun[1]+myhalf) ) / aux_barea(i,j,k);  // y (mapped)
+              aux_bcent(i,j,k,1) = ( lo_areaBoun * (lo_centBoun[1]-myhalf_d) + hi_areaBoun * (hi_centBoun[1]+myhalf_d) ) / aux_barea(i,j,k);  // y (mapped)
               aux_bcent(i,j,k,2) = ( lo_areaBoun * lo_centBoun[2] + hi_areaBoun * hi_centBoun[2] ) / aux_barea(i,j,k);              // z
             } else if (a_idim == 2) {
               aux_bcent(i,j,k,0) = ( lo_areaBoun * lo_centBoun[0] + hi_areaBoun * hi_centBoun[0] ) / aux_barea(i,j,k);              // x
               aux_bcent(i,j,k,1) = ( lo_areaBoun * lo_centBoun[1] + hi_areaBoun * hi_centBoun[1] ) / aux_barea(i,j,k);              // y
-              aux_bcent(i,j,k,2) = ( lo_areaBoun * (lo_centBoun[2]-myhalf) + hi_areaBoun * (hi_centBoun[2]+myhalf) ) / aux_barea(i,j,k);  // z (mapped)
+              aux_bcent(i,j,k,2) = ( lo_areaBoun * (lo_centBoun[2]-myhalf_d) + hi_areaBoun * (hi_centBoun[2]+myhalf_d) ) / aux_barea(i,j,k);  // z (mapped)
             }
 
             // Real(7.) Boundary Normal
@@ -828,11 +828,11 @@ define( [[maybe_unused]] int const& a_level,
 
       });
 
-      ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if (aux_vfrac(i,j,k) < small_volfrac)
         {
-          aux_vfrac(i,j,k)   = zero;
+          aux_vfrac(i,j,k)   = zero_d;
         }
       });
 
@@ -868,84 +868,84 @@ define( [[maybe_unused]] int const& a_level,
       Box my_xbx(bx); my_xbx.growHi(0,1);
       int xbx_lo = my_xbx.smallEnd(0);
       int xbx_hi = my_xbx.bigEnd(0);
-      ParallelFor(my_xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(my_xbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if ((i == xbx_lo && aux_vfrac(i,j,k) < small_volfrac) ||
             (i == xbx_hi && aux_vfrac(i-1,j,k) < small_volfrac) ||
             (i > xbx_lo && i < xbx_hi &&
             (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i-1,j,k) < small_volfrac))) {
-            aux_afrac_x(i,j,k) = zero;
+            aux_afrac_x(i,j,k) = zero_d;
         }
       });
 
       Box my_ybx(bx); my_ybx.growHi(1,1);
       int ybx_lo = my_ybx.smallEnd(1);
       int ybx_hi = my_ybx.bigEnd(1);
-      ParallelFor(my_ybx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(my_ybx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if ((j == ybx_lo && aux_vfrac(i,j,k) < small_volfrac) ||
             (j == ybx_hi && aux_vfrac(i,j-1,k) < small_volfrac) ||
             (j > ybx_lo && j < ybx_hi &&
             (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i,j-1,k) < small_volfrac))) {
-            aux_afrac_y(i,j,k) = zero;
+            aux_afrac_y(i,j,k) = zero_d;
         }
       });
 
       Box my_zbx(bx); my_zbx.growHi(2,1);
       int zbx_lo = my_zbx.smallEnd(2);
       int zbx_hi = my_zbx.bigEnd(2);
-      ParallelFor(my_zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(my_zbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if ((k == zbx_lo && aux_vfrac(i,j,k) < small_volfrac) ||
             (k == zbx_hi && aux_vfrac(i,j,k-1) < small_volfrac) ||
             (k > zbx_lo && k < zbx_hi &&
             (aux_vfrac(i,j,k) < small_volfrac || aux_vfrac(i,j,k-1) < small_volfrac))) {
-            aux_afrac_z(i,j,k) = zero;
+            aux_afrac_z(i,j,k) = zero_d;
         }
       });
 
-      ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+      ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
       {
         if (aux_vfrac(i,j,k) < small_volfrac)
         {
-          aux_vcent(i,j,k,0) = zero;
-          aux_vcent(i,j,k,1) = zero;
-          aux_vcent(i,j,k,2) = zero;
+          aux_vcent(i,j,k,0) = zero_d;
+          aux_vcent(i,j,k,1) = zero_d;
+          aux_vcent(i,j,k,2) = zero_d;
 
-          aux_fcent_x(i  ,j  ,k  ,0) = zero;
-          aux_fcent_x(i  ,j  ,k  ,1) = zero;
-          aux_fcent_x(i+1,j  ,k  ,0) = zero;
-          aux_fcent_x(i+1,j  ,k  ,1) = zero;
+          aux_fcent_x(i  ,j  ,k  ,0) = zero_d;
+          aux_fcent_x(i  ,j  ,k  ,1) = zero_d;
+          aux_fcent_x(i+1,j  ,k  ,0) = zero_d;
+          aux_fcent_x(i+1,j  ,k  ,1) = zero_d;
 
-          aux_fcent_y(i  ,j  ,k  ,0) = zero;
-          aux_fcent_y(i  ,j  ,k  ,1) = zero;
-          aux_fcent_y(i  ,j+1,k  ,0) = zero;
-          aux_fcent_y(i  ,j+1,k  ,1) = zero;
+          aux_fcent_y(i  ,j  ,k  ,0) = zero_d;
+          aux_fcent_y(i  ,j  ,k  ,1) = zero_d;
+          aux_fcent_y(i  ,j+1,k  ,0) = zero_d;
+          aux_fcent_y(i  ,j+1,k  ,1) = zero_d;
 
-          aux_fcent_z(i  ,j  ,k  ,0) = zero;
-          aux_fcent_z(i  ,j  ,k  ,1) = zero;
-          aux_fcent_z(i  ,j  ,k+1,0) = zero;
-          aux_fcent_z(i  ,j  ,k+1,1) = zero;
+          aux_fcent_z(i  ,j  ,k  ,0) = zero_d;
+          aux_fcent_z(i  ,j  ,k  ,1) = zero_d;
+          aux_fcent_z(i  ,j  ,k+1,0) = zero_d;
+          aux_fcent_z(i  ,j  ,k+1,1) = zero_d;
 
-          aux_barea(i,j,k) = zero;
+          aux_barea(i,j,k) = zero_d;
 
-          aux_bcent(i,j,k,0) = zero;
-          aux_bcent(i,j,k,1) = zero;
-          aux_bcent(i,j,k,2) = zero;
+          aux_bcent(i,j,k,0) = zero_d;
+          aux_bcent(i,j,k,1) = zero_d;
+          aux_bcent(i,j,k,2) = zero_d;
 
-          aux_bnorm(i,j,k,0) = zero;
-          aux_bnorm(i,j,k,1) = zero;
-          aux_bnorm(i,j,k,2) = zero;
+          aux_bnorm(i,j,k,0) = zero_d;
+          aux_bnorm(i,j,k,1) = zero_d;
+          aux_bnorm(i,j,k,2) = zero_d;
 
           aux_flag(i,j,k).setCovered();
         }
 
-        if (std::abs(aux_vcent(i,j,k,0)) < small_value) aux_vcent(i,j,k,0) = zero;
-        if (std::abs(aux_vcent(i,j,k,1)) < small_value) aux_vcent(i,j,k,1) = zero;
-        if (std::abs(aux_vcent(i,j,k,2)) < small_value) aux_vcent(i,j,k,2) = zero;
-        if (std::abs(aux_bcent(i,j,k,0)) < small_value) aux_bcent(i,j,k,0) = zero;
-        if (std::abs(aux_bcent(i,j,k,1)) < small_value) aux_bcent(i,j,k,1) = zero;
-        if (std::abs(aux_bcent(i,j,k,2)) < small_value) aux_bcent(i,j,k,2) = zero;
+        if (std::abs(aux_vcent(i,j,k,0)) < small_value) aux_vcent(i,j,k,0) = zero_d;
+        if (std::abs(aux_vcent(i,j,k,1)) < small_value) aux_vcent(i,j,k,1) = zero_d;
+        if (std::abs(aux_vcent(i,j,k,2)) < small_value) aux_vcent(i,j,k,2) = zero_d;
+        if (std::abs(aux_bcent(i,j,k,0)) < small_value) aux_bcent(i,j,k,0) = zero_d;
+        if (std::abs(aux_bcent(i,j,k,1)) < small_value) aux_bcent(i,j,k,1) = zero_d;
+        if (std::abs(aux_bcent(i,j,k,2)) < small_value) aux_bcent(i,j,k,2) = zero_d;
       });
 
       // Area fraction MultiFab has one more slice at bigEnd(idim),
@@ -1093,21 +1093,21 @@ define( [[maybe_unused]] int const& a_level,
     Array4<EBCellFlag> const& aux_flag  = m_cellflags->array(mfi);
     Array4<Real>       const& aux_vfrac = m_volfrac->array(mfi);
 
-    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
       for(int kk(-1); kk<=1; kk++) {
       for(int jj(-1); jj<=1; jj++) {
       for(int ii(-1); ii<=1; ii++)
       {
-        if (aux_vfrac(i+ii,j+jj,k+kk) == zero) {
+        if (aux_vfrac(i+ii,j+jj,k+kk) == zero_d) {
             aux_flag(i,j,k).setDisconnected(ii,jj,kk);
         }
       }}}
     });
 
-    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if (aux_vfrac(i,j,k)==zero) {
+        if (aux_vfrac(i,j,k)==zero_d) {
             aux_flag(i,j,k).setCovered();
         }
     });

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -2585,7 +2585,7 @@ ERF::MakeHorizontalAverages ()
             auto const cons_arr = vars_new[lev][Vars::cons].const_array(mfi);
             int ncomp = vars_new[lev][Vars::cons].nComp();
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 Real dens = cons_arr(i, j, k, Rho_comp);
                 if (is_anelastic) {
                     fab_arr(i,j,k,2) = hse_arr(i,j,k,BaseState::p0_comp);
@@ -2593,8 +2593,8 @@ ERF::MakeHorizontalAverages ()
                     Real qv = cons_arr(i, j, k, RhoQ1_comp) / dens;
                     fab_arr(i, j, k, 2) = getPgivenRTh(cons_arr(i, j, k, RhoTheta_comp), qv);
                 }
-                fab_arr(i, j, k, 3) = (ncomp > RhoQ1_comp ? cons_arr(i, j, k, RhoQ1_comp) / dens : zero);
-                fab_arr(i, j, k, 4) = (ncomp > RhoQ2_comp ? cons_arr(i, j, k, RhoQ2_comp) / dens : zero);
+                fab_arr(i, j, k, 3) = (ncomp > RhoQ1_comp ? cons_arr(i, j, k, RhoQ1_comp) / dens : zero_d);
+                fab_arr(i, j, k, 4) = (ncomp > RhoQ2_comp ? cons_arr(i, j, k, RhoQ2_comp) / dens : zero_d);
             });
         }
 
@@ -2903,12 +2903,12 @@ ERF::check_for_negative_theta(amrex::MultiFab& S)
     {
         Box bx = mfi.tilebox();
         const Array4<Real> &s_arr  = S.array(mfi);
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const Real rho      = s_arr(i, j, k, Rho_comp);
             const Real rhotheta = s_arr(i, j, k, RhoTheta_comp);
 
-            if (rho <= zero) {
+            if (rho <= zero_d) {
 #ifdef AMREX_USE_GPU
                 AMREX_DEVICE_PRINTF("Rho is negative at %d %d %d %e \n", i,j,k,rho);
 #else
@@ -2917,7 +2917,7 @@ ERF::check_for_negative_theta(amrex::MultiFab& S)
 #endif
             }
 
-            if (rhotheta <= zero) {
+            if (rhotheta <= zero_d) {
 #ifdef AMREX_USE_GPU
                 AMREX_DEVICE_PRINTF("RhoTheta is negative at %d %d %d %e \n", i,j,k,rhotheta);
 #else

--- a/Source/ERF_Derive.cpp
+++ b/Source/ERF_Derive.cpp
@@ -223,12 +223,12 @@ erf_dersoundspeed (const Box& bx,
     // NOTE: we compute the soundspeed of dry air -- we do not account for any moisture effects here
     Real qv = Real(0.0);
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,Gamma_d=Gamma] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real rhotheta = dat(i, j, k, RhoTheta_comp);
         const Real rho      = dat(i, j, k, Rho_comp);
         AMREX_ALWAYS_ASSERT(rhotheta > 0);
-        cfab(i,j,k) = std::sqrt(Gamma * getPgivenRTh(rhotheta,qv) / rho);
+        cfab(i,j,k) = std::sqrt(Gamma_d * getPgivenRTh(rhotheta,qv) / rho);
     });
 }
 
@@ -432,10 +432,10 @@ erf_dervortz ( const Box& bx,
     const Real dx = geomdata.CellSize(0);
     const Real dy = geomdata.CellSize(2);
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
-        tfab(i,j,k,dcomp) = (dat(i+1,j,k,1) - dat(i-1,j,k,1)) / (two*dx)  // dv/dx
-                          - (dat(i,j+1,k,0) - dat(i,j-1,k,0)) / (two*dy); // du/dy
+        tfab(i,j,k,dcomp) = (dat(i+1,j,k,1) - dat(i-1,j,k,1)) / (two_d*dx)  // dv/dx
+                          - (dat(i,j+1,k,0) - dat(i,j-1,k,0)) / (two_d*dy); // du/dy
     });
 }
 
@@ -668,7 +668,7 @@ erf_derhelicity ( const Box& bx,
     // Collapse to i,j box (ignore vertical for now)
     Box b2d = makeSlab(bx,2,0);
 
-    ParallelFor(b2d, [=] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
+    ParallelFor(b2d, [=,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE(int i, int j, int ) noexcept
     {
         Real int_hel = Real(0.0);
         for (int k = bx.smallEnd(2); k <= bx.bigEnd(2); ++k)
@@ -678,12 +678,12 @@ erf_derhelicity ( const Box& bx,
             // Helicity is defined as integral from 2km to 5km in vertical
             if (z > Real(2000.0) && z < Real(5000.0)) {
 
-                Real z_hi = myhalf * (z_arr(i,j,k) + z_arr(i,j,k+1));
-                Real z_lo = myhalf * (z_arr(i,j,k) + z_arr(i,j,k-1));
+                Real z_hi = myhalf_d * (z_arr(i,j,k) + z_arr(i,j,k+1));
+                Real z_lo = myhalf_d * (z_arr(i,j,k) + z_arr(i,j,k-1));
                 Real dz = z_hi - z_lo;
 
-                Real vortz = (dat(i+1,j,k,1) - dat(i-1,j,k,1)) / (two*dx)  // dv/dx
-                           - (dat(i,j+1,k,0) - dat(i,j-1,k,0)) / (two*dy); // du/dy
+                Real vortz = (dat(i+1,j,k,1) - dat(i-1,j,k,1)) / (two_d*dx)  // dv/dx
+                           - (dat(i,j+1,k,0) - dat(i,j-1,k,0)) / (two_d*dy); // du/dy
                 Real w     = dat(i,j,k,2); // vertical velocity
 
                 int_hel += vortz * w * dz;
@@ -720,14 +720,14 @@ erf_derprecipitable ( const Box& bx,
 
     auto z_arr     = zcc_fab.array(); // cell-centered height z
 
-    ParallelFor(b2d, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+    ParallelFor(b2d, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int) noexcept
     {
         Real integral_qv = Real(0.0);
 
         for (int k = 0; k <= bx.bigEnd(2); ++k)
         {
-            Real z_hi = myhalf * (z_arr(i,j,k+1) + z_arr(i,j,k));
-            Real z_lo = myhalf * (z_arr(i,j,k-1) + z_arr(i,j,k));
+            Real z_hi = myhalf_d * (z_arr(i,j,k+1) + z_arr(i,j,k));
+            Real z_lo = myhalf_d * (z_arr(i,j,k-1) + z_arr(i,j,k));
             Real dz = z_hi - z_lo;
 
             Real rhoQ1 = dat(i, j, k, RhoQ1_comp);
@@ -766,7 +766,7 @@ erf_dermucape ( const Box& bx,
     b2d.setSmall(2,0);
     b2d.setBig(2,0);
 
-    ParallelFor(b2d, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+    ParallelFor(b2d, [=,Cp_d_d=Cp_d,R_d_d=R_d,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int) noexcept
     {
         Real mucape = Real(0);
         int klo = bx.smallEnd(2);
@@ -799,10 +799,10 @@ erf_dermucape ( const Box& bx,
 
                     Real Td_src = mucape_dewpoint_temperature(p_src, qv_src, T_src);
                     Real Tlcl   = mucape_lcl_temperature(T_src, Td_src);
-                    Real plcl   = p_src * std::pow(Tlcl / T_src, Cp_d / R_d);
+                    Real plcl   = p_src * std::pow(Tlcl / T_src, Cp_d_d / R_d_d);
                     plcl = amrex::min(p_src, amrex::max(plcl, mucape_min_pressure_pa()));
 
-                    Real theta_src = getThgivenTandP(T_src, p_src, R_d / Cp_d);
+                    Real theta_src = getThgivenTandP(T_src, p_src, R_d_d / Cp_d_d);
 
                     Real candidate_cape = Real(0);
                     Real z_prev = z_arr(i,j,ks);
@@ -827,7 +827,7 @@ erf_dermucape ( const Box& bx,
                         Real qv_parcel;
 
                         if (p_env >= plcl) {
-                            T_parcel  = getTgivenPandTh(p_env, theta_src, R_d / Cp_d);
+                            T_parcel  = getTgivenPandTh(p_env, theta_src, R_d_d / Cp_d_d);
                             qv_parcel = qv_src;
                         } else {
                             if (!saturated) {
@@ -846,7 +846,7 @@ erf_dermucape ( const Box& bx,
                         }
 
                         Real Tv_parcel = mucape_virtual_temperature(T_parcel, qv_parcel);
-                        Real buoyancy = CONST_GRAV * (Tv_parcel - Tv_env) /
+                        Real buoyancy = CONST_GRAV_d * (Tv_parcel - Tv_env) /
                                         amrex::max(Tv_env, mucape_min_temperature());
 
                         candidate_cape += mucape_positive_area(b_prev, buoyancy, z_env - z_prev);

--- a/Source/ERF_Diagnostics.cpp
+++ b/Source/ERF_Diagnostics.cpp
@@ -89,8 +89,8 @@ ERF::compute_max_pressure_gradient_diagnostic(int lev)
             });
         } else {
             Array4<const Real> volfrac = (get_eb(lev).get_const_factory())->getVolFrac().const_array(mfi);
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (volfrac(i,j,k) > zero) {
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (volfrac(i,j,k) > zero_d) {
                     Real rhotheta = rhse_arr(i,j,k) * thhse_arr(i,j,k);
                     dpeos_arr(i,j,k) = std::abs(getPgivenRTh(rhotheta, qvhse_arr(i,j,k)) - phse_arr(i,j,k));
                 }
@@ -147,9 +147,9 @@ ERF::compute_max_pressure_gradient_diagnostic(int lev)
             auto        gpz_arr  = gradp_temp[2].array(mfi);
             auto const  rhse_arr  =  r_hse.const_array(mfi);
             auto const qvhse_arr  = qv_hse.const_array(mfi);
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                gpz_arr(i,j,k) += grav * myhalf * ( rhse_arr(i,j,k  ) * (one + qvhse_arr(i,j,k  ))
-                                                   +rhse_arr(i,j,k-1) * (one + qvhse_arr(i,j,k-1)) );
+            ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
+                gpz_arr(i,j,k) += grav * myhalf_d * ( rhse_arr(i,j,k  ) * (one_d + qvhse_arr(i,j,k  ))
+                                                   +rhse_arr(i,j,k-1) * (one_d + qvhse_arr(i,j,k-1)) );
             });
         }
     // EB case: check HSE only for uncovered cells
@@ -162,10 +162,10 @@ ERF::compute_max_pressure_gradient_diagnostic(int lev)
             auto const qvhse_arr  = qv_hse.const_array(mfi);
             Array4<const Real> w_volfrac = (get_eb(lev).get_w_const_factory())->getVolFrac().const_array(mfi);
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (w_volfrac(i,j,k) > zero) {
-                    gpz_arr(i,j,k) += grav * myhalf * ( rhse_arr(i,j,k  ) * (one + qvhse_arr(i,j,k  ))
-                                                       +rhse_arr(i,j,k-1) * (one + qvhse_arr(i,j,k-1)) );
+            ParallelFor(bx, [=,zero_d=zero,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (w_volfrac(i,j,k) > zero_d) {
+                    gpz_arr(i,j,k) += grav * myhalf_d * ( rhse_arr(i,j,k  ) * (one_d + qvhse_arr(i,j,k  ))
+                                                       +rhse_arr(i,j,k-1) * (one_d + qvhse_arr(i,j,k-1)) );
                 }
             });
         }
@@ -264,9 +264,9 @@ ERF::compute_max_pressure_gradient_diagnostic(int lev)
                 auto const  r_arr   = rho.const_array(mfi);
                 auto const qt_arr   =  qt.const_array(mfi);
 
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    gpz_arr(i,j,k) += grav * myhalf * (r_arr(i,j,k  )*(one+qt_arr(i,j,k  )) +
-                                                       r_arr(i,j,k-1)*(one+qt_arr(i,j,k-1)) );
+                ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    gpz_arr(i,j,k) += grav * myhalf_d * (r_arr(i,j,k  )*(one_d+qt_arr(i,j,k  )) +
+                                                       r_arr(i,j,k-1)*(one_d+qt_arr(i,j,k-1)) );
                 });
             }
 

--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -195,10 +195,10 @@ public:
             const amrex::Array4<amrex::Real>& src_arr = src->array(mfi);
             // src is a spatial function if erf.spatial_rhotheta_forcing = true
             // otherwise, qsrc_arr is defined only in over Z (box x and y dimensions are 1)
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 // const amrex::Real z_cc = prob_lo[2] + (k+myhalf)* dx[2];
                 // set RHS term of RhoTheta equation based on time, z_cc here
-                src_arr(i, j, k) = zero;
+                src_arr(i, j, k) = zero_d;
             });
         }
     }
@@ -227,10 +227,10 @@ public:
             const amrex::Array4<amrex::Real>& qsrc_arr = qsrc->array(mfi);
             // src is a spatial function if erf.spatial_moisture_forcing = true
             // otherwise, qsrc_arr is defined only in over Z (box x and y dimensions are 1)
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 // const amrex::Real z_cc = prob_lo[2] + (k+myhalf)* dx[2];
                 // set RHS term of RhoQ1 equation based on time, z_cc here
-                qsrc_arr(i, j, k) = zero;
+                qsrc_arr(i, j, k) = zero_d;
             });
         }
     }

--- a/Source/ERF_ReadWaves.cpp
+++ b/Source/ERF_ReadWaves.cpp
@@ -184,8 +184,8 @@ ERF::send_to_ww3 (int lev)
         const Array4<Real>& u_vel = x_avg.array(mfi);
         const Array4<const Real>& velx_arr = xvel_data.array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
-            u_vel(i,j,k)  = myhalf *( velx_arr(i,j,k) + velx_arr(i+1,j,k) );
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k){
+            u_vel(i,j,k)  = myhalf_d *( velx_arr(i,j,k) + velx_arr(i+1,j,k) );
 
             amrex::AllPrintToFile("uvel.txt") << amrex::IntVect(i,j,k) << " ["
                                               <<velx_arr(i,j,k) << "| avg:  "
@@ -200,9 +200,9 @@ ERF::send_to_ww3 (int lev)
         const Array4<Real>& v_vel = y_avg.array(mfi);
         const Array4<const Real>& vely_arr = yvel_data.array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k){
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k){
 
-            v_vel(i,j,k)  = myhalf *( vely_arr(i,j,k) + vely_arr(i,j+1,k) );
+            v_vel(i,j,k)  = myhalf_d *( vely_arr(i,j,k) + vely_arr(i,j+1,k) );
 
             amrex::AllPrintToFile("vvel.txt") << "%ld" << amrex::IntVect(i,j,k) << " ["
                                               <<vely_arr(i,j,k)<<"| avg: "
@@ -237,7 +237,7 @@ ERF::send_to_ww3 (int lev)
         DistributionMapping dm_onegrid(ba2d_onegrid);
         dm_onegrid.define(pmap);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx, [=,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             //magnitude(i,j,k)  = std::sqrt( pow(u(i,j,k), 2) + pow(v(i,j,k), 2) );
 
@@ -252,7 +252,7 @@ ERF::send_to_ww3 (int lev)
 
             if ( u_val < 0 && v_val > 0 || u_val < 0 && v_val < 0 ) {
 
-                theta(i,j,k) = PI + ( atan( v_val / u_val ) );
+                theta(i,j,k) = PI_d + ( atan( v_val / u_val ) );
 
             } else {
 
@@ -341,4 +341,3 @@ ERF::send_to_ww3 (int lev)
     } // mfi
 }
 #endif
-

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -761,9 +761,9 @@ ERF::ReadCheckpointFile ()
                 // We only compute theta_0 on valid cells since we will impose domain BC's after restart
                 const Box& bx = mfi.tilebox();
                 Array4<Real> const& fab = base_state[lev].array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    fab(i,j,k,BaseState::qv0_comp) = zero;
+                    fab(i,j,k,BaseState::qv0_comp) = zero_d;
                 });
             }
         }

--- a/Source/IO/ERF_Plotfile.cpp
+++ b/Source/IO/ERF_Plotfile.cpp
@@ -672,14 +672,14 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real const>& S_arr = vars_new[lev][Vars::cons].const_array(mfi);
                 const Array4<Real const>& p_arr = pressure.const_array(mfi);
                 const int ncomp = vars_new[lev][Vars::cons].nComp();
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    Real qv = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : zero;
-                    Real qc = (use_moisture && (ncomp > RhoQ2_comp)) ? S_arr(i,j,k,RhoQ2_comp)/S_arr(i,j,k,Rho_comp) : zero;
+                ParallelFor(bx, [=,zero_d=zero,Cp_d_d=Cp_d,Cp_l_d=Cp_l,p_0_d=p_0,R_d_d=R_d,L_v_d=L_v] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    Real qv = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : zero_d;
+                    Real qc = (use_moisture && (ncomp > RhoQ2_comp)) ? S_arr(i,j,k,RhoQ2_comp)/S_arr(i,j,k,Rho_comp) : zero_d;
                     Real T = getTgivenRandRTh(S_arr(i,j,k,Rho_comp), S_arr(i,j,k,RhoTheta_comp), qv);
-                    Real fac = Cp_d + Cp_l*(qv + qc);
+                    Real fac = Cp_d_d + Cp_l_d*(qv + qc);
                     Real pv = erf_esatw(T)*Real(100.0);
 
-                    derdat(i, j, k, mf_comp) = T*std::pow((p_arr(i,j,k) - pv)/p_0, -R_d/fac)*std::exp(L_v*qv/(fac*T)) ;
+                    derdat(i, j, k, mf_comp) = T*std::pow((p_arr(i,j,k) - pv)/p_0_d, -R_d_d/fac)*std::exp(L_v_d*qv/(fac*T)) ;
                 });
             }
             mf_comp ++;
@@ -697,9 +697,9 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real const>& S_arr = vars_new[lev][Vars::cons].const_array(mfi);
                 const Array4<Real const>& p_arr = pressure.const_array(mfi);
                 const int ncomp = vars_new[lev][Vars::cons].nComp();
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    const Real qv       = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : zero;
+                    const Real qv       = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : zero_d;
 
                     const Real T        = getTgivenRandRTh(S_arr(i,j,k,Rho_comp), S_arr(i,j,k,RhoTheta_comp), qv);
                     const Real e_sat = Real(100.0) * erf_esatw_cc(T);
@@ -776,8 +776,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real const>&   gpx_arr = (solverChoice.anelastic[lev] == 1) ?
                       gradp[lev][GpVars::gpx].array(mfi) : gradp_temp[GpVars::gpx].array(mfi);
                 const Array4<Real const>& mf_mx_arr = mapfac[lev][MapFacType::m_x]->const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    derdat(i ,j ,k, mf_comp) = myhalf * (gpx_arr(i+1,j,k) + gpx_arr(i,j,k)) * mf_mx_arr(i,j,0);
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    derdat(i ,j ,k, mf_comp) = myhalf_d * (gpx_arr(i+1,j,k) + gpx_arr(i,j,k)) * mf_mx_arr(i,j,0);
                 });
             }
             mf_comp ++;
@@ -791,8 +791,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real const>&   gpy_arr = (solverChoice.anelastic[lev] == 1) ?
                       gradp[lev][GpVars::gpy].array(mfi) : gradp_temp[GpVars::gpy].array(mfi);
                 const Array4<Real const>& mf_my_arr = mapfac[lev][MapFacType::m_y]->const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    derdat(i ,j ,k, mf_comp) = myhalf * (gpy_arr(i,j+1,k) + gpy_arr(i,j,k)) * mf_my_arr(i,j,0);
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    derdat(i ,j ,k, mf_comp) = myhalf_d * (gpy_arr(i,j+1,k) + gpy_arr(i,j,k)) * mf_my_arr(i,j,0);
                 });
             }
             mf_comp ++;
@@ -805,8 +805,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real      >&  derdat  = mf[lev].array(mfi);
                 const Array4<Real const>&  gpz_arr = (solverChoice.anelastic[lev] == 1) ?
                       gradp[lev][GpVars::gpz].array(mfi) : gradp_temp[GpVars::gpz].array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    derdat(i ,j ,k, mf_comp) = myhalf * (gpz_arr(i,j,k+1) + gpz_arr(i,j,k));
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    derdat(i ,j ,k, mf_comp) = myhalf_d * (gpz_arr(i,j,k+1) + gpz_arr(i,j,k));
                 });
             }
             mf_comp ++;
@@ -830,8 +830,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real      >&  derdat  = mf[lev].array(mfi);
                 const Array4<Real const>&  gpx_arr = gradp_temp[0].array(mfi);
                 const Array4<Real const>& mf_mx_arr = mapfac[lev][MapFacType::m_x]->const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    derdat(i ,j ,k, mf_comp) = myhalf * (gpx_arr(i+1,j,k) + gpx_arr(i,j,k)) * mf_mx_arr(i,j,0);
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    derdat(i ,j ,k, mf_comp) = myhalf_d * (gpx_arr(i+1,j,k) + gpx_arr(i,j,k)) * mf_mx_arr(i,j,0);
                 });
             }
             mf_comp += 1;
@@ -845,8 +845,8 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Array4<Real      >&  derdat  = mf[lev].array(mfi);
                 const Array4<Real const>&  gpy_arr = gradp_temp[1].array(mfi);
                 const Array4<Real const>& mf_my_arr = mapfac[lev][MapFacType::m_y]->const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-                    derdat(i ,j ,k, mf_comp) = myhalf * (gpy_arr(i,j+1,k) + gpy_arr(i,j,k)) * mf_my_arr(i,j,0);
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                    derdat(i ,j ,k, mf_comp) = myhalf_d * (gpy_arr(i,j+1,k) + gpy_arr(i,j,k)) * mf_my_arr(i,j,0);
                 });
             }
             mf_comp += 1;
@@ -1457,10 +1457,10 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 
                 const Array4<Real const>& z_nd = z_phys_nd[lev]->const_array(mfi);
 
-                ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(xbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     Real x = i * dx[0];
-                    Real z = fourth * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
+                    Real z = fourth_d * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
 
                     Real z_base = Ampl * std::sin(kp * x - omega_t);
                     z -= z_base;
@@ -1470,10 +1470,10 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                     xvel_arr(i,j,k) -= -Ampl * omega * fac * std::sin(kp * x - omega_t);
                 });
 
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(bx, [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real x   = (i + myhalf) * dx[0];
-                    Real z   = fourth * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k));
+                    Real x   = (i + myhalf_d) * dx[0];
+                    Real z   = fourth_d * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k));
 
                     Real z_base = Ampl * std::sin(kp * x - omega_t);
                     z -= z_base;
@@ -1515,10 +1515,10 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
 
                 const Array4<Real const>& z_nd = z_phys_nd[lev]->const_array(mfi);
 
-                ParallelFor(xbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(xbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     Real x = i * dx[0];
-                    Real z = fourth * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
+                    Real z = fourth_d * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
                     Real z_base = Ampl * std::sin(kp * x - omega_t);
 
                     z -= z_base;
@@ -1526,10 +1526,10 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                     Real fac = std::cosh( kp * (z - H) ) / std::sinh(kp * H);
                     xvel_arr(i,j,k) += -Ampl * omega * fac * std::sin(kp * x - omega_t);
                 });
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(bx, [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real x   = (i + myhalf) * dx[0];
-                    Real z   = fourth * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k));
+                    Real x   = (i + myhalf_d) * dx[0];
+                    Real z   = fourth_d * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k));
                     Real z_base = Ampl * std::sin(kp * x - omega_t);
 
                     z -= z_base;
@@ -1566,13 +1566,13 @@ ERF::Write3DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 Real omega       = std::sqrt(g * kp);
                 Real omega_t     = omega * t_new[lev];
 
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
                     derdat(i, j, k, mf_comp) = p_arr(i,j,k) - p0_arr(i,j,k);
 
                     Real rho_hse     = r0_arr(i,j,k);
 
-                    Real x   = (i + myhalf) * dx[0];
+                    Real x   = (i + myhalf_d) * dx[0];
                     Real z   = Real(0.125) * ( z_nd(i,j,k  ) + z_nd(i+1,j,k  ) + z_nd(i,j+1,k  ) + z_nd(i+1,j+1,k  )
                                         +z_nd(i,j,k+1) + z_nd(i+1,j,k+1) + z_nd(i,j+1,k+1) + z_nd(i+1,j+1,k+1) );
                     Real z_base = Ampl * std::sin(kp * x - omega_t);

--- a/Source/IO/ERF_Plotfile2D.cpp
+++ b/Source/IO/ERF_Plotfile2D.cpp
@@ -403,10 +403,10 @@ ERF::Write2DPlotFile (int which, PlotFileType plotfile_type, Vector<std::string>
                 const Box& bx = mfi.tilebox();
                 const auto& derdat   = mf[lev].array(mfi);
                 const auto& cons_arr = vars_new[lev][Vars::cons].const_array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                     auto rt = cons_arr(i,j,klo,RhoTheta_comp);
                     auto qv = (moist) ? cons_arr(i,j,klo,RhoQ1_comp)/cons_arr(i,j,klo,Rho_comp)
-                                      : zero;
+                                      : zero_d;
                     derdat(i, j, k, mf_comp) = getPgivenRTh(rt, qv);
                 });
             }

--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -451,8 +451,8 @@ void ReadBndryPlanes::read_file (const int idx,
             const auto& bx = d.box();
             Array4<Real> d_arr = d.array();
             ParallelFor(
-                bx, ncomp_for_bc, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
-                d_arr(i,j,k,n) = zero;
+                bx, ncomp_for_bc, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+                d_arr(i,j,k,n) = zero_d;
             });
         }
     }
@@ -560,7 +560,7 @@ void ReadBndryPlanes::read_file (const int idx,
                 if (n_for_density >= 0) {
                   if (var_name == "temperature") {
                     ParallelFor(
-                        bx_ghost, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        bx_ghost, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1 =  bndry_read_r_arr(i, j, k, 0);
                              Real R2 =  bndry_read_r_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2],0);
                              Real T1 =  bndry_read_arr(i, j, k, 0);
@@ -568,30 +568,30 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th1 = getThgivenRandT(R1,T1,rdOcp);
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                                                     myhalf * (R1*Th1 + R2*Th2);
+                                                                     myhalf_d * (R1*Th1 + R2*Th2);
                         });
                   } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
                              var_name == "qv"    || var_name == "qc") {
                     ParallelFor(
-                        bx_ghost, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        bx_ghost, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1 =  bndry_read_r_arr(i, j, k, 0);
                              Real R2 =  bndry_read_r_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2],0);
                              bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                 myhalf * ( R1 * bndry_read_arr(i, j, k, 0) +
+                                 myhalf_d * ( R1 * bndry_read_arr(i, j, k, 0) +
                                          R2 * bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2], 0));
                         });
                    } else if (var_name == "density") {
                     ParallelFor(
-                        bx_ghost, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        bx_ghost, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                 bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                    myhalf * ( bndry_read_arr(i, j, k, 0) +
+                                    myhalf_d * ( bndry_read_arr(i, j, k, 0) +
                                             bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2], 0));
                         });
                    }
                 } else if (!ingested_density()) {
                   if (var_name == "temperature") {
                     ParallelFor(
-                        bx_ghost, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        bx_ghost, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                              Real R2  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                              Real T1  = bndry_read_arr(i, j, k, 0);
@@ -599,16 +599,16 @@ void ReadBndryPlanes::read_file (const int idx,
                              Real Th1 = getThgivenRandT(R1,T1,rdOcp);
                              Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                              bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                                                     myhalf * (R1*Th1 + R2*Th2);
+                                                                     myhalf_d * (R1*Th1 + R2*Th2);
                         });
                   } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
                              var_name == "qv"    || var_name == "qc") {
                       ParallelFor(
-                        bx_ghost, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                        bx_ghost, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                              Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                              Real R2  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                              bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                myhalf * (R1 * bndry_read_arr(i, j, k, 0) +
+                                myhalf_d * (R1 * bndry_read_arr(i, j, k, 0) +
                                        R2 * bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2], 0));
                         });
                   }
@@ -617,9 +617,9 @@ void ReadBndryPlanes::read_file (const int idx,
                 // This is velocity
                 if (var_name == "velocity") {
                     ParallelFor(
-                        bx_ghost, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+                        bx_ghost, ncomp, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
                                 bndry_mf_arr(i, j, k, n) = (real_bcs) ? bndry_read_arr(i, j, k, n) :
-                                  myhalf * (bndry_read_arr(i, j, k, n) +
+                                  myhalf_d * (bndry_read_arr(i, j, k, n) +
                                          bndry_read_arr(i+v_offset[0],j+v_offset[1],k+v_offset[2], n));
                         });
                 }
@@ -630,7 +630,7 @@ void ReadBndryPlanes::read_file (const int idx,
                 if (n_for_density >= 0) {
                     if (var_name == "temperature") {
                         ParallelFor(
-                            bx_int, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            bx_int, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                  Real R1 =  bndry_read_r_arr(i, j, k, 0);
                                  Real R2 =  bndry_read_r_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2],0);
                                  Real T1 =  bndry_read_arr(i, j, k, 0);
@@ -638,30 +638,30 @@ void ReadBndryPlanes::read_file (const int idx,
                                  Real Th1 = getThgivenRandT(R1,T1,rdOcp);
                                  Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                                  bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                                                         myhalf * (R1*Th1 + R2*Th2);
+                                                                         myhalf_d * (R1*Th1 + R2*Th2);
                             });
                     } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
                                var_name == "qv"    || var_name == "qc") {
                         ParallelFor(
-                            bx_int, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            bx_int, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                  Real R1 =  bndry_read_r_arr(i, j, k, 0);
                                  Real R2 =  bndry_read_r_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2],0);
                                  bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                     myhalf * ( R1 * bndry_read_arr(i, j, k, 0) +
+                                     myhalf_d * ( R1 * bndry_read_arr(i, j, k, 0) +
                                              R2 * bndry_read_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2], 0));
                             });
                     } else if (var_name == "density") {
                         ParallelFor(
-                            bx_int, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            bx_int, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                     bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                        myhalf * ( bndry_read_arr(i, j, k, 0) +
+                                        myhalf_d * ( bndry_read_arr(i, j, k, 0) +
                                                 bndry_read_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2], 0));
                             });
                     }
                 } else if (!ingested_density()) {
                     if (var_name == "temperature") {
                         ParallelFor(
-                            bx_int, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            bx_int, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                  Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                                  Real R2  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                                  Real T1  = bndry_read_arr(i, j, k, 0);
@@ -669,16 +669,16 @@ void ReadBndryPlanes::read_file (const int idx,
                                  Real Th1 = getThgivenRandT(R1,T1,rdOcp);
                                  Real Th2 = getThgivenRandT(R2,T2,rdOcp);
                                  bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                                                         myhalf * (R1*Th1 + R2*Th2);
+                                                                         myhalf_d * (R1*Th1 + R2*Th2);
                             });
                     } else if (var_name == "theta" || var_name == "ke" || var_name == "scalar" ||
                                var_name == "qv"    || var_name == "qc") {
                           ParallelFor(
-                            bx_int, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+                            bx_int, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
                                  Real R1  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                                  Real R2  = l_bc_extdir_vals_d[BCVars::Rho_bc_comp][ori];
                                  bndry_mf_arr(i, j, k, 0) = (real_bcs) ? bndry_read_arr(i, j, k, 0) :
-                                    myhalf * (R1 * bndry_read_arr(i, j, k, 0) +
+                                    myhalf_d * (R1 * bndry_read_arr(i, j, k, 0) +
                                            R2 * bndry_read_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2], 0));
                             });
                     }
@@ -686,9 +686,9 @@ void ReadBndryPlanes::read_file (const int idx,
 
                 if (var_name == "velocity") {
                     ParallelFor(
-                        bx_int, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
+                        bx_int, ncomp, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept {
                                 bndry_mf_arr(i, j, k, n) = (real_bcs) ? bndry_read_arr(i, j, k, n) :
-                                  myhalf * (bndry_read_arr(i, j, k, n) +
+                                  myhalf_d * (bndry_read_arr(i, j, k, n) +
                                          bndry_read_arr(i+v_offset_int[0],j+v_offset_int[1],k+v_offset_int[2], n));
                         });
                 }

--- a/Source/IO/ERF_ReadFromWRFBdy.cpp
+++ b/Source/IO/ERF_ReadFromWRFBdy.cpp
@@ -222,7 +222,7 @@ convert_wrfbdy_data (const int itime,
 
         // New z values
         ParallelFor(bx_t, bx_u, bx_v,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Mass coupling
             Real mu    = mu_arr(i ,j ,0)  + mub_arr(i ,j ,0);
@@ -235,12 +235,12 @@ convert_wrfbdy_data (const int itime,
             Real P0_kp = phb_arr(i ,j ,k+1) + bdy_ph0_arr(i ,j ,k+1)/mu0;
 
             // New heights
-            bdy_c_z_src(i,j,k) = Real(0.5  ) * ( P + P_kp ) / CONST_GRAV;
+            bdy_c_z_src(i,j,k) = Real(0.5  ) * ( P + P_kp ) / CONST_GRAV_d;
 
             // Original heights
-            bdy_c_z_dst(i,j,k) = Real(0.5  ) * ( P0 + P0_kp ) / CONST_GRAV;
+            bdy_c_z_dst(i,j,k) = Real(0.5  ) * ( P0 + P0_kp ) / CONST_GRAV_d;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Prevent averaging outside domain and match init from WRF input
             int ii = std::max(std::min(i  ,ihi_ph),ilo_ph);
@@ -263,12 +263,12 @@ convert_wrfbdy_data (const int itime,
             Real P0_im_kp = phb_arr(im,j ,k+1) + bdy_ph0_arr(im,j ,k+1)/mu0_im;
 
             // New heights
-            bdy_u_z_src(i,j,k) = Real(0.25) * ( P + P_kp + P_im + P_im_kp ) / CONST_GRAV;
+            bdy_u_z_src(i,j,k) = Real(0.25) * ( P + P_kp + P_im + P_im_kp ) / CONST_GRAV_d;
 
             // Original heights
-            bdy_u_z_dst(i,j,k) = Real(0.25) * ( P0 + P0_kp + P0_im + P0_im_kp ) / CONST_GRAV;
+            bdy_u_z_dst(i,j,k) = Real(0.25) * ( P0 + P0_kp + P0_im + P0_im_kp ) / CONST_GRAV_d;
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Prevent averaging outside domain and match init from WRF input
             int jj = std::max(std::min(j  ,jhi_ph),jlo_ph);
@@ -291,14 +291,14 @@ convert_wrfbdy_data (const int itime,
             Real P0_jm_kp = phb_arr(i ,jm,k+1) + bdy_ph0_arr(i ,jm,k+1)/mu0_jm;
 
             // New heights
-            bdy_v_z_src(i,j,k) = Real(0.25) * ( P + P_kp + P_jm + P_jm_kp ) / CONST_GRAV;
+            bdy_v_z_src(i,j,k) = Real(0.25) * ( P + P_kp + P_jm + P_jm_kp ) / CONST_GRAV_d;
 
             // Original heights
-            bdy_v_z_dst(i,j,k) = Real(0.25) * ( P0 + P0_kp + P0_jm + P0_jm_kp ) / CONST_GRAV;
+            bdy_v_z_dst(i,j,k) = Real(0.25) * ( P0 + P0_kp + P0_jm + P0_jm_kp ) / CONST_GRAV_d;
         });
 
         // Define u velocity
-        ParallelFor(bx_u, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx_u, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             if (mask_u_arr(i,j,k)) {
                 Real xmu;
@@ -308,7 +308,7 @@ convert_wrfbdy_data (const int itime,
                     xmu  = mu_arr(i-1,j,0) + mub_arr(i-1,j,0);
                 } else {
                     xmu = (  mu_arr(i,j,0) +  mu_arr(i-1,j,0)
-                          + mub_arr(i,j,0) + mub_arr(i-1,j,0)) * myhalf;
+                          + mub_arr(i,j,0) + mub_arr(i-1,j,0)) * myhalf_d;
                 }
                 Real xmu_mult    = c1h_arr(0,0,k) * xmu + c2h_arr(0,0,k);
                 Real new_bdy     = bdy_u_arr(i,j,k) / xmu_mult;
@@ -317,7 +317,7 @@ convert_wrfbdy_data (const int itime,
         });
 
         // Define v velocity
-        ParallelFor(bx_v, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx_v, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             if (mask_v_arr(i,j,k)) {
                 Real xmu;
@@ -327,7 +327,7 @@ convert_wrfbdy_data (const int itime,
                     xmu  = mu_arr(i,j-1,0) + mub_arr(i,j-1,0);
                 } else {
                     xmu =  (  mu_arr(i,j,0) +  mu_arr(i,j-1,0)
-                           + mub_arr(i,j,0) + mub_arr(i,j-1,0) ) * myhalf;
+                           + mub_arr(i,j,0) + mub_arr(i,j-1,0) ) * myhalf_d;
                 }
                 Real xmu_mult    = c1h_arr(0,0,k) * xmu + c2h_arr(0,0,k);
                 Real new_bdy     = bdy_v_arr(i,j,k) / xmu_mult;
@@ -337,26 +337,26 @@ convert_wrfbdy_data (const int itime,
 
         // Convert perturbational moist pot. temp. (Th_m) to dry pot. temp. (Th_d)
         const Real wrf_theta_ref = Real(300.);
-        ParallelFor(bx_t, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx_t, [=,one_d=one,R_v_d=R_v,R_d_d=R_d] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             if (mask_c_arr(i,j,k)) {
                 Real xmu         = (mu_arr(i,j,0) + mub_arr(i,j,0));
                 Real xmu_mult    = c1h_arr(0,0,k) * xmu + c2h_arr(0,0,k);
                 Real new_bdy_Th  = bdy_t_arr(i,j,k) / xmu_mult + wrf_theta_ref;
-                Real qv_fac      = (one + (R_v/R_d) * bdy_qv_arr(i,j,k) / xmu_mult);
+                Real qv_fac      = (one_d + (R_v_d/R_d_d) * bdy_qv_arr(i,j,k) / xmu_mult);
                 new_bdy_Th      /= qv_fac;
                 bdy_t_tmp(i,j,k) = new_bdy_Th;
             }
         });
 
         // Define Qv
-        ParallelFor(bx_qv, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx_qv, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             if (mask_c_arr(i,j,k)) {
                 Real xmu          = (mu_arr(i,j,0) + mub_arr(i,j,0));
                 Real xmu_mult     = c1h_arr(0,0,k) * xmu + c2h_arr(0,0,k);
                 Real new_bdy_QV   = bdy_qv_arr(i,j,k) / xmu_mult;
-                bdy_qv_tmp(i,j,k) = (use_moist) ? new_bdy_QV : zero;
+                bdy_qv_tmp(i,j,k) = (use_moist) ? new_bdy_QV : zero_d;
             }
         });
 
@@ -478,7 +478,7 @@ convert_wrfbdy_data (const int itime,
 #endif
         Real grav = CONST_GRAV;
         ParallelFor(bx_t_slab,
-        [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
+        [=,R_d_d=R_d,Cp_d_d=Cp_d,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
         {
             // integrate from surface to domain top
             Real dz, F, C;
@@ -507,29 +507,29 @@ convert_wrfbdy_data (const int itime,
               qt_lo = bdy_qv_int(i,j,k-1);
               qv_lo = bdy_qv_int(i,j,k-1);
               Th_lo = bdy_t_int(i,j,k-1);
-              R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-              rho_tot_lo = R_lo * (one + qt_lo);
-              C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+              R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
+              rho_tot_lo = R_lo * (one_d + qt_lo);
+              C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
               // Initial guess and residual
               qt_hi = bdy_qv_int(i,j,k);
               qv_hi = bdy_qv_int(i,j,k);
               Th_hi = bdy_t_int(i,j,k);
-              T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-              R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-              rho_tot_hi = R_hi * (one + qt_hi);
-              F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+              T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+              R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
+              rho_tot_hi = R_hi * (one_d + qt_hi);
+              F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
               // Do iterations
               bool maintain_Th = false;
-              HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+              HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                            grav, C, Th_hi, T_hi,
                                            qt_hi, qv_hi,
                                            P_hi, R_hi, F, maintain_Th);
 
               // Assign data
               bdy_r_int(i,j,k) = R_hi;
-              bdy_t_int(i,j,k) = getThgivenTandP(T_hi, P_hi, R_d/Cp_d);
+              bdy_t_int(i,j,k) = getThgivenTandP(T_hi, P_hi, R_d_d/Cp_d_d);
               P_lo = P_hi;
               z_lo = z_hi;
             }

--- a/Source/IO/ERF_Write1DProfiles.cpp
+++ b/Source/IO/ERF_Write1DProfiles.cpp
@@ -287,12 +287,12 @@ ERF::derive_diag_profiles(double /*time*/,
         const Array4<const Real>& eta_arr = (eta_src) ? eta_src->const_array(mfi) :
                                                         Array4<const Real>{};
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             Real theta = cons_arr(i,j,k,RhoTheta_comp) / cons_arr(i,j,k,Rho_comp);
             fab_arr(i, j, k, 0) = cons_arr(i,j,k,Rho_comp);
             fab_arr(i, j, k, 1) = theta;
-            Real ksgs = zero;
+            Real ksgs = zero_d;
             if (l_use_KE) {
                 ksgs = cons_arr(i,j,k,RhoKE_comp) / cons_arr(i,j,k,Rho_comp);
             }
@@ -302,15 +302,15 @@ ERF::derive_diag_profiles(double /*time*/,
                 fab_arr(i, j, k, 3) = eta_arr(i,j,k,EddyDiff::Mom_v); // Kmv
                 fab_arr(i, j, k, 4) = eta_arr(i,j,k,EddyDiff::Theta_v); // Khv
             } else {
-                fab_arr(i, j, k, 3) = zero;
-                fab_arr(i, j, k, 4) = zero;
+                fab_arr(i, j, k, 3) = zero_d;
+                fab_arr(i, j, k, 4) = zero_d;
             }
 #else
             // Here we hijack the "Kturb" variable name to print out the resolved kinetic energy
             Real upert = u_cc_arr(i,j,k) - avg_u_ptr[k];
             Real vpert = v_cc_arr(i,j,k) - avg_v_ptr[k];
             Real wpert = w_cc_arr(i,j,k) - avg_w_ptr[k];
-            fab_arr(i, j, k, 3) = myhalf * (upert*upert + vpert*vpert + wpert*wpert);
+            fab_arr(i, j, k, 3) = myhalf_d * (upert*upert + vpert*vpert + wpert*wpert);
 #endif
             fab_arr(i, j, k, 5) = u_cc_arr(i,j,k) * u_cc_arr(i,j,k);   // u*u
             fab_arr(i, j, k, 6) = u_cc_arr(i,j,k) * v_cc_arr(i,j,k);   // u*v
@@ -337,16 +337,16 @@ ERF::derive_diag_profiles(double /*time*/,
                 fab_arr(i, j, k,19) = p * u_cc_arr(i,j,k);     // p*u
                 fab_arr(i, j, k,20) = p * v_cc_arr(i,j,k);     // p*v
                 fab_arr(i, j, k,21) = p * w_cc_arr(i,j,k);     // p*w
-                fab_arr(i, j, k,22) = zero;  // qv
-                fab_arr(i, j, k,23) = zero;  // qc
-                fab_arr(i, j, k,24) = zero;  // qr
-                fab_arr(i, j, k,25) = zero;  // w*qv
-                fab_arr(i, j, k,26) = zero;  // w*qc
-                fab_arr(i, j, k,27) = zero;  // w*qr
-                fab_arr(i, j, k,28) = zero;  // qi
-                fab_arr(i, j, k,29) = zero;  // qs
-                fab_arr(i, j, k,30) = zero;  // qg
-                fab_arr(i, j, k,31) = zero;  // w*thv
+                fab_arr(i, j, k,22) = zero_d;  // qv
+                fab_arr(i, j, k,23) = zero_d;  // qc
+                fab_arr(i, j, k,24) = zero_d;  // qr
+                fab_arr(i, j, k,25) = zero_d;  // w*qv
+                fab_arr(i, j, k,26) = zero_d;  // w*qc
+                fab_arr(i, j, k,27) = zero_d;  // w*qr
+                fab_arr(i, j, k,28) = zero_d;  // qi
+                fab_arr(i, j, k,29) = zero_d;  // qs
+                fab_arr(i, j, k,30) = zero_d;  // qg
+                fab_arr(i, j, k,31) = zero_d;  // w*thv
             }
         });
     } // mfi
@@ -367,12 +367,12 @@ ERF::derive_diag_profiles(double /*time*/,
 
             int rhoqr_comp = solverChoice.moisture_indices.qr;
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real qv = cons_arr(i,j,k,RhoQ1_comp) / cons_arr(i,j,k,Rho_comp);
                 Real qc = cons_arr(i,j,k,RhoQ2_comp) / cons_arr(i,j,k,Rho_comp);
                 Real qr = (rhoqr_comp > -1) ?  cons_arr(i,j,k,rhoqr_comp) / cons_arr(i,j,k,Rho_comp) :
-                                               zero;
+                                               zero_d;
                 Real p  = getPgivenRTh(cons_arr(i, j, k, RhoTheta_comp), qv);
 
                 p -= p0_arr(i,j,k);
@@ -391,9 +391,9 @@ ERF::derive_diag_profiles(double /*time*/,
                     fab_arr(i, j, k,29) = cons_arr(i,j,k,RhoQ5_comp) / cons_arr(i,j,k,Rho_comp);  // qs
                     fab_arr(i, j, k,30) = cons_arr(i,j,k,RhoQ6_comp) / cons_arr(i,j,k,Rho_comp);  // qg
                 } else {
-                    fab_arr(i, j, k,28) = zero;  // qi
-                    fab_arr(i, j, k,29) = zero;  // qs
-                    fab_arr(i, j, k,30) = zero;  // qg
+                    fab_arr(i, j, k,28) = zero_d;  // qi
+                    fab_arr(i, j, k,29) = zero_d;  // qs
+                    fab_arr(i, j, k,30) = zero_d;  // qg
                 }
                 Real ql    = qc + qr;
                 Real theta = cons_arr(i,j,k,RhoTheta_comp) / cons_arr(i,j,k,Rho_comp);
@@ -526,7 +526,7 @@ ERF::derive_stress_profiles (Gpu::HostVector<Real>& h_avg_tau11, Gpu::HostVector
                                                               Array4<const Real>{};
         const Array4<const Real>& diss_arr = SFS_diss_lev[lev]->const_array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // rho averaging should follow Diffusion/ERF_ComputeStress_*.cpp
             fab_arr(i, j, k, 0) = tau11_arr(i,j,k) / rho_arr(i,j,k);
@@ -544,9 +544,9 @@ ERF::derive_stress_profiles (Gpu::HostVector<Real>& h_avg_tau11, Gpu::HostVector
                                 / (   rho_arr(i,j,k  ) +   rho_arr(i,j+1,k  )
                                   +   rho_arr(i,j,k+1) +   rho_arr(i,j+1,k+1) );
             fab_arr(i, j, k, 5) = tau33_arr(i,j,k) / rho_arr(i,j,k);
-            fab_arr(i, j, k, 6) = myhalf * ( hfx3_arr(i,j,k) + hfx3_arr(i,j,k+1) ) / rho_arr(i,j,k);
-            fab_arr(i, j, k, 7) = (l_use_moist) ? myhalf * ( q1fx3_arr(i,j,k) + q1fx3_arr(i,j,k+1) ) / rho_arr(i,j,k) : zero;
-            fab_arr(i, j, k, 8) = (l_use_moist) ? myhalf * ( q2fx3_arr(i,j,k) + q2fx3_arr(i,j,k+1) ) / rho_arr(i,j,k) : zero;
+            fab_arr(i, j, k, 6) = myhalf_d * ( hfx3_arr(i,j,k) + hfx3_arr(i,j,k+1) ) / rho_arr(i,j,k);
+            fab_arr(i, j, k, 7) = (l_use_moist) ? myhalf_d * ( q1fx3_arr(i,j,k) + q1fx3_arr(i,j,k+1) ) / rho_arr(i,j,k) : zero_d;
+            fab_arr(i, j, k, 8) = (l_use_moist) ? myhalf_d * ( q2fx3_arr(i,j,k) + q2fx3_arr(i,j,k+1) ) / rho_arr(i,j,k) : zero_d;
             fab_arr(i, j, k, 9) =  diss_arr(i,j,k) / rho_arr(i,j,k);
         });
     }

--- a/Source/IO/ERF_Write1DProfiles_stag.cpp
+++ b/Source/IO/ERF_Write1DProfiles_stag.cpp
@@ -372,15 +372,15 @@ ERF::derive_diag_profiles_stag (double /*time*/,
         const Array4<const Real>& eta_arr = (eta_src) ? eta_src->const_array(mfi) :
                                                         Array4<const Real>{};
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            u_cc_arr(i,j,k) = myhalf * (u_arr(i,j,k) + u_arr(i+1,j  ,k));
-            v_cc_arr(i,j,k) = myhalf * (v_arr(i,j,k) + v_arr(i  ,j+1,k));
+            u_cc_arr(i,j,k) = myhalf_d * (u_arr(i,j,k) + u_arr(i+1,j  ,k));
+            v_cc_arr(i,j,k) = myhalf_d * (v_arr(i,j,k) + v_arr(i  ,j+1,k));
 
             Real theta = cons_arr(i,j,k,RhoTheta_comp) / cons_arr(i,j,k,Rho_comp);
             fab_arr(i, j, k, 0) = cons_arr(i,j,k,Rho_comp);
             fab_arr(i, j, k, 1) = theta;
-            Real ksgs = zero;
+            Real ksgs = zero_d;
             if (l_use_KE) {
                 ksgs = cons_arr(i,j,k,RhoKE_comp) / cons_arr(i,j,k,Rho_comp);
             }
@@ -389,8 +389,8 @@ ERF::derive_diag_profiles_stag (double /*time*/,
                 fab_arr(i, j, k, 3) = eta_arr(i,j,k,EddyDiff::Mom_v); // Kmv
                 fab_arr(i, j, k, 4) = eta_arr(i,j,k,EddyDiff::Theta_v); // Khv
             } else {
-                fab_arr(i, j, k, 3) = zero;
-                fab_arr(i, j, k, 4) = zero;
+                fab_arr(i, j, k, 3) = zero_d;
+                fab_arr(i, j, k, 4) = zero_d;
             }
             fab_arr(i, j, k, 5) = u_cc_arr(i,j,k) * u_cc_arr(i,j,k);   // u*u
             fab_arr(i, j, k, 6) = u_cc_arr(i,j,k) * v_cc_arr(i,j,k);   // u*v
@@ -399,7 +399,7 @@ ERF::derive_diag_profiles_stag (double /*time*/,
             fab_arr(i, j, k, 9) = v_cc_arr(i,j,k) * theta;             // v*th
             fab_arr(i, j, k,10) = theta * theta;                       // th*th
 
-            Real wcc = myhalf * (w_fc_arr(i,j,k) + w_fc_arr(i,j,k+1));
+            Real wcc = myhalf_d * (w_fc_arr(i,j,k) + w_fc_arr(i,j,k+1));
 
             // if the number of fields is changed above, then be sure to update
             // the following def!
@@ -413,26 +413,26 @@ ERF::derive_diag_profiles_stag (double /*time*/,
                 fab_arr(i, j, k,13) = p;                       // p
                 fab_arr(i, j, k,14) = p * u_cc_arr(i,j,k);     // p*u
                 fab_arr(i, j, k,15) = p * v_cc_arr(i,j,k);     // p*v
-                fab_arr(i, j, k,16) = zero;  // qv
-                fab_arr(i, j, k,17) = zero;  // qc
-                fab_arr(i, j, k,18) = zero;  // qr
-                fab_arr(i, j, k,19) = zero;  // qi
-                fab_arr(i, j, k,20) = zero;  // qs
-                fab_arr(i, j, k,21) = zero;  // qg
+                fab_arr(i, j, k,16) = zero_d;  // qv
+                fab_arr(i, j, k,17) = zero_d;  // qc
+                fab_arr(i, j, k,18) = zero_d;  // qr
+                fab_arr(i, j, k,19) = zero_d;  // qi
+                fab_arr(i, j, k,20) = zero_d;  // qs
+                fab_arr(i, j, k,21) = zero_d;  // qg
             }
         });
 
         const Box& zbx = mfi.tilebox(IntVect(0,0,1));
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // average to z faces (first to cell centers, then in z)
-            Real uface = fourth * ( u_arr(i  ,j,k) + u_arr(i  ,j,k-1)
+            Real uface = fourth_d * ( u_arr(i  ,j,k) + u_arr(i  ,j,k-1)
                                 + u_arr(i+1,j,k) + u_arr(i+1,j,k-1));
-            Real vface = fourth * ( v_arr(i,j  ,k) + v_arr(i,j  ,k-1)
+            Real vface = fourth_d * ( v_arr(i,j  ,k) + v_arr(i,j  ,k-1)
                                 + v_arr(i,j+1,k) + v_arr(i,j+1,k-1));
             Real theta0 = cons_arr(i,j,k  ,RhoTheta_comp) / cons_arr(i,j,k  ,Rho_comp);
             Real theta1 = cons_arr(i,j,k-1,RhoTheta_comp) / cons_arr(i,j,k-1,Rho_comp);
-            Real thface = myhalf*(theta0 + theta1);
+            Real thface = myhalf_d*(theta0 + theta1);
             fab_arr_stag(i,j,k,0) =           uface * w_fc_arr(i,j,k); // u*w
             fab_arr_stag(i,j,k,1) =           vface * w_fc_arr(i,j,k); // v*w
             fab_arr_stag(i,j,k,2) = w_fc_arr(i,j,k) * w_fc_arr(i,j,k); // w*w
@@ -442,12 +442,12 @@ ERF::derive_diag_profiles_stag (double /*time*/,
             if (!use_moisture) {
                 Real p0 = getPgivenRTh(cons_arr(i, j, k  , RhoTheta_comp)) - p0_arr(i,j,k  );
                 Real p1 = getPgivenRTh(cons_arr(i, j, k-1, RhoTheta_comp)) - p0_arr(i,j,k-1);
-                Real pface = myhalf * (p0 + p1);
+                Real pface = myhalf_d * (p0 + p1);
                 fab_arr_stag(i,j,k,5) = pface * w_fc_arr(i,j,k);       // p*w
-                fab_arr_stag(i,j,k,6) = zero;  // w*qv
-                fab_arr_stag(i,j,k,7) = zero;  // w*qc
-                fab_arr_stag(i,j,k,8) = zero;  // w*qr
-                fab_arr_stag(i,j,k,9) = zero;  // w*thv
+                fab_arr_stag(i,j,k,6) = zero_d;  // w*qv
+                fab_arr_stag(i,j,k,7) = zero_d;  // w*qc
+                fab_arr_stag(i,j,k,8) = zero_d;  // w*qr
+                fab_arr_stag(i,j,k,9) = zero_d;  // w*thv
             }
         });
 
@@ -470,12 +470,12 @@ ERF::derive_diag_profiles_stag (double /*time*/,
 
             int rhoqr_comp = solverChoice.moisture_indices.qr;
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real qv = cons_arr(i,j,k,RhoQ1_comp) / cons_arr(i,j,k,Rho_comp);
                 Real qc = cons_arr(i,j,k,RhoQ2_comp) / cons_arr(i,j,k,Rho_comp);
                 Real qr = (rhoqr_comp > -1) ?  cons_arr(i,j,k,rhoqr_comp) / cons_arr(i,j,k,Rho_comp) :
-                                               zero;
+                                               zero_d;
                 Real p = getPgivenRTh(cons_arr(i, j, k, RhoTheta_comp), qv);
 
                 p -= p0_arr(i,j,k);
@@ -490,34 +490,34 @@ ERF::derive_diag_profiles_stag (double /*time*/,
                     fab_arr(i, j, k,20) = cons_arr(i,j,k,RhoQ5_comp) / cons_arr(i,j,k,Rho_comp);  // qs
                     fab_arr(i, j, k,21) = cons_arr(i,j,k,RhoQ6_comp) / cons_arr(i,j,k,Rho_comp);  // qg
                 } else {
-                    fab_arr(i, j, k,19) = zero;  // qi
-                    fab_arr(i, j, k,20) = zero;  // qs
-                    fab_arr(i, j, k,21) = zero;  // qg
+                    fab_arr(i, j, k,19) = zero_d;  // qi
+                    fab_arr(i, j, k,20) = zero_d;  // qs
+                    fab_arr(i, j, k,21) = zero_d;  // qg
                 }
             });
 
             const Box& zbx = mfi.tilebox(IntVect(0,0,1));
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(zbx, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real qv0 = cons_arr(i,j,k  ,RhoQ1_comp) / cons_arr(i,j,k  ,Rho_comp);
                 Real qv1 = cons_arr(i,j,k-1,RhoQ1_comp) / cons_arr(i,j,k-1,Rho_comp);
                 Real qc0 = cons_arr(i,j,k  ,RhoQ2_comp) / cons_arr(i,j,k  ,Rho_comp);
                 Real qc1 = cons_arr(i,j,k-1,RhoQ2_comp) / cons_arr(i,j,k-1,Rho_comp);
                 Real qr0 = (rhoqr_comp > -1) ? cons_arr(i,j,k  ,RhoQ3_comp) / cons_arr(i,j,k  ,Rho_comp) :
-                                               zero;
+                                               zero_d;
                 Real qr1 = (rhoqr_comp > -1) ? cons_arr(i,j,k-1,RhoQ3_comp) / cons_arr(i,j,k-1,Rho_comp) :
-                                               zero;
-                Real qvface = myhalf * (qv0 + qv1);
-                Real qcface = myhalf * (qc0 + qc1);
-                Real qrface = myhalf * (qr0 + qr1);
+                                               zero_d;
+                Real qvface = myhalf_d * (qv0 + qv1);
+                Real qcface = myhalf_d * (qc0 + qc1);
+                Real qrface = myhalf_d * (qr0 + qr1);
 
                 Real p0 = getPgivenRTh(cons_arr(i, j, k  , RhoTheta_comp), qv0) - p0_arr(i,j,k  );
                 Real p1 = getPgivenRTh(cons_arr(i, j, k-1, RhoTheta_comp), qv1) - p0_arr(i,j,k-1);
-                Real pface = myhalf * (p0 + p1);
+                Real pface = myhalf_d * (p0 + p1);
 
                 Real theta0 = cons_arr(i,j,k  ,RhoTheta_comp) / cons_arr(i,j,k  ,Rho_comp);
                 Real theta1 = cons_arr(i,j,k-1,RhoTheta_comp) / cons_arr(i,j,k-1,Rho_comp);
-                Real thface = myhalf*(theta0 + theta1);
+                Real thface = myhalf_d*(theta0 + theta1);
                 Real ql = qcface + qrface;
                 Real thv = thface * (1 + Real(0.61)*qvface - ql);
 
@@ -674,16 +674,16 @@ ERF::derive_stress_profiles_stag (Gpu::HostVector<Real>& h_avg_tau11, Gpu::HostV
         });
 
         const Box& zbx = mfi.tilebox(IntVect(0,0,1));
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            Real rho_face = myhalf * (rho_arr(i,j,k-1) + rho_arr(i,j,k));
+            Real rho_face = myhalf_d * (rho_arr(i,j,k-1) + rho_arr(i,j,k));
             // average from edge to face center
-            fab_arr_stag(i,j,k,0) = myhalf*(tau13_arr(i,j,k) + tau13_arr(i+1,j  ,k)) / rho_face;
-            fab_arr_stag(i,j,k,1) = myhalf*(tau23_arr(i,j,k) + tau23_arr(i  ,j+1,k)) / rho_face;
+            fab_arr_stag(i,j,k,0) = myhalf_d*(tau13_arr(i,j,k) + tau13_arr(i+1,j  ,k)) / rho_face;
+            fab_arr_stag(i,j,k,1) = myhalf_d*(tau23_arr(i,j,k) + tau23_arr(i  ,j+1,k)) / rho_face;
 
             fab_arr_stag(i,j,k,2) = hfx3_arr(i,j,k) / rho_face;
-            fab_arr_stag(i,j,k,3) = (l_use_moist) ? q1fx3_arr(i,j,k) / rho_face : zero;
-            fab_arr_stag(i,j,k,4) = (l_use_moist) ? q2fx3_arr(i,j,k) / rho_face : zero;
+            fab_arr_stag(i,j,k,3) = (l_use_moist) ? q1fx3_arr(i,j,k) / rho_face : zero_d;
+            fab_arr_stag(i,j,k,4) = (l_use_moist) ? q2fx3_arr(i,j,k) / rho_face : zero_d;
         });
     }
 

--- a/Source/IO/ERF_WriteScalarProfiles.cpp
+++ b/Source/IO/ERF_WriteScalarProfiles.cpp
@@ -92,7 +92,7 @@ ERF::sum_integrated_quantities (double time)
     const int nfoo = 8;
     Real foo[nfoo] = {mass_sl,rhth_sl,scal_sl,mois_sl,mass_ml,rhth_ml,scal_ml,mois_ml};
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=]() mutable {
+    Lazy::QueueReduction([=,zero_d=zero]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());
@@ -136,7 +136,7 @@ ERF::sum_integrated_quantities (double time)
             int n_d = 0;
             std::ostream& data_log1 = DataLog(n_d);
             if (data_log1.good()) {
-                if (time == zero) {
+                if (time == zero_d) {
                     data_log1 << std::setw(datwidth) << "          time";
                     data_log1 << std::setw(datwidth) << "          u_star";
                     data_log1 << std::setw(datwidth) << "          t_star";
@@ -276,7 +276,7 @@ ERF::sum_derived_quantities (double time)
     const int nfoo = 4;
     Real foo[nfoo] = {unwted_avg,r_wted_avg,enstrsq_avg,theta_avg};
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=]() mutable {
+    Lazy::QueueReduction([=,zero_d=zero]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());
@@ -290,7 +290,7 @@ ERF::sum_derived_quantities (double time)
 
         std::ostream& data_log_der = DerDataLog(0);
 
-        if (time == zero) {
+        if (time == zero_d) {
             data_log_der << std::setw(datwidth) << "          time";
             data_log_der << std::setw(datwidth) << "        ke_den";
             data_log_der << std::setw(datwidth) << "         velsq";
@@ -363,26 +363,26 @@ ERF::sum_energy_quantities (double time)
         const Array4<const Real>& cons_arr = vars_new[lev][Vars::cons].const_array(mfi);
         const Array4<const Real>& z_arr    = (z_phys_nd[lev]) ? z_phys_nd[lev]->const_array(mfi) :
                                                                 Array4<const Real>{};
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,zero_d=zero,one_d=one,myhalf_d=myhalf,Cp_d_d=Cp_d,R_d_d=R_d,Cp_v_d=Cp_v,R_v_d=R_v,L_v_d=L_v,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
-            Real Qv   = (is_moist) ? cons_arr(i,j,k,RhoQ1_comp) : zero;
-            Real Qc   = (is_moist) ? cons_arr(i,j,k,RhoQ2_comp) : zero;
+            Real Qv   = (is_moist) ? cons_arr(i,j,k,RhoQ1_comp) : zero_d;
+            Real Qc   = (is_moist) ? cons_arr(i,j,k,RhoQ2_comp) : zero_d;
             Real Qt   = Qv + Qc;
             Real Rhod = cons_arr(i,j,k,Rho_comp);
-            Real Rhot = Rhod * (one + Qt);
+            Real Rhot = Rhod * (one_d + Qt);
             Real Temp = getTgivenRandRTh(Rhod, cons_arr(i,j,k,RhoTheta_comp), Qv);
-            Real TKE  = myhalf * ( cc_vel_arr(i,j,k,0)*cc_vel_arr(i,j,k,0)
+            Real TKE  = myhalf_d * ( cc_vel_arr(i,j,k,0)*cc_vel_arr(i,j,k,0)
                               + cc_vel_arr(i,j,k,1)*cc_vel_arr(i,j,k,1)
                               + cc_vel_arr(i,j,k,2)*cc_vel_arr(i,j,k,2) );
             Real zval = (z_arr) ? z_arr(i,j,k) : Real(k)*dx[2];
 
-            Real Cv   = Cp_d - R_d;
-            Real Cvv  = Cp_v - R_v;
-            Real Cpv  = Cp_v;
+            Real Cv   = Cp_d_d - R_d_d;
+            Real Cvv  = Cp_v_d - R_v_d;
+            Real Cpv  = Cp_v_d;
 
             tot_mass_arr(i,j,k)   = Rhot;
-            tot_energy_arr(i,j,k) = Rhod * ( (Cv + Cvv*Qv + Cpv*Qc)*Temp - L_v*Qc
-                                           + (one + Qt)*TKE + (one + Qt)*CONST_GRAV*zval );
+            tot_energy_arr(i,j,k) = Rhod * ( (Cv + Cvv*Qv + Cpv*Qc)*Temp - L_v_d*Qc
+                                           + (one_d + Qt)*TKE + (one_d + Qt)*CONST_GRAV_d*zval );
 
         });
 
@@ -421,7 +421,7 @@ ERF::sum_energy_quantities (double time)
     const int nfoo = 2;
     Real foo[nfoo] = {tot_mass_avg,tot_energy_avg};
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=]() mutable {
+    Lazy::QueueReduction([=,zero_d=zero]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());
@@ -433,7 +433,7 @@ ERF::sum_energy_quantities (double time)
 
         std::ostream& data_log_energy = *tot_e_datalog[0];
 
-        if (time == zero) {
+        if (time == zero_d) {
             data_log_energy << std::setw(datwidth) << "          time";
             data_log_energy << std::setw(datwidth) << "      tot_mass";
             data_log_energy << std::setw(datwidth) << "    tot_energy";

--- a/Source/IO/ERF_WriteScalarProfiles.cpp
+++ b/Source/IO/ERF_WriteScalarProfiles.cpp
@@ -91,8 +91,9 @@ ERF::sum_integrated_quantities (double time)
 
     const int nfoo = 8;
     Real foo[nfoo] = {mass_sl,rhth_sl,scal_sl,mois_sl,mass_ml,rhth_ml,scal_ml,mois_ml};
+    Real zero_d = zero;
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=,zero_d=zero]() mutable {
+    Lazy::QueueReduction([=]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());
@@ -275,8 +276,9 @@ ERF::sum_derived_quantities (double time)
 
     const int nfoo = 4;
     Real foo[nfoo] = {unwted_avg,r_wted_avg,enstrsq_avg,theta_avg};
+    Real zero_d = zero;
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=,zero_d=zero]() mutable {
+    Lazy::QueueReduction([=]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());
@@ -420,8 +422,9 @@ ERF::sum_energy_quantities (double time)
 
     const int nfoo = 2;
     Real foo[nfoo] = {tot_mass_avg,tot_energy_avg};
+    Real zero_d = zero;
 #ifdef AMREX_LAZY
-    Lazy::QueueReduction([=,zero_d=zero]() mutable {
+    Lazy::QueueReduction([=]() mutable {
 #endif
     ParallelDescriptor::ReduceRealSum(
         foo, nfoo, ParallelDescriptor::IOProcessorNumber());

--- a/Source/Initialization/ERF_Init1D.cpp
+++ b/Source/Initialization/ERF_Init1D.cpp
@@ -254,7 +254,7 @@ ERF::erf_enforce_hse (int lev,
 
         const Real rdOcp = solverChoice.rdOcp;
 
-        ParallelFor(b2d, [=] AMREX_GPU_DEVICE (int i, int j, int)
+        ParallelFor(b2d, [=,myhalf_d=myhalf,p_0_d=p_0] AMREX_GPU_DEVICE (int i, int j, int)
         {
             // Set value at surface from Newton iteration for rho
             if (klo == 0)
@@ -264,10 +264,10 @@ ERF::erf_enforce_hse (int lev,
                 if (l_use_terrain) {
                     hz = zcc_arr(i,j,klo);
                 } else {
-                    hz = myhalf*dz;
+                    hz = myhalf_d*dz;
                 }
 
-                pres_arr(i,j,klo) = p_0 - hz * rho_arr(i,j,klo) * l_gravity;
+                pres_arr(i,j,klo) = p_0_d - hz * rho_arr(i,j,klo) * l_gravity;
                   pi_arr(i,j,klo) = getExnergivenP(pres_arr(i,j,klo), rdOcp);
                   th_arr(i,j,klo) = getRhoThetagivenP(pres_arr(i,j,klo)) / rho_arr(i,j,klo);
 
@@ -275,7 +275,7 @@ ERF::erf_enforce_hse (int lev,
                 // Set ghost cell with dz and rho at boundary
                 // (We will set the rest of the ghost cells in the boundary condition routine)
                 //
-                pres_arr(i,j,klo-1) = p_0 + hz * rho_arr(i,j,klo) * l_gravity;
+                pres_arr(i,j,klo-1) = p_0_d + hz * rho_arr(i,j,klo) * l_gravity;
                   pi_arr(i,j,klo-1) = getExnergivenP(pres_arr(i,j,klo-1), rdOcp);
                   th_arr(i,j,klo-1) = getRhoThetagivenP(pres_arr(i,j,klo-1)) / rho_arr(i,j,klo-1);
 
@@ -290,7 +290,7 @@ ERF::erf_enforce_hse (int lev,
                     dz_loc = dz;
                 }
 
-                Real dens_interp = myhalf*(rho_arr(i,j,klo) + rho_arr(i,j,klo-1));
+                Real dens_interp = myhalf_d*(rho_arr(i,j,klo) + rho_arr(i,j,klo-1));
                 pres_arr(i,j,klo) = pres_arr(i,j,klo-1) - dz_loc * dens_interp * l_gravity;
 
                 pi_arr(i,j,klo  ) = getExnergivenP(pres_arr(i,j,klo  ), rdOcp);
@@ -304,14 +304,14 @@ ERF::erf_enforce_hse (int lev,
             if (l_use_terrain) {
                 for (int k = klo+1; k <= khi; k++) {
                     Real dz_loc = (zcc_arr(i,j,k) - zcc_arr(i,j,k-1));
-                    dens_interp = myhalf*(rho_arr(i,j,k) + rho_arr(i,j,k-1));
+                    dens_interp = myhalf_d*(rho_arr(i,j,k) + rho_arr(i,j,k-1));
                     pres_arr(i,j,k) = pres_arr(i,j,k-1) - dz_loc * dens_interp * l_gravity;
                     pi_arr(i,j,k) = getExnergivenP(pres_arr(i,j,k), rdOcp);
                     th_arr(i,j,k) = getRhoThetagivenP(pres_arr(i,j,k)) / rho_arr(i,j,k);
                 }
             } else {
                 for (int k = klo+1; k <= khi; k++) {
-                    dens_interp = myhalf*(rho_arr(i,j,k) + rho_arr(i,j,k-1));
+                    dens_interp = myhalf_d*(rho_arr(i,j,k) + rho_arr(i,j,k-1));
                     pres_arr(i,j,k) = pres_arr(i,j,k-1) - dz * dens_interp * l_gravity;
                     pi_arr(i,j,k) = getExnergivenP(pres_arr(i,j,k), rdOcp);
                     th_arr(i,j,k) = getRhoThetagivenP(pres_arr(i,j,k)) / rho_arr(i,j,k);

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -19,36 +19,36 @@ using namespace amrex;
  */
 void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
 {
-    auto f = [this,&rho_read,&read_prim_theta] (std::string const& bcid, Orientation ori)
+    auto f = [this,&rho_read,&read_prim_theta,one_d=one,zero_d=zero] (std::string const& bcid, Orientation ori)
     {
         // These are simply defaults for Dirichlet faces -- they should be over-written below
-        m_bc_extdir_vals[BCVars::Rho_bc_comp][ori]       =  one;
-        m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori]  = -one; // It is important to set this negative
+        m_bc_extdir_vals[BCVars::Rho_bc_comp][ori]       =  one_d;
+        m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori]  = -one_d; // It is important to set this negative
                                                                  // because the sign is tested on below
         for (int n = BCVars::RhoKE_bc_comp; n < BCVars::xvel_bc; n++) {
-            m_bc_extdir_vals[n][ori]                     = zero;
+            m_bc_extdir_vals[n][ori]                     = zero_d;
         }
 
-        m_bc_extdir_vals[BCVars::xvel_bc][ori] = zero; // default
-        m_bc_extdir_vals[BCVars::yvel_bc][ori] = zero;
-        m_bc_extdir_vals[BCVars::zvel_bc][ori] = zero;
+        m_bc_extdir_vals[BCVars::xvel_bc][ori] = zero_d; // default
+        m_bc_extdir_vals[BCVars::yvel_bc][ori] = zero_d;
+        m_bc_extdir_vals[BCVars::zvel_bc][ori] = zero_d;
 
         // These are simply defaults for Neumann gradients -- they should be over-written below
-        m_bc_neumann_vals[BCVars::Rho_bc_comp][ori]       = zero;
-        m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]  = zero;
+        m_bc_neumann_vals[BCVars::Rho_bc_comp][ori]       = zero_d;
+        m_bc_neumann_vals[BCVars::RhoTheta_bc_comp][ori]  = zero_d;
 
-        m_bc_neumann_vals[BCVars::RhoKE_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoScalar_bc_comp][ori] = zero;
-        m_bc_neumann_vals[BCVars::RhoQ1_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoQ2_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoQ3_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoQ4_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoQ5_bc_comp][ori]     = zero;
-        m_bc_neumann_vals[BCVars::RhoQ6_bc_comp][ori]     = zero;
+        m_bc_neumann_vals[BCVars::RhoKE_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoScalar_bc_comp][ori] = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ1_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ2_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ3_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ4_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ5_bc_comp][ori]     = zero_d;
+        m_bc_neumann_vals[BCVars::RhoQ6_bc_comp][ori]     = zero_d;
 
-        m_bc_neumann_vals[BCVars::xvel_bc][ori] = zero;
-        m_bc_neumann_vals[BCVars::yvel_bc][ori] = zero;
-        m_bc_neumann_vals[BCVars::zvel_bc][ori] = zero;
+        m_bc_neumann_vals[BCVars::xvel_bc][ori] = zero_d;
+        m_bc_neumann_vals[BCVars::yvel_bc][ori] = zero_d;
+        m_bc_neumann_vals[BCVars::zvel_bc][ori] = zero_d;
 
         std::string pp_text = pp_prefix + "." + bcid;
         ParmParse pp(pp_text);
@@ -102,9 +102,9 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
 
             std::vector<Real> v;
             if (input_bndry_planes && m_r2d->ingested_velocity()) {
-                m_bc_extdir_vals[BCVars::xvel_bc][ori] = zero;
-                m_bc_extdir_vals[BCVars::yvel_bc][ori] = zero;
-                m_bc_extdir_vals[BCVars::zvel_bc][ori] = zero;
+                m_bc_extdir_vals[BCVars::xvel_bc][ori] = zero_d;
+                m_bc_extdir_vals[BCVars::yvel_bc][ori] = zero_d;
+                m_bc_extdir_vals[BCVars::zvel_bc][ori] = zero_d;
             } else {
                 // Test for input data file if at xlo face
                 std::string dirichlet_file;
@@ -120,9 +120,9 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
                 }
             }
 
-            Real rho_in = zero;
+            Real rho_in = zero_d;
             if (input_bndry_planes && m_r2d->ingested_density()) {
-                m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = zero;
+                m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = zero_d;
             } else {
                 if (!pp.query("density", rho_in)) {
                     amrex::Print() << "Using interior values to set conserved vars" << std::endl;
@@ -131,9 +131,9 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
             }
 
             bool th_read  = (th_bc_data[0].data()!=nullptr);
-            Real theta_in = zero;
+            Real theta_in = zero_d;
             if (input_bndry_planes && m_r2d->ingested_theta()) {
-                m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] = zero;
+                m_bc_extdir_vals[BCVars::RhoTheta_bc_comp][ori] = zero_d;
             } else if (!th_read) {
                 if (rho_in > 0) {
                     pp.get("theta", theta_in);
@@ -149,34 +149,34 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
             pp.query("nonreflecting", nonreflecting);
             m_bc_nonreflecting[ori] = nonreflecting;
 
-            Real scalar_in = zero;
+            Real scalar_in = zero_d;
             if (input_bndry_planes && m_r2d->ingested_scalar()) {
-                m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = zero;
+                m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = zero_d;
             } else {
                 if (pp.query("scalar", scalar_in))
                 m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = rho_in*scalar_in;
             }
 
             if (solverChoice.moisture_type != MoistureType::None) {
-                Real qv_in = zero;
+                Real qv_in = zero_d;
                 if (input_bndry_planes && m_r2d->ingested_q1()) {
-                    m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = zero;
+                    m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = zero_d;
                 } else {
                     if (pp.query("qv", qv_in))
                     m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = rho_in*qv_in;
                 }
-                Real qc_in = zero;
+                Real qc_in = zero_d;
                 if (input_bndry_planes && m_r2d->ingested_q2()) {
-                    m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = zero;
+                    m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = zero_d;
                 } else {
                     if (pp.query("qc", qc_in))
                     m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = rho_in*qc_in;
                 }
             }
 
-            Real KE_in = zero;
+            Real KE_in = zero_d;
             if (input_bndry_planes && m_r2d->ingested_KE()) {
-                m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori] = zero;
+                m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori] = zero_d;
             } else {
                 if (pp.query("KE", KE_in))
                 m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori] = rho_in*KE_in;
@@ -194,7 +194,7 @@ void ERF::init_phys_bcs (bool& rho_read, bool& read_prim_theta)
             // But if we find "velocity" in the inputs file, use those values instead.
             if (pp.queryarr("velocity", v, 0, AMREX_SPACEDIM))
             {
-                v[ori.coordDir()] = zero;
+                v[ori.coordDir()] = zero_d;
                 m_bc_extdir_vals[BCVars::xvel_bc][ori] = v[0];
                 m_bc_extdir_vals[BCVars::yvel_bc][ori] = v[1];
                 m_bc_extdir_vals[BCVars::zvel_bc][ori] = v[2];

--- a/Source/Initialization/ERF_InitCustomTerrain.cpp
+++ b/Source/Initialization/ERF_InitCustomTerrain.cpp
@@ -85,7 +85,7 @@ init_my_custom_terrain ( const Geometry& geom,
                     }
                 });
             } else if (dir == 1) {
-                ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+                ParallelFor(zbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
                 {
                     // Clip indices for ghost-cells
                     int jj = amrex::min(amrex::max(j,domlo_y),domhi_y);
@@ -98,11 +98,11 @@ init_my_custom_terrain ( const Geometry& geom,
                         z_arr(i,j,k0) = num / (y*y + Real(4.0) * a * a);
                     } else {
                         Real y_L = y / L;
-                        z_arr(i,j,k0) = hm / (one + y_L*y_L) + z_offset;
+                        z_arr(i,j,k0) = hm / (one_d + y_L*y_L) + z_offset;
                     }
                 });
             } else if (dir == 2) {
-                ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+                ParallelFor(zbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
                 {
                     // Clip indices for ghost-cells
                     int ii = amrex::min(amrex::max(i,domlo_x),domhi_x);
@@ -118,7 +118,7 @@ init_my_custom_terrain ( const Geometry& geom,
                         z_arr(i,j,k0) = num / (r*r + Real(4.0) * a * a);
                     } else {
                         Real r_L = r / L;
-                        z_arr(i,j,k0) = hm / (one + r_L*r_L) + z_offset;
+                        z_arr(i,j,k0) = hm / (one_d + r_L*r_L) + z_offset;
                     }
                 });
             } else {
@@ -131,7 +131,7 @@ init_my_custom_terrain ( const Geometry& geom,
             Real Hm     =  Real(250.0);
             Real lambda = Real(4000.0);
 
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,domlo_x),domhi_x);
@@ -139,7 +139,7 @@ init_my_custom_terrain ( const Geometry& geom,
                 // Location of nodes
                 Real x = (ProbLoArr[0] + ii * dx[0] - xcen);
 
-                Real cosx = std::cos(PI * x / lambda);
+                Real cosx = std::cos(PI_d * x / lambda);
 
                 z_arr(i,j,k0) = Hm * std::exp(-x*x/asq) * cosx * cosx;
             });
@@ -148,7 +148,7 @@ init_my_custom_terrain ( const Geometry& geom,
 
             Real asq = myhalf * myhalf;
 
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,domlo_x),domhi_x);
@@ -161,7 +161,7 @@ init_my_custom_terrain ( const Geometry& geom,
                 if (rsq < asq) {
                     z_arr(i,j,k0) = std::sqrt(asq - rsq);
                 } else {
-                    z_arr(i,j,k0) = zero;
+                    z_arr(i,j,k0) = zero_d;
                 }
             });
 
@@ -169,7 +169,7 @@ init_my_custom_terrain ( const Geometry& geom,
 
             Real asq = myhalf * myhalf;
 
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,domlo_x),domhi_x);
@@ -182,9 +182,9 @@ init_my_custom_terrain ( const Geometry& geom,
                 Real rsq = x*x + y*y;
 
                 if (rsq < asq) {
-                    z_arr(i,j,k0) = std::pow(asq-rsq, myhalf);
+                    z_arr(i,j,k0) = std::pow(asq-rsq, myhalf_d);
                 } else {
-                    z_arr(i,j,k0) = zero;
+                    z_arr(i,j,k0) = zero_d;
                 }
             });
 
@@ -216,7 +216,7 @@ init_my_custom_terrain ( const Geometry& geom,
 
         } else if (custom_terrain_type == "WindFarmTest") {
 
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int)
             {
                 // Clip indices for ghost-cells
                 int ii = amrex::min(amrex::max(i,domlo_x),domhi_x);
@@ -229,7 +229,7 @@ init_my_custom_terrain ( const Geometry& geom,
                 Real x_L = x/Real(100.0);
                 Real y_L = y/Real(100.0);
 
-                z_arr(i,j,k0) = Real(100.0) / (one + x_L*x_L + y_L*y_L);
+                z_arr(i,j,k0) = Real(100.0) / (one_d + x_L*x_L + y_L*y_L);
             });
 
         } else if (custom_terrain_type == "RaisedFlat") {
@@ -246,7 +246,7 @@ init_my_custom_terrain ( const Geometry& geom,
             Real z_offset = zero; pp_prob.query("z_offset", z_offset);
             Real fourL = four * L;
 
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,one_d=one,PI_d=PI,four_d=four] AMREX_GPU_DEVICE (int i, int j, int)
             {
 
                 // Clip indices for ghost-cells
@@ -259,16 +259,16 @@ init_my_custom_terrain ( const Geometry& geom,
                 Real r = std::sqrt(x*x + y*y);
 
                 if (r < fourL) {
-                    z_arr(i,j,k0) = z_offset + hm * Real(0.0625) * std::pow(one + std::cos(PI*r/fourL), four);
+                    z_arr(i,j,k0) = z_offset + hm * Real(0.0625) * std::pow(one_d + std::cos(PI_d*r/fourL), four_d);
                 } else {
                     z_arr(i,j,k0) = z_offset;
                 }
             });
 
         } else if (custom_terrain_type == "None") {
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
+            ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int)
             {
-                z_arr(i,j,k0) = zero;
+                z_arr(i,j,k0) = zero_d;
             });
         } else {
             Abort("Don't know this custom_terrain_type");

--- a/Source/Initialization/ERF_InitForEnsemble.cpp
+++ b/Source/Initialization/ERF_InitForEnsemble.cpp
@@ -142,9 +142,9 @@ ERF::apply_gaussian_smoothing_to_perturbations(const int lev,
         auto const& out = mf_cc_pert.array(mfi);
 
         ParallelFor(bx, ncomp,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
         {
-            Real sum = zero;
+            Real sum = zero_d;
 
             for (int m = -r; m <= r; ++m) {
                 for (int nn = -r; nn <= r; ++nn) {
@@ -385,17 +385,17 @@ InterpolateToFineMF(
         auto arr = mf_fine.array(mfi);
 
         amrex::ParallelFor(bx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // physical location (fine cell center)
-            Real x = problo_f[0] + (i + myhalf) * dx_f[0];
-            Real y = problo_f[1] + (j + myhalf) * dx_f[1];
-            Real z = problo_f[2] + (k + myhalf) * dx_f[2];
+            Real x = problo_f[0] + (i + myhalf_d) * dx_f[0];
+            Real y = problo_f[1] + (j + myhalf_d) * dx_f[1];
+            Real z = problo_f[2] + (k + myhalf_d) * dx_f[2];
 
             // map to coarse index space
-            Real rx = (x - problo[0]) / dx_c[0] - myhalf;
-            Real ry = (y - problo[1]) / dx_c[1] - myhalf;
-            Real rz = (z - problo[2]) / dx_c[2] - myhalf;
+            Real rx = (x - problo[0]) / dx_c[0] - myhalf_d;
+            Real ry = (y - problo[1]) / dx_c[1] - myhalf_d;
+            Real rz = (z - problo[2]) / dx_c[2] - myhalf_d;
 
             int ic = static_cast<int>(floor(rx));
             int jc = static_cast<int>(floor(ry));
@@ -453,9 +453,9 @@ MakeFinalMultiFabs (const MultiFab& mf_cc_fine,
         auto const& uface = xvel_pert.array(mfi);
         auto const& cc    = mf_cc_fine.const_array(mfi);
 
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        amrex::ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            uface(i,j,k) = myhalf * (cc(i-1,j,k,2) + cc(i,j,k,2));
+            uface(i,j,k) = myhalf_d * (cc(i-1,j,k,2) + cc(i,j,k,2));
         });
     }
 
@@ -466,9 +466,9 @@ MakeFinalMultiFabs (const MultiFab& mf_cc_fine,
         auto const& vface = yvel_pert.array(mfi);
         auto const& cc    = mf_cc_fine.const_array(mfi);
 
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        amrex::ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            vface(i,j,k) = myhalf * (cc(i,j-1,k,3) + cc(i,j,k,3));
+            vface(i,j,k) = myhalf_d * (cc(i,j-1,k,3) + cc(i,j,k,3));
         });
     }
 
@@ -479,9 +479,9 @@ MakeFinalMultiFabs (const MultiFab& mf_cc_fine,
         auto const& wface = zvel_pert.array(mfi);
         //auto const& cc    = mf_cc_fine.const_array(mfi);
 
-        amrex::ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        amrex::ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            wface(i,j,k) = zero; //myhalf * (cc(i,j,k-1,4) + cc(i,j,k,4));
+            wface(i,j,k) = zero_d; //myhalf * (cc(i,j,k-1,4) + cc(i,j,k,4));
         });
     }
 }

--- a/Source/Initialization/ERF_InitFromInputSounding.cpp
+++ b/Source/Initialization/ERF_InitFromInputSounding.cpp
@@ -238,10 +238,10 @@ init_state_from_input_sounding (const Box &bx,
     Box gbx = bx; // Copy constructor
     gbx.grow(0,1); gbx.grow(1,1); // Grow by one in the lateral directions
 
-    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-        const Real z = (z_cc_arr) ? z_cc_arr(i,j,k) : z_lo + (k + myhalf) * dz;
+    ParallelFor(gbx, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        const Real z = (z_cc_arr) ? z_cc_arr(i,j,k) : z_lo + (k + myhalf_d) * dz;
 
-        Real rho_0 = one;
+        Real rho_0 = one_d;
 
         // Set the density
         state(i, j, k, Rho_comp) = rho_0;
@@ -308,9 +308,9 @@ init_state_from_input_sounding_hse (const Box &bx,
     Box gbx = bx; // Copy constructor
     gbx.grow(0,1); gbx.grow(1,1); // Grow by one in the lateral directions
 
-    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    ParallelFor(gbx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         const Real z = (z_cc_arr) ? z_cc_arr(i,j,k)
-                                  : z_lo + (k + myhalf) * dz;
+                                  : z_lo + (k + myhalf_d) * dz;
 
         Real rho_k   = interpolate_1d(z_inp_sound, rho_inp_sound, z, inp_sound_size);
         Real rhoTh_k = rho_k * interpolate_1d(z_inp_sound, theta_inp_sound, z, inp_sound_size);
@@ -337,7 +337,7 @@ init_state_from_input_sounding_hse (const Box &bx,
 
         // Total nonprecipitating water (Q1) == water vapor (Qv), i.e., there
         // is no cloud water or cloud ice
-        Real qv_k = zero;
+        Real qv_k = zero_d;
         if (l_moist) {
             qv_k = interpolate_1d(z_inp_sound, qv_inp_sound, z, inp_sound_size);
             state(i, j, k, RhoQ1_comp) = rho_k * qv_k;
@@ -434,31 +434,31 @@ init_velocities_from_input_sounding (const Box &bx,
 
     // Set the x,y,z-velocities
     ParallelFor(xbx, ybx, zbx,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         // Note that this is called on a box of x-faces
-        const Real z = (z_nd_arr) ? fourth*( z_nd_arr(i,j  ,k  )
+        const Real z = (z_nd_arr) ? fourth_d*( z_nd_arr(i,j  ,k  )
                                          + z_nd_arr(i,j+1,k  )
                                          + z_nd_arr(i,j  ,k+1)
                                          + z_nd_arr(i,j+1,k+1))
-                                  : z_lo + (k + myhalf) * dz;
+                                  : z_lo + (k + myhalf_d) * dz;
 
         // Set the x-velocity
         x_vel(i, j, k) = interpolate_1d(z_inp_sound, U_inp_sound, z, inp_sound_size);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         // Note that this is called on a box of y-faces
-        const Real z = (z_nd_arr) ? fourth*( z_nd_arr(i  ,j,k  )
+        const Real z = (z_nd_arr) ? fourth_d*( z_nd_arr(i  ,j,k  )
                                          + z_nd_arr(i+1,j,k  )
                                          + z_nd_arr(i  ,j,k+1)
                                          + z_nd_arr(i+1,j,k+1))
-                                  : z_lo + (k + myhalf) * dz;
+                                  : z_lo + (k + myhalf_d) * dz;
 
         // Set the y-velocity
         y_vel(i, j, k) = interpolate_1d(z_inp_sound, V_inp_sound, z, inp_sound_size);
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
         // Note that this is called on a box of z-faces
         // Set the z-velocity
-        z_vel(i, j, k) = zero;
+        z_vel(i, j, k) = zero_d;
     });
 }

--- a/Source/Initialization/ERF_InitFromMetgrid.cpp
+++ b/Source/Initialization/ERF_InitFromMetgrid.cpp
@@ -449,13 +449,13 @@ ERF::init_from_metgrid (int lev)
                 const Array4<      Real>& cos_arr = (cosPhi_m[lev])->array(mfi);
                 const Array4<      Real>& dst_arr = dst.array();
                 const Array4<const Real>& src_arr = src.const_array();
-                ParallelFor(gtbx, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+                ParallelFor(gtbx, [=,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int) noexcept
                 {
                     int li = min(max(i, i_lo), i_hi);
                     int lj = min(max(j, j_lo), j_hi);
                     dst_arr(i,j,0) = src_arr(li,lj,0);
 
-                    Real lat_rad = dst_arr(i,j,0) * (PI/Real(180.));
+                    Real lat_rad = dst_arr(i,j,0) * (PI_d/Real(180.));
                     sin_arr(i,j,0) = std::sin(lat_rad);
                     cos_arr(i,j,0) = std::cos(lat_rad);
                 });
@@ -679,11 +679,11 @@ init_terrain_from_metgrid (FArrayBox& z_phys_nd_fab,
 
    Box bx = z_phys_box & from_box;
 
-   ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+   ParallelFor(bx, [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
    {
        int ii = std::max(std::min(i,ihi-1),ilo+1);
        int jj = std::max(std::min(j,jhi-1),jlo+1);
-       z_arr(i,j,k) =  fourth * ( nc_hgt_arr (ii,jj  ,k) + nc_hgt_arr(ii-1,jj  ,k) +
+       z_arr(i,j,k) =  fourth_d * ( nc_hgt_arr (ii,jj  ,k) + nc_hgt_arr(ii-1,jj  ,k) +
                                 nc_hgt_arr (ii,jj-1,k) + nc_hgt_arr(ii-1,jj-1,k) );
    });
 }
@@ -792,11 +792,11 @@ init_state_from_metgrid (const int  lev,
     int tmp_indx = 0;
     int dst_indx = 0;
 
-    ParallelFor(bx2d, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    ParallelFor(bx2d, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
         if (metgrid_debug_quiescent) { // Debugging option to run quiescent.
             for (int k(0); k<=kmax; k++) {
-                new_data(i,j,k,tmp_indx) = zero;
+                new_data(i,j,k,tmp_indx) = zero_d;
             }
         } else if (metgrid_basic_linear) { // Linear interpolation with no quality control.
             for (int k(0); k<=kmax; k++) {
@@ -840,11 +840,11 @@ init_state_from_metgrid (const int  lev,
     int tmp_indx = 0;
     int dst_indx = 0;
 
-    ParallelFor(bx2d, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    ParallelFor(bx2d, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
         if (metgrid_debug_quiescent) { // Debugging option to run quiescent.
             for (int k(0); k<=kmax; k++) {
-                new_data(i,j,k,tmp_indx) = zero;
+                new_data(i,j,k,tmp_indx) = zero_d;
             }
         } else if (metgrid_basic_linear) { // Linear interpolation with no quality control.
             for (int k(0); k<=kmax; k++) {
@@ -1082,11 +1082,11 @@ init_state_from_metgrid (const int  lev,
             int tmp_indx = MetGridTmpDstVars::QV;
             int dst_indx = RhoQ1_comp;
 
-            ParallelFor(bx2d, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+            ParallelFor(bx2d, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int) noexcept
             {
                 if (metgrid_debug_dry) { // Debugging option to run dry.
                     for (int k(0); k<=kmax; k++) {
-                        new_data(i,j,k,tmp_indx)   = zero;
+                        new_data(i,j,k,tmp_indx)   = zero_d;
                     }
                 } else if (metgrid_basic_linear) { // Linear interpolation with no quality control.
                     for (int k(0); k<=kmax; k++) {
@@ -1296,7 +1296,7 @@ init_base_state_from_metgrid (const bool use_moisture,
         const Array4<Real>& qv_hse_arr = qv_hse_fab.array();
         auto const z_arr = z_phys_nd_fab.const_array();
 
-        ParallelFor(valid_bx2d, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        ParallelFor(valid_bx2d, [=,p_0_d=p_0,two_d=two,R_d_d=R_d,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int) noexcept
         {
             // Surface values and constants
             Real dz, F, C;
@@ -1304,8 +1304,8 @@ init_base_state_from_metgrid (const bool use_moisture,
 
             // Surface quantities
             Real z_lo  = Real(0.25) * ( z_arr(i,j,klo  ) + z_arr(i+1,j,klo  ) + z_arr(i,j+1,klo  ) + z_arr(i+1,j+1,klo  ) );
-            Real Pd_lo = p_0 * std::exp( -T00/TLP + std::sqrt( (T00/TLP)*(T00/TLP) - two * grav * z_lo / (TLP * R_d) ) );
-            Real Td_lo = std::max(TISO, T00 + TLP * std::log(Pd_lo/p_0));
+            Real Pd_lo = p_0_d * std::exp( -T00/TLP + std::sqrt( (T00/TLP)*(T00/TLP) - two_d * grav * z_lo / (TLP * R_d_d) ) );
+            Real Td_lo = std::max(TISO, T00 + TLP * std::log(Pd_lo/p_0_d));
             Real Rd_lo = getRhogivenTandPress(Td_lo, Pd_lo);
 
             for (int k(klo); k<=khi; ++k) {
@@ -1315,28 +1315,28 @@ init_base_state_from_metgrid (const bool use_moisture,
                 dz   = z_hi - z_lo;
 
                 // Establish known constant
-                C  = -Pd_lo + myhalf*Rd_lo*grav*dz;
+                C  = -Pd_lo + myhalf_d*Rd_lo*grav*dz;
 
                 // Initial guess and residual
                 Pd_hi = Pd_lo;
                 Td_hi = Td_lo;
                 Rd_hi = Rd_lo;
-                F = Pd_hi + myhalf*Rd_hi*grav*dz + C;
+                F = Pd_hi + myhalf_d*Rd_hi*grav*dz + C;
 
                 // Iterate to solution
                 int niter = 0;
                 while (std::fabs(F)>tol && niter<maxiter) {
                     Real dP      = amrex::max(Real(1.0e-3),Real(1.0e-3)*Pd_hi);
                     Real Pd_plus = Pd_hi + dP;
-                    Real Td_plus = std::max(TISO, T00 + TLP * std::log(Pd_plus/p_0));
+                    Real Td_plus = std::max(TISO, T00 + TLP * std::log(Pd_plus/p_0_d));
                     Real Rd_plus = getRhogivenTandPress(Td_plus, Pd_plus);
-                    Real F_plus  = Pd_plus + myhalf*Rd_plus*grav*dz + C;
+                    Real F_plus  = Pd_plus + myhalf_d*Rd_plus*grav*dz + C;
                     Real dFdP    = (F_plus - F) / dP;
 
                     Pd_hi -= F / dFdP;
-                    Td_hi  = std::max(TISO, T00 + TLP * std::log(Pd_hi/p_0));
+                    Td_hi  = std::max(TISO, T00 + TLP * std::log(Pd_hi/p_0_d));
                     Rd_hi  = getRhogivenTandPress(Td_hi, Pd_hi);
-                    F      = Pd_hi + myhalf*Rd_hi*grav*dz + C;
+                    F      = Pd_hi + myhalf_d*Rd_hi*grav*dz + C;
                     ++niter;
                 }
 
@@ -1430,7 +1430,7 @@ init_base_state_from_metgrid (const bool use_moisture,
         auto       new_data  = state_fab.array();
         auto const new_z     = z_phys_cc_fab.const_array();
 
-        ParallelFor(valid_bx2d, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        ParallelFor(valid_bx2d, [=,p_0_d=p_0,two_d=two,R_d_d=R_d,zero_d=zero,one_d=one,R_v_d=R_v,iGamma_d=iGamma,Cp_d_d=Cp_d,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int) noexcept
         {
             // Low and Hi column variables
             Real psurf;
@@ -1450,26 +1450,26 @@ init_base_state_from_metgrid (const bool use_moisture,
                 z_lo     = new_z(i,j,0);
                 Real t_0 = Real(290.0); // WRF's model_config_rec%base_temp
                 Real a   = Real(50.0);  // WRF's model_config_rec%base_lapse
-                psurf = p_0*std::exp(-t_0/a + std::sqrt(std::pow(t_0/a, two)-two*grav*z_lo/(a*R_d)));
+                psurf = p_0_d*std::exp(-t_0/a + std::sqrt(std::pow(t_0/a, two_d)-two_d*grav*z_lo/(a*R_d_d)));
             }
-            AMREX_ALWAYS_ASSERT(psurf > zero);
-            AMREX_ALWAYS_ASSERT(new_data(i,j,0,RhoTheta_comp) > zero);
+            AMREX_ALWAYS_ASSERT(psurf > zero_d);
+            AMREX_ALWAYS_ASSERT(new_data(i,j,0,RhoTheta_comp) > zero_d);
 
             // Iterations for the first CC point that is 1/2 dz off the surface
             {
                 z_lo  = new_z(i,j,0);
-                qv_lo = (use_moisture) ? new_data(i,j,0,RhoQ_comp) : zero;
-                rd_lo = zero; // initial guess
+                qv_lo = (use_moisture) ? new_data(i,j,0,RhoQ_comp) : zero_d;
+                rd_lo = zero_d; // initial guess
                 th_lo = new_data(i,j,0,RhoTheta_comp);
                 // NOTE: The first iteration is from z=0 to z_cc(i,j,0) since the
                 //       reference pressure (psurf) is at the ground.
                 Real myhalf_dz = z_lo;
-                Real qvf       = one+(R_v/R_d)*qv_lo;
+                Real qvf       = one_d+(R_v_d/R_d_d)*qv_lo;
                 Real thetam    = th_lo*qvf;
                 for (int it(0); it<maxiter; it++) {
-                    p_lo = psurf-myhalf_dz*rd_lo*(one+qv_lo)*grav;
-                    if (p_lo < zero) { p_lo = zero; }
-                    rd_lo = (p_0/(R_d*thetam))*std::pow(p_lo/p_0, iGamma);
+                    p_lo = psurf-myhalf_dz*rd_lo*(one_d+qv_lo)*grav;
+                    if (p_lo < zero_d) { p_lo = zero_d; }
+                    rd_lo = (p_0_d/(R_d_d*thetam))*std::pow(p_lo/p_0_d, iGamma_d);
                 } // it
 
                 // Copy solution to state
@@ -1479,7 +1479,7 @@ init_base_state_from_metgrid (const bool use_moisture,
                     new_data(i,j,0,RhoQ_comp) *= rd_lo;
                 }
                 for (int n(0); n < NSCALARS; n++) {
-                    new_data(i,j,0,RhoScalar_comp+n) = zero;
+                    new_data(i,j,0,RhoScalar_comp+n) = zero_d;
                 }
             }
 
@@ -1487,29 +1487,29 @@ init_base_state_from_metgrid (const bool use_moisture,
             for (int k(1); k<=kmax; k++) {
                 // Known hi data
                 z_hi  = new_z(i,j,k);
-                qv_hi = (use_moisture) ? new_data(i,j,k,RhoQ_comp) : zero;
+                qv_hi = (use_moisture) ? new_data(i,j,k,RhoQ_comp) : zero_d;
                 th_hi = new_data(i,j,k,RhoTheta_comp);
 
                 // Initial guesses for hi data
                  p_hi = p_lo;
-                 t_hi = getTgivenPandTh(p_hi, th_hi, R_d/Cp_d);
-                rd_hi = getRhogivenThetaPress(th_hi, p_hi, R_d/Cp_d, qv_hi);
+                 t_hi = getTgivenPandTh(p_hi, th_hi, R_d_d/Cp_d_d);
+                rd_hi = getRhogivenThetaPress(th_hi, p_hi, R_d_d/Cp_d_d, qv_hi);
 
                 // Vertical grid spacing
                 Real dz = z_hi - z_lo;
 
                 // Establish known constant
-                Real rho_tot_lo = rd_lo * (one + qv_lo);
-                Real C = -p_lo + myhalf*rho_tot_lo*grav*dz;
+                Real rho_tot_lo = rd_lo * (one_d + qv_lo);
+                Real C = -p_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                 // Initial residual
-                Real rho_tot_hi = rd_hi * (one + qv_hi);
-                Real F = p_hi + myhalf*rho_tot_hi*grav*dz + C;
+                Real rho_tot_hi = rd_hi * (one_d + qv_hi);
+                Real F = p_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                 // Do iterations
                 if (std::abs(F)>tol) {
                     bool maintain_Th = true;
-                    HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                    HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                                  grav, C, th_hi, t_hi,
                                                  qv_hi, qv_hi, p_hi,
                                                  rd_hi, F, maintain_Th);
@@ -1522,7 +1522,7 @@ init_base_state_from_metgrid (const bool use_moisture,
                     new_data(i,j,k,RhoQ_comp) *= rd_hi;
                 }
                 for (int n(0); n < NSCALARS; n++) {
-                    new_data(i,j,k,RhoScalar_comp+n) = zero;
+                    new_data(i,j,k,RhoScalar_comp+n) = zero_d;
                 }
 
                 // Copy hi to lo

--- a/Source/Initialization/ERF_InitFromNCFile.cpp
+++ b/Source/Initialization/ERF_InitFromNCFile.cpp
@@ -219,7 +219,7 @@ ERF::init_from_ncfile (int lev)
             const Array4<Real>& pi_hse_arr = pi_hse.array(mfi);
             const Array4<Real>& qv_hse_arr = (have_moisture) ? qv_hse.array(mfi) : Array4<Real>{};
 
-            ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(gtbx, [=,R_d_d=R_d,Cp_d_d=Cp_d] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 // Base state needs ghost cells filled, protect FAB access
                 int ii = std::max(i , ilo);
@@ -232,7 +232,7 @@ ERF::init_from_ncfile (int lev)
                  r_hse_arr(i,j,k) =  r_hse_arr(ii,jj,kk);
                  p_hse_arr(i,j,k) =  p_hse_arr(ii,jj,kk);
                 th_hse_arr(i,j,k) = th_hse_arr(ii,jj,kk);
-                pi_hse_arr(i,j,k) = getExnergivenP(p_hse_arr(ii,jj,kk), R_d/Cp_d);
+                pi_hse_arr(i,j,k) = getExnergivenP(p_hse_arr(ii,jj,kk), R_d_d/Cp_d_d);
 
                 // qv_hse == qv
                 if (have_moisture) qv_hse_arr(i,j,k) = con_arr(ii,jj,kk,RhoQ1_comp);
@@ -268,7 +268,7 @@ ERF::init_from_ncfile (int lev)
             const Array4<      Real>& pi_hse_arr = pi_hse.array(mfi);
             const Array4<      Real>& qv_hse_arr = (have_moisture) ? qv_hse.array(mfi) : Array4<Real>{};
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+            ParallelFor(bx, [=,zero_d=zero,p_0_d=p_0,R_d_d=R_d,Cp_d_d=Cp_d,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
             {
                 // integrate from surface to domain top
                 Real dz, F, C;
@@ -283,32 +283,32 @@ ERF::init_from_ncfile (int lev)
                 // First integrate from sea level to the height at klo
                 {
                     // Vertical grid spacing
-                    z_lo = zero; // corresponding to p_0
+                    z_lo = zero_d; // corresponding to p_0
                     z_hi = Real(0.125) * (z_arr(i,j,klo  ) + z_arr(i+1,j,klo  ) + z_arr(i,j+1,klo  ) + z_arr(i+1,j+1,klo  )
                                          +z_arr(i,j,klo+1) + z_arr(i+1,j,klo+1) + z_arr(i,j+1,klo+1) + z_arr(i+1,j+1,klo+1));
                     dz = z_hi - z_lo;
 
                     // Establish known constant
-                    qv_lo = (have_moisture) ? con_arr(i,j,klo,RhoQ1_comp) / con_arr(i,j,klo,Rho_comp) : zero;
+                    qv_lo = (have_moisture) ? con_arr(i,j,klo,RhoQ1_comp) / con_arr(i,j,klo,Rho_comp) : zero_d;
                     Th_lo = con_arr(i,j,klo,RhoTheta_comp) / con_arr(i,j,klo,Rho_comp);
-                    P_lo  = p_0;
-                    T_lo  = getTgivenPandTh(P_lo, Th_lo, R_d/Cp_d);
-                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-                    rho_tot_lo = R_lo * (one + qv_lo);
-                    C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+                    P_lo  = p_0_d;
+                    T_lo  = getTgivenPandTh(P_lo, Th_lo, R_d_d/Cp_d_d);
+                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
+                    rho_tot_lo = R_lo * (one_d + qv_lo);
+                    C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                     // Initial guess and residual
-                    qv_hi = (have_moisture) ? con_arr(i,j,klo,RhoQ1_comp) / con_arr(i,j,klo,Rho_comp) : zero;
+                    qv_hi = (have_moisture) ? con_arr(i,j,klo,RhoQ1_comp) / con_arr(i,j,klo,Rho_comp) : zero_d;
                     Th_hi = con_arr(i,j,klo,RhoTheta_comp) / con_arr(i,j,klo,Rho_comp);
-                    P_hi  = p_0;
-                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-                    rho_tot_hi = R_hi * (one + qv_hi);
-                    F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+                    P_hi  = p_0_d;
+                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
+                    rho_tot_hi = R_hi * (one_d + qv_hi);
+                    F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                     // Do iterations
                     bool maintain_Th = true;
-                    HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                    HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                                  grav, C, Th_hi, T_hi,
                                                  qv_hi, qv_hi,
                                                  P_hi, R_hi, F, maintain_Th);
@@ -317,7 +317,7 @@ ERF::init_from_ncfile (int lev)
                      r_hse_arr(i,j,klo) = R_hi;
                      p_hse_arr(i,j,klo) = P_hi;
                     th_hse_arr(i,j,klo) = Th_hi;
-                    pi_hse_arr(i,j,klo) = getExnergivenP(p_hse_arr(i,j,klo), R_d/Cp_d);
+                    pi_hse_arr(i,j,klo) = getExnergivenP(p_hse_arr(i,j,klo), R_d_d/Cp_d_d);
                     if (have_moisture) { qv_hse_arr(i,j,klo) = qv_hi; }
                     P_lo = P_hi;
                     z_lo = z_hi;
@@ -330,23 +330,23 @@ ERF::init_from_ncfile (int lev)
                     dz   = z_hi - z_lo;
 
                     // Establish known constant
-                    qv_lo = (have_moisture) ? con_arr(i,j,k,RhoQ1_comp) / con_arr(i,j,k,Rho_comp) : zero;
+                    qv_lo = (have_moisture) ? con_arr(i,j,k,RhoQ1_comp) / con_arr(i,j,k,Rho_comp) : zero_d;
                     Th_lo = con_arr(i,j,k,RhoTheta_comp) / con_arr(i,j,k,Rho_comp);
-                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-                    rho_tot_lo = R_lo * (one + qv_lo);
-                    C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
+                    rho_tot_lo = R_lo * (one_d + qv_lo);
+                    C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                     // Initial guess and residual
-                    qv_hi = (have_moisture) ? con_arr(i,j,k,RhoQ1_comp) / con_arr(i,j,k,Rho_comp) : zero;
+                    qv_hi = (have_moisture) ? con_arr(i,j,k,RhoQ1_comp) / con_arr(i,j,k,Rho_comp) : zero_d;
                     Th_hi = con_arr(i,j,k,RhoTheta_comp) / con_arr(i,j,k,Rho_comp);
-                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-                    rho_tot_hi = R_hi * (one + qv_hi);
-                    F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
+                    rho_tot_hi = R_hi * (one_d + qv_hi);
+                    F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                     // Do iterations
                     bool maintain_Th = true;
-                    HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                    HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                                  grav, C, Th_hi, T_hi,
                                                  qv_hi, qv_hi,
                                                  P_hi, R_hi, F, maintain_Th);
@@ -355,7 +355,7 @@ ERF::init_from_ncfile (int lev)
                      r_hse_arr(i,j,k) = R_hi;
                      p_hse_arr(i,j,k) = P_hi;
                     th_hse_arr(i,j,k) = Th_hi;
-                    pi_hse_arr(i,j,k) = getExnergivenP(p_hse_arr(i,j,k), R_d/Cp_d);
+                    pi_hse_arr(i,j,k) = getExnergivenP(p_hse_arr(i,j,k), R_d_d/Cp_d_d);
                     if (have_moisture) { qv_hse_arr(i,j,k) = qv_hi; }
                     P_lo = P_hi;
                     z_lo = z_hi;

--- a/Source/Initialization/ERF_InitFromNCFile.cpp
+++ b/Source/Initialization/ERF_InitFromNCFile.cpp
@@ -277,7 +277,7 @@ ERF::init_from_ncfile (int lev)
                 Real R_lo, R_hi;
                 Real qv_lo, qv_hi;
                 Real Th_lo, Th_hi;
-                Real T_lo, T_hi;
+                Real T_hi;
                 Real P_lo, P_hi;
 
                 // First integrate from sea level to the height at klo
@@ -292,7 +292,6 @@ ERF::init_from_ncfile (int lev)
                     qv_lo = (have_moisture) ? con_arr(i,j,klo,RhoQ1_comp) / con_arr(i,j,klo,Rho_comp) : zero_d;
                     Th_lo = con_arr(i,j,klo,RhoTheta_comp) / con_arr(i,j,klo,Rho_comp);
                     P_lo  = p_0_d;
-                    T_lo  = getTgivenPandTh(P_lo, Th_lo, R_d_d/Cp_d_d);
                     R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
                     rho_tot_lo = R_lo * (one_d + qv_lo);
                     C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -741,13 +741,13 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
                   const Array4<      Real>& cos_arr = (cosPhi_m[lev])->array(mfi);
                   const Array4<      Real>& dst_arr = (lat_m[lev])->array(mfi);
                   const Array4<const Real>& src_arr = var_fab.const_array();
-                  ParallelFor(gtbx, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+                  ParallelFor(gtbx, [=,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int) noexcept
                   {
                       int li = amrex::min(amrex::max(i, i_lo), i_hi);
                       int lj = amrex::min(amrex::max(j, j_lo), j_hi);
                       dst_arr(i,j,0) = src_arr(li,lj,0);
 
-                      Real lat_rad = dst_arr(i,j,0) * (PI/Real(180.));
+                      Real lat_rad = dst_arr(i,j,0) * (PI_d/Real(180.));
                       sin_arr(i,j,0) = std::sin(lat_rad);
                       cos_arr(i,j,0) = std::cos(lat_rad);
                   });
@@ -1347,7 +1347,7 @@ init_base_state_from_wrfinput (const Box& subdomain,
         const Array4<Real const>&     ALB_arr = (mf_ALB) ? mf_ALB->const_array(mfi) :
                                                            Array4<const Real> {};
 
-        ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(gtbx, [=,R_d_d=R_d] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // Base state needs ghost cells filled, protect FAB access
             int ii = std::max(i , dom_lo.x);
@@ -1362,7 +1362,7 @@ init_base_state_from_wrfinput (const Box& subdomain,
             // Have inverse base density
             if (ALB_arr) {
                 Rd  = Real(1.0) / ALB_arr(ii,jj,kk);
-                Td  = Pd / (R_d * Rd);
+                Td  = Pd / (R_d_d * Rd);
                 Thd = getThgivenTandP(Td, Pd, l_rdOcp);
             } else {
                 Td  = std::max(TISO, T00 + TLP * std::log(Pd/P00));
@@ -1413,7 +1413,7 @@ init_base_state_from_wrfinput (const Box& subdomain,
 
             const Array4<const Real>& z_arr = z_phys_nd->const_array(mfi);
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+            ParallelFor(bx, [=,zero_d=zero,R_d_d=R_d,Cp_d_d=Cp_d,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
             {
                 // integrate from surface to domain top
                 Real dz, F, C;
@@ -1424,13 +1424,13 @@ init_base_state_from_wrfinput (const Box& subdomain,
                 Real T_hi;
                 Real P_lo, P_hi;
 
-                Real qv_lo = zero;
-                Real qv_hi = zero;
+                Real qv_lo = zero_d;
+                Real qv_hi = zero_d;
 
                 // First integrate from surface to first CC at klo
                 {
                     // Vertical grid spacing
-                    z_lo = zero; // corresponding to p_0
+                    z_lo = zero_d; // corresponding to p_0
                     z_hi = Real(0.125) * ( z_arr(i,j,klo  ) + z_arr(i+1,j,klo  ) + z_arr(i,j+1,klo  ) + z_arr(i+1,j+1,klo  )
                                          + z_arr(i,j,klo+1) + z_arr(i+1,j,klo+1) + z_arr(i,j+1,klo+1) + z_arr(i+1,j+1,klo+1) );
 
@@ -1439,22 +1439,22 @@ init_base_state_from_wrfinput (const Box& subdomain,
 
                     // Known surface values
                     P_lo  = P00;
-                    Th_lo = getThgivenTandP(T00, P00, R_d/Cp_d);
-                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d);
+                    Th_lo = getThgivenTandP(T00, P00, R_d_d/Cp_d_d);
+                    R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d);
                     rho_tot_lo = R_lo;
-                    C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+                    C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                     // Initial guess and residual
                     P_hi  = P_lo;
                     Th_hi = th_hse_arr(i,j,klo);
-                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d);
+                    T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+                    R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d);
                     rho_tot_hi = R_hi;
-                    F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+                    F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                     // Do iterations
                     bool maintain_Th = true;
-                    HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                    HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                                  grav, C, Th_hi, T_hi,
                                                  qv_hi, qv_hi,
                                                  P_hi, R_hi, F, maintain_Th);
@@ -1476,20 +1476,20 @@ init_base_state_from_wrfinput (const Box& subdomain,
 
                   // Establish known constant
                   Th_lo = th_hse_arr(i,j,k-1);
-                  R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
+                  R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
                   rho_tot_lo = R_lo;
-                  C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+                  C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                   // Initial guess and residual
                   Th_hi = th_hse_arr(i,j,k);
-                  T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-                  R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
+                  T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+                  R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
                   rho_tot_hi = R_hi;
-                  F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+                  F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                   // Do iterations
                   bool maintain_Th = true;
-                  HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                  HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                                grav, C, Th_hi, T_hi,
                                                qv_hi, qv_hi,
                                                P_hi, R_hi, F, maintain_Th);
@@ -1573,14 +1573,14 @@ compute_terrain_top_and_bottom (const MultiFab& mf_PH,
         //
         // This loop computes the min and max values of the bottom surface
         //
-        ParallelFor(Fab2dBox_lo, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+        ParallelFor(Fab2dBox_lo, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             int ii = std::max(std::min(i,ihi-1),ilo+1);
             int jj = std::max(std::min(j,jhi-1),jlo+1);
             Real z_calc_lo = Real(0.25) * ( ph (ii,jj  ,klo) + ph (ii-1,jj  ,klo) +
                                             ph (ii,jj-1,klo) + ph (ii-1,jj-1,klo) +
                                             phb(ii,jj  ,klo) + phb(ii-1,jj  ,klo) +
-                                            phb(ii,jj-1,klo) + phb(ii-1,jj-1,klo) ) / CONST_GRAV;
+                                            phb(ii,jj-1,klo) + phb(ii-1,jj-1,klo) ) / CONST_GRAV_d;
             amrex::Gpu::Atomic::Min(&(min_d[0]),z_calc_lo);
             amrex::Gpu::Atomic::Max(&(max_d[0]),z_calc_lo);
         });
@@ -1588,14 +1588,14 @@ compute_terrain_top_and_bottom (const MultiFab& mf_PH,
         //
         // This loop computes the max value of the top surface
         //
-        ParallelFor(Fab2dBox_hi, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+        ParallelFor(Fab2dBox_hi, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             int ii = std::max(std::min(i,ihi-1),ilo+1);
             int jj = std::max(std::min(j,jhi-1),jlo+1);
             Real z_calc_hi = Real(0.25) * ( ph (ii,jj  ,khi) + ph (ii-1,jj  ,khi) +
                                             ph (ii,jj-1,khi) + ph (ii-1,jj-1,khi) +
                                             phb(ii,jj  ,khi) + phb(ii-1,jj  ,khi) +
-                                            phb(ii,jj-1,khi) + phb(ii-1,jj-1,khi) ) / CONST_GRAV;
+                                            phb(ii,jj-1,khi) + phb(ii-1,jj-1,khi) ) / CONST_GRAV_d;
             amrex::Gpu::Atomic::Max(&(max_d[1]),z_calc_hi);
             amrex::Gpu::Atomic::Min(&(min_d[1]),z_calc_hi);
         });
@@ -1603,14 +1603,14 @@ compute_terrain_top_and_bottom (const MultiFab& mf_PH,
         //
         // This loop computes the max value of the layer just below the top surface
         //
-        ParallelFor(Fab2dBox_hi_m1, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+        ParallelFor(Fab2dBox_hi_m1, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             int ii = std::max(std::min(i,ihi-1),ilo+1);
             int jj = std::max(std::min(j,jhi-1),jlo+1);
             Real z_calc_hi = Real(0.25) * ( ph (ii,jj  ,khi-1) + ph (ii-1,jj  ,khi-1) +
                                             ph (ii,jj-1,khi-1) + ph (ii-1,jj-1,khi-1) +
                                             phb(ii,jj  ,khi-1) + phb(ii-1,jj  ,khi-1) +
-                                            phb(ii,jj-1,khi-1) + phb(ii-1,jj-1,khi-1) ) / CONST_GRAV;
+                                            phb(ii,jj-1,khi-1) + phb(ii-1,jj-1,khi-1) ) / CONST_GRAV_d;
             amrex::Gpu::Atomic::Max(&(max_d[2]),z_calc_hi);
         });
     } // mfi
@@ -1685,7 +1685,7 @@ init_terrain_from_wrfinput (int /*lev*/,
         int klo = z_face_box.smallEnd()[2];
         int khi = z_face_box.bigEnd()[2];
 
-        ParallelFor(gnbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(gnbx, [=,CONST_GRAV_d=CONST_GRAV,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             int ii = std::max(std::min(i,ihi),ilo);
             int jj = std::max(std::min(j,jhi),jlo);
@@ -1697,23 +1697,23 @@ init_terrain_from_wrfinput (int /*lev*/,
                 Real z_klo   = Real(0.25) * ( nc_ph_arr (ii,jj,klo  ) + nc_ph_arr (im,jj,klo  ) +
                                               nc_ph_arr (ii,jm,klo  ) + nc_ph_arr (im,jm,klo) +
                                               nc_phb_arr(ii,jj,klo  ) + nc_phb_arr(im,jj,klo  ) +
-                                              nc_phb_arr(ii,jm,klo  ) + nc_phb_arr(im,jm,klo) ) / CONST_GRAV;
+                                              nc_phb_arr(ii,jm,klo  ) + nc_phb_arr(im,jm,klo) ) / CONST_GRAV_d;
                 Real z_klop1 = Real(0.25) * ( nc_ph_arr (ii,jj,klo+1) + nc_ph_arr (im,jj,klo+1) +
                                               nc_ph_arr (ii,jm,klo+1) + nc_ph_arr (im,jm,klo+1) +
                                               nc_phb_arr(ii,jj,klo+1) + nc_phb_arr(im,jj,klo+1) +
-                                              nc_phb_arr(ii,jm,klo+1) + nc_phb_arr(im,jm,klo+1) ) / CONST_GRAV;
-                z_arr(i, j, k) = two * z_klo - z_klop1;
+                                              nc_phb_arr(ii,jm,klo+1) + nc_phb_arr(im,jm,klo+1) ) / CONST_GRAV_d;
+                z_arr(i, j, k) = two_d * z_klo - z_klop1;
             } else if (k > khi) {
                 Real z_khim1 = Real(0.25) * ( nc_ph_arr (ii,jj,khi-1) + nc_ph_arr (im,jj,khi-1) +
                                               nc_ph_arr (ii,jm,khi-1) + nc_ph_arr (im,jm,khi-1) +
                                               nc_phb_arr(ii,jj,khi-1) + nc_phb_arr(im,jj,khi-1) +
-                                              nc_phb_arr(ii,jm,khi-1) + nc_phb_arr(im,jm,khi-1) ) / CONST_GRAV;
-                z_arr(i, j, k) = two * z_top - z_khim1;
+                                              nc_phb_arr(ii,jm,khi-1) + nc_phb_arr(im,jm,khi-1) ) / CONST_GRAV_d;
+                z_arr(i, j, k) = two_d * z_top - z_khim1;
             } else if (k == khi) {
                 z_arr(i, j, k) = Real(0.25) * ( nc_ph_arr (ii,jj,k) + nc_ph_arr (im,jj,k) +
                                                 nc_ph_arr (ii,jm,k) + nc_ph_arr (im,jm,k) +
                                                 nc_phb_arr(ii,jj,k) + nc_phb_arr(im,jj,k) +
-                                                nc_phb_arr(ii,jm,k) + nc_phb_arr(im,jm,k) ) / CONST_GRAV;
+                                                nc_phb_arr(ii,jm,k) + nc_phb_arr(im,jm,k) ) / CONST_GRAV_d;
                 z_arr(i, j, k) = z_top;
             } else {
                 // Note: wrfinput geopotentials ph, phb are only staggered in the vertical, i.e.,
@@ -1723,7 +1723,7 @@ init_terrain_from_wrfinput (int /*lev*/,
                 z_arr(i, j, k) = Real(0.25) * ( nc_ph_arr (ii,jj,k) + nc_ph_arr (im,jj,k) +
                                                 nc_ph_arr (ii,jm,k) + nc_ph_arr (im,jm,k) +
                                                 nc_phb_arr(ii,jj,k) + nc_phb_arr(im,jj,k) +
-                                                nc_phb_arr(ii,jm,k) + nc_phb_arr(im,jm,k) ) / CONST_GRAV;
+                                                nc_phb_arr(ii,jm,k) + nc_phb_arr(im,jm,k) ) / CONST_GRAV_d;
             }
         });
 

--- a/Source/Initialization/ERF_InitImmersedForcing.cpp
+++ b/Source/Initialization/ERF_InitImmersedForcing.cpp
@@ -35,17 +35,17 @@ ERF::init_immersed_forcing (int lev)
 
         // Set the x,y,z-velocities
         ParallelFor(xbx, ybx, zbx,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
-            if (t_blank == one) { xvel_arr(i, j, k) = epsilon; }
+        [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
+            if (t_blank == one_d) { xvel_arr(i, j, k) = epsilon; }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
-            if (t_blank == one) { yvel_arr(i, j, k) = epsilon; }
+        [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
+            if (t_blank == one_d) { yvel_arr(i, j, k) = epsilon; }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
-            if (t_blank == one) { zvel_arr(i, j, k) = epsilon; }
+        [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
+            if (t_blank == one_d) { zvel_arr(i, j, k) = epsilon; }
         });
     } //mfi
 }

--- a/Source/LandSurfaceModel/MM5/ERF_MM5.cpp
+++ b/Source/LandSurfaceModel/MM5/ERF_MM5.cpp
@@ -75,9 +75,9 @@ MM5::ComputeTsurf ()
 
         auto theta_array = lsm_fab_vars[LsmVar_MM5::theta]->array(mfi);
 
-        ParallelFor( box2d, [=] AMREX_GPU_DEVICE (int i, int j, int )
+        ParallelFor( box2d, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int )
         {
-            theta_array(i,j,khi+1) = Real(1.5)*theta_array(i,j,khi) - myhalf*theta_array(i,j,khi-1);
+            theta_array(i,j,khi+1) = Real(1.5)*theta_array(i,j,khi) - myhalf_d*theta_array(i,j,khi-1);
         });
     }
 }

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP_Advance.cpp
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP_Advance.cpp
@@ -115,11 +115,11 @@ NOAHMP::stage_forcing (const MFIter& mfi,
     const int kklo = klo;
 
     // (1) Stage ERF forcing into the pinned buffer (device).
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real qv = (is_moist) ? CONS(i,j,k,RhoQ1_comp)/CONS(i,j,k,Rho_comp) : Real(0.);
-        noah_input_arr(i,j,0,NoahmpInputComp::u_phy)   = myhalf*(U_PHY(i,j,k)+U_PHY(i+1,j,k));
-        noah_input_arr(i,j,0,NoahmpInputComp::v_phy)   = myhalf*(V_PHY(i,j,k)+V_PHY(i  ,j+1,k));
+        Real qv = (is_moist) ? CONS(i,j,k,RhoQ1_comp)/CONS(i,j,k,Rho_comp) : zero_d;
+        noah_input_arr(i,j,0,NoahmpInputComp::u_phy)   = myhalf_d*(U_PHY(i,j,k)+U_PHY(i+1,j,k));
+        noah_input_arr(i,j,0,NoahmpInputComp::v_phy)   = myhalf_d*(V_PHY(i,j,k)+V_PHY(i  ,j+1,k));
         noah_input_arr(i,j,0,NoahmpInputComp::t_phy)   = getTgivenRandRTh(CONS(i,j,k,Rho_comp),CONS(i,j,k,RhoTheta_comp),qv);
         noah_input_arr(i,j,0,NoahmpInputComp::qv_curr) = qv;
         noah_input_arr(i,j,0,NoahmpInputComp::p8w)     = getPgivenRTh(CONS(i,j,k,RhoTheta_comp),qv);
@@ -129,13 +129,13 @@ NOAHMP::stage_forcing (const MFIter& mfi,
 
         // RAW water-equivalent interval precip [mm]: per slot d = max(0, (now-prev)
         // * native_to_kg_m2). Host applies the guard and derives SR / MP_RAINNC.
-        Real drain = Real(0.), dsnow = Real(0.), dgraup = Real(0.);
+        Real drain = zero_d, dsnow = zero_d, dgraup = zero_d;
         if (hp) {
             Real dd[NoahmpPrecipSlot::NumSlots];
             for (int s(0); s < NoahmpPrecipSlot::NumSlots; ++s) {
                 dd[s] = slot_present[s]
-                    ? amrex::max(Real(0.), (accum_now[s](i,j,kklo) - accum_prv[s](i,j,kklo)) * accum_fac[s])
-                    : Real(0.);
+                    ? amrex::max(zero_d, (accum_now[s](i,j,kklo) - accum_prv[s](i,j,kklo)) * accum_fac[s])
+                    : zero_d;
             }
             // Hail is folded into MP_GRAUP (no ERF scheme fills the hail slot
             // today); to feed it separately, stage dd[hail] into MP_HAIL instead.
@@ -157,7 +157,8 @@ NOAHMP::stage_forcing (const MFIter& mfi,
 
     // (3) Copy pinned staged data to NoahmpIO on the host (3D members take the k/j
     // transpose (i,1,j), 2D take (i,j)); precip is derived below.
-    LoopOnCpu(bx, [&] (int i, int j, int ) noexcept
+    LoopOnCpu(bx, [&,zero_d=zero,one_d=one,lsm_max_precip_interval_d=lsm_max_precip_interval]
+                      (int i, int j, int ) noexcept
     {
 #define NOAHMP_STAGE_IN_3D(comp,member) noahmpio->member(i,1,j) = noah_input_arr(i,j,0,NoahmpInputComp::comp);
 #define NOAHMP_STAGE_IN_2D(comp,member) noahmpio->member(i,j)   = noah_input_arr(i,j,0,NoahmpInputComp::comp);
@@ -170,17 +171,17 @@ NOAHMP::stage_forcing (const MFIter& mfi,
         Real dsnow_h  = noah_input_arr(i,j,0,NoahmpInputComp::mp_snow);
         Real dgraup_h = noah_input_arr(i,j,0,NoahmpInputComp::mp_graup);
         Real drain_h  = noah_input_arr(i,j,0,NoahmpInputComp::rainbl);
-        if (drain_h > lsm_max_precip_interval) {
+        if (drain_h > lsm_max_precip_interval_d) {
             clamped_cells.push_back(erf_noahmp::ClampedPrecipCell{i, j, drain_h});
-            drain_h = lsm_max_precip_interval;
+            drain_h = lsm_max_precip_interval_d;
         }
         // Frozen/total invariant: MP_SNOW+MP_GRAUP are subsets of MP_RAINNC; if
         // their sum exceeds it, rescale the frozen components down and record the cell.
         Real dfroz_h = dsnow_h + dgraup_h;
-        const Real inv_tol = Real(1.0e-6) * (Real(1.0) + drain_h);
+        const Real inv_tol = Real(1.0e-6) * (one_d + drain_h);
         if (dfroz_h > drain_h + inv_tol) {
             invariant_cells.push_back(erf_noahmp::InvariantPrecipCell{i, j, dfroz_h, drain_h});
-            if (dfroz_h > Real(0.)) {
+            if (dfroz_h > zero_d) {
                 const Real scale = drain_h / dfroz_h;   // <= 1
                 dsnow_h  *= scale;
                 dgraup_h *= scale;
@@ -188,12 +189,12 @@ NOAHMP::stage_forcing (const MFIter& mfi,
             }
         }
         noahmpio->RAINBL(i,j)    = drain_h;                                       // [mm]
-        noahmpio->SR(i,j)        = (drain_h > Real(0.)) ? amrex::min(Real(1.0), dfroz_h/drain_h) : Real(0.); // [-]
+        noahmpio->SR(i,j)        = (drain_h > zero_d) ? amrex::min(one_d, dfroz_h/drain_h) : zero_d; // [-]
         noahmpio->MP_RAINNC(i,j) = drain_h;                                       // [mm]
         noahmpio->MP_SNOW(i,j)   = dsnow_h;                                       // [mm]
         noahmpio->MP_GRAUP(i,j)  = dgraup_h;                                      // [mm] (includes folded hail)
         // 0 = "no hail" (a real value, not a sentinel; lsm_undefined would corrupt opt_snf=4)
-        noahmpio->MP_HAIL(i,j)   = Real(0.);                                      // [mm]
+        noahmpio->MP_HAIL(i,j)   = zero_d;                                        // [mm]
     });
 }
 
@@ -272,7 +273,8 @@ NOAHMP::read_results (const MFIter& mfi,
 
     // (6) Copy Noahmp results to ERF (device; from pinned buffer): per-field math
     // (flux ÷rho, -9999 fill guard, sentinels, soil loop), deliberately not table-driven.
-    ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(gbx, [=,Cp_d_d=Cp_d,L_v_d=L_v,lsm_undefined_d=lsm_undefined]
+                         AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         // Limit indices to the valid box. FillBoundary will pick these up below.
         int ii = std::min(std::max(i,i_lo),i_hi);
@@ -287,15 +289,15 @@ NOAHMP::read_results (const MFIter& mfi,
             // rho for the kinematic MOST form ERF stores. Exner factor on t_flux is
             // omitted to match WRF (<~1% error near surface, ~6-7% at p~800 hPa).
             Real rho_l  = CONS(ii,jj,k,Rho_comp);
-            t_flux_arr(i,j,k) = hfx_lsm/(rho_l*Cp_d);
-            q_flux_arr(i,j,k) = noah_output_arr(ii,jj,0,NoahmpOutputComp::lh)/(rho_l*L_v);
+            t_flux_arr(i,j,k) = hfx_lsm/(rho_l*Cp_d_d);
+            q_flux_arr(i,j,k) = noah_output_arr(ii,jj,0,NoahmpOutputComp::lh)/(rho_l*L_v_d);
             tau13_arr(i,j,k)  = noah_output_arr(ii,jj,0,NoahmpOutputComp::tau_ew)/rho_l;
             tau23_arr(i,j,k)  = noah_output_arr(ii,jj,0,NoahmpOutputComp::tau_ns)/rho_l;
         } else {
-            t_flux_arr(i,j,k) = lsm_undefined;
-            q_flux_arr(i,j,k) = lsm_undefined;
-            tau13_arr(i,j,k)  = lsm_undefined;
-            tau23_arr(i,j,k)  = lsm_undefined;
+            t_flux_arr(i,j,k) = lsm_undefined_d;
+            q_flux_arr(i,j,k) = lsm_undefined_d;
+            tau13_arr(i,j,k)  = lsm_undefined_d;
+            tau23_arr(i,j,k)  = lsm_undefined_d;
         }
 
         // RRTMGP + return-term results: mechanical 1:1 copy from the buffer,
@@ -305,20 +307,20 @@ NOAHMP::read_results (const MFIter& mfi,
             NOAHMP_RESULT_FIELDS(NOAHMP_COPY_RESULT)
 #undef NOAHMP_COPY_RESULT
             // Not computed by this core -> sentinel, not a misleading 0.
-            SMSTAV_o(i,j,0)      = lsm_undefined;
-            SMSTOT_o(i,j,0)      = lsm_undefined;
+            SMSTAV_o(i,j,0)      = lsm_undefined_d;
+            SMSTOT_o(i,j,0)      = lsm_undefined_d;
             for (int s(0); s < n_soil_fld; ++s) {
                 soil_arr[s](i,j,0) = noah_output_arr(ii,jj,0,soil_out_base + s);
             }
         } else {
             // Fill-value cell (sea-ice / open-water): every result is the sentinel.
-#define NOAHMP_UNDEF_RESULT(alias,lsm,out) alias(i,j,0) = lsm_undefined;
+#define NOAHMP_UNDEF_RESULT(alias,lsm,out) alias(i,j,0) = lsm_undefined_d;
             NOAHMP_RESULT_FIELDS(NOAHMP_UNDEF_RESULT)
 #undef NOAHMP_UNDEF_RESULT
-            SMSTAV_o(i,j,0)      = lsm_undefined;
-            SMSTOT_o(i,j,0)      = lsm_undefined;
+            SMSTAV_o(i,j,0)      = lsm_undefined_d;
+            SMSTOT_o(i,j,0)      = lsm_undefined_d;
             for (int s(0); s < n_soil_fld; ++s) {
-                soil_arr[s](i,j,0) = lsm_undefined;
+                soil_arr[s](i,j,0) = lsm_undefined_d;
             }
         }
     });

--- a/Source/LandSurfaceModel/SLM/ERF_SLM.cpp
+++ b/Source/LandSurfaceModel/SLM/ERF_SLM.cpp
@@ -75,9 +75,9 @@ SLM::ComputeTsurf ()
 
         auto theta_array = lsm_fab_vars[LsmVar_SLM::theta]->array(mfi);
 
-        ParallelFor( box2d, [=] AMREX_GPU_DEVICE (int i, int j, int )
+        ParallelFor( box2d, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int )
         {
-            theta_array(i,j,khi+1) = Real(1.5)*theta_array(i,j,khi) - myhalf*theta_array(i,j,khi-1);
+            theta_array(i,j,khi+1) = Real(1.5)*theta_array(i,j,khi) - myhalf_d*theta_array(i,j,khi-1);
         });
     }
 }

--- a/Source/LinearSolvers/ERF_ComputeDivergence.cpp
+++ b/Source/LinearSolvers/ERF_ComputeDivergence.cpp
@@ -44,9 +44,9 @@ void ERF::compute_divergence (int lev, MultiFab& rhs, Array<MultiFab const*,AMRE
             if (SolverChoice::mesh_type == MeshType::StretchedDz)
             {
                 Real* stretched_dz_d_ptr = stretched_dz_d[lev].data();
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(bx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real inv_dz = one/stretched_dz_d_ptr[k];
+                    Real inv_dz = one_d/stretched_dz_d_ptr[k];
                     Real mfsq   = mf_mx(i,j,0) * mf_my(i,j,0);
                     rhs_arr(i,j,k) = (  (rho0u_arr(i+1,j  ,k  )/mf_uy(i+1,j,0) - rho0u_arr(i,j,k)/mf_uy(i,j,0)) * dxInv[0]
                                        +(rho0v_arr(i  ,j+1,k  )/mf_vx(i,j+1,0) - rho0v_arr(i,j,k)/mf_vx(i,j,0)) * dxInv[1]

--- a/Source/LinearSolvers/ERF_FillZeroAreaFaceFluxes.cpp
+++ b/Source/LinearSolvers/ERF_FillZeroAreaFaceFluxes.cpp
@@ -43,40 +43,40 @@ FillZeroAreaFaceFluxes (MultiFab& phi, Array<MultiFab,AMREX_SPACEDIM>& fluxes,
 
             ParallelFor(xbx, ybx, zbx,
             // x-face
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                if (apx(i,j,k) == zero) {
+                if (apx(i,j,k) == zero_d) {
                     if (!u_cflag(i,j,k).isCovered()) {
                         if (cflag(i,j,k).isCovered() && !cflag(i-1,j,k).isCovered()) {
-                            fx(i,j,k) = dxInv[0] * (p_arr(i-3,j,k) - three*p_arr(i-2,j,k) + two*p_arr(i-1,j,k));
+                            fx(i,j,k) = dxInv[0] * (p_arr(i-3,j,k) - three_d*p_arr(i-2,j,k) + two_d*p_arr(i-1,j,k));
                         } else if (cflag(i-1,j,k).isCovered() && !cflag(i,j,k).isCovered()) {
-                            fx(i,j,k) = dxInv[0] * (three*p_arr(i+1,j,k) - p_arr(i+2,j,k) - two*p_arr(i,j,k));
+                            fx(i,j,k) = dxInv[0] * (three_d*p_arr(i+1,j,k) - p_arr(i+2,j,k) - two_d*p_arr(i,j,k));
                         }
                     }
                 }
             },
             // y-face
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                if (apy(i,j,k) == zero) {
+                if (apy(i,j,k) == zero_d) {
                     if (!v_cflag(i,j,k).isCovered()) {
                         if (cflag(i,j,k).isCovered() && !cflag(i,j-1,k).isCovered()) {
-                            fy(i,j,k) = dxInv[1] * (p_arr(i,j-3,k) - three*p_arr(i,j-2,k) + two*p_arr(i,j-1,k));
+                            fy(i,j,k) = dxInv[1] * (p_arr(i,j-3,k) - three_d*p_arr(i,j-2,k) + two_d*p_arr(i,j-1,k));
                         } else if (cflag(i,j-1,k).isCovered() && !cflag(i,j,k).isCovered()) {
-                            fy(i,j,k) = dxInv[1] * (three*p_arr(i,j+1,k) - p_arr(i,j+2,k) - two*p_arr(i,j,k));
+                            fy(i,j,k) = dxInv[1] * (three_d*p_arr(i,j+1,k) - p_arr(i,j+2,k) - two_d*p_arr(i,j,k));
                         }
                     }
                 }
             },
             // z-face
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                if (apz(i,j,k) == zero) {
+                if (apz(i,j,k) == zero_d) {
                     if (!w_cflag(i,j,k).isCovered()) {
                         if (cflag(i,j,k).isCovered() && !cflag(i,j,k-1).isCovered()) {
-                            fz(i,j,k) = dxInv[2] * (p_arr(i,j,k-3) - three*p_arr(i,j,k-2) + two*p_arr(i,j,k-1));
+                            fz(i,j,k) = dxInv[2] * (p_arr(i,j,k-3) - three_d*p_arr(i,j,k-2) + two_d*p_arr(i,j,k-1));
                         } else if (cflag(i,j,k-1).isCovered() && !cflag(i,j,k).isCovered()) {
-                            fz(i,j,k) = dxInv[2] * (three*p_arr(i,j,k+1) - p_arr(i,j,k+2) - two*p_arr(i,j,k));
+                            fz(i,j,k) = dxInv[2] * (three_d*p_arr(i,j,k+1) - p_arr(i,j,k+2) - two_d*p_arr(i,j,k));
                         }
                     }
                 }

--- a/Source/LinearSolvers/ERF_PoissonSolve.cpp
+++ b/Source/LinearSolvers/ERF_PoissonSolve.cpp
@@ -203,9 +203,9 @@ void ERF::project_momenta (int lev, double l_time, double l_dt_d, Vector<MultiFa
             // Define Omega from (rho0 W) but store it in the same array
             //
             Box tbz = mfi.nodaltilebox(2);
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 if (k == 0) {
-                    rho0w_arr(i,j,k) = zero;
+                    rho0w_arr(i,j,k) = zero_d;
                 } else {
                     Real rho0w = rho0w_arr(i,j,k);
                     rho0w_arr(i,j,k) = OmegaFromW(i,j,k,rho0w,

--- a/Source/LinearSolvers/ERF_PoissonWallDist.cpp
+++ b/Source/LinearSolvers/ERF_PoissonWallDist.cpp
@@ -48,8 +48,8 @@ void ERF::poisson_wall_dist (int lev)
             for (MFIter mfi(*walldist[lev]); mfi.isValid(); ++mfi) {
                 const Box& bx = mfi.validbox();
                 auto dist_arr = walldist[lev]->array(mfi);
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-                    dist_arr(i, j, k) = prob_lo[2] + (k + myhalf) * dx[2];
+                ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) {
+                    dist_arr(i, j, k) = prob_lo[2] + (k + myhalf_d) * dx[2];
                 });
             }
             return;
@@ -292,8 +292,8 @@ void ERF::poisson_wall_dist (int lev)
     ParallelFor(beta[1], [=] AMREX_GPU_DEVICE(int b, int i, int j, int k) {
         beta1_arr[b](i, j, k) = Compute_h_zeta_AtJface(i, j, k, dxinv, zphys_arr[b]);;
     });
-    ParallelFor(beta[2], [=] AMREX_GPU_DEVICE(int b, int i, int j, int k) {
-        Real inv_h_zeta = one / Compute_h_zeta_AtKface(i, j, k, dxinv, zphys_arr[b]);
+    ParallelFor(beta[2], [=,one_d=one] AMREX_GPU_DEVICE(int b, int i, int j, int k) {
+        Real inv_h_zeta = one_d / Compute_h_zeta_AtKface(i, j, k, dxinv, zphys_arr[b]);
         Real h_xi = Compute_h_xi_AtKface(i, j, k, dxinv, zphys_arr[b]);
         Real h_eta = Compute_h_eta_AtKface(i, j, k, dxinv, zphys_arr[b]);
         beta2_arr[b](i, j, k) = inv_h_zeta * (1 + h_xi*h_xi + h_eta*h_eta);
@@ -420,7 +420,7 @@ void ERF::poisson_wall_dist (int lev)
         //auto rhs_arr = rhs[0].arrays();
         auto dist_arr = walldist[lev]->arrays();
 
-        ParallelFor(*walldist[lev], [=] AMREX_GPU_DEVICE(int b, int i, int j, int k) {
+        ParallelFor(*walldist[lev], [=,fourth_d=fourth] AMREX_GPU_DEVICE(int b, int i, int j, int k) {
             Real dpdx{0}, dpdy{0}, dpdz{0};
 
             dpdx = terrpoisson_flux_x(i, j, k, phi_arr[b], zphys_arr[b], dxinv[0]);
@@ -445,33 +445,33 @@ void ERF::poisson_wall_dist (int lev)
             // Update RHS source term to explicitly include cross-terms
             if (n_corr > 0) {
                 // d/dxi ( h_xi * dphi/dzeta )
-                Real phi_zeta_xlo = fourth * dxinv[2] * ( phi_arr[b](i  , j, k+1) - phi_arr[b](i  , j, k-1)
+                Real phi_zeta_xlo = fourth_d * dxinv[2] * ( phi_arr[b](i  , j, k+1) - phi_arr[b](i  , j, k-1)
                                                       + phi_arr[b](i-1, j, k+1) - phi_arr[b](i-1, j, k-1) );
-                Real phi_zeta_xhi = fourth * dxinv[2] * ( phi_arr[b](i  , j, k+1) - phi_arr[b](i  , j, k-1)
+                Real phi_zeta_xhi = fourth_d * dxinv[2] * ( phi_arr[b](i  , j, k+1) - phi_arr[b](i  , j, k-1)
                                                       + phi_arr[b](i+1, j, k+1) - phi_arr[b](i+1, j, k-1) );
                 Real h_xi_xlo = Compute_h_xi_AtIface(i  , j, k, dxinv, zphys_arr[b]);
                 Real h_xi_xhi = Compute_h_xi_AtIface(i+1, j, k, dxinv, zphys_arr[b]);
 
                 // d/deta ( h_eta * dphi/dzeta )
-                Real phi_zeta_ylo = fourth * dxinv[2] * ( phi_arr[b](i, j  , k+1) - phi_arr[b](i, j  , k-1)
+                Real phi_zeta_ylo = fourth_d * dxinv[2] * ( phi_arr[b](i, j  , k+1) - phi_arr[b](i, j  , k-1)
                                                       + phi_arr[b](i, j-1, k+1) - phi_arr[b](i, j-1, k-1) );
-                Real phi_zeta_yhi = fourth * dxinv[2] * ( phi_arr[b](i, j  , k+1) - phi_arr[b](i, j  , k-1)
+                Real phi_zeta_yhi = fourth_d * dxinv[2] * ( phi_arr[b](i, j  , k+1) - phi_arr[b](i, j  , k-1)
                                                       + phi_arr[b](i, j+1, k+1) - phi_arr[b](i, j+1, k-1) );
                 Real h_eta_ylo = Compute_h_eta_AtJface(i, j  , k, dxinv, zphys_arr[b]);
                 Real h_eta_yhi = Compute_h_eta_AtJface(i, j+1, k, dxinv, zphys_arr[b]);
 
                 // d/dzeta ( h_xi * dphi/dxi )
-                Real phi_xi_zlo = fourth * dxinv[0] * ( phi_arr[b](i+1, j, k  ) - phi_arr[b](i-1, j, k  )
+                Real phi_xi_zlo = fourth_d * dxinv[0] * ( phi_arr[b](i+1, j, k  ) - phi_arr[b](i-1, j, k  )
                                                     + phi_arr[b](i+1, j, k-1) - phi_arr[b](i-1, j, k-1) );
-                Real phi_xi_zhi = fourth * dxinv[0] * ( phi_arr[b](i+1, j, k  ) - phi_arr[b](i-1, j, k  )
+                Real phi_xi_zhi = fourth_d * dxinv[0] * ( phi_arr[b](i+1, j, k  ) - phi_arr[b](i-1, j, k  )
                                                     + phi_arr[b](i+1, j, k+1) - phi_arr[b](i-1, j, k+1) );
                 Real h_xi_zlo = Compute_h_xi_AtKface(i, j, k  , dxinv, zphys_arr[b]);
                 Real h_xi_zhi = Compute_h_xi_AtKface(i, j, k+1, dxinv, zphys_arr[b]);
 
                 // d/dzeta ( h_eta * dphi/deta )
-                Real phi_eta_zlo = fourth * dxinv[1] * ( phi_arr[b](i, j+1, k  ) - phi_arr[b](i, j-1, k  )
+                Real phi_eta_zlo = fourth_d * dxinv[1] * ( phi_arr[b](i, j+1, k  ) - phi_arr[b](i, j-1, k  )
                                                      + phi_arr[b](i, j+1, k-1) - phi_arr[b](i, j-1, k-1) );
-                Real phi_eta_zhi = fourth * dxinv[1] * ( phi_arr[b](i, j+1, k  ) - phi_arr[b](i, j-1, k  )
+                Real phi_eta_zhi = fourth_d * dxinv[1] * ( phi_arr[b](i, j+1, k  ) - phi_arr[b](i, j-1, k  )
                                                      + phi_arr[b](i, j+1, k+1) - phi_arr[b](i, j-1, k+1) );
                 Real h_eta_zlo = Compute_h_eta_AtKface(i, j, k  , dxinv, zphys_arr[b]);
                 Real h_eta_zhi = Compute_h_eta_AtKface(i, j, k+1, dxinv, zphys_arr[b]);

--- a/Source/LinearSolvers/ERF_SolveWithFFT.cpp
+++ b/Source/LinearSolvers/ERF_SolveWithFFT.cpp
@@ -204,21 +204,21 @@ void ERF::solve_with_fft (int lev, int isub, const Box& subdomain,
         Array4<Real> const& fz_arr  = fluxes[2].array(mfi);
         if (solverChoice.mesh_type != MeshType::ConstantDz) {
             Real* stretched_dz_d_ptr = stretched_dz_d[lev].data();
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(zbx, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 if (k == sub_lo.z || k == sub_hi.z+1) {
-                    fz_arr(i,j,k) = zero;
+                    fz_arr(i,j,k) = zero_d;
                 } else {
-                    Real dz = myhalf * (stretched_dz_d_ptr[k] + stretched_dz_d_ptr[k-1]);
+                    Real dz = myhalf_d * (stretched_dz_d_ptr[k] + stretched_dz_d_ptr[k-1]);
                     fz_arr(i,j,k) = -(p_arr(i,j,k) - p_arr(i,j,k-1)) / dz;
                 }
             });
         } else { // no grid stretching
             const Real dz_inv = dxInv[2];
-            ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 if (k == sub_lo.z || k == sub_hi.z+1) {
-                    fz_arr(i,j,k) = zero;
+                    fz_arr(i,j,k) = zero_d;
                 } else {
                     fz_arr(i,j,k) = -(p_arr(i,j,k) - p_arr(i,j,k-1)) * dz_inv;
                 }

--- a/Source/LinearSolvers/ERF_TerrainPoisson.cpp
+++ b/Source/LinearSolvers/ERF_TerrainPoisson.cpp
@@ -261,26 +261,26 @@ void TerrainPoisson::precond (MultiFab& lhs, MultiFab const& rhs)
         auto dxinv = m_geom.InvCellSize(0);
         auto dyinv = m_geom.InvCellSize(1);
         m_2D_fft_precond->solve(lhs, rhs,
-            [=] AMREX_GPU_DEVICE (int ii, int jj, int k) -> Real
+            [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int ii, int jj, int k) -> Real
             {
                 int i = 0; int j = 0;
                 Real hzeta_inv_on_cc = Real(4.0) / ( (za(i,j,k+1) + za(i+1,j,k+1) + za(i,j+1,k+1) + za(i+1,j+1,k+1))
                                                     -(za(i,j,k  ) + za(i+1,j,k  ) + za(i,j+1,k  ) + za(i+1,j+1,k  )) );
                 eal hzeta_inv_on_zlo = Real(8.0) / ( (za(i,j,k+1) + za(i+1,j,k+1) + za(i,j+1,k+1) + za(i+1,j+1,k+1))
                                                     -(za(i,j,k-1) + za(i+1,j,k-1) + za(i,j+1,k-1) + za(i+1,j+1,k-1)) );
-                Real h_xi_on_zlo  = myhalf * (za(i+1,j+1,k  ) + za(i+1,j,k  ) - za(i,j+1,k  ) - za(i,j,k  )) * dxinv;
-                Real h_eta_on_zlo = myhalf * (za(i+1,j+1,k  ) + za(i,j+1,k  ) - za(i+1,j,k  ) - za(i,j,k  )) * dyinv;
-                return hzeta_inv_on_cc * (one + h_xi_on_zlo*h_xi_on_zlo + h_eta_on_zlo*h_eta_on_zlo) * hzeta_inv_on_zlo;
+                Real h_xi_on_zlo  = myhalf_d * (za(i+1,j+1,k  ) + za(i+1,j,k  ) - za(i,j+1,k  ) - za(i,j,k  )) * dxinv;
+                Real h_eta_on_zlo = myhalf_d * (za(i+1,j+1,k  ) + za(i,j+1,k  ) - za(i+1,j,k  ) - za(i,j,k  )) * dyinv;
+                return hzeta_inv_on_cc * (one_d + h_xi_on_zlo*h_xi_on_zlo + h_eta_on_zlo*h_eta_on_zlo) * hzeta_inv_on_zlo;
             },
-            [=] AMREX_GPU_DEVICE (int ii, int jj, int k) -> Real
+            [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int ii, int jj, int k) -> Real
             {
                 Real hzeta_inv_on_cc = Real(4.0) / ( (za(i,j,k+1) + za(i+1,j,k+1) + za(i,j+1,k+1) + za(i+1,j+1,k+1))
                                                     -(za(i,j,k  ) + za(i+1,j,k  ) + za(i,j+1,k  ) + za(i+1,j+1,k  )) );
                 Real hzeta_inv_on_zhi = Real(8.0) / ( (za(i,j,k+2) + za(i+1,j,k+2) + za(i,j+1,k+2) + za(i+1,j+1,k+2))
                                                      -(za(i,j,k  ) + za(i+1,j,k  ) + za(i,j+1,k  ) + za(i+1,j+1,k  )) );
-                Real h_xi_on_zhi  = myhalf * (za(i+1,j+1,k+1) + za(i+1,j,k+1) - za(i,j+1,k+1) - za(i,j,k+1)) * dxinv;
-                Real h_eta_on_zhi = myhalf * (za(i+1,j+1,k+1) + za(i,j+1,k+1) - za(i+1,j,k+1) - za(i,j,k+1)) * dyinv;
-                return hzeta_inv_on_cc * (one + h_xi_on_zhi*h_xi_on_zhi + h_eta_on_zhi*h_eta_on_zhi) * hzeta_inv_on_zhi;
+                Real h_xi_on_zhi  = myhalf_d * (za(i+1,j+1,k+1) + za(i+1,j,k+1) - za(i,j+1,k+1) - za(i,j,k+1)) * dxinv;
+                Real h_eta_on_zhi = myhalf_d * (za(i+1,j+1,k+1) + za(i,j+1,k+1) - za(i+1,j,k+1) - za(i,j,k+1)) * dyinv;
+                return hzeta_inv_on_cc * (one_d + h_xi_on_zhi*h_xi_on_zhi + h_eta_on_zhi*h_eta_on_zhi) * hzeta_inv_on_zhi;
             });
 #endif
     } else

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -687,7 +687,7 @@ namespace MORRInd {
             morr_arr(i,j,k,MORRInd::qicu1d) = Real(0); //morr_arr(i,j,k,MORRInd::qicuten_arr);              // ICE FROM CUMULUS PARAMETERIZATION
           });
 
-          ParallelFor( boxD, [=] AMREX_GPU_DEVICE (int i, int j, int )
+          ParallelFor( boxD, [=,one_d=one,three_d=three,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int )
           {
            int ltrue=0;                      // LTRUE: SWITCH = 0: NO HYDROMETEORS IN COLUMN, = 1: HYDROMETEORS IN COLUMN
            int nstep;                        // NSTEP: Timestep counter
@@ -836,7 +836,7 @@ namespace MORRInd {
 
             // Assuming CP is a constant defined elsewhere (specific heat of dry air at constant pressure)
             const Real CP = Real(1004.5); // J/kg/K
-            morr_arr(i,j,k,MORRInd::cpm) = CP * (one + Real(0.887) * morr_arr(i,j,k,MORRInd::qv3d));
+            morr_arr(i,j,k,MORRInd::cpm) = CP * (one_d + Real(0.887) * morr_arr(i,j,k,MORRInd::qv3d));
 
             // SATURATION VAPOR PRESSURE AND MIXING RATIO
             // hm, add fix for low pressure, 5/12/10
@@ -859,20 +859,20 @@ namespace MORRInd {
             // AIR DENSITY
             morr_arr(i,j,k,MORRInd::rho) = morr_arr(i,j,k,MORRInd::pres) / (m_R * morr_arr(i,j,k,MORRInd::t3d)); // budget equation: calculate air density
 
-            ds0 = three;       // Size distribution parameter for snow
-            di0 = three;       // Size distribution parameter for cloud ice
-            dg0 = three;       // Size distribution parameter for graupel
+            ds0 = three_d;       // Size distribution parameter for snow
+            di0 = three_d;       // Size distribution parameter for cloud ice
+            dg0 = three_d;       // Size distribution parameter for graupel
 
             // ADD NUMBER CONCENTRATION DUE TO CUMULUS TENDENCY
             // ASSUME N0 ASSOCIATED WITH CUMULUS PARAM RAIN IS 10^7 M^-4
             // ASSUME N0 ASSOCIATED WITH CUMULUS PARAM SNOW IS 2 X 10^7 M^-4
             // FOR DETRAINED CLOUD ICE, ASSUME MEAN VOLUME DIAM OF 80 MICRON
             if (morr_arr(i,j,k,MORRInd::qrcu1d) >= Real(1.0e-10)) {
-              dum = Real(1.8e5) * std::pow(morr_arr(i,j,k,MORRInd::qrcu1d) * dt / (m_pi * m_rhow * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::rho))), fourth); // rate equation: calculate rain number concentration from cumulus
+              dum = Real(1.8e5) * std::pow(morr_arr(i,j,k,MORRInd::qrcu1d) * dt / (m_pi * m_rhow * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::rho))), fourth_d); // rate equation: calculate rain number concentration from cumulus
               morr_arr(i,j,k,MORRInd::nr3d) += dum; // budget equation: update rain number concentration
             }
             if (morr_arr(i,j,k,MORRInd::qscu1d) >= Real(1.0e-10)) {
-              dum = Real(3.e5) * std::pow(morr_arr(i,j,k,MORRInd::qscu1d) * dt / (m_cons1 * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::rho))), one / (ds0 + one)); // rate equation: calculate snow number concentration from cumulus
+              dum = Real(3.e5) * std::pow(morr_arr(i,j,k,MORRInd::qscu1d) * dt / (m_cons1 * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::rho))), one_d / (ds0 + one_d)); // rate equation: calculate snow number concentration from cumulus
               morr_arr(i,j,k,MORRInd::ns3d) += dum; // budget equation: update snow number concentration
             }
             if (morr_arr(i,j,k,MORRInd::qicu1d) >= Real(1.0e-10)) {
@@ -994,8 +994,8 @@ namespace MORRInd {
             dum = (m_Rv * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::t3d))); // temporary update: calculate temperature factor
             dqsdt = morr_arr(i,j,k,MORRInd::xxlv) * qvs / dum; // budget equation: calculate DQSDT
             dqsidt = morr_arr(i,j,k,MORRInd::xxls) * qvi / dum; // budget equation: calculate DQSIDT
-            abi = one + dqsidt * morr_arr(i,j,k,MORRInd::xxls) / morr_arr(i,j,k,MORRInd::cpm); // budget equation: calculate ABI
-            ab = one + dqsdt * morr_arr(i,j,k,MORRInd::xxlv) / morr_arr(i,j,k,MORRInd::cpm); // budget equation: calculate AB
+            abi = one_d + dqsidt * morr_arr(i,j,k,MORRInd::xxls) / morr_arr(i,j,k,MORRInd::cpm); // budget equation: calculate ABI
+            ab = one_d + dqsdt * morr_arr(i,j,k,MORRInd::xxlv) / morr_arr(i,j,k,MORRInd::cpm); // budget equation: calculate AB
 
             // CASE FOR TEMPERATURE ABOVE FREEZING
             if (morr_arr(i,j,k,MORRInd::t3d) >= Real(273.15)) {
@@ -1043,7 +1043,7 @@ namespace MORRInd {
                 // Rain
                 if (morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
                   // Calculate lambda parameter using cons26 (pi*rhow/6)
-                  morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one/three);
+                  morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one_d/three_d);
                   morr_arr(i,j,k,MORRInd::n0r) = morr_arr(i,j,k,MORRInd::nr3d)*morr_arr(i,j,k,MORRInd::lamr);
 
                   // Check for slope and adjust vars
@@ -1065,31 +1065,31 @@ namespace MORRInd {
 
                   // MARTIN ET AL. (1994) FORMULA FOR PGAM (WRF implementation)
                   morr_arr(i,j,k,MORRInd::pgam) = Real(0.0005714)*(morr_arr(i,j,k,MORRInd::nc3d)/Real(1.0e6)*dum) + Real(0.2714);
-                  morr_arr(i,j,k,MORRInd::pgam) = one/(morr_arr(i,j,k,MORRInd::pgam)*morr_arr(i,j,k,MORRInd::pgam)) - one;
+                  morr_arr(i,j,k,MORRInd::pgam) = one_d/(morr_arr(i,j,k,MORRInd::pgam)*morr_arr(i,j,k,MORRInd::pgam)) - one_d;
                   morr_arr(i,j,k,MORRInd::pgam) = amrex::max(morr_arr(i,j,k,MORRInd::pgam), Real(2));
                   morr_arr(i,j,k,MORRInd::pgam) = amrex::min(morr_arr(i,j,k,MORRInd::pgam), Real(10.0));
 
                   // Calculate gamma function values
-                  Real gamma_pgam_plus_1 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one);
+                  Real gamma_pgam_plus_1 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d);
                   Real gamma_pgam_plus_4 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0));
 
                   // Calculate lambda parameter
-                  morr_arr(i,j,k,MORRInd::lamc) = std::pow((m_cons26 * morr_arr(i,j,k,MORRInd::nc3d) * gamma_pgam_plus_4) / (morr_arr(i,j,k,MORRInd::qc3d) * gamma_pgam_plus_1), one/three);
+                  morr_arr(i,j,k,MORRInd::lamc) = std::pow((m_cons26 * morr_arr(i,j,k,MORRInd::nc3d) * gamma_pgam_plus_4) / (morr_arr(i,j,k,MORRInd::qc3d) * gamma_pgam_plus_1), one_d/three_d);
 
                   // Lambda bounds from WRF - 60 micron max diameter, 1 micron min diameter
-                  Real lambda_min = (morr_arr(i,j,k,MORRInd::pgam) + one)/Real(60.0e-6);
-                  Real lambda_max = (morr_arr(i,j,k,MORRInd::pgam) + one)/Real(1.0e-6);
+                  Real lambda_min = (morr_arr(i,j,k,MORRInd::pgam) + one_d)/Real(60.0e-6);
+                  Real lambda_max = (morr_arr(i,j,k,MORRInd::pgam) + one_d)/Real(1.0e-6);
 
                   // Check bounds and update number concentration if needed
                   if (morr_arr(i,j,k,MORRInd::lamc) < lambda_min) {
                     morr_arr(i,j,k,MORRInd::lamc) = lambda_min;
                     // Update cloud droplet number using the same formula as in WRF
-                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
                                std::log(gamma_pgam_plus_1) - std::log(gamma_pgam_plus_4))/ m_cons26;
                   } else if (morr_arr(i,j,k,MORRInd::lamc) > lambda_max) {
                     morr_arr(i,j,k,MORRInd::lamc) = lambda_max;
                     // Update cloud droplet number using the same formula as in WRF
-                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
                                std::log(gamma_pgam_plus_1) - std::log(gamma_pgam_plus_4))/ m_cons26;
                   }
 
@@ -1100,7 +1100,7 @@ namespace MORRInd {
                 // Snow
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
                   // Calculate lambda parameter
-                  morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one/ds0);
+                  morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one_d/ds0);
 
                   // Calculate intercept parameter
                   morr_arr(i,j,k,MORRInd::n0s) = morr_arr(i,j,k,MORRInd::ns3d) * morr_arr(i,j,k,MORRInd::lams);
@@ -1120,7 +1120,7 @@ namespace MORRInd {
                 // Graupel
                 if (morr_arr(i,j,k,MORRInd::qg3d) >= m_qsmall) {
                   // Calculate lambda parameter
-                  morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one/dg0);
+                  morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one_d/dg0);
 
                   // Calculate intercept parameter
                   morr_arr(i,j,k,MORRInd::n0g) = morr_arr(i,j,k,MORRInd::ng3d) * morr_arr(i,j,k,MORRInd::lamg);
@@ -1214,7 +1214,7 @@ namespace MORRInd {
                                       morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0s) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) *
                                       (Real(5.0)/(amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lams)) +
                                        Real(2)/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lams))) +
-                                       myhalf/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)))));
+                                       myhalf_d/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)))));
                 }
                 // ADD COLLECTION OF GRAUPEL BY RAIN ABOVE FREEZING
                 // ASSUME ALL RAIN COLLECTION BY GRAUPEL ABOVE FREEZING IS SHED
@@ -1241,16 +1241,16 @@ namespace MORRInd {
                                       morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0g) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) *
                                       (Real(5.0)/(amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
                                        Real(2)/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
-                                       myhalf/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
+                                       myhalf_d/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
 
                   // ASSUME 1 MM DROPS ARE SHED, GET NUMBER SHED PER SEC
                   dum = pracg/Real(5.2e-7);
 
                   npracg = m_cons32 * morr_arr(i,j,k,MORRInd::rho) * (std::sqrt(Real(1.7)*amrex::Math::powi<2>(unr_local-ung_local) +
                                                               Real(0.3)*unr_local*ung_local) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0g) *
-                                                    (one/(amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
-                                                     one/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
-                                                     one/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
+                                                    (one_d/(amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
+                                                     one_d/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
+                                                     one_d/(morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
                   // hm 7/15/13, remove limit so that the number of collected drops can smaller than
                   // number of shed drops
                   npracg = npracg - dum;
@@ -1275,10 +1275,10 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qr3d) >= Real(1.0e-8)) {
                   // include breakup add 10/09/09
                   dum1 = Real(300.0e-6);
-                  if (one/morr_arr(i,j,k,MORRInd::lamr) < dum1) {
-                    dum = one;
+                  if (one_d/morr_arr(i,j,k,MORRInd::lamr) < dum1) {
+                    dum = one_d;
                   } else {
-                    dum = Real(2) - std::exp(Real(2300.0) * (one/morr_arr(i,j,k,MORRInd::lamr) - dum1));
+                    dum = Real(2) - std::exp(Real(2300.0) * (one_d/morr_arr(i,j,k,MORRInd::lamr) - dum1));
                   }
                   nragg = -Real(5.78) * dum * morr_arr(i,j,k,MORRInd::nr3d) * morr_arr(i,j,k,MORRInd::qr3d) * morr_arr(i,j,k,MORRInd::rho);
                 }
@@ -1287,7 +1287,7 @@ namespace MORRInd {
                   epsr = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::rho) * dv *
                     (m_f1r/(morr_arr(i,j,k,MORRInd::lamr)*morr_arr(i,j,k,MORRInd::lamr)) +
                      m_f2r * std::sqrt(morr_arr(i,j,k,MORRInd::arn)*morr_arr(i,j,k,MORRInd::rho)/morr_arr(i,j,k,MORRInd::mu)) *
-                     std::pow(sc_schmidt, one/three) * m_cons9 /
+                     std::pow(sc_schmidt, one_d/three_d) * m_cons9 /
                      std::pow(morr_arr(i,j,k,MORRInd::lamr), m_cons34));
                 } else {
                   epsr = Real(0);
@@ -1312,15 +1312,15 @@ namespace MORRInd {
                   psmlt = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0s) * kap * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d)) /
                     morr_arr(i,j,k,MORRInd::xlf) * (m_f1s/(morr_arr(i,j,k,MORRInd::lams)*morr_arr(i,j,k,MORRInd::lams)) +
                            m_f2s * std::sqrt(morr_arr(i,j,k,MORRInd::asn)*morr_arr(i,j,k,MORRInd::rho)/morr_arr(i,j,k,MORRInd::mu)) *
-                           std::pow(sc_schmidt, one/three) * m_cons10 /
+                           std::pow(sc_schmidt, one_d/three_d) * m_cons10 /
                            std::pow(morr_arr(i,j,k,MORRInd::lams), m_cons35)) + dum;
 
                   // IN WATER SUBSATURATION, SNOW MELTS AND EVAPORATES
-                  if (qvqvs < one) {
+                  if (qvqvs < one_d) {
                     epss = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0s) * morr_arr(i,j,k,MORRInd::rho) * dv *
                       (m_f1s/(morr_arr(i,j,k,MORRInd::lams)*morr_arr(i,j,k,MORRInd::lams)) +
                        m_f2s * std::sqrt(morr_arr(i,j,k,MORRInd::asn)*morr_arr(i,j,k,MORRInd::rho)/morr_arr(i,j,k,MORRInd::mu)) *
-                       std::pow(sc_schmidt, one/three) * m_cons10 /
+                       std::pow(sc_schmidt, one_d/three_d) * m_cons10 /
                        std::pow(morr_arr(i,j,k,MORRInd::lams), m_cons35));
 
                     // hm fix 8/4/08
@@ -1343,15 +1343,15 @@ namespace MORRInd {
                   pgmlt = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0g) * kap * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d)) /
                     morr_arr(i,j,k,MORRInd::xlf) * (m_f1s/(morr_arr(i,j,k,MORRInd::lamg)*morr_arr(i,j,k,MORRInd::lamg)) +
                            m_f2s * std::sqrt(morr_arr(i,j,k,MORRInd::agn)*morr_arr(i,j,k,MORRInd::rho)/morr_arr(i,j,k,MORRInd::mu)) *
-                           std::pow(sc_schmidt, one/three) * m_cons11 /
+                           std::pow(sc_schmidt, one_d/three_d) * m_cons11 /
                            std::pow(morr_arr(i,j,k,MORRInd::lamg), m_cons36)) + dum;
 
                   // IN WATER SUBSATURATION, GRAUPEL MELTS AND EVAPORATES
-                  if (qvqvs < one) {
+                  if (qvqvs < one_d) {
                     epsg = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0g) * morr_arr(i,j,k,MORRInd::rho) * dv *
                       (m_f1s/(morr_arr(i,j,k,MORRInd::lamg)*morr_arr(i,j,k,MORRInd::lamg)) +
                        m_f2s * std::sqrt(morr_arr(i,j,k,MORRInd::agn)*morr_arr(i,j,k,MORRInd::rho)/morr_arr(i,j,k,MORRInd::mu)) *
-                       std::pow(sc_schmidt, one/three) * m_cons11 /
+                       std::pow(sc_schmidt, one_d/three_d) * m_cons11 /
                        std::pow(morr_arr(i,j,k,MORRInd::lamg), m_cons36));
 
                     // hm fix 8/4/08
@@ -1429,31 +1429,31 @@ namespace MORRInd {
 
                 if (pre < Real(0)) {
                   dum = pre * dt / morr_arr(i,j,k,MORRInd::qr3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsubr = dum * morr_arr(i,j,k,MORRInd::nr3d) / dt;
                 }
 
                 if (evpms + psmlt < Real(0)) {
                   dum = (evpms + psmlt) * dt / morr_arr(i,j,k,MORRInd::qni3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsmlts = dum * morr_arr(i,j,k,MORRInd::ns3d) / dt;
                 }
 
                 if (psmlt < Real(0)) {
                   dum = psmlt * dt / morr_arr(i,j,k,MORRInd::qni3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsmltr = dum * morr_arr(i,j,k,MORRInd::ns3d) / dt;
                 }
 
                 if (evpmg + pgmlt < Real(0)) {
                   dum = (evpmg + pgmlt) * dt / morr_arr(i,j,k,MORRInd::qg3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   ngmltg = dum * morr_arr(i,j,k,MORRInd::ng3d) / dt;
                 }
 
                 if (pgmlt < Real(0)) {
                   dum = pgmlt * dt / morr_arr(i,j,k,MORRInd::qg3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   ngmltr = dum * morr_arr(i,j,k,MORRInd::ng3d) / dt;
                 }
 
@@ -1477,7 +1477,7 @@ namespace MORRInd {
 
                 // Saturation adjustment for liquid
                 dums = dumqv - dumqss;
-                pcc = dums / (one + amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::xxlv)) * dumqss / (morr_arr(i,j,k,MORRInd::cpm) * m_Rv * amrex::Math::powi<2>(dumt))) / dt;
+                pcc = dums / (one_d + amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::xxlv)) * dumqss / (morr_arr(i,j,k,MORRInd::cpm) * m_Rv * amrex::Math::powi<2>(dumt))) / dt;
                 if (pcc * dt + dumqc < Real(0)) {
                   pcc = -dumqc / dt;
                 }
@@ -1511,7 +1511,7 @@ namespace MORRInd {
               // Rain
               if (morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
                 // Calculate lambda parameter using cons26 (pi*rhow/6)
-                morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one/three);
+                morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one_d/three_d);
 
                 // Check for slope and adjust vars
                 if (morr_arr(i,j,k,MORRInd::lamr) < m_lamminr) {
@@ -1536,31 +1536,31 @@ namespace MORRInd {
 
                 // MARTIN ET AL. (1994) FORMULA FOR PGAM (WRF implementation)
                 morr_arr(i,j,k,MORRInd::pgam) = Real(0.0005714)*(morr_arr(i,j,k,MORRInd::nc3d)/Real(1.0e6)*dum) + Real(0.2714);
-                morr_arr(i,j,k,MORRInd::pgam) = one/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::pgam))) - one;
+                morr_arr(i,j,k,MORRInd::pgam) = one_d/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::pgam))) - one_d;
                 morr_arr(i,j,k,MORRInd::pgam) = amrex::max(morr_arr(i,j,k,MORRInd::pgam), Real(2));
                 morr_arr(i,j,k,MORRInd::pgam) = amrex::min(morr_arr(i,j,k,MORRInd::pgam), Real(10.0));
 
                 // Calculate gamma function values
-                Real gamma_pgam_plus_1 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one);
+                Real gamma_pgam_plus_1 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d);
                 Real gamma_pgam_plus_4 = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0));
 
                 // Calculate lambda parameter
-                morr_arr(i,j,k,MORRInd::lamc) = std::pow((m_cons26 * morr_arr(i,j,k,MORRInd::nc3d) * gamma_pgam_plus_4) / (morr_arr(i,j,k,MORRInd::qc3d) * gamma_pgam_plus_1), one/three);
+                morr_arr(i,j,k,MORRInd::lamc) = std::pow((m_cons26 * morr_arr(i,j,k,MORRInd::nc3d) * gamma_pgam_plus_4) / (morr_arr(i,j,k,MORRInd::qc3d) * gamma_pgam_plus_1), one_d/three_d);
 
                 // Lambda bounds from WRF - 60 micron max diameter, 1 micron min diameter
-                Real lambda_min = (morr_arr(i,j,k,MORRInd::pgam) + one)/Real(60.0e-6);
-                Real lambda_max = (morr_arr(i,j,k,MORRInd::pgam) + one)/Real(1.0e-6);
+                Real lambda_min = (morr_arr(i,j,k,MORRInd::pgam) + one_d)/Real(60.0e-6);
+                Real lambda_max = (morr_arr(i,j,k,MORRInd::pgam) + one_d)/Real(1.0e-6);
 
                 // Check bounds and update number concentration if needed
                 if (morr_arr(i,j,k,MORRInd::lamc) < lambda_min) {
                   morr_arr(i,j,k,MORRInd::lamc) = lambda_min;
                   // Update cloud droplet number using the same formula as in WRF
-                  morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                  morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
                                     std::log(gamma_pgam_plus_1) - std::log(gamma_pgam_plus_4))/ m_cons26;
                 } else if (morr_arr(i,j,k,MORRInd::lamc) > lambda_max) {
                   morr_arr(i,j,k,MORRInd::lamc) = lambda_max;
                   // Update cloud droplet number using the same formula as in WRF
-                  morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                  morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d*std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
                                     std::log(gamma_pgam_plus_1) - std::log(gamma_pgam_plus_4))/ m_cons26;
                 }
 
@@ -1571,7 +1571,7 @@ namespace MORRInd {
               // Snow
               if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
                 // Calculate lambda parameter
-                morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one/ds0);
+                morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one_d/ds0);
 
                 // Calculate intercept parameter
                 morr_arr(i,j,k,MORRInd::n0s) = morr_arr(i,j,k,MORRInd::ns3d) * morr_arr(i,j,k,MORRInd::lams);
@@ -1591,7 +1591,7 @@ namespace MORRInd {
               // Cloud ice
               if (morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall) {
                 // Calculate lambda parameter
-                morr_arr(i,j,k,MORRInd::lami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::ni3d) / morr_arr(i,j,k,MORRInd::qi3d), one/three);
+                morr_arr(i,j,k,MORRInd::lami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::ni3d) / morr_arr(i,j,k,MORRInd::qi3d), one_d/three_d);
 
                 // Calculate intercept parameter (initial calculation)
                 morr_arr(i,j,k,MORRInd::n0i) = morr_arr(i,j,k,MORRInd::ni3d) * morr_arr(i,j,k,MORRInd::lami);
@@ -1614,7 +1614,7 @@ namespace MORRInd {
               // Graupel
               if (morr_arr(i,j,k,MORRInd::qg3d) >= m_qsmall) {
                 // Calculate lambda parameter
-                morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one/dg0);
+                morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one_d/dg0);
 
                 // Calculate intercept parameter
                 morr_arr(i,j,k,MORRInd::n0g) = morr_arr(i,j,k,MORRInd::ng3d) * morr_arr(i,j,k,MORRInd::lamg);
@@ -1707,7 +1707,7 @@ namespace MORRInd {
 
                   // EFFECTIVE DIFFUSIVITY OF CONTACT NUCLEI
                   // BASED ON BROWNIAN DIFFUSION
-                  Real dap = m_cons37 * morr_arr(i,j,k,MORRInd::t3d) * (one + dum / m_rin) / morr_arr(i,j,k,MORRInd::mu);
+                  Real dap = m_cons37 * morr_arr(i,j,k,MORRInd::t3d) * (one_d + dum / m_rin) / morr_arr(i,j,k,MORRInd::mu);
 
                   // CONTACT FREEZING
                   mnuccc = m_cons38 * dap * nacnt * std::exp(std::log(morr_arr(i,j,k,MORRInd::cdist1)) +
@@ -1719,11 +1719,11 @@ namespace MORRInd {
                   // hm 7/15/13 fix for consistency w/ original formula
                   mnuccc = mnuccc + m_cons39 *
                     std::exp(std::log(morr_arr(i,j,k,MORRInd::cdist1)) + std::log(gamma_function(Real(7.0) + morr_arr(i,j,k,MORRInd::pgam))) - Real(6.0) * std::log(morr_arr(i,j,k,MORRInd::lamc))) *
-                    (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one);
+                    (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one_d);
 
                   nnuccc = nnuccc +
-                    m_cons40 * std::exp(std::log(morr_arr(i,j,k,MORRInd::cdist1)) + std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0))) - three * std::log(morr_arr(i,j,k,MORRInd::lamc))) *
-                    (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one);
+                    m_cons40 * std::exp(std::log(morr_arr(i,j,k,MORRInd::cdist1)) + std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0))) - three_d * std::log(morr_arr(i,j,k,MORRInd::lamc))) *
+                    (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one_d);
 
                   // PUT IN A CATCH HERE TO PREVENT DIVERGENCE BETWEEN NUMBER CONC. AND
                   // MIXING RATIO, SINCE STRICT CONSERVATION NOT CHECKED FOR NUMBER CONC
@@ -1755,9 +1755,9 @@ namespace MORRInd {
                 // SNOW AGGREGATION FROM PASSARELLI, 1978, USED BY REISNER, 1998
                 // THIS IS HARD-WIRED FOR BS = Real(0.4) FOR NOW
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= Real(1.0e-8)) {
-                  nsagg = m_cons15 * morr_arr(i,j,k,MORRInd::asn) * std::pow(morr_arr(i,j,k,MORRInd::rho), ((Real(2) + m_bs) / three)) *
-                    std::pow(morr_arr(i,j,k,MORRInd::qni3d), ((Real(2) + m_bs) / three)) *
-                    std::pow((morr_arr(i,j,k,MORRInd::ns3d) * morr_arr(i,j,k,MORRInd::rho)), ((Real(4.0) - m_bs) / three)) / morr_arr(i,j,k,MORRInd::rho);
+                  nsagg = m_cons15 * morr_arr(i,j,k,MORRInd::asn) * std::pow(morr_arr(i,j,k,MORRInd::rho), ((Real(2) + m_bs) / three_d)) *
+                    std::pow(morr_arr(i,j,k,MORRInd::qni3d), ((Real(2) + m_bs) / three_d)) *
+                    std::pow((morr_arr(i,j,k,MORRInd::ns3d) * morr_arr(i,j,k,MORRInd::rho)), ((Real(4.0) - m_bs) / three_d)) / morr_arr(i,j,k,MORRInd::rho);
                 }
 
                 // ACCRETION OF CLOUD DROPLETS ONTO SNOW/GRAUPEL
@@ -1767,19 +1767,19 @@ namespace MORRInd {
                 // SNOW
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= Real(1.0e-8) && morr_arr(i,j,k,MORRInd::qc3d) >= m_qsmall) {
                   psacws = m_cons13 * morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::qc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                    morr_arr(i,j,k,MORRInd::n0s) / std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three));
+                    morr_arr(i,j,k,MORRInd::n0s) / std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three_d));
 
                   npsacws = m_cons13 * morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::nc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                    morr_arr(i,j,k,MORRInd::n0s) / std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three));
+                    morr_arr(i,j,k,MORRInd::n0s) / std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three_d));
                 }
 
                 // COLLECTION OF CLOUD WATER BY GRAUPEL
                 if (morr_arr(i,j,k,MORRInd::qg3d) >= Real(1.0e-8) && morr_arr(i,j,k,MORRInd::qc3d) >= m_qsmall) {
                   psacwg = m_cons14 * morr_arr(i,j,k,MORRInd::agn) * morr_arr(i,j,k,MORRInd::qc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                    morr_arr(i,j,k,MORRInd::n0g) / std::pow(morr_arr(i,j,k,MORRInd::lamg), (m_bg + three));
+                    morr_arr(i,j,k,MORRInd::n0g) / std::pow(morr_arr(i,j,k,MORRInd::lamg), (m_bg + three_d));
 
                   npsacwg = m_cons14 * morr_arr(i,j,k,MORRInd::agn) * morr_arr(i,j,k,MORRInd::nc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                    morr_arr(i,j,k,MORRInd::n0g) / std::pow(morr_arr(i,j,k,MORRInd::lamg), (m_bg + three));
+                    morr_arr(i,j,k,MORRInd::n0g) / std::pow(morr_arr(i,j,k,MORRInd::lamg), (m_bg + three_d));
                 }
                 // hm, add 12/13/06
                 // CLOUD ICE COLLECTING DROPLETS, ASSUME THAT CLOUD ICE MEAN DIAM > 100 MICRON
@@ -1789,12 +1789,12 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qi3d) >= Real(1.0e-8) && morr_arr(i,j,k,MORRInd::qc3d) >= m_qsmall) {
                   // PUT IN SIZE DEPENDENT COLLECTION EFFICIENCY BASED ON STOKES LAW
                   // FROM THOMPSON ET AL. 2004, MWR
-                  if (one / morr_arr(i,j,k,MORRInd::lami) >= Real(100.0e-6)) {
+                  if (one_d / morr_arr(i,j,k,MORRInd::lami) >= Real(100.0e-6)) {
                     psacwi = m_cons16 * morr_arr(i,j,k,MORRInd::ain) * morr_arr(i,j,k,MORRInd::qc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                      morr_arr(i,j,k,MORRInd::n0i) / std::pow(morr_arr(i,j,k,MORRInd::lami), (m_bi + three));
+                      morr_arr(i,j,k,MORRInd::n0i) / std::pow(morr_arr(i,j,k,MORRInd::lami), (m_bi + three_d));
 
                     npsacwi = m_cons16 * morr_arr(i,j,k,MORRInd::ain) * morr_arr(i,j,k,MORRInd::nc3d) * morr_arr(i,j,k,MORRInd::rho) *
-                      morr_arr(i,j,k,MORRInd::n0i) / std::pow(morr_arr(i,j,k,MORRInd::lami), (m_bi + three));
+                      morr_arr(i,j,k,MORRInd::n0i) / std::pow(morr_arr(i,j,k,MORRInd::lami), (m_bi + three_d));
                   }
                 }
 
@@ -1818,13 +1818,13 @@ namespace MORRInd {
                                                 Real(0.08) * ums_local * umr_local) * morr_arr(i,j,k,MORRInd::rho) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0s) /
                                       amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * (Real(5.0) / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lams)) +
                                                            Real(2) / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lams))) +
-                                                           myhalf / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)))));
+                                                           myhalf_d / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)))));
 
                   npracs = m_cons32 * morr_arr(i,j,k,MORRInd::rho) * std::sqrt(Real(1.7) * amrex::Math::powi<2>(unr_local - uns_local) +
                                                              Real(0.3) * unr_local * uns_local) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0s) *
-                    (one / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lams)) +
-                     one / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lams))) +
-                     one / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams))));
+                    (one_d / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lams)) +
+                     one_d / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lams))) +
+                     one_d / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams))));
 
                   // MAKE SURE PRACS DOESN'T EXCEED TOTAL RAIN MIXING RATIO
                   // AS THIS MAY OTHERWISE RESULT IN TOO MUCH TRANSFER OF WATER DURING
@@ -1839,7 +1839,7 @@ namespace MORRInd {
                                                   Real(0.08) * ums_local * umr_local) * morr_arr(i,j,k,MORRInd::rho) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0s) /
                                         amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)) * (Real(5.0) / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lams)) * morr_arr(i,j,k,MORRInd::lamr)) +
                                                              Real(2) / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lams)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr))) +
-                                                             myhalf / (morr_arr(i,j,k,MORRInd::lams) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)))));
+                                                             myhalf_d / (morr_arr(i,j,k,MORRInd::lams) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)))));
                   }
                 }
 
@@ -1863,13 +1863,13 @@ namespace MORRInd {
                                                 Real(0.08) * umg_local * umr_local) * morr_arr(i,j,k,MORRInd::rho) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0g) /
                                       amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * (Real(5.0) / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
                                                            Real(2) / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
-                                                           myhalf / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
+                                                           myhalf_d / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg)))));
 
                   npracg = m_cons32 * morr_arr(i,j,k,MORRInd::rho) * std::sqrt(Real(1.7) * amrex::Math::powi<2>(unr_local - ung_local) +
                                                              Real(0.3) * unr_local * ung_local) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::n0g) *
-                    (one / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
-                     one / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
-                     one / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg))));
+                    (one_d / (amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::lamg)) +
+                     one_d / (amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamr)) * amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::lamg))) +
+                     one_d / (morr_arr(i,j,k,MORRInd::lamr) * amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamg))));
 
                   // MAKE SURE PRACG DOESN'T EXCEED TOTAL RAIN MIXING RATIO
                   // AS THIS MAY OTHERWISE RESULT IN TOO MUCH TRANSFER OF WATER DURING
@@ -1895,7 +1895,7 @@ namespace MORRInd {
                         } else if (morr_arr(i,j,k,MORRInd::t3d) <= Real(270.16) && morr_arr(i,j,k,MORRInd::t3d) > Real(268.16)) {
                           fmult = (Real(270.16) - morr_arr(i,j,k,MORRInd::t3d)) / Real(2);
                         } else if (morr_arr(i,j,k,MORRInd::t3d) >= Real(265.16) && morr_arr(i,j,k,MORRInd::t3d) <= Real(268.16)) {
-                          fmult = (morr_arr(i,j,k,MORRInd::t3d) - Real(265.16)) / three;
+                          fmult = (morr_arr(i,j,k,MORRInd::t3d) - Real(265.16)) / three_d;
                         } else if (morr_arr(i,j,k,MORRInd::t3d) < Real(265.16)) {
                           fmult = Real(0);
                         }
@@ -1944,7 +1944,7 @@ namespace MORRInd {
                         } else if (morr_arr(i,j,k,MORRInd::t3d) <= Real(270.16) && morr_arr(i,j,k,MORRInd::t3d) > Real(268.16)) {
                           fmult = (Real(270.16) - morr_arr(i,j,k,MORRInd::t3d)) / Real(2);
                         } else if (morr_arr(i,j,k,MORRInd::t3d) >= Real(265.16) && morr_arr(i,j,k,MORRInd::t3d) <= Real(268.16)) {
-                          fmult = (morr_arr(i,j,k,MORRInd::t3d) - Real(265.16)) / three;
+                          fmult = (morr_arr(i,j,k,MORRInd::t3d) - Real(265.16)) / three_d;
                         } else if (morr_arr(i,j,k,MORRInd::t3d) < Real(265.16)) {
                           fmult = Real(0);
                         }
@@ -2009,8 +2009,8 @@ namespace MORRInd {
                     dum = std::min(dum, Real(1));
                     dum = std::max(dum, Real(0));
 
-                    pgracs = (one - dum) * pracs;
-                    ngracs = (one - dum) * npracs;
+                    pgracs = (one_d - dum) * pracs;
+                    ngracs = (one_d - dum) * npracs;
 
                     // LIMIT MAX NUMBER CONVERTED TO MIN OF EITHER RAIN OR SNOW NUMBER CONCENTRATION
                     ngracs = std::min(ngracs, morr_arr(i,j,k,MORRInd::nr3d) / dt);
@@ -2021,7 +2021,7 @@ namespace MORRInd {
                     npracs = npracs - ngracs;
 
                     // CONVERSION TO GRAUPEL DUE TO COLLECTION OF SNOW BY RAIN
-                    psacr = psacr * (one - dum);
+                    psacr = psacr * (one_d - dum);
                   }
                 }
 
@@ -2030,10 +2030,10 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::t3d) < Real(269.15) && morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
                   // IMMERSION FREEZING (BIGG 1953)
                   // hm fix 7/15/13 for consistency w/ original formula
-                  mnuccr = m_cons20 * morr_arr(i,j,k,MORRInd::nr3d) * (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one) /
+                  mnuccr = m_cons20 * morr_arr(i,j,k,MORRInd::nr3d) * (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one_d) /
                     amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr));
 
-                  nnuccr = m_pi * morr_arr(i,j,k,MORRInd::nr3d) * m_bimm * (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one) /
+                  nnuccr = m_pi * morr_arr(i,j,k,MORRInd::nr3d) * m_bimm * (std::exp(m_aimm * (Real(273.15) - morr_arr(i,j,k,MORRInd::t3d))) - one_d) /
                     amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr));
 
                   // PREVENT DIVERGENCE BETWEEN MIXING RATIO AND NUMBER CONC
@@ -2058,10 +2058,10 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qr3d) >= Real(1.0e-8)) {
                   // include breakup add 10/09/09
                   dum1 = Real(300.0e-6);
-                  if (one / morr_arr(i,j,k,MORRInd::lamr) < dum1) {
-                    dum = one;
-                  } else if (one / morr_arr(i,j,k,MORRInd::lamr) >= dum1) {
-                    dum = Real(2) - std::exp(Real(2300.0) * (one / morr_arr(i,j,k,MORRInd::lamr) - dum1));
+                  if (one_d / morr_arr(i,j,k,MORRInd::lamr) < dum1) {
+                    dum = one_d;
+                  } else if (one_d / morr_arr(i,j,k,MORRInd::lamr) >= dum1) {
+                    dum = Real(2) - std::exp(Real(2300.0) * (one_d / morr_arr(i,j,k,MORRInd::lamr) - dum1));
                   }
                   nragg = -Real(5.78) * dum * morr_arr(i,j,k,MORRInd::nr3d) * morr_arr(i,j,k,MORRInd::qr3d) * morr_arr(i,j,k,MORRInd::rho);
                 }
@@ -2070,7 +2070,7 @@ namespace MORRInd {
                 // FOLLOWING HARRINGTON ET AL. (1995) WITH MODIFICATION
                 // HERE IT IS ASSUMED THAT AUTOCONVERSION CAN ONLY OCCUR WHEN THE
                 // ICE IS GROWING, I.E. IN CONDITIONS OF ICE SUPERSATURATION
-                if (morr_arr(i,j,k,MORRInd::qi3d) >= Real(1.0e-8) && qvqvsi >= one) {
+                if (morr_arr(i,j,k,MORRInd::qi3d) >= Real(1.0e-8) && qvqvsi >= one_d) {
                   nprci = m_cons21 * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) * morr_arr(i,j,k,MORRInd::rho) *
                     morr_arr(i,j,k,MORRInd::n0i) * std::exp(-morr_arr(i,j,k,MORRInd::lami) * m_dcs) * dv / abi;
                   prci = m_cons22 * nprci;
@@ -2082,10 +2082,10 @@ namespace MORRInd {
                 // AND DS >> DI FOR CONTINUOUS COLLECTION
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= Real(1.0e-8) && morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall) {
                   prai = m_cons23 * morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::qi3d) * morr_arr(i,j,k,MORRInd::rho) * morr_arr(i,j,k,MORRInd::n0s) /
-                    std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three));
+                    std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three_d));
                   nprai = m_cons23 * morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::ni3d) *
                     morr_arr(i,j,k,MORRInd::rho) * morr_arr(i,j,k,MORRInd::n0s) /
-                    std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three));
+                    std::pow(morr_arr(i,j,k,MORRInd::lams), (m_bs + three_d));
                   nprai = std::min(nprai, morr_arr(i,j,k,MORRInd::ni3d) / dt);
                 }
 
@@ -2097,20 +2097,20 @@ namespace MORRInd {
                   // otherwise add to snow
                   if (morr_arr(i,j,k,MORRInd::qr3d) >= Real(0.1e-3)) {
                     niacr = m_cons24 * morr_arr(i,j,k,MORRInd::ni3d) * morr_arr(i,j,k,MORRInd::n0r)* morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) * morr_arr(i,j,k,MORRInd::rho);
                     piacr = m_cons25 * morr_arr(i,j,k,MORRInd::ni3d) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::rho);
                     praci = m_cons24 * morr_arr(i,j,k,MORRInd::qi3d) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) * morr_arr(i,j,k,MORRInd::rho);
                     niacr = std::min(niacr, morr_arr(i,j,k,MORRInd::nr3d) / dt);
                     niacr = std::min(niacr, morr_arr(i,j,k,MORRInd::ni3d) / dt);
                   } else {
                     niacrs = m_cons24 * morr_arr(i,j,k,MORRInd::ni3d) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) * morr_arr(i,j,k,MORRInd::rho);
                     piacrs = m_cons25 * morr_arr(i,j,k,MORRInd::ni3d) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) / amrex::Math::powi<3>(morr_arr(i,j,k,MORRInd::lamr)) * morr_arr(i,j,k,MORRInd::rho);
                     pracis = m_cons24 * morr_arr(i,j,k,MORRInd::qi3d) * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::arn) /
-                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three)) * morr_arr(i,j,k,MORRInd::rho);
+                      std::pow(morr_arr(i,j,k,MORRInd::lamr), (m_br + three_d)) * morr_arr(i,j,k,MORRInd::rho);
                     niacrs = std::min(niacrs, morr_arr(i,j,k,MORRInd::nr3d) / dt);
                     niacrs = std::min(niacrs, morr_arr(i,j,k,MORRInd::ni3d) / dt);
                   }
@@ -2132,7 +2132,7 @@ namespace MORRInd {
                     }
                   }
                 } else if (m_inuc == 1) {
-                  if (morr_arr(i,j,k,MORRInd::t3d) < Real(273.15) && qvqvsi > one) {
+                  if (morr_arr(i,j,k,MORRInd::t3d) < Real(273.15) && qvqvsi > one_d) {
                     kc2 = Real(0.16) * Real(1000.0) / morr_arr(i,j,k,MORRInd::rho);  // CONVERT FROM L-1 TO KG-1
                     if (kc2 > morr_arr(i,j,k,MORRInd::ni3d) + morr_arr(i,j,k,MORRInd::ns3d) + morr_arr(i,j,k,MORRInd::ng3d)) {
                       nnuccd = (kc2 - morr_arr(i,j,k,MORRInd::ni3d) - morr_arr(i,j,k,MORRInd::ns3d) - morr_arr(i,j,k,MORRInd::ng3d)) / dt;
@@ -2153,8 +2153,8 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
                   epss = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0s) * morr_arr(i,j,k,MORRInd::rho) * dv *
                     (m_f1s / (morr_arr(i,j,k,MORRInd::lams) * morr_arr(i,j,k,MORRInd::lams)) +
-                     m_f2s * std::pow(morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf) *
-                     std::pow(sc_schmidt, (one / three)) * m_cons10 /
+                     m_f2s * std::pow(morr_arr(i,j,k,MORRInd::asn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf_d) *
+                     std::pow(sc_schmidt, (one_d / three_d)) * m_cons10 /
                      std::pow(morr_arr(i,j,k,MORRInd::lams), m_cons35));
                 }
 
@@ -2163,8 +2163,8 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qg3d) >= m_qsmall) {
                   epsg = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0g) * morr_arr(i,j,k,MORRInd::rho) * dv *
                     (m_f1s / (morr_arr(i,j,k,MORRInd::lamg) * morr_arr(i,j,k,MORRInd::lamg)) +
-                     m_f2s * std::pow(morr_arr(i,j,k,MORRInd::agn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf) *
-                     std::pow(sc_schmidt, (one / three)) * m_cons11 /
+                     m_f2s * std::pow(morr_arr(i,j,k,MORRInd::agn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf_d) *
+                     std::pow(sc_schmidt, (one_d / three_d)) * m_cons11 /
                      std::pow(morr_arr(i,j,k,MORRInd::lamg), m_cons36));
                 }
 
@@ -2173,8 +2173,8 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
                   epsr = Real(2) * m_pi * morr_arr(i,j,k,MORRInd::n0r) * morr_arr(i,j,k,MORRInd::rho) * dv *
                     (m_f1r / (morr_arr(i,j,k,MORRInd::lamr) * morr_arr(i,j,k,MORRInd::lamr)) +
-                     m_f2r * std::pow(morr_arr(i,j,k,MORRInd::arn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf) *
-                     std::pow(sc_schmidt, (one / three)) * m_cons9 /
+                     m_f2r * std::pow(morr_arr(i,j,k,MORRInd::arn) * morr_arr(i,j,k,MORRInd::rho) / morr_arr(i,j,k,MORRInd::mu), myhalf_d) *
+                     std::pow(sc_schmidt, (one_d / three_d)) * m_cons9 /
                      std::pow(morr_arr(i,j,k,MORRInd::lamr), m_cons34));
                 }
 
@@ -2182,7 +2182,7 @@ namespace MORRInd {
                 // DUM IS FRACTION OF D*N(D) < DCS
                 // LOGIC BELOW FOLLOWS THAT OF HARRINGTON ET AL. 1995 (JAS)
                 if (morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall) {
-                  dum = (one - std::exp(-morr_arr(i,j,k,MORRInd::lami) * m_dcs) * (one + morr_arr(i,j,k,MORRInd::lami) * m_dcs));
+                  dum = (one_d - std::exp(-morr_arr(i,j,k,MORRInd::lami) * m_dcs) * (one_d + morr_arr(i,j,k,MORRInd::lami) * m_dcs));
                   prd = epsi * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi * dum;
                 } else {
                   dum = Real(0);
@@ -2191,10 +2191,10 @@ namespace MORRInd {
                 // ADD DEPOSITION IN TAIL OF ICE SIZE DIST TO SNOW IF SNOW IS PRESENT
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
                   prds = epss * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi +
-                    epsi * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi * (one - dum);
+                    epsi * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi * (one_d - dum);
                 } else {
                   // OTHERWISE ADD TO CLOUD ICE
-                  prd = prd + epsi * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi * (one - dum);
+                  prd = prd + epsi * (morr_arr(i,j,k,MORRInd::qv3d) - qvi) / abi * (one_d - dum);
                 }
 
                 // VAPOR DPEOSITION ON GRAUPEL
@@ -2442,7 +2442,7 @@ namespace MORRInd {
                   // SATURATION ADJUSTMENT FOR LIQUID
                   dums = dumqv - dumqss;
 
-                  pcc = dums / (one + amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::xxlv)) * dumqss / (morr_arr(i,j,k,MORRInd::cpm) * m_Rv * amrex::Math::powi<2>(dumt))) / dt;
+                  pcc = dums / (one_d + amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::xxlv)) * dumqss / (morr_arr(i,j,k,MORRInd::cpm) * m_Rv * amrex::Math::powi<2>(dumt))) / dt;
 
                   if (pcc * dt + dumqc < Real(0)) {
                     pcc = -dumqc / dt;
@@ -2457,25 +2457,25 @@ namespace MORRInd {
                 // LOSS OF NUMBER CONCENTRATION
                 if (eprd < Real(0)) {
                   dum = eprd * dt / morr_arr(i,j,k,MORRInd::qi3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsubi = dum * morr_arr(i,j,k,MORRInd::ni3d) / dt;
                 }
 
                 if (eprds < Real(0)) {
                   dum = eprds * dt / morr_arr(i,j,k,MORRInd::qni3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsubs = dum * morr_arr(i,j,k,MORRInd::ns3d) / dt;
                 }
 
                 if (pre < Real(0)) {
                   dum = pre * dt / morr_arr(i,j,k,MORRInd::qr3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsubr = dum * morr_arr(i,j,k,MORRInd::nr3d) / dt;
                 }
 
                 if (eprdg < Real(0)) {
                   dum = eprdg * dt / morr_arr(i,j,k,MORRInd::qg3d);
-                  dum = std::max(-one, dum);
+                  dum = std::max(-one_d, dum);
                   nsubg = dum * morr_arr(i,j,k,MORRInd::ng3d) / dt;
                 }
 
@@ -2518,9 +2518,9 @@ namespace MORRInd {
               Real lammax;             // LAMMAX: Maximum value for slope parameter
               Real lammin;             // LAMMIN: Minimum value for slope parameter
 
-              ds0 = three;       // Size distribution parameter for snow
-              di0 = three;       // Size distribution parameter for cloud ice
-              dg0 = three;       // Size distribution parameter for graupel
+              ds0 = three_d;       // Size distribution parameter for snow
+              di0 = three_d;       // Size distribution parameter for cloud ice
+              dg0 = three_d;       // Size distribution parameter for graupel
 
               // Update prognostic variables with tendencies
               morr_arr(i,j,k,MORRInd::dumi) = morr_arr(i,j,k,MORRInd::qi3d) + morr_arr(i,j,k,MORRInd::qi3dten) * dt;
@@ -2548,14 +2548,14 @@ namespace MORRInd {
 
               // CLOUD ICE
               if (morr_arr(i,j,k,MORRInd::dumi) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::dlami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::dumfni) / morr_arr(i,j,k,MORRInd::dumi), one/di0);
+                morr_arr(i,j,k,MORRInd::dlami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::dumfni) / morr_arr(i,j,k,MORRInd::dumi), one_d/di0);
                 morr_arr(i,j,k,MORRInd::dlami) = amrex::max(morr_arr(i,j,k,MORRInd::dlami), m_lammini);
                 morr_arr(i,j,k,MORRInd::dlami) = amrex::min(morr_arr(i,j,k,MORRInd::dlami), m_lammaxi);
               }
 
               // RAIN
               if (morr_arr(i,j,k,MORRInd::dumr) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::dlamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::dumfnr) / morr_arr(i,j,k,MORRInd::dumr), one/three);
+                morr_arr(i,j,k,MORRInd::dlamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::dumfnr) / morr_arr(i,j,k,MORRInd::dumr), one_d/three_d);
                 morr_arr(i,j,k,MORRInd::dlamr) = amrex::max(morr_arr(i,j,k,MORRInd::dlamr), m_lamminr);
                 morr_arr(i,j,k,MORRInd::dlamr) = amrex::min(morr_arr(i,j,k,MORRInd::dlamr), m_lammaxr);
               }
@@ -2564,28 +2564,28 @@ namespace MORRInd {
               if (morr_arr(i,j,k,MORRInd::dumc) >= m_qsmall) {
                 dum = morr_arr(i,j,k,MORRInd::pres) / (Real(287.15) * morr_arr(i,j,k,MORRInd::t3d));
                 morr_arr(i,j,k,MORRInd::pgam) = Real(0.0005714) * (morr_arr(i,j,k,MORRInd::nc3d) / Real(1.0e6) * dum) + Real(0.2714);
-                morr_arr(i,j,k,MORRInd::pgam) = one / (morr_arr(i,j,k,MORRInd::pgam) * morr_arr(i,j,k,MORRInd::pgam)) - one;
+                morr_arr(i,j,k,MORRInd::pgam) = one_d / (morr_arr(i,j,k,MORRInd::pgam) * morr_arr(i,j,k,MORRInd::pgam)) - one_d;
                 morr_arr(i,j,k,MORRInd::pgam) = amrex::max(morr_arr(i,j,k,MORRInd::pgam), Real(2));
                 morr_arr(i,j,k,MORRInd::pgam) = amrex::min(morr_arr(i,j,k,MORRInd::pgam), Real(10.0));
 
                 morr_arr(i,j,k,MORRInd::dlamc) = std::pow(m_cons26 * morr_arr(i,j,k,MORRInd::dumfnc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)) /
-                                        (morr_arr(i,j,k,MORRInd::dumc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one)), one/three);
-                lammin = (morr_arr(i,j,k,MORRInd::pgam) + one) / Real(60.0e-6);
-                lammax = (morr_arr(i,j,k,MORRInd::pgam) + one) / Real(1.0e-6);
+                                        (morr_arr(i,j,k,MORRInd::dumc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d)), one_d/three_d);
+                lammin = (morr_arr(i,j,k,MORRInd::pgam) + one_d) / Real(60.0e-6);
+                lammax = (morr_arr(i,j,k,MORRInd::pgam) + one_d) / Real(1.0e-6);
                 morr_arr(i,j,k,MORRInd::dlamc) = amrex::max(morr_arr(i,j,k,MORRInd::dlamc), lammin);
                 morr_arr(i,j,k,MORRInd::dlamc) = amrex::min(morr_arr(i,j,k,MORRInd::dlamc), lammax);
               }
 
               // SNOW
               if (morr_arr(i,j,k,MORRInd::dumqs) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::dlams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::dumfns) / morr_arr(i,j,k,MORRInd::dumqs), one/ds0);
+                morr_arr(i,j,k,MORRInd::dlams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::dumfns) / morr_arr(i,j,k,MORRInd::dumqs), one_d/ds0);
                 morr_arr(i,j,k,MORRInd::dlams) = amrex::max(morr_arr(i,j,k,MORRInd::dlams), m_lammins);
                 morr_arr(i,j,k,MORRInd::dlams) = amrex::min(morr_arr(i,j,k,MORRInd::dlams), m_lammaxs);
               }
 
               // GRAUPEL
               if (morr_arr(i,j,k,MORRInd::dumg) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::dlamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::dumfng) / morr_arr(i,j,k,MORRInd::dumg), one/dg0);
+                morr_arr(i,j,k,MORRInd::dlamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::dumfng) / morr_arr(i,j,k,MORRInd::dumg), one_d/dg0);
                 morr_arr(i,j,k,MORRInd::dlamg) = amrex::max(morr_arr(i,j,k,MORRInd::dlamg), m_lamming);
                 morr_arr(i,j,k,MORRInd::dlamg) = amrex::min(morr_arr(i,j,k,MORRInd::dlamg), m_lammaxg);
               }
@@ -2593,8 +2593,8 @@ namespace MORRInd {
               // Calculate number-weighted and mass-weighted terminal fall speeds
               // CLOUD WATER
               if (morr_arr(i,j,k,MORRInd::dumc) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::unc) = morr_arr(i,j,k,MORRInd::acn) * gamma_function(one + m_bc + morr_arr(i,j,k,MORRInd::pgam)) /
-                             (std::pow(morr_arr(i,j,k,MORRInd::dlamc), m_bc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one));
+                morr_arr(i,j,k,MORRInd::unc) = morr_arr(i,j,k,MORRInd::acn) * gamma_function(one_d + m_bc + morr_arr(i,j,k,MORRInd::pgam)) /
+                             (std::pow(morr_arr(i,j,k,MORRInd::dlamc), m_bc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d));
                 morr_arr(i,j,k,MORRInd::umc) = morr_arr(i,j,k,MORRInd::acn) * gamma_function(Real(4.) + m_bc + morr_arr(i,j,k,MORRInd::pgam)) /
                              (std::pow(morr_arr(i,j,k,MORRInd::dlamc), m_bc) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.)));
               } else {
@@ -2704,7 +2704,7 @@ namespace MORRInd {
                   morr_arr(i,j,k,MORRInd::fg), morr_arr(i,j,k,MORRInd::fng)});
 
               // Calculate number of steps (dt and nstep would need to be defined elsewhere)
-              nstep = std::max(static_cast<int>(morr_arr(i,j,k,MORRInd::rgvm) * dt / morr_arr(i,j,k,MORRInd::dzq) + one), nstep);
+              nstep = std::max(static_cast<int>(morr_arr(i,j,k,MORRInd::rgvm) * dt / morr_arr(i,j,k,MORRInd::dzq) + one_d), nstep);
               // MULTIPLY VARIABLES BY RHO
               morr_arr(i,j,k,MORRInd::dumr) = morr_arr(i,j,k,MORRInd::dumr) * morr_arr(i,j,k,MORRInd::rho);       // Rain water content * density
               morr_arr(i,j,k,MORRInd::dumi) = morr_arr(i,j,k,MORRInd::dumi) * morr_arr(i,j,k,MORRInd::rho);       // Cloud ice content * density
@@ -2840,7 +2840,7 @@ namespace MORRInd {
               // PUT ALL CLOUD ICE IN SNOW CATEGORY IF MEAN DIAMETER EXCEEDS 2 * dcs
               // bug fix
               if (morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall && morr_arr(i,j,k,MORRInd::t3d) < Real(273.15) && morr_arr(i,j,k,MORRInd::lami) >= Real(1.e-10)) {
-                if (one/morr_arr(i,j,k,MORRInd::lami) >= Real(2)*m_dcs) {
+                if (one_d/morr_arr(i,j,k,MORRInd::lami) >= Real(2)*m_dcs) {
                   morr_arr(i,j,k,MORRInd::qni3dten) = morr_arr(i,j,k,MORRInd::qni3dten) + morr_arr(i,j,k,MORRInd::qi3d)/dt + morr_arr(i,j,k,MORRInd::qi3dten);
                   morr_arr(i,j,k,MORRInd::ns3dten) = morr_arr(i,j,k,MORRInd::ns3dten) + morr_arr(i,j,k,MORRInd::ni3d)/dt + morr_arr(i,j,k,MORRInd::ni3dten);
                   morr_arr(i,j,k,MORRInd::qi3dten) = -morr_arr(i,j,k,MORRInd::qi3d)/dt;
@@ -3007,7 +3007,7 @@ namespace MORRInd {
 
                 // CLOUD ICE
                 if (morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall) {
-                  morr_arr(i,j,k,MORRInd::lami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::ni3d) / morr_arr(i,j,k,MORRInd::qi3d), one/m_di);
+                  morr_arr(i,j,k,MORRInd::lami) = std::pow(m_cons12 * morr_arr(i,j,k,MORRInd::ni3d) / morr_arr(i,j,k,MORRInd::qi3d), one_d/m_di);
                   // CHECK FOR SLOPE
                   // ADJUST VARS
                   if (morr_arr(i,j,k,MORRInd::lami) < m_lammini) {
@@ -3023,7 +3023,7 @@ namespace MORRInd {
 
                 // RAIN
                 if (morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
-                  morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one/three);
+                  morr_arr(i,j,k,MORRInd::lamr) = std::pow(m_pi * m_rhow * morr_arr(i,j,k,MORRInd::nr3d) / morr_arr(i,j,k,MORRInd::qr3d), one_d/three_d);
 
                   // CHECK FOR SLOPE
                   // ADJUST VARS
@@ -3043,33 +3043,33 @@ namespace MORRInd {
                 if (morr_arr(i,j,k,MORRInd::qc3d) >= m_qsmall) {
                   Real dum = morr_arr(i,j,k,MORRInd::pres) / (Real(287.15) * morr_arr(i,j,k,MORRInd::t3d));
                   morr_arr(i,j,k,MORRInd::pgam) = Real(0.0005714) * (morr_arr(i,j,k,MORRInd::nc3d) / Real(1.0e6) * dum) + Real(0.2714);
-                  morr_arr(i,j,k,MORRInd::pgam) = one/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::pgam))) - one;
+                  morr_arr(i,j,k,MORRInd::pgam) = one_d/(amrex::Math::powi<2>(morr_arr(i,j,k,MORRInd::pgam))) - one_d;
                   morr_arr(i,j,k,MORRInd::pgam) = std::max(morr_arr(i,j,k,MORRInd::pgam), Real(2));
                   morr_arr(i,j,k,MORRInd::pgam) = std::min(morr_arr(i,j,k,MORRInd::pgam), Real(10.0));
 
                   // CALCULATE LAMC
                   morr_arr(i,j,k,MORRInd::lamc) = std::pow(m_cons26 * morr_arr(i,j,k,MORRInd::nc3d) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)) /
-                                  (morr_arr(i,j,k,MORRInd::qc3d) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one)), one/three);
+                                  (morr_arr(i,j,k,MORRInd::qc3d) * gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d)), one_d/three_d);
 
                   // LAMMIN, 60 MICRON DIAMETER
                   // LAMMAX, 1 MICRON
-                  Real lammin = (morr_arr(i,j,k,MORRInd::pgam) + one) / Real(60.0e-6);
-                  Real lammax = (morr_arr(i,j,k,MORRInd::pgam) + one) / Real(1.0e-6);
+                  Real lammin = (morr_arr(i,j,k,MORRInd::pgam) + one_d) / Real(60.0e-6);
+                  Real lammax = (morr_arr(i,j,k,MORRInd::pgam) + one_d) / Real(1.0e-6);
 
                   if (morr_arr(i,j,k,MORRInd::lamc) < lammin) {
                     morr_arr(i,j,k,MORRInd::lamc) = lammin;
-                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three * std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
-                                           std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one)) - std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)))) / m_cons26;
+                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d * std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                                           std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d)) - std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)))) / m_cons26;
                   } else if (morr_arr(i,j,k,MORRInd::lamc) > lammax) {
                     morr_arr(i,j,k,MORRInd::lamc) = lammax;
-                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three * std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
-                                           std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one)) - std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)))) / m_cons26;
+                    morr_arr(i,j,k,MORRInd::nc3d) = std::exp(three_d * std::log(morr_arr(i,j,k,MORRInd::lamc)) + std::log(morr_arr(i,j,k,MORRInd::qc3d)) +
+                                           std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + one_d)) - std::log(gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)))) / m_cons26;
                   }
                 }
 
                 // SNOW
                 if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
-                  morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one/m_ds);
+                  morr_arr(i,j,k,MORRInd::lams) = std::pow(m_cons1 * morr_arr(i,j,k,MORRInd::ns3d) / morr_arr(i,j,k,MORRInd::qni3d), one_d/m_ds);
 
                   // CHECK FOR SLOPE
                   // ADJUST VARS
@@ -3086,7 +3086,7 @@ namespace MORRInd {
 
                 // GRAUPEL
                 if (morr_arr(i,j,k,MORRInd::qg3d) >= m_qsmall) {
-                  morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one/m_dg);
+                  morr_arr(i,j,k,MORRInd::lamg) = std::pow(m_cons2 * morr_arr(i,j,k,MORRInd::ng3d) / morr_arr(i,j,k,MORRInd::qg3d), one_d/m_dg);
 
                   // CHECK FOR SLOPE
                   // ADJUST VARS
@@ -3105,31 +3105,31 @@ namespace MORRInd {
 //            label_500:
               // CALCULATE EFFECTIVE RADIUS
               if (morr_arr(i,j,k,MORRInd::qi3d) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::effi) = three / morr_arr(i,j,k,MORRInd::lami) / Real(2) * Real(1.0e6);
+                morr_arr(i,j,k,MORRInd::effi) = three_d / morr_arr(i,j,k,MORRInd::lami) / Real(2) * Real(1.0e6);
               } else {
                 morr_arr(i,j,k,MORRInd::effi) = Real(25.0);
               }
 
               if (morr_arr(i,j,k,MORRInd::qni3d) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::effs) = three / morr_arr(i,j,k,MORRInd::lams) / Real(2) * Real(1.0e6);
+                morr_arr(i,j,k,MORRInd::effs) = three_d / morr_arr(i,j,k,MORRInd::lams) / Real(2) * Real(1.0e6);
               } else {
                 morr_arr(i,j,k,MORRInd::effs) = Real(25.0);
               }
 
               if (morr_arr(i,j,k,MORRInd::qr3d) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::effr) = three / morr_arr(i,j,k,MORRInd::lamr) / Real(2) * Real(1.0e6);
+                morr_arr(i,j,k,MORRInd::effr) = three_d / morr_arr(i,j,k,MORRInd::lamr) / Real(2) * Real(1.0e6);
               } else {
                 morr_arr(i,j,k,MORRInd::effr) = Real(25.0);
               }
 
               if (morr_arr(i,j,k,MORRInd::qc3d) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::effc) = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)) / gamma_function(morr_arr(i,j,k,MORRInd::pgam) + three) / morr_arr(i,j,k,MORRInd::lamc) / Real(2) * Real(1.0e6);
+                morr_arr(i,j,k,MORRInd::effc) = gamma_function(morr_arr(i,j,k,MORRInd::pgam) + Real(4.0)) / gamma_function(morr_arr(i,j,k,MORRInd::pgam) + three_d) / morr_arr(i,j,k,MORRInd::lamc) / Real(2) * Real(1.0e6);
               } else {
                 morr_arr(i,j,k,MORRInd::effc) = Real(25.0);
               }
 
               if (morr_arr(i,j,k,MORRInd::qg3d) >= m_qsmall) {
-                morr_arr(i,j,k,MORRInd::effg) = three / morr_arr(i,j,k,MORRInd::lamg) / Real(2) * Real(1.0e6);
+                morr_arr(i,j,k,MORRInd::effg) = three_d / morr_arr(i,j,k,MORRInd::lamg) / Real(2) * Real(1.0e6);
               } else {
                 morr_arr(i,j,k,MORRInd::effg) = Real(25.0);
               }

--- a/Source/Microphysics/SAM/ERF_CloudSAM.cpp
+++ b/Source/Microphysics/SAM/ERF_CloudSAM.cpp
@@ -40,7 +40,7 @@ SAM::Cloud (const SolverChoice& sc)
 
         auto tbx = mfi.tilebox();
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(tbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // Saturation moisture fractions
             Real omn;
@@ -110,9 +110,9 @@ SAM::Cloud (const SolverChoice& sc)
 
                 // Partition the change in non-precipitating q
                  qv_array(i,j,k) += delta_qv;
-                qcl_array(i,j,k)  = zero;
-                qci_array(i,j,k)  = zero;
-                 qn_array(i,j,k)  = zero;
+                qcl_array(i,j,k)  = zero_d;
+                qci_array(i,j,k)  = zero_d;
+                 qn_array(i,j,k)  = zero_d;
                  qt_array(i,j,k)  = qv_array(i,j,k);
 
                 // Update temperature (endothermic since we evap/sublime)

--- a/Source/Microphysics/SAM/ERF_IceFall.cpp
+++ b/Source/Microphysics/SAM/ERF_IceFall.cpp
@@ -43,7 +43,7 @@ void SAM::IceFall (const SolverChoice& sc) {
 
         const auto& box3d  = mfi.tilebox();
 
-        ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(box3d, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
             const Real rho_k = (k == k_hi + 1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
@@ -51,9 +51,9 @@ void SAM::IceFall (const SolverChoice& sc) {
             const Real qci_k = (k == k_hi + 1) ? qci_array(i,j,k-1) : qci_array(i,j,k);
             const SAMFaceState face_state = sam_face_average_state(k, k_lo, k_hi,
                                                                    rho_km1, rho_k,
-                                                                   zero, zero,
+                                                                   zero_d, zero_d,
                                                                    qci_km1, qci_k,
-                                                                   zero, zero);
+                                                                   zero_d, zero_d);
             const Real vt_ice = sam_cloud_ice_terminal_velocity(face_state.qci_avg);
 
             // NOTE: Fz is the sedimentation flux from the advective operator.
@@ -103,7 +103,7 @@ void SAM::IceFall (const SolverChoice& sc) {
             const auto& tbz = mfi.tilebox(IntVect(0,0,1),IntVect(0));
 
             // Update vertical flux every substep
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const Real rho_km1 = (k == k_lo) ? rho_array(i,j,k) : rho_array(i,j,k-1);
                 const Real rho_k = (k == k_hi + 1) ? rho_array(i,j,k-1) : rho_array(i,j,k);
@@ -111,9 +111,9 @@ void SAM::IceFall (const SolverChoice& sc) {
                 const Real qci_k = (k == k_hi + 1) ? qci_array(i,j,k-1) : qci_array(i,j,k);
                 const SAMFaceState face_state = sam_face_average_state(k, k_lo, k_hi,
                                                                        rho_km1, rho_k,
-                                                                       zero, zero,
+                                                                       zero_d, zero_d,
                                                                        qci_km1, qci_k,
-                                                                       zero, zero);
+                                                                       zero_d, zero_d);
                 const Real vt_ice = sam_cloud_ice_terminal_velocity(face_state.qci_avg);
 
                 // NOTE: Fz is the sedimentation flux from the advective operator.
@@ -126,10 +126,10 @@ void SAM::IceFall (const SolverChoice& sc) {
             });
 
             // Update precip every substep
-            ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 // Jacobian determinant
-                Real dJinv = (dJ_array) ? one/dJ_array(i,j,k) : one;
+                Real dJinv = (dJ_array) ? one_d/dJ_array(i,j,k) : one_d;
 
                 //==================================================
                 // Cloud ice sedimentation (A32)
@@ -150,4 +150,3 @@ void SAM::IceFall (const SolverChoice& sc) {
         } // mfi
     } // nsub
 }
-

--- a/Source/Microphysics/SAM/ERF_PrecipFall.cpp
+++ b/Source/Microphysics/SAM/ERF_PrecipFall.cpp
@@ -138,7 +138,7 @@ SAM::PrecipFall (const SolverChoice& sc)
             const auto& tbz = mfi.tilebox(IntVect(0,0,1),IntVect(0));
 
             // Update vertical flux every substep
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbz, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const SAMPrecipComponentFaceState face_state =
                     sam_precip_component_face_state(rho_array, tabs_array,
@@ -152,7 +152,7 @@ SAM::PrecipFall (const SolverChoice& sc)
                                                                  rho_0,
                                                                  face_state.rho_avg);
                 const int donor_k = sam_precip_face_donor_k(k, k_lo, k_hi);
-                const Real detJ_donor = (dJ_array) ? dJ_array(i,j,donor_k) : one;
+                const Real detJ_donor = (dJ_array) ? dJ_array(i,j,donor_k) : one_d;
 
                 // NOTE: Fz is the sedimentation flux from the advective operator.
                 //       In the terrain-following coordinate system, the z-deriv in
@@ -188,10 +188,10 @@ SAM::PrecipFall (const SolverChoice& sc)
             });
 
             // Update precip every substep
-            ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 // Jacobian determinant
-                Real dJinv = (dJ_array) ? one/dJ_array(i,j,k) : one;
+                Real dJinv = (dJ_array) ? one_d/dJ_array(i,j,k) : one_d;
 
                 //==================================================
                 // Precipitating sedimentation (A19)
@@ -215,4 +215,3 @@ SAM::PrecipFall (const SolverChoice& sc)
         } // mfi
     } // nsub
 }
-

--- a/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistPhaseChange.cpp
+++ b/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistPhaseChange.cpp
@@ -117,16 +117,16 @@ void SuperDropletsMoist::phaseChange ( const Real& a_dt,
 
                     auto fac_cond = vapour_mat.m_lat_vap / m_Cp;
 
-                    ParallelFor( bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    ParallelFor( bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
                         if (mask_arr(i,j,k) == 0) return;
                         auto old_qv = qv_arr(i,j,k);
                         if (is == idx_w) {
                             auto qw = qc_arr(i,j,k) + qr_arr(i,j,k);
                             if (qw > qt_arr(i,j,k)) {
-                                qv_arr(i,j,k) = zero;
+                                qv_arr(i,j,k) = zero_d;
                                 if (qr_arr(i,j,k) > qt_arr(i,j,k)) {
-                                    qc_arr(i,j,k) = zero;
+                                    qc_arr(i,j,k) = zero_d;
                                     qr_arr(i,j,k) = qt_arr(i,j,k);
                                 } else {
                                     qc_arr(i,j,k) = qt_arr(i,j,k) - qr_arr(i,j,k);
@@ -134,17 +134,17 @@ void SuperDropletsMoist::phaseChange ( const Real& a_dt,
                             } else {
                                 qv_arr(i,j,k) = qt_arr(i,j,k) - qw;
                             }
-                            AMREX_ALWAYS_ASSERT(qr_arr(i,j,k) >= zero);
+                            AMREX_ALWAYS_ASSERT(qr_arr(i,j,k) >= zero_d);
                         } else {
                             if (qc_arr(i,j,k) > qt_arr(i,j,k)) {
-                                qv_arr(i,j,k) = zero;
+                                qv_arr(i,j,k) = zero_d;
                                 qc_arr(i,j,k) = qt_arr(i,j,k);
                             } else {
                                 qv_arr(i,j,k) = qt_arr(i,j,k) - qc_arr(i,j,k);
                             }
                         }
-                        AMREX_ALWAYS_ASSERT(qv_arr(i,j,k) >= zero);
-                        AMREX_ALWAYS_ASSERT(qc_arr(i,j,k) >= zero);
+                        AMREX_ALWAYS_ASSERT(qv_arr(i,j,k) >= zero_d);
+                        AMREX_ALWAYS_ASSERT(qc_arr(i,j,k) >= zero_d);
 
                         if (is == idx_w) { dqc_arr(i,j,k) = - (qv_arr(i,j,k) - old_qv) / dt_s; }
 

--- a/Source/Microphysics/WSM6/ERF_UpdateWSM6.cpp
+++ b/Source/Microphysics/WSM6/ERF_UpdateWSM6.cpp
@@ -21,8 +21,8 @@ WSM6::Copy_Micro_to_State(MultiFab& cons)
         auto qs = mic_fab_vars[MicVar_WSM6::qs]->array(mfi);
         auto qg = mic_fab_vars[MicVar_WSM6::qg]->array(mfi);
 
-        ParallelFor(box3d, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
-            theta(i,j,k) = getThgivenRandT(rho(i,j,k), tabs(i,j,k), R_d / Cp_d, qv(i,j,k));
+        ParallelFor(box3d, [=,R_d_d=R_d,Cp_d_d=Cp_d] AMREX_GPU_DEVICE(int i, int j, int k) {
+            theta(i,j,k) = getThgivenRandT(rho(i,j,k), tabs(i,j,k), R_d_d / Cp_d_d, qv(i,j,k));
             states(i,j,k,RhoTheta_comp) = rho(i,j,k) * theta(i,j,k);
             states(i,j,k,RhoQ1_comp) = rho(i,j,k) * amrex::max(Real(0), qv(i,j,k));
             states(i,j,k,RhoQ2_comp) = rho(i,j,k) * amrex::max(Real(0), qc(i,j,k));

--- a/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
@@ -224,7 +224,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
         // WRF reference (module_bl_mrf.F lines 813-842):
         // https://github.com/wrf-model/WRF/blob/master/phys/module_bl_mrf.F#L813-L842
         //
-        ParallelFor(xybx, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+        ParallelFor(xybx, [=,myhalf_d=myhalf,fourth_d=fourth,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int) noexcept
         {
             const Real t_layer = t10av_arr(i, j, 0);
             const Real moisture_fraction = use_moisture ? q10av_arr(i, j, 0) : Real(0);
@@ -236,16 +236,16 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
             {
                 zval = (use_terrain_fitted_coords)
                      ? Compute_Zrel_AtCellCenter(i, j, kpbl, z_nd_arr)
-                     : (kpbl + myhalf) * gdata.CellSize(2);
+                     : (kpbl + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
                                               (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) +
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) *
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib = CONST_GRAV * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
+                Rib = CONST_GRAV_d * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
             }
 
             Real zval0 = zval, Rib0 = Rib;
@@ -257,25 +257,25 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
 
                 zval = (use_terrain_fitted_coords)
                      ? Compute_Zrel_AtCellCenter(i, j, kpbl, z_nd_arr)
-                     : (kpbl + myhalf) * gdata.CellSize(2);
+                     : (kpbl + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
                                               (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) +
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) *
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib = CONST_GRAV * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
+                Rib = CONST_GRAV_d * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
                 above_critical = (Rib >= Ribcr);
             }
 
             const Real pblh_emp = (use_terrain_fitted_coords)
                                 ? Compute_Zrel_AtCellCenter(i, j, klo, z_nd_arr)
-                                : myhalf * gdata.CellSize(2);
+                                : myhalf_d * gdata.CellSize(2);
             const Real z_max = (use_terrain_fitted_coords)
                              ? Compute_Zrel_AtCellCenter(i, j, khi, z_nd_arr)
-                             : (khi + myhalf) * gdata.CellSize(2);
+                             : (khi + myhalf_d) * gdata.CellSize(2);
             const Real pblh_max = Real(0.9) * z_max;
             const Real pblh_min = amrex::max(pblh_emp, Real(10.0));
 
@@ -396,7 +396,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
         // WRF reference (module_bl_mrf.F lines 932-964):
         // https://github.com/wrf-model/WRF/blob/master/phys/module_bl_mrf.F#L932-L964
         //
-        ParallelFor(xybx, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+        ParallelFor(xybx, [=,myhalf_d=myhalf,fourth_d=fourth,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int) noexcept
         {
             const Real t_layer  = t10av_arr(i, j, 0);
             const Real moisture_fraction = use_moisture ? q10av_arr(i, j, 0) : Real(0);
@@ -414,16 +414,16 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
             {
                 zval = (use_terrain_fitted_coords)
                      ? Compute_Zrel_AtCellCenter(i, j, kpbl, z_nd_arr)
-                     : (kpbl + myhalf) * gdata.CellSize(2);
+                     : (kpbl + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
                                               (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) +
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) *
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib = CONST_GRAV * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
+                Rib = CONST_GRAV_d * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
             }
             Real zval0 = zval, Rib0 = Rib;         // FIX: initialize here, mirrors Pass 1
 
@@ -435,25 +435,25 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
 
                 zval = (use_terrain_fitted_coords)
                      ? Compute_Zrel_AtCellCenter(i, j, kpbl, z_nd_arr)
-                     : (kpbl + myhalf) * gdata.CellSize(2);
+                     : (kpbl + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) *
                                               (uvel(i, j, kpbl) + uvel(i + 1, j, kpbl)) +
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) *
                                               (vvel(i, j, kpbl) + vvel(i, j + 1, kpbl)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib = CONST_GRAV * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
+                Rib = CONST_GRAV_d * zval * (theta_v - t_layer_v) / (ws2 * theta_v_klo);
                 above_critical = (Rib >= Ribcr);
             }
 
             const Real pblh_emp = (use_terrain_fitted_coords)
                                 ? Compute_Zrel_AtCellCenter(i, j, klo, z_nd_arr)
-                                : myhalf * gdata.CellSize(2);
+                                : myhalf_d * gdata.CellSize(2);
             const Real z_max = (use_terrain_fitted_coords)
                              ? Compute_Zrel_AtCellCenter(i, j, khi, z_nd_arr)
-                             : (khi + myhalf) * gdata.CellSize(2);
+                             : (khi + myhalf_d) * gdata.CellSize(2);
             const Real pblh_max = Real(0.9) * z_max;
             const Real pblh_min = amrex::max(pblh_emp, Real(10.0));
 
@@ -559,7 +559,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
         // https://github.com/wrf-model/WRF/blob/master/phys/module_bl_mrf.F#L932-L964
         //
         constexpr Real Ribcr_zero = Real(0);
-        ParallelFor(xybx, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+        ParallelFor(xybx, [=,myhalf_d=myhalf,fourth_d=fourth,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int) noexcept
         {
             const Real t_layer  = t10av_arr(i, j, 0);
             const Real moisture_fraction = use_moisture ? q10av_arr(i, j, 0) : Real(0);
@@ -571,16 +571,16 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
             {
                 zval_zero = (use_terrain_fitted_coords)
                           ? Compute_Zrel_AtCellCenter(i, j, kpbl_zero, z_nd_arr)
-                          : (kpbl_zero + myhalf) * gdata.CellSize(2);
+                          : (kpbl_zero + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl_zero, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) *
                                                 (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) +
                                                 (vvel(i, j, kpbl_zero) + vvel(i, j + 1, kpbl_zero)) *
                                                 (vvel(i, j, kpbl_zero) + vvel(i, j + 1, kpbl_zero)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib_zero = CONST_GRAV * zval_zero * (theta_v - t_layer_v_enhanced) / (ws2 * theta_v_klo);
+                Rib_zero = CONST_GRAV_d * zval_zero * (theta_v - t_layer_v_enhanced) / (ws2 * theta_v_klo);
             }
 
             bool above_critical_zero = false;
@@ -588,16 +588,16 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 kpbl_zero += 1;
                 zval_zero = (use_terrain_fitted_coords)
                           ? Compute_Zrel_AtCellCenter(i, j, kpbl_zero, z_nd_arr)
-                          : (kpbl_zero + myhalf) * gdata.CellSize(2);
+                          : (kpbl_zero + myhalf_d) * gdata.CellSize(2);
                 const Real theta_v     = GetThetav(i, j, kpbl_zero, cell_data, moisture_indices);
                 // FIX: guard theta_v_klo against zero to prevent NaN in Rib
                 const Real theta_v_klo = amrex::max(GetThetav(i, j, klo, cell_data, moisture_indices), Real(1.0));
-                const Real ws2_raw = fourth * ( (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) *
+                const Real ws2_raw = fourth_d * ( (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) *
                                                 (uvel(i, j, kpbl_zero) + uvel(i + 1, j, kpbl_zero)) +
                                                 (vvel(i, j, kpbl_zero) + vvel(i, j + 1, kpbl_zero)) *
                                                 (vvel(i, j, kpbl_zero) + vvel(i, j + 1, kpbl_zero)) );
                 const Real ws2 = amrex::max(ws2_raw, Real(1.0));
-                Rib_zero = CONST_GRAV * zval_zero * (theta_v - t_layer_v_enhanced) / (ws2 * theta_v_klo);
+                Rib_zero = CONST_GRAV_d * zval_zero * (theta_v - t_layer_v_enhanced) / (ws2 * theta_v_klo);
                 above_critical_zero = (Rib_zero >= Ribcr_zero);
             }
 
@@ -624,7 +624,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
         const int izmin   = geom.Domain().smallEnd(2);
         const int izmax   = geom.Domain().bigEnd(2);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(gbx, [=,myhalf_d=myhalf,KAPPA_d=KAPPA,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             Real obuk_val = l_obuk_arr(i, j, 0);
             if (std::abs(obuk_val) < amrex::Real(1.0e-10)) {
@@ -633,7 +633,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
 
             const Real zval = (use_terrain_fitted_coords)
                             ? Compute_Zrel_AtCellCenter(i, j, k, z_nd_arr)
-                            : (k + myhalf) * gdata.CellSize(2);
+                            : (k + myhalf_d) * gdata.CellSize(2);
             const Real rho = cell_data(i, j, k, Rho_comp);
             // FIX: skip ghost cells with uninitialized (zero) density — prevents
             // division-by-zero inside GetThetav at lateral ghost cells of gbx
@@ -696,7 +696,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 const Real phit_eff = phit_cloud;
 
                 Real Prt_base = phit_eff / phiM_eff;
-                const Real Prt = amrex::min(amrex::max(Prt_base + const_b * KAPPA * sf, prmin), prmax);
+                const Real Prt = amrex::min(amrex::max(Prt_base + const_b * KAPPA_d * sf, prmin), prmax);
 
                 const Real wstar = wstar_arr(i, j, 0);
 
@@ -711,19 +711,19 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                     const Real pblh_rel = pblh - z_sfc;
                     const Real zfac = amrex::max(Real(1) - zrel / pblh_rel, Real(1.0e-8));
 
-                    K_turb(i, j, k, EddyDiff::Mom_v)   = rho * wstar * KAPPA * zrel * zfac * zfac;
+                    K_turb(i, j, k, EddyDiff::Mom_v)   = rho * wstar * KAPPA_d * zrel * zfac * zfac;
                     K_turb(i, j, k, EddyDiff::Theta_v) = K_turb(i, j, k, EddyDiff::Mom_v) / Prt;
 
                     if (turbChoice.mrf_moistvars) {
                         Real Prq_base = phit_eff / phiM_eff;
-                        const Real Prq = amrex::min(amrex::max(Prq_base + const_b * KAPPA * sf, prmin), prmax);
+                        const Real Prq = amrex::min(amrex::max(Prq_base + const_b * KAPPA_d * sf, prmin), prmax);
                         K_turb(i, j, k, EddyDiff::Q_v) = K_turb(i, j, k, EddyDiff::Mom_v) / Prq;
                     } else {
                         K_turb(i, j, k, EddyDiff::Q_v) = K_turb(i, j, k, EddyDiff::Theta_v);
                     }
                 } else {
                     const Real lambda = Real(150.0);
-                    const Real lscale = (KAPPA * zval * lambda) / (KAPPA * zval + lambda);
+                    const Real lscale = (KAPPA_d * zval * lambda) / (KAPPA_d * zval + lambda);
                     Real dthetadz, dudz, dvdz;
                     ComputeVerticalDerivativesPBL(i, j, k, uvel, vvel, cell_data, izmin, izmax, Real(1) / dz_terrain,
                                                   c_ext_dir_on_zlo, c_ext_dir_on_zhi, u_ext_dir_on_zlo,
@@ -739,9 +739,9 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                     const Real theta_v     = amrex::max(GetThetav(i, j, k,   cell_data, moisture_indices), Real(1.0));
                     const Real theta_v_kp1 = (k < izmax) ? GetThetav(i, j, k+1, cell_data, moisture_indices) : theta_v;
                     const Real theta_v_km1 = (k > izmin) ? GetThetav(i, j, k-1, cell_data, moisture_indices) : theta_v;
-                    const Real dtheta_v_dz = myhalf * (theta_v_kp1 - theta_v_km1) * (Real(1) / dz_terrain);
+                    const Real dtheta_v_dz = myhalf_d * (theta_v_kp1 - theta_v_km1) * (Real(1) / dz_terrain);
 
-                    Real grad_Ri = CONST_GRAV / theta_v * dtheta_v_dz / wind_shear_safe;
+                    Real grad_Ri = CONST_GRAV_d / theta_v * dtheta_v_dz / wind_shear_safe;
                     grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                     const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));
@@ -766,7 +766,7 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 }
             } else if (k >= pbli_extent) {
                 const Real lambda = Real(150.0);
-                const Real lscale = (KAPPA * zval * lambda) / (KAPPA * zval + lambda);
+                const Real lscale = (KAPPA_d * zval * lambda) / (KAPPA_d * zval + lambda);
                 Real dthetadz, dudz, dvdz;
                 ComputeVerticalDerivativesPBL(i, j, k, uvel, vvel, cell_data, izmin, izmax, Real(1) / dz_terrain,
                                               c_ext_dir_on_zlo, c_ext_dir_on_zhi, u_ext_dir_on_zlo,
@@ -782,9 +782,9 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 const Real theta_v     = amrex::max(GetThetav(i, j, k,   cell_data, moisture_indices), Real(1.0));
                 const Real theta_v_kp1 = (k < izmax) ? GetThetav(i, j, k+1, cell_data, moisture_indices) : theta_v;
                 const Real theta_v_km1 = (k > izmin) ? GetThetav(i, j, k-1, cell_data, moisture_indices) : theta_v;
-                const Real dtheta_v_dz = myhalf * (theta_v_kp1 - theta_v_km1) * (Real(1) / dz_terrain);
+                const Real dtheta_v_dz = myhalf_d * (theta_v_kp1 - theta_v_km1) * (Real(1) / dz_terrain);
 
-                Real grad_Ri = CONST_GRAV / theta_v * dtheta_v_dz / wind_shear_safe;
+                Real grad_Ri = CONST_GRAV_d / theta_v * dtheta_v_dz / wind_shear_safe;
                 grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                 const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));

--- a/Source/PBL/ERF_ComputeDiffusivityMYJ.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMYJ.cpp
@@ -148,12 +148,12 @@ ComputeDiffusivityMYJ (double dt,
 
         // Vertical integrals to compute l0
         if (use_terrain_fitted_coords) {
-            ParallelFor(planexy, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
+            ParallelFor(planexy, [=,two_d=two,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
             {
                 // Locate PBL k index and set qvel
                 for (int k(klo); k<=khi; ++k) {
-                    Real q2 = two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp);
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(q2 > zero, "KE must have a positive value");
+                    Real q2 = two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp);
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(q2 > zero_d, "KE must have a positive value");
                     qvel(i,j,k) = std::sqrt(q2);
                     if (q2<=EPSQ2*FH) {
                         k_arr(i,j,0) = std::min(k,k_arr(i,j,0));
@@ -169,12 +169,12 @@ ComputeDiffusivityMYJ (double dt,
                 }
             });
         } else {
-            ParallelFor(planexy, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
+            ParallelFor(planexy, [=,two_d=two,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
             {
                 // Locate PBL k index and set qvel
                 for (int k(klo); k<=khi; ++k) {
-                    Real q2 = two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp);
-                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(q2 > zero, "KE must have a positive value");
+                    Real q2 = two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp);
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(q2 > zero_d, "KE must have a positive value");
                     qvel(i,j,k) = std::sqrt(q2);
                     if (q2<=EPSQ2*FH) {
                         k_arr(i,j,0) = std::min(k,k_arr(i,j,0));
@@ -184,7 +184,7 @@ ComputeDiffusivityMYJ (double dt,
                 // Perform integral over PBL height
                 for (int k(klo); k<=k_arr(i,j,0); ++k) {
                     // Not multiplying by dz: it's constant and would fall out when we divide qint0/qint1 anyway
-                    const Real Zval = gdata.ProbLo(2) + (k + myhalf)*gdata.CellSize(2);
+                    const Real Zval = gdata.ProbLo(2) + (k + myhalf_d)*gdata.CellSize(2);
                     Gpu::Atomic::Add(&qint(i,j,0,0), Zval*qvel(i,j,k));
                     Gpu::Atomic::Add(&qint(i,j,0,1),      qvel(i,j,k));
                 }
@@ -192,7 +192,7 @@ ComputeDiffusivityMYJ (double dt,
         }
 
         // Main work to fill diffusivities
-        ParallelFor(planexy, [=] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
+        ParallelFor(planexy, [=,one_d=one,myhalf_d=myhalf,fourth_d=fourth,two_d=two] AMREX_GPU_DEVICE (int i, int j, int /*k*/) noexcept
         {
             // Get the PBL k index
             int kpbl = k_arr(i,j,0);
@@ -203,7 +203,7 @@ ComputeDiffusivityMYJ (double dt,
             // Compute diffusivities in each column
             for (int k(klo); k<=khi; ++k) {
                 // Gradients for shear and buoy production
-                const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one;
+                const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one_d;
                 Real dthetavdz, dudz, dvdz;
                 ComputeVerticalDerivativesPBL(i, j, k,
                                               uvel, vvel, cell_data, izmin, izmax, dxInv[2]/met_h_zeta,
@@ -228,15 +228,15 @@ ComputeDiffusivityMYJ (double dt,
                     } else {
                       Real AUBR   = (AUBM*GML+AUBH*GHL)*GHL;
                       Real BUBR   = BUBM*GML+BUBH*GHL;
-                      Real QOL2ST = (-myhalf*BUBR+std::sqrt(BUBR*BUBR*fourth-AUBR*CUBR))*RCUBR;
-                      Real ELOQ2X = one/QOL2ST;
+                      Real QOL2ST = (-myhalf_d*BUBR+std::sqrt(BUBR*BUBR*fourth_d-AUBR*CUBR))*RCUBR;
+                      Real ELOQ2X = one_d/QOL2ST;
                       ELM = std::max(std::sqrt(ELOQ2X*qvel(i,j,k)*qvel(i,j,k)),EPSL);
                     }
                 } else {
                     Real ADEN   = (ADNM*GML+ADNH*GHL)*GHL;
                     Real BDEN   = BDNM*GML+BDNH*GHL;
-                    Real QOL2UN = -myhalf*BDEN+std::sqrt(BDEN*BDEN*fourth-ADEN);
-                    Real ELOQ2X = one/(QOL2UN+EPSRU);
+                    Real QOL2UN = -myhalf_d*BDEN+std::sqrt(BDEN*BDEN*fourth_d-ADEN);
+                    Real ELOQ2X = one_d/(QOL2UN+EPSRU);
                     ELM = std::max(std::sqrt(ELOQ2X*qvel(i,j,k)*qvel(i,j,k)),EPSL);
                 }
 
@@ -246,7 +246,7 @@ ComputeDiffusivityMYJ (double dt,
                     L = std::min((met_h_zeta/dxInv[2])*ELFC, ELM);
                 } else {
                     const Real zval = use_terrain_fitted_coords ? Compute_Zrel_AtCellCenter(i,j,k,z_nd_arr)
-                                                                : gdata.ProbLo(2) + (k + myhalf)*gdata.CellSize(2);
+                                                                : gdata.ProbLo(2) + (k + myhalf_d)*gdata.CellSize(2);
                     L = std::min(l0*d_kappa*zval / (d_kappa*zval + l0), ELM);
                 }
 
@@ -254,7 +254,7 @@ ComputeDiffusivityMYJ (double dt,
                 Real AEQU  = (AEQM*GML+AEQH*GHL)*GHL;
                 Real BEQU  = BEQM*GML+BEQH*GHL;
 
-                Real EQOL2 = -myhalf*BEQU+std::sqrt(BEQU*BEQU*fourth-AEQU);
+                Real EQOL2 = -myhalf_d*BEQU+std::sqrt(BEQU*BEQU*fourth_d-AEQU);
 
                 if ( ((GML+GHL*GHL)<=EPSTRB) ||
                      ((GHL>=EPSGH) && ((GML/GHL)<=REQU)) ||
@@ -267,21 +267,21 @@ ComputeDiffusivityMYJ (double dt,
 
                     Real ADEN=(ADNM*GML+ADNH*GHL)*GHL;
                     Real BDEN= BDNM*GML+BDNH*GHL;
-                    Real CDEN= one;
+                    Real CDEN= one_d;
 
-                    Real ARHS=-(ANUM*BDEN-BNUM*ADEN)*two;
+                    Real ARHS=-(ANUM*BDEN-BNUM*ADEN)*two_d;
                     Real BRHS=- ANUM*Real(4.);
-                    Real CRHS=- BNUM*two;
+                    Real CRHS=- BNUM*two_d;
 
                     Real DLOQ1=L/qvel(i,j,k);
 
-                    Real ELOQ21=one/EQOL2;
+                    Real ELOQ21=one_d/EQOL2;
                     Real ELOQ11=std::sqrt(ELOQ21);
                     Real ELOQ31=ELOQ21*ELOQ11;
                     Real ELOQ41=ELOQ21*ELOQ21;
                     Real ELOQ51=ELOQ21*ELOQ31;
 
-                    Real RDEN1=one/(ADEN*ELOQ41+BDEN*ELOQ21+CDEN);
+                    Real RDEN1=one_d/(ADEN*ELOQ41+BDEN*ELOQ21+CDEN);
 
                     Real RHSP1=(ARHS*ELOQ51+BRHS*ELOQ31+CRHS*ELOQ11)*RDEN1*RDEN1;
 
@@ -293,7 +293,7 @@ ComputeDiffusivityMYJ (double dt,
                     Real ELOQ42=ELOQ22*ELOQ22;
                     Real ELOQ52=ELOQ22*ELOQ32;
 
-                    Real RDEN2=one/(ADEN*ELOQ42+BDEN*ELOQ22+CDEN);
+                    Real RDEN2=one_d/(ADEN*ELOQ42+BDEN*ELOQ22+CDEN);
                     Real RHS2 =-(ANUM*ELOQ42+BNUM*ELOQ22)*RDEN2+RB1;
                     Real RHSP2= (ARHS*ELOQ52+BRHS*ELOQ32+CRHS*ELOQ12)*RDEN2*RDEN2;
                     Real RHST2=RHS2/RHSP2;
@@ -317,7 +317,7 @@ ComputeDiffusivityMYJ (double dt,
                     qvel(i,j,k) = myhalf * (q + qvel(i,j,k));
                 }
                 */
-                cell_data(i,j,k,RhoKE_comp) = myhalf*cell_data(i,j,k,Rho_comp)*qvel(i,j,k)*qvel(i,j,k);
+                cell_data(i,j,k,RhoKE_comp) = myhalf_d*cell_data(i,j,k,Rho_comp)*qvel(i,j,k)*qvel(i,j,k);
 
                 // L^n/Q^n
                 Real ELOQ2 = L*L/(qvel(i,j,k)*qvel(i,j,k));
@@ -326,7 +326,7 @@ ComputeDiffusivityMYJ (double dt,
                 // COEFFICIENTS OF THE TERMS IN THE DENOMINATOR
                 Real ADEN=(ADNM*GML+ADNH*GHL)*GHL;
                 Real BDEN= BDNM*GML+BDNH*GHL;
-                Real CDEN= one;
+                Real CDEN= one_d;
 
                 // COEFFICIENTS FOR THE SM DETERMINANT
                 Real BESM=BSMH*GHL;
@@ -335,7 +335,7 @@ ComputeDiffusivityMYJ (double dt,
                 Real BESH=BSHM*GML+BSHH*GHL;
 
                 // one/DENOMINATOR
-                Real RDEN=one/(ADEN*ELOQ4+BDEN*ELOQ2+CDEN);
+                Real RDEN=one_d/(ADEN*ELOQ4+BDEN*ELOQ2+CDEN);
 
                 // SM, SH, SQ
                 Real SM=(BESM*ELOQ2+CESM)*RDEN;

--- a/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMYNN25.cpp
@@ -73,29 +73,29 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
         if (use_terrain_fitted_coords) {
             const Array4<Real const> &z_nd_arr = z_phys_nd->array(mfi);
             const auto invCellSize = geom.InvCellSizeArray();
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,two_d=two,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // q^2 / 2 is the TKE
-                qvel(i,j,k) = std::sqrt(two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero, "KE must have a positive value");
+                qvel(i,j,k) = std::sqrt(two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero_d, "KE must have a positive value");
 
-                Real fac = (sbx.contains(i,j,k)) ? one : zero;
+                Real fac = (sbx.contains(i,j,k)) ? one_d : zero_d;
                 const Real Zval = Compute_Zrel_AtCellCenter(i,j,k,z_nd_arr);
                 const Real dz   = Compute_h_zeta_AtCellCenter(i,j,k,invCellSize,z_nd_arr);
                 Gpu::Atomic::Add(&qint(i,j,0,0), Zval*qvel(i,j,k)*dz*fac);
                 Gpu::Atomic::Add(&qint(i,j,0,1),      qvel(i,j,k)*dz*fac);
             });
         } else {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,two_d=two,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // q^2 / 2 is the TKE
-                qvel(i,j,k) = std::sqrt(two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero, "KE must have a positive value");
+                qvel(i,j,k) = std::sqrt(two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero_d, "KE must have a positive value");
 
                 // Not multiplying by dz: it's constant and would fall out when we divide qint0/qint1 anyway
 
-                Real fac = (sbx.contains(i,j,k)) ? one : zero;
-                const Real Zval = gdata.ProbLo(2) + (k + myhalf)*gdata.CellSize(2);
+                Real fac = (sbx.contains(i,j,k)) ? one_d : zero_d;
+                const Real Zval = gdata.ProbLo(2) + (k + myhalf_d)*gdata.CellSize(2);
                 Gpu::Atomic::Add(&qint(i,j,0,0), Zval*qvel(i,j,k)*fac);
                 Gpu::Atomic::Add(&qint(i,j,0,1),      qvel(i,j,k)*fac);
             });
@@ -124,11 +124,11 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
 
         const Array4<Real const> z_nd_arr = z_phys_nd->const_array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf,KAPPA_d=KAPPA,zero_d=zero,CONST_GRAV_d=CONST_GRAV,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Compute some partial derivatives that we will need (second order)
             // U and V derivatives are interpolated to account for staggered grid
-            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one;
+            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one_d;
 
             Real dthetavdz, dudz, dvdz;
             ComputeVerticalDerivativesPBL(i, j, k,
@@ -147,7 +147,7 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             if (use_moisture) {
                 // Compute buoyancy flux (Stull Eqn. 4.4.5d)
                 surface_latent_heat = -u_star_arr(i,j,0) * q_star_arr(i,j,0);
-                surface_heat_flux *= (one + Real(0.61)*qv0);
+                surface_heat_flux *= (one_d + Real(0.61)*qv0);
                 surface_heat_flux += Real(0.61) * theta0 * surface_latent_heat;
             }
 
@@ -163,20 +163,20 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             AMREX_ASSERT(l_obukhov != 0);
             int lk = amrex::max(k,0);
             const Real zval = use_terrain_fitted_coords ? Compute_Zrel_AtCellCenter(i,j,lk,z_nd_arr)
-                                          : gdata.ProbLo(2) + (lk + myhalf)*gdata.CellSize(2);
+                                          : gdata.ProbLo(2) + (lk + myhalf_d)*gdata.CellSize(2);
             const Real zeta = zval/l_obukhov;
             Real l_S;
-            if (zeta >= one) {
-                l_S = KAPPA*zval/Real(3.7);
+            if (zeta >= one_d) {
+                l_S = KAPPA_d*zval/Real(3.7);
             } else if (zeta >= 0) {
-                l_S = KAPPA*zval/(1+Real(2.7)*zeta);
+                l_S = KAPPA_d*zval/(1+Real(2.7)*zeta);
             } else {
-                l_S = KAPPA*zval*std::pow(one - Real(100.0) * zeta, Real(0.2));
+                l_S = KAPPA_d*zval*std::pow(one_d - Real(100.0) * zeta, Real(0.2));
             }
 
             // ABL-depth length scale (NN09, Eqn. 54)
             Real l_T;
-            if (qint(i,j,0,1) > zero) {
+            if (qint(i,j,0,1) > zero_d) {
                 l_T = Lt_alpha*qint(i,j,0,0)/qint(i,j,0,1);
             } else {
                 l_T = std::numeric_limits<Real>::max();
@@ -185,11 +185,11 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             // Buoyancy length scale (NN09, Eqn. 55)
             Real l_B;
             if (dthetavdz > 0) {
-                Real N_brunt_vaisala = std::sqrt(CONST_GRAV/theta0 * dthetavdz);
+                Real N_brunt_vaisala = std::sqrt(CONST_GRAV_d/theta0 * dthetavdz);
                 if (zeta < 0) {
-                    Real qc = CONST_GRAV/theta0 * surface_heat_flux * l_T; // velocity scale
-                    qc = std::pow(qc,one/three);
-                    l_B = (one + Real(5.0)*std::sqrt(qc/(N_brunt_vaisala * l_T))) * qvel(i,j,k)/N_brunt_vaisala;
+                    Real qc = CONST_GRAV_d/theta0 * surface_heat_flux * l_T; // velocity scale
+                    qc = std::pow(qc,one_d/three_d);
+                    l_B = (one_d + Real(5.0)*std::sqrt(qc/(N_brunt_vaisala * l_T))) * qvel(i,j,k)/N_brunt_vaisala;
                 } else {
                     l_B = qvel(i,j,k) / N_brunt_vaisala;
                 }
@@ -200,15 +200,15 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             // Master length scale
             Real Lm;
             if (mynn.config == MYNNConfigType::CHEN2021) {
-                Lm = std::pow(one/(l_S*l_S) + one/(l_T*l_T) + one/(l_B*l_B), -myhalf);
+                Lm = std::pow(one_d/(l_S*l_S) + one_d/(l_T*l_T) + one_d/(l_B*l_B), -myhalf_d);
             } else {
                 // NN09, Eqn 52
-                Lm = one / (one/l_S + one/l_T + one/l_B);
+                Lm = one_d / (one_d/l_S + one_d/l_T + one_d/l_B);
             }
 
             // Calculate nondimensional production terms
             Real shearProd  = dudz*dudz + dvdz*dvdz;
-            Real buoyProd   = -(CONST_GRAV/theta0) * dthetavdz;
+            Real buoyProd   = -(CONST_GRAV_d/theta0) * dthetavdz;
             Real L2_over_q2 = Lm*Lm/(qvel(i,j,k)*qvel(i,j,k));
             Real GM         = L2_over_q2 * shearProd;
             Real GH         = L2_over_q2 * buoyProd;
@@ -216,11 +216,11 @@ ComputeDiffusivityMYNN25 (const MultiFab& xvel,
             // Equilibrium (Level-2) q calculation follows NN09, Appendix A
             Real Rf  = level2.calc_Rf(GM, GH);
             Real SM2 = level2.calc_SM(Rf);
-            Real qe2 = mynn.B1 * Lm*Lm * SM2 * (one-Rf) * shearProd;
-            Real qe  = (qe2 < zero) ? zero : std::sqrt(qe2);
+            Real qe2 = mynn.B1 * Lm*Lm * SM2 * (one_d-Rf) * shearProd;
+            Real qe  = (qe2 < zero_d) ? zero_d : std::sqrt(qe2);
 
             // Level 2 limiting introduced by Helfand and Labraga 1988 (NN09, Eqn. 42)
-            Real alphac  = (qvel(i,j,k) >= qe) ? one : qvel(i,j,k) / (qe + eps);
+            Real alphac  = (qvel(i,j,k) >= qe) ? one_d : qvel(i,j,k) / (qe + eps);
 //#if EXTRA_MYNN25_CHECKS
 #if 0
             // VERY verbose diagnostic

--- a/Source/PBL/ERF_ComputeDiffusivityMYNNEDMF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMYNNEDMF.cpp
@@ -4251,27 +4251,27 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
         if (use_terrain_fitted_coords) {
             const Array4<Real const> &z_nd_arr = z_phys_nd->array(mfi);
             const auto invCellSize = geom.InvCellSizeArray();
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,two_d=two,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                qvel(i,j,k) = std::sqrt(two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
-                AMREX_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero, "KE must have a positive value");
+                qvel(i,j,k) = std::sqrt(two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
+                AMREX_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero_d, "KE must have a positive value");
 
-                Real fac = (sbx.contains(i,j,k)) ? one : zero;
+                Real fac = (sbx.contains(i,j,k)) ? one_d : zero_d;
                 const Real Zval = Compute_Zrel_AtCellCenter(i,j,k,z_nd_arr);
                 const Real dz   = Compute_h_zeta_AtCellCenter(i,j,k,invCellSize,z_nd_arr);
                 Gpu::Atomic::Add(&qint(i,j,0,0), Zval*qvel(i,j,k)*dz*fac);
                 Gpu::Atomic::Add(&qint(i,j,0,1),      qvel(i,j,k)*dz*fac);
             });
         } else {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,two_d=two,zero_d=zero,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                qvel(i,j,k) = std::sqrt(two * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
-                AMREX_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero, "KE must have a positive value");
+                qvel(i,j,k) = std::sqrt(two_d * cell_data(i,j,k,RhoKE_comp) / cell_data(i,j,k,Rho_comp));
+                AMREX_ASSERT_WITH_MESSAGE(qvel(i,j,k) > zero_d, "KE must have a positive value");
 
                 // Not multiplying by dz: its constant and would fall out when we divide qint0/qint1 anyway
 
-                Real fac = (sbx.contains(i,j,k)) ? one : zero;
-                const Real Zval = gdata.ProbLo(2) + (k + myhalf)*gdata.CellSize(2);
+                Real fac = (sbx.contains(i,j,k)) ? one_d : zero_d;
+                const Real Zval = gdata.ProbLo(2) + (k + myhalf_d)*gdata.CellSize(2);
                 Gpu::Atomic::Add(&qint(i,j,0,0), Zval*qvel(i,j,k)*fac);
                 Gpu::Atomic::Add(&qint(i,j,0,1),      qvel(i,j,k)*fac);
             });
@@ -4300,11 +4300,11 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
 
         const Array4<Real const> z_nd_arr = z_phys_nd->const_array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf,KAPPA_d=KAPPA,zero_d=zero,CONST_GRAV_d=CONST_GRAV,three_d=three] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // Compute some partial derivatives that we will need (second order)
             // U and V derivatives are interpolated to account for staggered grid
-            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one;
+            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one_d;
             Real dthetadz, dudz, dvdz;
             ComputeVerticalDerivativesPBL(i, j, k,
                                           uvel, vvel, cell_data, izmin, izmax, dz_inv/met_h_zeta,
@@ -4322,7 +4322,7 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
             if (use_moisture) {
                 // Compute buoyancy flux (Stull Eqn. 4.4.5d)
                 surface_latent_heat = -u_star_arr(i,j,0) * q_star_arr(i,j,0);
-                surface_heat_flux *= (one + Real(0.61)*qv0);
+                surface_heat_flux *= (one_d + Real(0.61)*qv0);
                 surface_heat_flux += Real(0.61) * theta0 * surface_latent_heat;
             }
 
@@ -4338,20 +4338,20 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
             AMREX_ASSERT(l_obukhov != 0);
             int lk = amrex::max(k,0);
             const Real zval = use_terrain_fitted_coords ? Compute_Zrel_AtCellCenter(i,j,lk,z_nd_arr)
-                                          : gdata.ProbLo(2) + (lk + myhalf)*gdata.CellSize(2);
+                                          : gdata.ProbLo(2) + (lk + myhalf_d)*gdata.CellSize(2);
             const Real zeta = zval/l_obukhov;
             Real l_S;
-            if (zeta >= one) {
-                l_S = KAPPA*zval/Real(3.7);
+            if (zeta >= one_d) {
+                l_S = KAPPA_d*zval/Real(3.7);
             } else if (zeta >= 0) {
-                l_S = KAPPA*zval/(1+Real(2.7)*zeta);
+                l_S = KAPPA_d*zval/(1+Real(2.7)*zeta);
             } else {
-                l_S = KAPPA*zval*std::pow(one - Real(100.0) * zeta, Real(0.2));
+                l_S = KAPPA_d*zval*std::pow(one_d - Real(100.0) * zeta, Real(0.2));
             }
 
             // ABL-depth length scale (NN09, Eqn. 54)
             Real l_T;
-            if (qint(i,j,0,1) > zero) {
+            if (qint(i,j,0,1) > zero_d) {
                 l_T = Lt_alpha*qint(i,j,0,0)/qint(i,j,0,1);
             } else {
                 l_T = std::numeric_limits<Real>::max();
@@ -4360,11 +4360,11 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
             // Buoyancy length scale (NN09, Eqn. 55)
             Real l_B;
             if (dthetadz > 0) {
-                Real N_brunt_vaisala = std::sqrt(CONST_GRAV/theta0 * dthetadz);
+                Real N_brunt_vaisala = std::sqrt(CONST_GRAV_d/theta0 * dthetadz);
                 if (zeta < 0) {
-                    Real qc = CONST_GRAV/theta0 * surface_heat_flux * l_T; // velocity scale
-                    qc = std::pow(qc,one/three);
-                    l_B = (one + Real(5.0)*std::sqrt(qc/(N_brunt_vaisala * l_T))) * qvel(i,j,k)/N_brunt_vaisala;
+                    Real qc = CONST_GRAV_d/theta0 * surface_heat_flux * l_T; // velocity scale
+                    qc = std::pow(qc,one_d/three_d);
+                    l_B = (one_d + Real(5.0)*std::sqrt(qc/(N_brunt_vaisala * l_T))) * qvel(i,j,k)/N_brunt_vaisala;
                 } else {
                     l_B = qvel(i,j,k) / N_brunt_vaisala;
                 }
@@ -4375,15 +4375,15 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
             // Master length scale
             Real Lm;
             if (mynn.config == MYNNConfigType::CHEN2021) {
-                Lm = std::pow(one/(l_S*l_S) + one/(l_T*l_T) + one/(l_B*l_B), -myhalf);
+                Lm = std::pow(one_d/(l_S*l_S) + one_d/(l_T*l_T) + one_d/(l_B*l_B), -myhalf_d);
             } else {
                 // NN09, Eqn 52
-                Lm = one / (one/l_S + one/l_T + one/l_B);
+                Lm = one_d / (one_d/l_S + one_d/l_T + one_d/l_B);
             }
 
             // Calculate nondimensional production terms
             Real shearProd  = dudz*dudz + dvdz*dvdz;
-            Real buoyProd   = -(CONST_GRAV/theta0) * dthetadz;
+            Real buoyProd   = -(CONST_GRAV_d/theta0) * dthetadz;
             Real L2_over_q2 = Lm*Lm/(qvel(i,j,k)*qvel(i,j,k));
             Real GM         = L2_over_q2 * shearProd;
             Real GH         = L2_over_q2 * buoyProd;
@@ -4391,11 +4391,11 @@ ComputeDiffusivityMYNNEDMF (const MultiFab& xvel,
             // Equilibrium (Level-2) q calculation follows NN09, Appendix 2
             Real Rf  = level2.calc_Rf(GM, GH);
             Real SM2 = level2.calc_SM(Rf);
-            Real qe2 = mynn.B1*Lm*Lm*SM2*(one-Rf)*shearProd;
-            Real qe  = (qe2 < zero) ? zero : std::sqrt(qe2);
+            Real qe2 = mynn.B1*Lm*Lm*SM2*(one_d-Rf)*shearProd;
+            Real qe  = (qe2 < zero_d) ? zero_d : std::sqrt(qe2);
 
             // Level 2 limiting (Helfand and Labraga 1988)
-            Real alphac  = (qvel(i,j,k) > qe) ? one : qvel(i,j,k) / (qe + eps);
+            Real alphac  = (qvel(i,j,k) > qe) ? one_d : qvel(i,j,k) / (qe + eps);
 
             // Level Real(2.5) stability functions
             Real SM, SH, SQ;

--- a/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
@@ -86,14 +86,14 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
         const bool force_over_water = turbChoice.pbl_ysu_force_over_water;
         const Real land_Ribcr = turbChoice.pbl_ysu_land_Ribcr;
         const Real unst_Ribcr = turbChoice.pbl_ysu_unst_Ribcr;
-        ParallelFor(xybx, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+        ParallelFor(xybx, [=,CONST_GRAV_d=CONST_GRAV,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) noexcept
         {
             // Reconstruct a surface bulk Richardson number from the surface layer model
             // In WRF, this value is supplied to YSU by the MM5 surface layer model
             const Real t_surf = t_surf_arr(i,j,0);
             const Real t_layer = t10av_arr(i,j,0);
             const Real ws_layer = ws10av_arr(i,j,0);
-            const Real Rib_layer = CONST_GRAV * most_zref / (ws_layer*ws_layer) * (t_layer - t_surf)/(t_layer);
+            const Real Rib_layer = CONST_GRAV_d * most_zref / (ws_layer*ws_layer) * (t_layer - t_surf)/(t_layer);
 
             // For now, we only support stable boundary layers
             if (Rib_layer < unst_Ribcr) {
@@ -122,35 +122,35 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
             while (!above_critical and bx.contains(i,j,kpbl+1)) {
                 kpbl += 1;
                 const Real zval = use_terrain_fitted_coords ?
-                                  Compute_Zrel_AtCellCenter(i,j,kpbl,z_nd_arr) : gdata.ProbLo(2) + (kpbl + myhalf)*gdata.CellSize(2);
-                const Real ws2_level = fourth*( (uvel(i,j,kpbl)+uvel(i+1,j  ,kpbl))*(uvel(i,j,kpbl)+uvel(i+1,j  ,kpbl))
+                                  Compute_Zrel_AtCellCenter(i,j,kpbl,z_nd_arr) : gdata.ProbLo(2) + (kpbl + myhalf_d)*gdata.CellSize(2);
+                const Real ws2_level = fourth_d*( (uvel(i,j,kpbl)+uvel(i+1,j  ,kpbl))*(uvel(i,j,kpbl)+uvel(i+1,j  ,kpbl))
                                             + (vvel(i,j,kpbl)+vvel(i  ,j+1,kpbl))*(vvel(i,j,kpbl)+vvel(i  ,j+1,kpbl)) );
                 const Real theta = cell_data(i,j,kpbl,RhoTheta_comp) / cell_data(i,j,kpbl,Rho_comp);
                 Rib_dn = Rib_up;
-                Rib_up = (theta-base_theta)/base_theta * CONST_GRAV * zval / ws2_level;
+                Rib_up = (theta-base_theta)/base_theta * CONST_GRAV_d * zval / ws2_level;
                 above_critical = Rib_up >= Rib_cr;
             }
 
             Real interp_fact;
             if (Rib_dn >= Rib_cr) {
-                interp_fact = zero;
+                interp_fact = zero_d;
             } else if (Rib_up <= Rib_cr)
-                interp_fact = one;
+                interp_fact = one_d;
             else {
                 interp_fact = (Rib_cr - Rib_dn) / (Rib_up - Rib_dn);
             }
 
             const Real zval_up = use_terrain_fitted_coords ?
-                                 Compute_Zrel_AtCellCenter(i,j,kpbl,z_nd_arr) : gdata.ProbLo(2) + (kpbl + myhalf)*gdata.CellSize(2);
+                                 Compute_Zrel_AtCellCenter(i,j,kpbl,z_nd_arr) : gdata.ProbLo(2) + (kpbl + myhalf_d)*gdata.CellSize(2);
             const Real zval_dn = use_terrain_fitted_coords ?
-                                 Compute_Zrel_AtCellCenter(i,j,kpbl-1,z_nd_arr) : gdata.ProbLo(2) + (kpbl-1 + myhalf)*gdata.CellSize(2);
+                                 Compute_Zrel_AtCellCenter(i,j,kpbl-1,z_nd_arr) : gdata.ProbLo(2) + (kpbl-1 + myhalf_d)*gdata.CellSize(2);
             pblh_arr(i,j,0) = zval_dn + interp_fact*(zval_up-zval_dn);
 
             const Real zval_0 = use_terrain_fitted_coords ?
-                                 Compute_Zrel_AtCellCenter(i,j,0,z_nd_arr) : gdata.ProbLo(2) + (myhalf)*gdata.CellSize(2);
+                                 Compute_Zrel_AtCellCenter(i,j,0,z_nd_arr) : gdata.ProbLo(2) + (myhalf_d)*gdata.CellSize(2);
             const Real zval_1 = use_terrain_fitted_coords ?
                                  Compute_Zrel_AtCellCenter(i,j,1,z_nd_arr) : gdata.ProbLo(2) + (Real(1.5))*gdata.CellSize(2);
-            if (pblh_arr(i,j,0) < myhalf*(zval_0+zval_1) ) {
+            if (pblh_arr(i,j,0) < myhalf_d*(zval_0+zval_1) ) {
                 kpbl = 0;
             }
             pbli_arr(i,j,0) = kpbl;
@@ -181,28 +181,28 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
         const int izmin = geom.Domain().smallEnd(2);
         const int izmax = geom.Domain().bigEnd(2);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,zero_d=zero,two_d=two,KAPPA_d=KAPPA,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             const Real zval = use_terrain_fitted_coords ?
-                              Compute_Zrel_AtCellCenter(i,j,k,z_nd_arr) : gdata.ProbLo(2) + (k + myhalf)*gdata.CellSize(2);
+                              Compute_Zrel_AtCellCenter(i,j,k,z_nd_arr) : gdata.ProbLo(2) + (k + myhalf_d)*gdata.CellSize(2);
             const Real rho = cell_data(i,j,k,Rho_comp);
-            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one;
+            const Real met_h_zeta = use_terrain_fitted_coords ? Compute_h_zeta_AtCellCenter(i,j,k,dxInv,z_nd_arr) : one_d;
             const Real dz_terrain = met_h_zeta/dz_inv;
             if (k < pbli_arr(i,j,0)) {
                 // -- Compute diffusion coefficients within PBL
                 constexpr Real zfacmin = Real(1e-8); // value from WRF
                 constexpr Real phifac = Real(8.0); // value from H10 and WRF
-                constexpr Real wstar3 = zero; // only nonzero for unstable
-                constexpr Real pfac = two; // profile exponent
+                constexpr Real wstar3 = zero_d; // only nonzero for unstable
+                constexpr Real pfac = two_d; // profile exponent
                 const Real zfac = std::min(std::max(amrex::Real(1) - zval / pblh_arr(i,j,0), zfacmin ), amrex::Real(1));
                 // Not including YSU top down PBL term (not in H10, added to WRF later)
                 const Real ust3 = u_star_arr(i,j,0) * u_star_arr(i,j,0) * u_star_arr(i,j,0);
-                Real wscalek = ust3 + phifac * KAPPA * wstar3 * (amrex::Real(1) - zfac);
+                Real wscalek = ust3 + phifac * KAPPA_d * wstar3 * (amrex::Real(1) - zfac);
                 wscalek = std::pow(wscalek, amrex::Real(1.0/3.0));
                 // stable only
                 const Real phi_term = amrex::Real(1) + amrex::Real(5) * zval / l_obuk_arr(i,j,0); // phi_term appears in WRF but not papers
                 wscalek = std::max(u_star_arr(i,j,0) / phi_term, Real(0.001)); // Real(0.001) limit appears in WRF but not papers
-                K_turb(i,j,k,EddyDiff::Mom_v) = rho * wscalek * KAPPA * zval * std::pow(zfac, pfac);
+                K_turb(i,j,k,EddyDiff::Mom_v) = rho * wscalek * KAPPA_d * zval * std::pow(zfac, pfac);
                 K_turb(i,j,k,EddyDiff::Theta_v) = K_turb(i,j,k,EddyDiff::Mom_v);
             } else {
                 // -- Compute coefficients in free stream above PBL
@@ -211,27 +211,27 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
                 constexpr Real prandtl_max = Real(4.0);
                 Real dthetadz, dudz, dvdz;
                 ComputeVerticalDerivativesPBL(i, j, k,
-                                              uvel, vvel, cell_data, izmin, izmax, one/dz_terrain,
+                                              uvel, vvel, cell_data, izmin, izmax, one_d/dz_terrain,
                                               c_ext_dir_on_zlo, c_ext_dir_on_zhi,
                                               u_ext_dir_on_zlo, u_ext_dir_on_zhi,
                                               v_ext_dir_on_zlo, v_ext_dir_on_zhi,
                                               dthetadz, dudz, dvdz, moisture_indices);
                 const Real shear_squared = dudz*dudz + dvdz*dvdz + Real(1.0e-9); // Real(1.0e-9) from WRF to avoid divide by zero
                 const Real theta = cell_data(i,j,k,RhoTheta_comp) / cell_data(i,j,k,Rho_comp);
-                Real richardson = CONST_GRAV / theta * dthetadz / shear_squared;
+                Real richardson = CONST_GRAV_d / theta * dthetadz / shear_squared;
                 const Real lambdadz = std::min(std::max(Real(0.1)*dz_terrain , lam0), Real(300.0)); // in WRF, H10 paper just says use lam0
-                const Real lengthscale = lambdadz * KAPPA * zval / (lambdadz + KAPPA * zval);
+                const Real lengthscale = lambdadz * KAPPA_d * zval / (lambdadz + KAPPA_d * zval);
                 const Real turbfact = lengthscale * lengthscale * std::sqrt(shear_squared);
 
                 if (richardson < 0) {
                     richardson = max(richardson, min_richardson);
                     Real sqrt_richardson = std::sqrt(-richardson);
-                    K_turb(i,j,k,EddyDiff::Mom_v) = rho * turbfact * (one - Real(8.0) * richardson / (one + Real(1.746) * sqrt_richardson));
-                    K_turb(i,j,k,EddyDiff::Theta_v) = rho * turbfact * (one - Real(8.0) * richardson / (one + Real(1.286) * sqrt_richardson));
+                    K_turb(i,j,k,EddyDiff::Mom_v) = rho * turbfact * (one_d - Real(8.0) * richardson / (one_d + Real(1.746) * sqrt_richardson));
+                    K_turb(i,j,k,EddyDiff::Theta_v) = rho * turbfact * (one_d - Real(8.0) * richardson / (one_d + Real(1.286) * sqrt_richardson));
                 } else {
-                    const Real oneplus5ri = one + Real(5.0) * richardson;
+                    const Real oneplus5ri = one_d + Real(5.0) * richardson;
                     K_turb(i,j,k,EddyDiff::Theta_v) = rho * turbfact / (oneplus5ri * oneplus5ri);
-                    const Real prandtl = std::min(one+Real(2.1)*richardson, prandtl_max); // limit from WRF
+                    const Real prandtl = std::min(one_d+Real(2.1)*richardson, prandtl_max); // limit from WRF
                     K_turb(i,j,k,EddyDiff::Mom_v) = K_turb(i,j,k,EddyDiff::Theta_v) * prandtl;
                 }
             }

--- a/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityYSU.cpp
@@ -191,9 +191,9 @@ ComputeDiffusivityYSU (const MultiFab& xvel,
             if (k < pbli_arr(i,j,0)) {
                 // -- Compute diffusion coefficients within PBL
                 constexpr Real zfacmin = Real(1e-8); // value from WRF
-                constexpr Real phifac = Real(8.0); // value from H10 and WRF
-                constexpr Real wstar3 = zero_d; // only nonzero for unstable
-                constexpr Real pfac = two_d; // profile exponent
+                constexpr Real phifac  = Real(8.0); // value from H10 and WRF
+                constexpr Real wstar3  = Real(0.);  // only nonzero for unstable
+                constexpr Real pfac    = Real(2.);  // profile exponent
                 const Real zfac = std::min(std::max(amrex::Real(1) - zval / pblh_arr(i,j,0), zfacmin ), amrex::Real(1));
                 // Not including YSU top down PBL term (not in H10, added to WRF later)
                 const Real ust3 = u_star_arr(i,j,0) * u_star_arr(i,j,0) * u_star_arr(i,j,0);

--- a/Source/PBL/ERF_PBLHeight.H
+++ b/Source/PBL/ERF_PBLHeight.H
@@ -168,7 +168,7 @@ struct MYNNPBLH {
                 });
 
                 // This depends on TileNoZ and k increasing monotonically
-                ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(gtbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
                     if (pblh_arr(i,j,0) == 0)
                     {
@@ -183,7 +183,7 @@ struct MYNNPBLH {
                                     && (thv  <  min_thv_arr(i,j,0) + theta_incr_land))
                         {
                             // Interpolate to get lowest height where theta = min_theta + theta_incr
-                            pblh_arr(i,j,0) = (k+myhalf)*dz_no_terrain
+                            pblh_arr(i,j,0) = (k+myhalf_d)*dz_no_terrain
                                             + dz_no_terrain/(thv1-thv)
                                               * (min_thv_arr(i,j,0) + theta_incr_land - thv);
                         }
@@ -191,7 +191,7 @@ struct MYNNPBLH {
                                           && (thv  <  min_thv_arr(i,j,0) + theta_incr_water))
                         {
                             // Interpolate to get lowest height where theta = min_theta + theta_incr
-                            pblh_arr(i,j,0) = (k+myhalf)*dz_no_terrain
+                            pblh_arr(i,j,0) = (k+myhalf_d)*dz_no_terrain
                                             + dz_no_terrain/(thv1-thv)
                                               * (min_thv_arr(i,j,0) + theta_incr_water - thv);
                         }
@@ -211,7 +211,7 @@ struct MYNNPBLH {
                         if ((tke1 <= TKEeps) && (tke > TKEeps))
                         {
                             // Interpolate to get lowest height where TKE -> 0
-                            pblh_tke_arr(i,j,0) = (k+myhalf)*dz_no_terrain
+                            pblh_tke_arr(i,j,0) = (k+myhalf_d)*dz_no_terrain
                                                 + dz_no_terrain/(tke1-tke) * (TKEeps - tke);
                         }
                     }
@@ -229,7 +229,7 @@ struct MYNNPBLH {
             auto pblh_arr     = pblh->array(mfi);
 
             amrex::Box gtbx = mfi.growntilebox();
-            ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int) noexcept
+            ParallelFor(gtbx, [=,two_d=two,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE(int i, int j, int) noexcept
             {
                 //
                 // Clip PBLH_TKE to more realistic values
@@ -248,10 +248,10 @@ struct MYNNPBLH {
                 //
                 // Finally, blend between the two PBLH estimates
                 //
-                amrex::Real maxqke = two * cons_arr(i,j,0  ,RhoKE_comp) / cons_arr(i,j,0  ,Rho_comp);
+                amrex::Real maxqke = two_d * cons_arr(i,j,0  ,RhoKE_comp) / cons_arr(i,j,0  ,Rho_comp);
                 if (maxqke > amrex::Real(0.05)) {
-                    amrex::Real wt = myhalf*std::tanh((zi - sbl_lim)/sbl_damp) + myhalf;
-                    pblh_arr(i,j,0) = (one-wt)*pblh_tke_arr(i,j,0) + wt*pblh_arr(i,j,0);
+                    amrex::Real wt = myhalf_d*std::tanh((zi - sbl_lim)/sbl_damp) + myhalf_d;
+                    pblh_arr(i,j,0) = (one_d-wt)*pblh_tke_arr(i,j,0) + wt*pblh_arr(i,j,0);
                 }
             });
         }//MFIter

--- a/Source/PBL/Shoc/ERF_ShocImplicit.cpp
+++ b/Source/PBL/Shoc/ERF_ShocImplicit.cpp
@@ -224,13 +224,13 @@ ShocImplicit::advance_implicit_state (ShocColumnData& col,
     auto coeffC = coeffC_fab.array();
 
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         for (int k = 0; k <= nlev; ++k) {
-            tmpi(ic,k,0) = dt * CONST_GRAV * amrex::max(rho_zi(ic,k,0), 1.0e-12_rt) /
+            tmpi(ic,k,0) = dt * CONST_GRAV_d * amrex::max(rho_zi(ic,k,0), 1.0e-12_rt) /
                            interface_spacing(zt, zi, layout, ic, k);
             if (k < nlev) {
-                rdp_zt(ic,k,0) = 1.0_rt / amrex::max(CONST_GRAV * rho(ic,k,0) * dz(ic,k,0), 1.0e-12_rt);
+                rdp_zt(ic,k,0) = 1.0_rt / amrex::max(CONST_GRAV_d * rho(ic,k,0) * dz(ic,k,0), 1.0e-12_rt);
             }
         }
 
@@ -238,7 +238,7 @@ ShocImplicit::advance_implicit_state (ShocColumnData& col,
         // The tmpi array includes a 1/dz_zi interface-spacing factor that
         // belongs only in the tridiagonal diffusion matrix, NOT in the
         // explicit surface-flux injection.
-        const Real cmnfac = dt * CONST_GRAV * amrex::max(rho_zi(ic,0,0), 1.0e-12_rt) * rdp_zt(ic,0,0);
+        const Real cmnfac = dt * CONST_GRAV_d * amrex::max(rho_zi(ic,0,0), 1.0e-12_rt) * rdp_zt(ic,0,0);
 
         const Real uw_sfc = surf_tau_u(ic,0,0);
         const Real vw_sfc = surf_tau_v(ic,0,0);
@@ -262,7 +262,7 @@ ShocImplicit::advance_implicit_state (ShocColumnData& col,
             coeffC(ic,0,k) = (k < nlev - 1) ? -tk_zi(ic,k+1,0) * tmpi(ic,k+1,0) * rdp_zt(ic,k,0) : 0.0_rt;
             coeffB(ic,0,k) = 1.0_rt - coeffA(ic,0,k) - coeffC(ic,0,k);
         }
-        coeffB(ic,0,0) += ksrf * dt * CONST_GRAV * rdp_zt(ic,0,0);
+        coeffB(ic,0,0) += ksrf * dt * CONST_GRAV_d * rdp_zt(ic,0,0);
         SolveTridiag(ic, 0, 0, nlev - 1, soln, coeffA, coeffB, inv_coeffB, coeffC, rhs);
         for (int k = 0; k < nlev; ++k) {
             u(ic,k,0) = soln(ic,0,k);
@@ -274,7 +274,7 @@ ShocImplicit::advance_implicit_state (ShocColumnData& col,
             coeffC(ic,0,k) = (k < nlev - 1) ? -tk_zi(ic,k+1,0) * tmpi(ic,k+1,0) * rdp_zt(ic,k,0) : 0.0_rt;
             coeffB(ic,0,k) = 1.0_rt - coeffA(ic,0,k) - coeffC(ic,0,k);
         }
-        coeffB(ic,0,0) += ksrf * dt * CONST_GRAV * rdp_zt(ic,0,0);
+        coeffB(ic,0,0) += ksrf * dt * CONST_GRAV_d * rdp_zt(ic,0,0);
         SolveTridiag(ic, 0, 0, nlev - 1, soln, coeffA, coeffB, inv_coeffB, coeffC, rhs);
         for (int k = 0; k < nlev; ++k) {
             v(ic,k,0) = soln(ic,0,k);
@@ -377,7 +377,7 @@ ShocImplicit::finalize_from_pdf (ShocColumnData& col,
 
     {
         BL_PROFILE("SHOC::advance::finalize::reconstruct");
-        ParallelFor(cell_box, [=] AMREX_GPU_DEVICE (int ic, int k, int) noexcept
+        ParallelFor(cell_box, [=,Cp_d_d=Cp_d,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int k, int) noexcept
         {
             const Real qw_new_loc = amrex::max(qw(ic,k,0), shoc_min_qw());
             const Real ql_base = amrex::max(0.0_rt, qc_base(ic,k,0) + qi_base(ic,k,0));
@@ -402,7 +402,7 @@ ShocImplicit::finalize_from_pdf (ShocColumnData& col,
             qi(ic,k,0) = qi_new_loc;
             shoc_ql(ic,k,0) = ql_total;
             theta_v(ic,k,0) = theta(ic,k,0) * (1.0_rt + shoc_zvir() * qv_new_loc - ql_total);
-            host_dse(ic,k,0) = Cp_d * tabs_new + CONST_GRAV * zt(ic,k,0);
+            host_dse(ic,k,0) = Cp_d_d * tabs_new + CONST_GRAV_d * zt(ic,k,0);
 
             theta_tend(ic,k,0) = (theta(ic,k,0) - theta_base(ic,k,0)) / dt;
             qv_tend(ic,k,0) = (qv_new_loc - qv_base(ic,k,0)) / dt;

--- a/Source/PBL/Shoc/ERF_ShocMoments.cpp
+++ b/Source/PBL/Shoc/ERF_ShocMoments.cpp
@@ -147,7 +147,7 @@ namespace
 
         const auto layout = col.layout;
         const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
-        ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+        ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int, int) noexcept
         {
             const Real wthl_sfc = sflux(ic,0,0);
             const Real wqw_sfc = lflux(ic,0,0);
@@ -155,7 +155,7 @@ namespace
             const Real vw_sfc = tauv(ic,0,0);
             const Real ustar2 = std::sqrt(uw_sfc * uw_sfc + vw_sfc * vw_sfc);
             const Real wstar = (wthl_sfc >= 0.0_rt)
-                ? std::cbrt((CONST_GRAV / shoc_base_temp()) * wthl_sfc)
+                ? std::cbrt((CONST_GRAV_d / shoc_base_temp()) * wthl_sfc)
                 : 0.0_rt;
             const Real uf = amrex::max(shoc_ufmin(),
                                        std::sqrt(ustar2 + 0.3_rt * wstar * wstar));
@@ -404,7 +404,7 @@ ShocMoments::diagnose_third_moments (ShocColumnData& col,
     const auto zi = col.zi.const_array();
     const auto layout = col.layout;
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         w3(ic,0,0) = 0.0_rt;
         w3(ic,layout.nlev,0) = 0.0_rt;
@@ -423,7 +423,7 @@ ShocMoments::diagnose_third_moments (ShocColumnData& col,
             const Real iso = isotropy_i(ic,k,0);
             const Real isosq = iso * iso;
             const Real buoy_sgs2 = isosq * brunt_i(ic,k,0);
-            const Real bet2 = CONST_GRAV / amrex::max(thetal_i(ic,k,0), eps());
+            const Real bet2 = CONST_GRAV_d / amrex::max(thetal_i(ic,k,0), eps());
 
             // E3SM's top-down indexing forms above-minus-below centered
             // differences here. In ERF's bottom-up ordering, the upper

--- a/Source/PBL/Shoc/ERF_ShocPreprocess.cpp
+++ b/Source/PBL/Shoc/ERF_ShocPreprocess.cpp
@@ -88,7 +88,7 @@ ShocPreprocess::fill_columns (ShocColumnData& col,
     amrex::ignore_unused(problo, dx);
     const Box xy_box = amrex::makeSlab(mfi.validbox(), 2, klo);
 
-    ParallelFor(xy_box, [=] AMREX_GPU_DEVICE (int i, int j, int) noexcept
+    ParallelFor(xy_box, [=,Cp_d_d=Cp_d,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int) noexcept
     {
         const int ic = shoc_column_index(layout, i, j);
         const Real rho_sfc = amrex::max(cons_arr(i,j,klo,Rho_comp), 1.0e-12_rt);
@@ -146,7 +146,7 @@ ShocPreprocess::fill_columns (ShocColumnData& col,
             shoc_ql_arr(ic,kk,0) = ql_np;
             tabs_arr(ic,kk,0) = tabs;
             tke_arr(ic,kk,0) = qke;
-            dse_arr(ic,kk,0) = Cp_d * tabs + CONST_GRAV * zc;
+            dse_arr(ic,kk,0) = Cp_d_d * tabs + CONST_GRAV_d * zc;
 
             ucol_arr(ic,kk,0) = 0.5_rt * (u_arr(i,j,k) + u_arr(i+1,j,k));
             vcol_arr(ic,kk,0) = 0.5_rt * (v_arr(i,j,k) + v_arr(i,j+1,k));

--- a/Source/PBL/Shoc/ERF_ShocStructure.cpp
+++ b/Source/PBL/Shoc/ERF_ShocStructure.cpp
@@ -83,7 +83,7 @@ ShocStructure::diagnose_surface_layer (ShocColumnData& col)
     const auto layout = col.layout;
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
 
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV,KAPPA_d=KAPPA] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         const Real cldliq_sfc = qc(ic,0,0) + qi(ic,0,0);
         const Real th_sfc = theta_from_shoc_state(thetal(ic,0,0), qc(ic,0,0), qi(ic,0,0), exner(ic,0,0));
@@ -97,7 +97,7 @@ ShocStructure::diagnose_surface_layer (ShocColumnData& col)
         ustar(ic,0,0) = amrex::max(shoc_u_star_min(), ustar_val);
         const Real ustar_cu = ustar(ic,0,0) * ustar(ic,0,0) * ustar(ic,0,0);
         obklen(ic,0,0) = -thv_sfc * ustar_cu /
-                         (CONST_GRAV * KAPPA * (kbfs + sign_val));
+                         (CONST_GRAV_d * KAPPA_d * (kbfs + sign_val));
         pblh(ic,0,0) = shoc::height_agl(zt(ic,0,0), zi(ic,0,0));
 
         // E3SM SHOC advances TKE using the carried buoyancy-flux profile from
@@ -128,7 +128,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
     const auto layout = col.layout;
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
 
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         const int npbl = diagnose_npbl(p_mid, layout, ic);
         const Real ustar_loc = ustar(ic,0,0);
@@ -150,7 +150,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
                                         du * du +
                                         dv * dv +
                                         shoc_pbl_fac() * ustar_loc * ustar_loc);
-            const Real rino = CONST_GRAV * (thvk - thv0) * (ztk_agl - zt0_agl) /
+            const Real rino = CONST_GRAV_d * (thvk - thv0) * (ztk_agl - zt0_agl) /
                               (amrex::max(thv0, 1.0e-12_rt) * vvk);
             if (rino >= shoc_pbl_ricr()) {
                 if (k == 1 || amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
@@ -188,7 +188,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
                                             du * du +
                                             dv * dv +
                                             shoc_pbl_fac() * ustar_loc * ustar_loc);
-                const Real rino = CONST_GRAV * (thvk - tlv) * (ztk_agl - zt0_agl) /
+                const Real rino = CONST_GRAV_d * (thvk - tlv) * (ztk_agl - zt0_agl) /
                                   (amrex::max(thv0, 1.0e-12_rt) * vvk);
                 if (rino >= shoc_pbl_ricr()) {
                     if (k == 1 || amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
@@ -233,7 +233,7 @@ ShocStructure::diagnose_length_and_brunt (ShocColumnData& col,
     const auto layout = col.layout;
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
 
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV,KAPPA_d=KAPPA] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         const Real z_sfc = zi(ic,0,0);
         Real numerator = 0.0_rt;
@@ -281,12 +281,12 @@ ShocStructure::diagnose_length_and_brunt (ShocColumnData& col,
             // ERF columns use bottom-up indexing, so the upper interface is
             // k+1 and the lower interface is k. Stable stratification must
             // therefore yield positive Brunt-Vaisala frequency.
-            brunt(ic,k,0) = (CONST_GRAV / amrex::max(theta_v_k, 1.0e-12_rt)) *
+            brunt(ic,k,0) = (CONST_GRAV_d / amrex::max(theta_v_k, 1.0e-12_rt)) *
                             (theta_v_hi - theta_v_lo) / amrex::max(dz(ic,k,0), 1.0e-12_rt);
             const Real tkes = std::sqrt(amrex::max(tke(ic,k,0), shoc_min_tke()));
             const Real brunt_pos = amrex::max(brunt(ic,k,0), 0.0_rt);
             const Real zt_agl = shoc::height_agl(zt(ic,k,0), z_sfc);
-            const Real inv_term = (1.0_rt / amrex::max(400.0_rt * tkes * KAPPA * amrex::max(zt_agl, 1.0_rt), 1.0e-12_rt)) +
+            const Real inv_term = (1.0_rt / amrex::max(400.0_rt * tkes * KAPPA_d * amrex::max(zt_agl, 1.0_rt), 1.0e-12_rt)) +
                                   (1.0_rt / amrex::max(400.0_rt * tkes * amrex::max(l_inf, shoc_min_len()), 1.0e-12_rt)) +
                                   0.01_rt * brunt_pos / amrex::max(tke(ic,k,0), shoc_min_tke());
             Real mix = amrex::min(shoc_max_len(),

--- a/Source/PBL/Shoc/ERF_ShocTKE.cpp
+++ b/Source/PBL/Shoc/ERF_ShocTKE.cpp
@@ -188,7 +188,7 @@ ShocTKE::diagnose_tke_and_diffusivities (ShocColumnData& col,
     const auto layout = col.layout;
     const Box col_box(IntVect(0,0,0), IntVect(layout.ncell - 1, 0, 0));
 
-    ParallelFor(col_box, [=] AMREX_GPU_DEVICE (int ic, int, int) noexcept
+    ParallelFor(col_box, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int ic, int, int) noexcept
     {
         const Real z_sfc = zi(ic,0,0);
         Real brunt_int = 0.0_rt;
@@ -200,7 +200,7 @@ ShocTKE::diagnose_tke_and_diffusivities (ShocColumnData& col,
             const Real old_tke = amrex::max(0.0_rt, tke(ic,k,0));
             const Real buoy_prod = opts.shoc_1p5tke
                 ? -old_tke * brunt(ic,k,0)
-                : (CONST_GRAV / shoc_base_temp()) * wthv_sec(ic,k,0);
+                : (CONST_GRAV_d / shoc_base_temp()) * wthv_sec(ic,k,0);
             const Real shear_prod = tk(ic,k,0) * sterm(ic,k,0);
             const Real mix = amrex::max(shoc_mix(ic,k,0), 1.0e-12_rt);
             const Real diss = shoc_tke_cee() / mix * old_tke * std::sqrt(old_tke);
@@ -222,7 +222,7 @@ ShocTKE::diagnose_tke_and_diffusivities (ShocColumnData& col,
             tke(ic,k,0) = new_tke;
         }
 
-        Real lambda = opts.lambda_low + ((brunt_int / CONST_GRAV) - opts.lambda_thresh) * opts.lambda_slope;
+        Real lambda = opts.lambda_low + ((brunt_int / CONST_GRAV_d) - opts.lambda_thresh) * opts.lambda_slope;
         lambda = shoc_clamp(lambda, opts.lambda_low, opts.lambda_high);
 
         for (int k = 0; k < layout.nlev; ++k) {

--- a/Source/Particles/ERFPCEvolve.cpp
+++ b/Source/Particles/ERFPCEvolve.cpp
@@ -249,7 +249,7 @@ void ERFPC::AdvectWithGravity (int                              a_lev,
 
         auto zheight = (*a_z_height)[grid].array();
 
-        ParallelFor(n, [=] AMREX_GPU_DEVICE (int i)
+        ParallelFor(n, [=,CONST_GRAV_d=CONST_GRAV,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i)
         {
             ParticleType& p = p_pbox[i];
             if (p.id() <= 0) { return; }
@@ -259,10 +259,10 @@ void ERFPC::AdvectWithGravity (int                              a_lev,
             // Define acceleration to be (gravity minus drag) where drag is defined
             // such the particles will reach a terminal velocity of Real(5.0) (totally arbitrary)
             ParticleReal terminal_vel = Real(5.0);
-            ParticleReal grav = CONST_GRAV;
-            ParticleReal drag = CONST_GRAV * (v * v) / (terminal_vel*terminal_vel);
+            ParticleReal grav = CONST_GRAV_d;
+            ParticleReal drag = CONST_GRAV_d * (v * v) / (terminal_vel*terminal_vel);
 
-            ParticleReal myhalf_dt = myhalf * a_dt;
+            ParticleReal myhalf_dt = myhalf_d * a_dt;
 
             // Update the particle velocity over first half of step (a_dt/2)
             vz_ptr[i] -= (grav - drag) * myhalf_dt;

--- a/Source/Particles/ERFPCInitializations.cpp
+++ b/Source/Particles/ERFPCInitializations.cpp
@@ -113,10 +113,10 @@ void ERFPC::initializeParticlesUniformDistributionInBox (const std::unique_ptr<M
         auto num_particles_arr = num_particles[mfi].array();
         if (a_height_ptr) {
             const auto height_arr = (*a_height_ptr)[mfi].array();
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real x  = plo[0] + (i + myhalf)*dx[0];
-                Real y  = plo[1] + (j + myhalf)*dx[1];
+                Real x  = plo[0] + (i + myhalf_d)*dx[0];
+                Real y  = plo[1] + (j + myhalf_d)*dx[1];
                 Real zh = Real(0.125) * (height_arr(i,j  ,k  ) + height_arr(i+1,j  ,k  ) +
                                    height_arr(i,j+1,k  ) + height_arr(i+1,j+1,k  ) +
                                    height_arr(i,j  ,k+1) + height_arr(i+1,j  ,k+1) +
@@ -137,11 +137,11 @@ void ERFPC::initializeParticlesUniformDistributionInBox (const std::unique_ptr<M
             });
 
         } else {
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real x = plo[0] + (i + myhalf)*dx[0];
-                Real y = plo[1] + (j + myhalf)*dx[1];
-                Real z = plo[2] + (k + myhalf)*dx[2];
+                Real x = plo[0] + (i + myhalf_d)*dx[0];
+                Real y = plo[1] + (j + myhalf_d)*dx[1];
+                Real z = plo[2] + (k + myhalf_d)*dx[2];
                 bool in_box = AMREX_D_TERM(   (x >= blo0) && (x < bhi0),
                                            && (y >= blo1) && (y < bhi1),
                                            && (z >= blo2) && (z < bhi2) );
@@ -196,13 +196,13 @@ void ERFPC::initializeParticlesUniformDistributionInBox (const std::unique_ptr<M
 
         if (place_randomly_in_cells) {
 
-            ParallelForRNG(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k,
+            ParallelForRNG(tile_box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k,
                                                            const RandomEngine& rnd_engine) noexcept
             {
                 int start = offset_arr(i,j,k);
                 for (int n = start; n < start+num_particles_arr(i,j,k); n++) {
                     Real r[3] = {Random(rnd_engine), Random(rnd_engine), Random(rnd_engine)};
-                    Real v[3] = {zero, zero, zero};
+                    Real v[3] = {zero_d, zero_d, zero_d};
 
                     Real x = plo[0] + (i + r[0])*dx[0];
                     Real y = plo[1] + (j + r[1])*dx[1];
@@ -217,18 +217,18 @@ void ERFPC::initializeParticlesUniformDistributionInBox (const std::unique_ptr<M
                     vx_ptr[n] = v[0]; vy_ptr[n] = v[1]; vz_ptr[n] = v[2];
 
                     mass_ptr[n] = Real(1.0e-6);
-                    T_ptr[n] = zero;
+                    T_ptr[n] = zero_d;
                }
             });
 
         } else {
 
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,fourth_d=fourth,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 int start = offset_arr(i,j,k);
                 for (int n = start; n < start+num_particles_arr(i,j,k); n++) {
-                    Real r[3] = {Real(0.3), Real(0.7), fourth};
-                    Real v[3] = {zero, zero, zero};
+                    Real r[3] = {Real(0.3), Real(0.7), fourth_d};
+                    Real v[3] = {zero_d, zero_d, zero_d};
 
                     Real x = plo[0] + (i + r[0])*dx[0];
                     Real y = plo[1] + (j + r[1])*dx[1];
@@ -243,7 +243,7 @@ void ERFPC::initializeParticlesUniformDistributionInBox (const std::unique_ptr<M
                     vx_ptr[n] = v[0]; vy_ptr[n] = v[1]; vz_ptr[n] = v[2];
 
                     mass_ptr[n] = Real(1.0e-6);
-                    T_ptr[n] = zero;
+                    T_ptr[n] = zero_d;
                }
             });
         }

--- a/Source/Particles/ERF_SuperDropletPCAddParticles.cpp
+++ b/Source/Particles/ERF_SuperDropletPCAddParticles.cpp
@@ -40,7 +40,7 @@ void SuperDropletPC::setNumSDBoxDistribution (int a_lev,
         auto num_superdroplets_arr = a_num_sd[mfi].array();
         if (a_height_ptr) {
             const auto height_arr = (*a_height_ptr)[mfi].array();
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 bool flag = false;
                 if (a_subgrid) {
@@ -52,8 +52,8 @@ void SuperDropletPC::setNumSDBoxDistribution (int a_lev,
                                       height_arr(i+1,j+1,k+1) );
                     if (gridcell.contains(a_box)) { flag = true; }
                 } else {
-                    Real x = plo[0] + (i + myhalf)*dx[0];
-                    Real y = plo[1] + (j + myhalf)*dx[1];
+                    Real x = plo[0] + (i + myhalf_d)*dx[0];
+                    Real y = plo[1] + (j + myhalf_d)*dx[1];
                     Real z = Real(0.125) * (height_arr(i,j  ,k  ) + height_arr(i+1,j  ,k  ) +
                                       height_arr(i,j+1,k  ) + height_arr(i+1,j+1,k  ) +
                                       height_arr(i,j  ,k+1) + height_arr(i+1,j  ,k+1) +
@@ -66,7 +66,7 @@ void SuperDropletPC::setNumSDBoxDistribution (int a_lev,
                 if (flag) { num_superdroplets_arr(i,j,k) = a_n_per_cell; }
             });
         } else {
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 bool flag = false;
                 if (a_subgrid) {
@@ -78,9 +78,9 @@ void SuperDropletPC::setNumSDBoxDistribution (int a_lev,
                                       plo[2]+(k+1)*dx[2] );
                     if (gridcell.contains(a_box)) { flag = true; }
                 } else {
-                    Real x = plo[0] + (i + myhalf)*dx[0];
-                    Real y = plo[1] + (j + myhalf)*dx[1];
-                    Real z = plo[2] + (k + myhalf)*dx[2];
+                    Real x = plo[0] + (i + myhalf_d)*dx[0];
+                    Real y = plo[1] + (j + myhalf_d)*dx[1];
+                    Real z = plo[2] + (k + myhalf_d)*dx[2];
                     bool in_box = AMREX_D_TERM(   (x >= blo0) && (x < bhi0),
                                                && (y >= blo1) && (y < bhi1),
                                                && (z >= blo2) && (z < bhi2) );
@@ -113,7 +113,7 @@ void SuperDropletPC::setNumSDBubbleDistribution ( int a_lev,
         auto num_superdroplets_arr = a_num_sd[mfi].array();
         if (a_height_ptr) {
             const auto height_arr = (*a_height_ptr)[mfi].array();
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 bool flag = false;
                 if (a_subgrid) {
@@ -125,8 +125,8 @@ void SuperDropletPC::setNumSDBubbleDistribution ( int a_lev,
                                       height_arr(i+1,j+1,k+1) );
                     if (gridcell.contains(a_bubble.lo())) { flag = true; }
                 } else {
-                    Real x = plo[0] + (i + myhalf)*dx[0];
-                    Real y = plo[1] + (j + myhalf)*dx[1];
+                    Real x = plo[0] + (i + myhalf_d)*dx[0];
+                    Real y = plo[1] + (j + myhalf_d)*dx[1];
                     Real z = Real(0.125) * (height_arr(i,j  ,k  ) + height_arr(i+1,j  ,k  ) +
                                       height_arr(i,j+1,k  ) + height_arr(i+1,j+1,k  ) +
                                       height_arr(i,j  ,k+1) + height_arr(i+1,j  ,k+1) +
@@ -136,18 +136,18 @@ void SuperDropletPC::setNumSDBubbleDistribution ( int a_lev,
                     const auto& x_c = a_bubble.lo(); // center
                     const auto& x_r = a_bubble.hi(); // radius
 
-                    Real rad = zero;
+                    Real rad = zero_d;
                     if (x_r[0] > 0) rad += amrex::Math::powi<2>((x - x_c[0])/x_r[0]);
                     if (x_r[1] > 0) rad += amrex::Math::powi<2>((y - x_c[1])/x_r[1]);
                     if (x_r[2] > 0) rad += amrex::Math::powi<2>((z - x_c[2])/x_r[2]);
                     rad = std::sqrt(rad);
 
-                    if(rad <= one) { flag = true; }
+                    if(rad <= one_d) { flag = true; }
                 }
                 if (flag) { num_superdroplets_arr(i,j,k) = a_n_per_cell; }
             });
         } else {
-            ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tile_box, [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 bool flag = false;
                 if (a_subgrid) {
@@ -159,21 +159,21 @@ void SuperDropletPC::setNumSDBubbleDistribution ( int a_lev,
                                       plo[2]+(k+1)*dx[2] );
                     if (gridcell.contains(a_bubble.lo())) { flag = true; }
                 } else {
-                    Real x = plo[0] + (i + myhalf)*dx[0];
-                    Real y = plo[1] + (j + myhalf)*dx[1];
-                    Real z = plo[2] + (k + myhalf)*dx[2];
+                    Real x = plo[0] + (i + myhalf_d)*dx[0];
+                    Real y = plo[1] + (j + myhalf_d)*dx[1];
+                    Real z = plo[2] + (k + myhalf_d)*dx[2];
 
                     // Extract bubble params
                     const auto& x_c = a_bubble.lo();       // center
                     const auto& x_r = a_bubble.hi();       // radius
 
-                    Real rad = zero;
+                    Real rad = zero_d;
                     if (x_r[0] > 0) rad += amrex::Math::powi<2>((x - x_c[0])/x_r[0]);
                     if (x_r[1] > 0) rad += amrex::Math::powi<2>((y - x_c[1])/x_r[1]);
                     if (x_r[2] > 0) rad += amrex::Math::powi<2>((z - x_c[2])/x_r[2]);
                     rad = std::sqrt(rad);
 
-                    if(rad <= one) { flag = true; }
+                    if(rad <= one_d) { flag = true; }
                 }
                 if (flag) { num_superdroplets_arr(i,j,k) = a_n_per_cell; }
             });
@@ -343,18 +343,18 @@ void SuperDropletPC::addParticles ( int a_lev,
         auto* mult_ptr_init = multiplicity_d.data();
 
         // Generate species and aerosol distributions directly into particle SoA
-        ParallelForRNG(np, [=] AMREX_GPU_DEVICE (int n, const RandomEngine& engine) noexcept
+        ParallelForRNG(np, [=,zero_d=zero] AMREX_GPU_DEVICE (int n, const RandomEngine& engine) noexcept
         {
             // Sample species masses directly into particle storage
             for (int s = 0; s < num_sp; s++) {
-                Real sp_mult = zero;
+                Real sp_mult = zero_d;
                 sp_mass_ptrs[s][n] = SD_sample_mass_gpu(sp_params_ptr[s], engine, sp_mult);
             }
 
             // Sample aerosol masses directly into particle storage
-            Real total_mult = zero;
+            Real total_mult = zero_d;
             for (int a = 0; a < num_ae; a++) {
-                Real ae_mult = zero;
+                Real ae_mult = zero_d;
                 ae_mass_ptrs[a][n] = SD_sample_mass_gpu(ae_params_ptr[a], engine, ae_mult);
                 if (sampled_multiplicity) {
                     total_mult += ae_mult;
@@ -380,15 +380,15 @@ void SuperDropletPC::addParticles ( int a_lev,
 
         auto pdomain = a_init.m_particle_domain;
 
-        ParallelForRNG(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k, const RandomEngine& rnd_engine) noexcept
+        ParallelForRNG(tile_box, [=,one_d=one,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, const RandomEngine& rnd_engine) noexcept
         {
             int num_sd_this_cell = num_superdroplets_arr(i,j,k);
             Real num_to_add = num_par_per_cell;
             Real n_par_per_supdrop = std::ceil(num_par_per_cell/num_sd_per_cell);
 
-            Real mult_scale = one;
+            Real mult_scale = one_d;
             if (sampled_multiplicity) {
-                Real mult_sum = zero;
+                Real mult_sum = zero_d;
                 int start = offset_arr(i,j,k);
                 for (int n = start; n < start+num_sd_this_cell; n++) { mult_sum += mult_arr[n]; }
                 mult_scale = num_par_per_cell / mult_sum;
@@ -408,9 +408,9 @@ void SuperDropletPC::addParticles ( int a_lev,
                             p.pos(1) = pdomain.lo(1) + Random(rnd_engine) * (pdomain.hi(1) - pdomain.lo(1));
                             p.pos(2) = pdomain.lo(2) + Random(rnd_engine) * (pdomain.hi(2) - pdomain.lo(2));
                         } else {
-                            p.pos(0) = pdomain.lo(0) + myhalf * (pdomain.hi(0) - pdomain.lo(0));
-                            p.pos(1) = pdomain.lo(1) + myhalf * (pdomain.hi(1) - pdomain.lo(1));
-                            p.pos(2) = pdomain.lo(2) + myhalf * (pdomain.hi(2) - pdomain.lo(2));
+                            p.pos(0) = pdomain.lo(0) + myhalf_d * (pdomain.hi(0) - pdomain.lo(0));
+                            p.pos(1) = pdomain.lo(1) + myhalf_d * (pdomain.hi(1) - pdomain.lo(1));
+                            p.pos(2) = pdomain.lo(2) + myhalf_d * (pdomain.hi(2) - pdomain.lo(2));
                         }
                     } else if (itype == SDInitShape::bubble) {
                         if (random_place) {
@@ -440,14 +440,14 @@ void SuperDropletPC::addParticles ( int a_lev,
                         p.pos(1) = plo[1] + (j + Random(rnd_engine))*dx[1];
                         p.pos(2) = plo[2] + (k + Random(rnd_engine))*dx[2];
                     } else {
-                        p.pos(0) = plo[0] + (i + myhalf)*dx[0];
-                        p.pos(1) = plo[1] + (j + myhalf)*dx[1];
-                        p.pos(2) = plo[2] + (k + myhalf)*dx[2];
+                        p.pos(0) = plo[0] + (i + myhalf_d)*dx[0];
+                        p.pos(1) = plo[1] + (j + myhalf_d)*dx[1];
+                        p.pos(2) = plo[2] + (k + myhalf_d)*dx[2];
                     }
                 }
 
                 active_ptr[n] = 1;
-                vx_ptr[n] = vy_ptr[n] = vz_ptr[n] = zero;
+                vx_ptr[n] = vy_ptr[n] = vz_ptr[n] = zero_d;
 
                 Real mult_this_sd = 0;
                 if (sampled_multiplicity) {
@@ -473,16 +473,16 @@ void SuperDropletPC::addParticles ( int a_lev,
                                                      sp_rho_arr, ae_rho_arr );
                 mass_ptr[n] = SD_total_mass( n, num_sp, num_ae, sp_mass_ptrs, ae_mass_ptrs);
 
-                vterm_ptr[n] = zero;
+                vterm_ptr[n] = zero_d;
 #ifdef ERF_USE_ML_UPHYS_DIAGNOSTICS
-                condt_ptr[n] = zero;
+                condt_ptr[n] = zero_d;
 #endif
                 uid_ptr[n] = ParticleReal((pid+n-1)*nprocs + my_proc + 1);
             }
         });
 
         const auto height_arr = (*a_height_ptr)[mfi].array();
-        ParallelFor(tile_box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(tile_box, [=,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             int num_sd_this_cell = num_superdroplets_arr(i,j,k);
             int start = offset_arr(i,j,k);
@@ -495,11 +495,11 @@ void SuperDropletPC::addParticles ( int a_lev,
                               (y-plo[1])/dx[1] - j,
                               (z-plo[2])/dx[2] - k };
 
-                Real sx[] = { one - r[0], r[0]};
-                Real sy[] = { one - r[1], r[1]};
+                Real sx[] = { one_d - r[0], r[0]};
+                Real sy[] = { one_d - r[1], r[1]};
 
-                Real height_at_pxy_lo = zero;
-                Real height_at_pxy_hi = zero;
+                Real height_at_pxy_lo = zero_d;
+                Real height_at_pxy_hi = zero_d;
                 for (int ii = 0; ii < 2; ++ii) {
                     for (int jj = 0; jj < 2; ++jj) {
                         height_at_pxy_lo += sx[ii] * sy[jj]

--- a/Source/Particles/ERF_SuperDropletPCAdvection.cpp
+++ b/Source/Particles/ERF_SuperDropletPCAdvection.cpp
@@ -83,18 +83,18 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
         const auto& temperature_arr = a_temperature[grid].array();
         const auto& pressure_arr = a_pressure[grid].array();
 
-        ParallelFor(ptrs.num_particles, [=] AMREX_GPU_DEVICE (int i)
+        ParallelFor(ptrs.num_particles, [=,zero_d=zero,two_d=two,PI_d=PI] AMREX_GPU_DEVICE (int i)
         {
             ParticleType& p = p_pbox[i];
             if (p.id() <= 0) { return; }
             if (ptrs.active_ptr[i] == 0) { return; }
 
             ParticleReal v[AMREX_SPACEDIM];
-            v[0] = v[1] = v[2] = zero;
+            v[0] = v[1] = v[2] = zero_d;
 
             mac_interpolate(p, ctx.plo, ctx.dxi, umacarr, v);
             if (amrex::isnan(v[0]) || amrex::isnan(v[1]) || amrex::isnan(v[2])) {
-                v[0] = zero; v[1] = zero; v[2] = zero;
+                v[0] = zero_d; v[1] = zero_d; v[2] = zero_d;
             }
 
             // Interpolate density, pressure, temperature at particle position
@@ -112,9 +112,9 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
 
             if (prescribed_advection) {
                if (a_time < 600) {
-                   v[2] = two*sin(PI*a_time/600)/density;
+                   v[2] = two_d*sin(PI_d*a_time/600)/density;
                } else {
-                   v[2] = zero;
+                   v[2] = zero_d;
                }
             }
 
@@ -126,7 +126,7 @@ void SuperDropletPC::AdvectParticles ( int                   a_lev,
                                               ptrs.sp_mass_ptrs, ptrs.ae_mass_ptrs,
                                               ptrs.sp_rho_arr, ptrs.ae_rho_arr );
 
-            ParticleReal terminal_vel = zero;
+            ParticleReal terminal_vel = zero_d;
             if (vterm_type_w == SDTerminalVelocityType::AtlasUlbrich) {
                 terminal_vel = term_vel.AtlasUlbrich( r_eff );
             } else if (vterm_type_w == SDTerminalVelocityType::RogersYau) {

--- a/Source/Particles/ERF_SuperDropletPCBoundaries.cpp
+++ b/Source/Particles/ERF_SuperDropletPCBoundaries.cpp
@@ -43,7 +43,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
         Gpu::Buffer<Long> deactivated_particles({0});
         auto* deactivated_particles_ptr = deactivated_particles.data();
 
-        ParallelFor(ptrs.num_particles, [=] AMREX_GPU_DEVICE (int i)
+        ParallelFor(ptrs.num_particles, [=,zero_d=zero] AMREX_GPU_DEVICE (int i)
         {
             ParticleType& p = p_pbox[i];
             if (p.id() <= 0) { return; }
@@ -61,7 +61,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                 }
                 if (p.pos(2) < z_ground) {
                     p.pos(2) = z_ground + Real(0.01)*ctx.dx[2];
-                    ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                    ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
                     ptrs.active_ptr[i] = 0;
                     if ((!a_recycle) && (!save_inac)) { p.id() = -1; }
                     Gpu::Atomic::Add(deactivated_particles_ptr, Long(1));
@@ -80,7 +80,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                 }
                 if (p.pos(2) > z_roof) {
                     p.pos(2) = z_roof - ctx.dx[2];
-                    ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                    ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
                     ptrs.active_ptr[i] = 0;
                     if ((!a_recycle) && (!save_inac)) { p.id() = -1; }
                     Gpu::Atomic::Add(deactivated_particles_ptr, Long(1));
@@ -102,7 +102,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                     if ((bc_lo == ERF_BC::slip_wall) || (bc_lo == ERF_BC::no_slip_wall)) {
 
                         p.pos(d) = x_min + Real(0.01)*ctx.dx[d];
-                        ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                        ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
                         ptrs.active_ptr[i] = 0;
                         if ((!a_recycle) && (!save_inac)) { p.id() = -1; }
                         Gpu::Atomic::Add(deactivated_particles_ptr, Long(1));
@@ -112,10 +112,10 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                         auto delta = x_min - p.pos(d);
                         p.pos(d) = x_max - delta;
                         if (!ctx.is_periodic[d]) {
-                            ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                            ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
 
                             for (int ctr = 0; ctr < ctx.num_species; ctr++) {
-                                ptrs.sp_mass_ptrs[ctr][i] = zero;
+                                ptrs.sp_mass_ptrs[ctr][i] = zero_d;
                             }
 
                             ptrs.mult_ptr[i] = multiplicity;
@@ -133,7 +133,7 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                     if ((bc_hi == ERF_BC::slip_wall) || (bc_hi == ERF_BC::no_slip_wall)) {
 
                         p.pos(d) = x_max - Real(0.01)*ctx.dx[d];
-                        ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                        ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
                         ptrs.active_ptr[i] = 0;
                         if ((!a_recycle) && (!save_inac)) { p.id() = -1; }
                         Gpu::Atomic::Add(deactivated_particles_ptr, Long(1));
@@ -143,10 +143,10 @@ void SuperDropletPC::applyBoundaryTreatment ( int                   a_lev,
                         auto delta = p.pos(d) - x_max;
                         p.pos(d) = x_min + delta;
                         if (!ctx.is_periodic[d]) {
-                            ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                            ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
 
                             for (int ctr = 0; ctr < ctx.num_species; ctr++) {
-                                ptrs.sp_mass_ptrs[ctr][i] = zero;
+                                ptrs.sp_mass_ptrs[ctr][i] = zero_d;
                             }
 
                             ptrs.mult_ptr[i] = multiplicity;

--- a/Source/Particles/ERF_SuperDropletPCCoalescence.cpp
+++ b/Source/Particles/ERF_SuperDropletPCCoalescence.cpp
@@ -311,13 +311,13 @@ void SuperDropletPC::Coalescence( int   a_lev,
         auto flag_prey_ptr = flag_prey.data();
         auto coal_rate_ptr = coal_rate.data();
         auto coal_rmndr_ptr = coal_rmndr.data();
-        ParallelFor( np, [=] AMREX_GPU_DEVICE (int i) noexcept
+        ParallelFor( np, [=,zero_d=zero] AMREX_GPU_DEVICE (int i) noexcept
         {
             np_bin_ptr[i] = 0;
             partner_idx_ptr[i] = -1;
             flag_prey_ptr[i] = -1;
-            coal_rate_ptr[i] = zero;
-            coal_rmndr_ptr[i] = zero;
+            coal_rate_ptr[i] = zero_d;
+            coal_rmndr_ptr[i] = zero_d;
         });
         Gpu::synchronize();
 
@@ -372,7 +372,7 @@ void SuperDropletPC::Coalescence( int   a_lev,
         auto ae_rho_arr = ae_density.data();
         auto ae_sol_arr = ae_solubility.data();
 
-        ParallelForRNG( np, [=] AMREX_GPU_DEVICE (int i, RandomEngine const& rnd_eng) noexcept
+        ParallelForRNG( np, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, RandomEngine const& rnd_eng) noexcept
         {
             if (partner_idx_ptr[i] < 0) { return; }
             if (!flag_prey_ptr[i]) { return; }
@@ -381,7 +381,7 @@ void SuperDropletPC::Coalescence( int   a_lev,
             int pj = partner_idx_ptr[i];
             AMREX_ALWAYS_ASSERT(mult_ptr[pi] >= mult_ptr[pj]);
 
-            ParticleReal k_val = zero;
+            ParticleReal k_val = zero_d;
             if (kernel_choice == SDCoalescenceKernelType::golovin) {
 
                 k_val = ckernel.golovin(radius_ptr[pi],radius_ptr[pj]);
@@ -404,14 +404,14 @@ void SuperDropletPC::Coalescence( int   a_lev,
                     k_val = ckernel.Halls(radius_ptr[pi],radius_ptr[pj],v_i,v_j);
                 }
 
-                if (k_val < zero) {
+                if (k_val < zero_d) {
                     amrex::Abort("Invalid value for k_val");
                 }
             }
 
             if (include_brownian_coalescence) {
 
-                ParticleReal pressure = zero, temperature = zero;
+                ParticleReal pressure = zero_d, temperature = zero_d;
                 {
                     ParticleType& par_1 = pstruct_ptr[pi];
                     auto iv = getParticleCell(par_1, plo, dxi, domain);
@@ -419,8 +419,8 @@ void SuperDropletPC::Coalescence( int   a_lev,
                     temperature = temperature_arr(iv[0],iv[1],iv[2],0);
                 }
 
-                ParticleReal sd_mass_1 = zero,
-                             sd_mass_2 = zero;
+                ParticleReal sd_mass_1 = zero_d,
+                             sd_mass_2 = zero_d;
                 for (int ia = 0; ia < num_ae; ia++) {
                     sd_mass_1 += ae_mass_ptrs[ia][pi];
                     sd_mass_2 += ae_mass_ptrs[ia][pj];
@@ -449,7 +449,7 @@ void SuperDropletPC::Coalescence( int   a_lev,
                                                                 sd_mass_2,
                                                                 pressure,
                                                                 temperature );
-                if (k_brown < zero) {
+                if (k_brown < zero_d) {
                     amrex::Abort("Invalid value for k_brown");
                 }
 
@@ -461,7 +461,7 @@ void SuperDropletPC::Coalescence( int   a_lev,
             auto prob_sd_ij = std::max(mult_ptr[pi],mult_ptr[pj])*prob_ij;
 
             auto ns = static_cast<ParticleReal>(np_bin_ptr[i]);
-            auto scaling_factor = myhalf*ns*(ns-1)/std::floor(myhalf*ns);
+            auto scaling_factor = myhalf_d*ns*(ns-1)/std::floor(myhalf_d*ns);
             auto scaled_prob = prob_sd_ij * scaling_factor;
 
             auto gamma = coalescence_rate ( rnd_eng, static_cast<Real>(scaled_prob*a_dt) );

--- a/Source/Particles/ERF_SuperDropletPCDiagnostics.cpp
+++ b/Source/Particles/ERF_SuperDropletPCDiagnostics.cpp
@@ -663,7 +663,7 @@ void SuperDropletPC::ComputeBinnedDistributionsCell( const int a_iter,
         varnames[n] = std::string(r_str);
 
         ParticleToMesh( *this, m_mass_ln_R_mf, a_lev,
-            [=] AMREX_GPU_DEVICE (  const SDTDType& ptd, int i, Array4<Real> const& mf_arr)
+            [=,four_thirds_pi_d=four_thirds_pi,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (  const SDTDType& ptd, int i, Array4<Real> const& mf_arr)
             {
                 auto p = ptd.m_aos[i];
                 auto iv = getParticleCell(p, plo, dxi, domain);
@@ -671,14 +671,14 @@ void SuperDropletPC::ComputeBinnedDistributionsCell( const int a_iter,
                 auto ai = ptd.m_runtime_idata[SuperDropletsIntIdxSoA_RT::active][i];
                 auto ni = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
                 auto mi = ptd.m_runtime_rdata[ridx_s(idx_w,na,ns)][i];
-                auto ri = std::cbrt( mi / (four_thirds_pi*density) );
-                auto inbin = (r_l <= ri && ri < r_r) ? one : zero;
+                auto ri = std::cbrt( mi / (four_thirds_pi_d*density) );
+                auto inbin = (r_l <= ri && ri < r_r) ? one_d : zero_d;
 
                 Gpu::Atomic::AddNoRet(&mf_arr(iv, n), (ai*ni*mi*inbin * inv_cell_volume / dln_R));
             }, false);
 
         ParticleToMesh( *this, m_num_ln_R_mf, a_lev,
-            [=] AMREX_GPU_DEVICE (  const SDTDType& ptd, int i, Array4<Real> const& mf_arr)
+            [=,four_thirds_pi_d=four_thirds_pi,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (  const SDTDType& ptd, int i, Array4<Real> const& mf_arr)
             {
                 auto p = ptd.m_aos[i];
                 auto iv = getParticleCell(p, plo, dxi, domain);
@@ -686,8 +686,8 @@ void SuperDropletPC::ComputeBinnedDistributionsCell( const int a_iter,
                 auto ai = ptd.m_runtime_idata[SuperDropletsIntIdxSoA_RT::active][i];
                 auto ni = ptd.m_runtime_rdata[SuperDropletsRealIdxSoA_RT::multiplicity][i];
                 auto mi = ptd.m_runtime_rdata[ridx_s(idx_w,na,ns)][i];
-                auto ri = std::cbrt( mi / (four_thirds_pi*density) );
-                auto inbin = (r_l <= ri && ri < r_r) ? one : zero;
+                auto ri = std::cbrt( mi / (four_thirds_pi_d*density) );
+                auto inbin = (r_l <= ri && ri < r_r) ? one_d : zero_d;
 
                 Gpu::Atomic::AddNoRet(&mf_arr(iv, n), (ai*ni*inbin * inv_cell_volume / dln_R) );
             }, false);

--- a/Source/Particles/ERF_SuperDropletPCInitializations.cpp
+++ b/Source/Particles/ERF_SuperDropletPCInitializations.cpp
@@ -389,7 +389,7 @@ void SuperDropletPC::SetAttributes (MultiFab& a_rhoc /*!< mass density of conden
     {
         auto condensate_mass_density = a_rhoc[grid].array();
 
-        ParallelForRNG(np, [=] AMREX_GPU_DEVICE (int i, const RandomEngine& rnd_engine)
+        ParallelForRNG(np, [=,zero_d=zero,four_thirds_pi_d=four_thirds_pi] AMREX_GPU_DEVICE (int i, const RandomEngine& rnd_engine)
         {
             ParticleType& p = p_pbox[i];
             if (p.id() <= 0) { return; }
@@ -401,14 +401,14 @@ void SuperDropletPC::SetAttributes (MultiFab& a_rhoc /*!< mass density of conden
             Real mult_rnd = static_cast<Real>(-ptrs.mult_ptr[i]/3 + 2*ptrs.mult_ptr[i]/3*Random(rnd_engine));
             ptrs.mult_ptr[i] += mult_rnd;
 
-            ParticleReal species_mass_total = zero;
+            ParticleReal species_mass_total = zero_d;
             for (int ctr = 0; ctr < num_sp; ctr++) {
                 if (ctr != idx_w) {
                     species_mass_total += ptrs.sp_mass_ptrs[ctr][np];
                 }
             }
 
-            ParticleReal aerosol_mass_total = zero;
+            ParticleReal aerosol_mass_total = zero_d;
             for (int ctr = 0; ctr < num_ae; ctr++) {
                 aerosol_mass_total += ptrs.ae_mass_ptrs[ctr][np];
             }
@@ -416,8 +416,8 @@ void SuperDropletPC::SetAttributes (MultiFab& a_rhoc /*!< mass density of conden
             const Real mass_particle = static_cast<Real>(mass_condensate_sd / ptrs.mult_ptr[i] + aerosol_mass_total + species_mass_total);
             ptrs.mass_ptr[i] = mass_particle;
 
-            Real radius_cubed = mass_particle / (four_thirds_pi*rho_w);
-            Real radius = (radius_cubed == zero ? zero : std::cbrt(radius_cubed));
+            Real radius_cubed = mass_particle / (four_thirds_pi_d*rho_w);
+            Real radius = (radius_cubed == zero_d ? zero_d : std::cbrt(radius_cubed));
             ptrs.radius_ptr[i] = radius;
         });
     }); // end forEachParticleTile

--- a/Source/Particles/ERF_SuperDropletPCMassChange.cpp
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.cpp
@@ -100,7 +100,7 @@ void SuperDropletPC::MassChange ( int                                         a_
                                    ti_choice == SDMassChangeTIMethod::DIRK2,
                                    "ERROR: invalid time integrator choice!" );
 
-        ParallelFor(ptrs.num_particles, [=] AMREX_GPU_DEVICE (int i)
+        ParallelFor(ptrs.num_particles, [=,zero_d=zero,four_thirds_pi_d=four_thirds_pi] AMREX_GPU_DEVICE (int i)
         {
             ParticleType& p = p_pbox[i];
             if (p.id() <= 0) { return; }
@@ -128,7 +128,7 @@ void SuperDropletPC::MassChange ( int                                         a_
             const auto temperature = fv[static_cast<int>(InterpFieldsLV::temperature)];
             const auto pressure    = fv[static_cast<int>(InterpFieldsLV::pressure)];
 
-            ParticleReal solute_moles = zero;
+            ParticleReal solute_moles = zero_d;
             if (a_is_water) {
                 for (int j = 0; j < ctx.num_species; j++) {
                     if (j != idx_vap) {
@@ -202,7 +202,7 @@ void SuperDropletPC::MassChange ( int                                         a_
             } else {
                 // update particle attributes
                 auto r_new = std::sqrt(r_sq);
-                auto d_mass = four_thirds_pi*mat_density * (r_new*r_new*r_new - r_init*r_init*r_init);
+                auto d_mass = four_thirds_pi_d*mat_density * (r_new*r_new*r_new - r_init*r_init*r_init);
                 ptrs.sp_mass_ptrs[idx_vap][i] += d_mass;
                 // don't let it go negative
                 ptrs.sp_mass_ptrs[idx_vap][i] = std::max(ptrs.sp_mass_ptrs[idx_vap][i],ParticleReal(0));

--- a/Source/Particles/ERF_SuperDropletPCRecycle.cpp
+++ b/Source/Particles/ERF_SuperDropletPCRecycle.cpp
@@ -130,7 +130,7 @@ void SuperDropletPC::Recycle ( const int             a_lev,
         const auto z_max = m_recyc_zmax;
 
         forEachParticleTile(a_lev, proc_ctx,
-            [&](ParIterType& /*pti*/, int grid, ParticleType* p_pbox,
+            [&,one_d=one,zero_d=zero](ParIterType& /*pti*/, int grid, ParticleType* p_pbox,
                 const SDProcess::ParticlePointers& ptrs,
                 const SDProcess::ProcessContext& ctx)
         {
@@ -140,9 +140,9 @@ void SuperDropletPC::Recycle ( const int             a_lev,
             // Get sampled aerosol mass values based on initialization
             Gpu::DeviceVector<Real> aerosol_mass_d(ctx.num_aerosols*np);
             Gpu::DeviceVector<Real> multiplicity_d(np);
-            ParticleReal mult_scale = one;
+            ParticleReal mult_scale = one_d;
             {
-                Vector<Real> multiplicity_h(np, zero);
+                Vector<Real> multiplicity_h(np, zero_d);
                 for (int i = 0; i < ctx.num_aerosols; i++) {
                     Vector<Real> aerosol_mass_h;
                     if (sampled_multiplicity) {
@@ -167,7 +167,7 @@ void SuperDropletPC::Recycle ( const int             a_lev,
                 }
                 if (sampled_multiplicity) {
                     // compute multiplicity scale
-                    ParticleReal mult_sum = zero;
+                    ParticleReal mult_sum = zero_d;
                     for (int ctr=0; ctr < multiplicity_h.size(); ctr++) {
                         mult_sum += multiplicity_h[ctr];
                     }
@@ -187,7 +187,7 @@ void SuperDropletPC::Recycle ( const int             a_lev,
             Gpu::Buffer<Long> np_recycle_buf({0});
             auto* np_recycle_ptr = np_recycle_buf.data();
 
-            ParallelForRNG(np, [=] AMREX_GPU_DEVICE (int i, const RandomEngine& rnd_engine) noexcept
+            ParallelForRNG(np, [=,zero_d=zero,four_thirds_pi_d=four_thirds_pi] AMREX_GPU_DEVICE (int i, const RandomEngine& rnd_engine) noexcept
             {
                 ParticleType& p = p_pbox[i];
                 if (p.id() <= 0) { return; }
@@ -206,15 +206,15 @@ void SuperDropletPC::Recycle ( const int             a_lev,
                                                   ctx.plo, ctx.dxi, zheight, k_max));
 
                 // Set velocities to zero
-                ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero;
+                ptrs.v_ptr[0][i] = ptrs.v_ptr[1][i] = ptrs.v_ptr[2][i] = ptrs.vterm_ptr[i] = zero_d;
 
                 // reset all species masses to zero
                 for (int ctr = 0; ctr < ctx.num_species; ctr++) {
-                    ptrs.sp_mass_ptrs[ctr][i] = zero;
+                    ptrs.sp_mass_ptrs[ctr][i] = zero_d;
                 }
                 // Reset water mass
                 auto water_radius = Real(1.0e-15);
-                auto water_mass = four_thirds_pi
+                auto water_mass = four_thirds_pi_d
                                  * water_radius*water_radius*water_radius*ctx.rho_water;
                 ptrs.sp_mass_ptrs[ctx.idx_water][i] = water_mass;
 

--- a/Source/Particles/ERF_SuperDropletPCUtils.cpp
+++ b/Source/Particles/ERF_SuperDropletPCUtils.cpp
@@ -363,12 +363,12 @@ void SuperDropletPC::effectiveRadius (  MultiFab& a_mf,
         const auto& box = mfi.tilebox();
         auto mf_arr = a_mf.array(mfi);
         const auto nd_arr = number_density.const_array(mfi);
-        ParallelFor( box, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor( box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                           {
                               if (nd_arr(i,j,k,0) > 0) {
                                   mf_arr(i,j,k,a_comp) /= nd_arr(i,j,k,0);
                               } else {
-                                  mf_arr(i,j,k,a_comp) = zero;
+                                  mf_arr(i,j,k,a_comp) = zero_d;
                               }
                           } );
     }

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -639,7 +639,7 @@ Radiation::mf_to_kokkos_buffers (iMultiFab* lmask,
                                                                   Array4<const Real> {};
                 const Array4<      Real>& lsm_in_arr = (lsm_input_ptrs[ivar]) ? lsm_input_ptrs[ivar]->array(mfi) :
                                                                                 Array4<      Real> {};
-                ParallelFor(sbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(sbx, [=,lsm_undefined_d=lsm_undefined] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     // map [i,j,k] 0-based to [icol, ilay] 0-based
                     const int icol   = (j-jmin)*nx + (i-imin) + offset;
@@ -648,7 +648,7 @@ Radiation::mf_to_kokkos_buffers (iMultiFab* lmask,
                     bool is_land = (lmask_arr) ? lmask_arr(i,j,k) : 1;
 
                     // Check if valid LSM data
-                    bool valid_lsm_data = (lsm_in_arr && (lsm_in_arr(i,j,k) < lsm_undefined));
+                    bool valid_lsm_data = (lsm_in_arr && (lsm_in_arr(i,j,k) < lsm_undefined_d));
 
                     // Have LSM and are over land
                     if (is_land && valid_lsm_data) {
@@ -715,7 +715,7 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
         const int offset     = m_col_offsets[mfi.index()];
         const Array4<Real>& q_arr = m_qheating_rates->array(mfi);
         const Array4<Real>& f_arr = m_rad_fluxes->array(mfi);
-        ParallelFor(vbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(vbx, [=,one_d=one,R_d_d=R_d,Cp_d_d=Cp_d] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             // map [i,j,k] 0-based to [icol, ilay] 0-based
             const int icol = (j-jmin)*nx + (i-imin) + offset;
@@ -726,7 +726,7 @@ Radiation::kokkos_buffers_to_mf (Vector<MultiFab*>& lsm_output_ptrs)
             q_arr(i,j,k,1) = lw_heating_tab(icol,ilay);
 
             // Convert the dT/dz to dTheta/dz
-            Real iexner = one/getExnergivenP(Real(p_lay_tab(icol,ilay)), R_d/Cp_d);
+            Real iexner = one_d/getExnergivenP(Real(p_lay_tab(icol,ilay)), R_d_d/Cp_d_d);
             q_arr(i,j,k,0) *= iexner;
             q_arr(i,j,k,1) *= iexner;
 
@@ -1162,11 +1162,11 @@ Radiation::run_impl ()
         double dt  = double(m_dt);
         auto rad_freq_in_steps = m_rad_freq_in_steps;
         Kokkos::parallel_for(Kokkos::RangePolicy<Kokkos::Serial>(0, ncol),
-                             [&] (int icol)
+                             [&,PI_d=PI] (int icol)
         {
             // Convert lat/lon to radians
-            double lat_col = h_lat(icol)*PI/Real(180.0);
-            double lon_col = h_lon(icol)*PI/Real(180.0);
+            double lat_col = h_lat(icol)*PI_d/Real(180.0);
+            double lon_col = h_lon(icol)*PI_d/Real(180.0);
             double lcalday = calday;
             double ldelta  = delta;
             double dt_avg  = static_cast<double>(rad_freq_in_steps) * dt;

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -421,7 +421,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
 
         const Array4<const Real>& z_arr    = (m_z_phys) ? m_z_phys->const_array(mfi) :
                                                           Array4<const Real>{};
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(gbx, [=,CONST_GRAV_d=CONST_GRAV] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // NOTE: k gets permuted with ilay
             // map [i,j,k] 0-based to [icol, ilay] 0-based
@@ -464,7 +464,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             // Interface data structures
             //=======================================================
             // eamxx_common_physics_functions_impl.hpp: calculate_vertical_velocity
-            omega_d(icol,ilay)         = -w_limited * r * CONST_GRAV;
+            omega_d(icol,ilay)         = -w_limited * r * CONST_GRAV_d;
             if (k==0) {
                 int ii  = std::min(std::max(i,ilo),ihi);
                 int jj  = std::min(std::max(j,jlo),jhi);
@@ -488,7 +488,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
             p_mid_d(icol,ilay)       = getPgivenRTh(rt, qv);
             p_int_d(icol,ilayi)      = getPgivenRTh(rt_avg, qv_avg);
             // eamxx_common_physics_functions_impl.hpp: calculate_density
-            pseudo_dens_d(icol,ilay) = r * CONST_GRAV * delz;
+            pseudo_dens_d(icol,ilay) = r * CONST_GRAV_d * delz;
             // Enforce the grid spacing
             dz_d(icol,ilay) = delz;
             // Surface geopotential
@@ -497,7 +497,7 @@ SHOCInterface::mf_to_kokkos_buffers ()
                                                  + (z_arr(i+1,j  ,k+1) + z_arr(i+1,j  ,k))
                                                  + (z_arr(i  ,j+1,k+1) + z_arr(i  ,j+1,k))
                                                  + (z_arr(i+1,j+1,k+1) + z_arr(i+1,j+1,k)) ) : ProbLoArr[2];
-                phis_d(icol) = CONST_GRAV * z;
+                phis_d(icol) = CONST_GRAV_d * z;
             }
 
             if (ilay==0) {
@@ -559,7 +559,7 @@ SHOCInterface::kokkos_buffers_to_mf (const double dt)
         const Array4<Real>& v_tend_arr     = v_tend.array(mfi);
 
         ParallelFor(vbx_cc, vbx_x, vbx_y,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             // NOTE: k gets permuted with ilay
             // map [i,j,k] 0-based to [icol, ilay] 0-based
@@ -570,7 +570,7 @@ SHOCInterface::kokkos_buffers_to_mf (const double dt)
             Real r  = cons_arr(i,j,k,Rho_comp);
 
             // Theta at CC (eamxx_common_physics_functions_impl.hpp L123)
-            Real Th = thlm_d(icol,ilay)[0] / ( one - (one / T_mid_d(icol,ilay)[0])
+            Real Th = thlm_d(icol,ilay)[0] / ( one_d - (one_d / T_mid_d(icol,ilay)[0])
                                              * (C::LatVap/C::Cpair) * qc_d(icol,ilay)[0] );
 
             // Populate the tendencies

--- a/Source/Prob/ERF_InitCustomPertVels_ABL.H
+++ b/Source/Prob/ERF_InitCustomPertVels_ABL.H
@@ -40,60 +40,60 @@
     }
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+    ParallelForRNG(xbx, [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = (z_nd) ? fourth*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = (z_nd) ? fourth_d*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
                                      + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
-                                   : prob_lo[2] + (k + myhalf) * dx[2];
+                                   : prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = U_0;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
-        if (pert_deltaU != zero)
+        if (pert_deltaU != zero_d)
         {
             const amrex::Real yl = y - prob_lo[1];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             x_vel_pert(i, j, k) += ufac * damp * z * std::cos(aval * yl);
         }
     });
 
     // Set the y-velocity
-    ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(ybx, [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real z = (z_nd) ? fourth*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real z = (z_nd) ? fourth_d*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
                                      + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
-                                   : prob_lo[2] + (k + myhalf) * dx[2];
+                                   : prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the y-velocity
         y_vel_pert(i, j, k) = V_0;
-        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+            Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
             y_vel_pert(i, j, k) += y_vel_prime;
         }
-        if (pert_deltaV != zero)
+        if (pert_deltaV != zero_d)
         {
             const amrex::Real xl = x - prob_lo[0];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
         }
     });
 
     // Set the z-velocity
-    ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const int dom_lo_z = geomdata.Domain().smallEnd()[2];
         const int dom_hi_z = geomdata.Domain().bigEnd()[2];
@@ -101,12 +101,12 @@
         // Set the z-velocity
         if (k == dom_lo_z || k == dom_hi_z+1)
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         }
-        else if (W_0_Pert_Mag != zero)
+        else if (W_0_Pert_Mag != zero_d)
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+            Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
             z_vel_pert(i, j, k) = W_0 + z_vel_prime;
         }
     });

--- a/Source/Prob/ERF_InitCustomPertVels_Bomex.H
+++ b/Source/Prob/ERF_InitCustomPertVels_Bomex.H
@@ -27,69 +27,69 @@
     Real vfac = pert_deltaV * std::exp(myhalf) / pert_ref_height;
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(xbx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = U_0;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
-        if (pert_deltaU != zero)
+        if (pert_deltaU != zero_d)
         {
             const amrex::Real yl = y - prob_lo[1];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             x_vel_pert(i, j, k) += ufac * damp * z * std::cos(aval * yl);
         }
     });
 
   // Set the y-velocity
-  ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+  ParallelForRNG(ybx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
   {
       const Real* prob_lo = geomdata.ProbLo();
       const Real* dx = geomdata.CellSize();
-      const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-      const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+      const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+      const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
       // Set the y-velocity
       y_vel_pert(i, j, k) = V_0;
-      if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+      if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
       {
           Real rand_double = amrex::Random(engine); // Between zero and one
-          Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+          Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
           y_vel_pert(i, j, k) += y_vel_prime;
       }
-      if (pert_deltaV != zero)
+      if (pert_deltaV != zero_d)
       {
           const amrex::Real xl = x - prob_lo[0];
           const amrex::Real zl = z / pert_ref_height;
-          const amrex::Real damp = std::exp(-myhalf * zl * zl);
+          const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
           y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
       }
   });
 
   // Set the z-velocity
-  ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+  ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
   {
       const int dom_lo_z = geomdata.Domain().smallEnd()[2];
       const int dom_hi_z = geomdata.Domain().bigEnd()[2];
 // Set the z-velocity
       if (k == dom_lo_z || k == dom_hi_z+1)
       {
-          z_vel_pert(i, j, k) = zero;
+          z_vel_pert(i, j, k) = zero_d;
       }
-      else if (W_0_Pert_Mag != zero)
+      else if (W_0_Pert_Mag != zero_d)
       {
           Real rand_double = amrex::Random(engine); // Between zero and one
-          Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+          Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
           z_vel_pert(i, j, k) = W_0 + z_vel_prime;
       }
   });

--- a/Source/Prob/ERF_InitCustomPertVels_CouettePoiseuille.H
+++ b/Source/Prob/ERF_InitCustomPertVels_CouettePoiseuille.H
@@ -34,17 +34,17 @@
     // Couette flow
     if (prob_type == 1) {
 
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             const auto *const prob_hi  = geomdata.ProbHi();
             const auto *const dx       = geomdata.CellSize();
-            const Real z = (k + myhalf) * dx[2];
+            const Real z = (k + myhalf_d) * dx[2];
             x_vel_pert(i, j, k) = U_0 * z / prob_hi[2];
         });
 
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             const auto *const prob_hi  = geomdata.ProbHi();
             const auto *const dx       = geomdata.CellSize();
-            const Real z = (k + myhalf) * dx[2];
+            const Real z = (k + myhalf_d) * dx[2];
             y_vel_pert(i, j, k) = V_0 * z / prob_hi[2];
         });
 
@@ -55,86 +55,86 @@
     // Poiseuille flow
     } else if (prob_type == 10 || prob_type == 11) {
 
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,myhalf_d=myhalf,one_d=one,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             const Real* prob_lo = geomdata.ProbLo();
             const Real* dx      = geomdata.CellSize();
-            const Real z_h = prob_lo[2] + (k + myhalf) *  dx[2];
+            const Real z_h = prob_lo[2] + (k + myhalf_d) *  dx[2];
 
             // Set the x-velocity to be a parabolic profile with max 1 at z = 0 and 0 at z = +/-1
             if (prob_type == 10) {
-                x_vel_pert(i, j, k) = one - z_h * z_h;
+                x_vel_pert(i, j, k) = one_d - z_h * z_h;
             } else {
-                x_vel_pert(i, j, k) = zero;
+                x_vel_pert(i, j, k) = zero_d;
             }
         });
 
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,myhalf_d=myhalf,one_d=one,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             const Real* prob_lo = geomdata.ProbLo();
             const Real* dx      = geomdata.CellSize();
-            const Real z_h = prob_lo[2] + (k + myhalf) *  dx[2];
+            const Real z_h = prob_lo[2] + (k + myhalf_d) *  dx[2];
 
             // Set the x-velocity to be a parabolic profile with max 1 at z = 0 and 0 at z = +/-1
             if (prob_type == 11) {
-               y_vel_pert(i, j, k) = one - z_h * z_h;
+               y_vel_pert(i, j, k) = one_d - z_h * z_h;
             } else {
-               y_vel_pert(i, j, k) = zero;
+               y_vel_pert(i, j, k) = zero_d;
             }
         });
 
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         });
 
     // plane channel flow initialization
     } else if (prob_type == 20 || prob_type == 21) {
 
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(xbx, [=,fourth_d=fourth,two_d=two,myhalf_d=myhalf,one_d=one,zero_d=zero,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             const Real* prob_lo = geomdata.ProbLo();
             const Real* prob_hi = geomdata.ProbHi();
             const Real* dx      = geomdata.CellSize();
 
 
-            const Real z = fourth*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1) + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) );
+            const Real z = fourth_d*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1) + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) );
 
             // Normalized wall-normal dist between -1 and 1
-            Real y_h = (prob_type == 20) ? two * (j + myhalf) * dx[1] / (prob_hi[1] - prob_lo[1]) - one
-                                                 : two * (z - prob_lo[2])  / (prob_hi[2] - prob_lo[2]) - one;
+            Real y_h = (prob_type == 20) ? two_d * (j + myhalf_d) * dx[1] / (prob_hi[1] - prob_lo[1]) - one_d
+                                                 : two_d * (z - prob_lo[2])  / (prob_hi[2] - prob_lo[2]) - one_d;
 
-            x_vel_pert(i, j, k) = U_0 * (one - y_h * y_h);
+            x_vel_pert(i, j, k) = U_0 * (one_d - y_h * y_h);
 
-            if (pert_delta_u != zero) {
-                const Real yl = (j + myhalf) * dx[1];
-                const Real scaling = std::cos(PI/two * y_h);
+            if (pert_delta_u != zero_d) {
+                const Real yl = (j + myhalf_d) * dx[1];
+                const Real scaling = std::cos(PI_d/two_d * y_h);
                 x_vel_pert(i, j, k) += pert_delta_u * scaling * std::cos(aval * yl);
             }
         });
 
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(ybx, [=,zero_d=zero,fourth_d=fourth,myhalf_d=myhalf,two_d=two,one_d=one,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             const Real* prob_lo = geomdata.ProbLo();
             const Real* prob_hi = geomdata.ProbHi();
             const Real* dx      = geomdata.CellSize();
 
             // Normalized wall-normal dist between -1 and 1
-            y_vel_pert(i, j, k) = zero;
+            y_vel_pert(i, j, k) = zero_d;
 
-            const Real z = fourth*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1) + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) );
+            const Real z = fourth_d*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1) + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) );
 
-            if (pert_delta_u != zero) {
-                const Real xl = (i + myhalf) * dx[0];
-                Real y_h = (prob_type == 20) ? two * (j + myhalf) * dx[1] / (prob_hi[1] - prob_lo[1]) - one
-                                                     : two * (z - prob_lo[2])  / (prob_hi[2] - prob_lo[2]) - one;
-                const Real scaling = std::cos(PI/two * y_h);
+            if (pert_delta_u != zero_d) {
+                const Real xl = (i + myhalf_d) * dx[0];
+                Real y_h = (prob_type == 20) ? two_d * (j + myhalf_d) * dx[1] / (prob_hi[1] - prob_lo[1]) - one_d
+                                                     : two_d * (z - prob_lo[2])  / (prob_hi[2] - prob_lo[2]) - one_d;
+                const Real scaling = std::cos(PI_d/two_d * y_h);
                 y_vel_pert(i, j, k) += pert_delta_v * scaling * std::cos(bval * xl);
             }
         });
 
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         });
     } // prob_type

--- a/Source/Prob/ERF_InitCustomPertVels_DataAssimilation_ISV.H
+++ b/Source/Prob/ERF_InitCustomPertVels_DataAssimilation_ISV.H
@@ -21,13 +21,13 @@
     amrex::Real a_inf = std::sqrt(gamma * R_d * T_inf);
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
         const Real x =  i           * dx[0]; // face center
-        const Real y = (j + myhalf) * dx[1]; // cell center
+        const Real y = (j + myhalf_d) * dx[1]; // cell center
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
 
         x_vel_pert(i, j, k) = (M_inf * std::cos(alpha)
@@ -35,12 +35,12 @@
     });
 
     // Set the y-velocity
-    ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
-        const Real x = (i + myhalf) * dx[0]; // cell center
+        const Real x = (i + myhalf_d) * dx[0]; // cell center
         const Real y =  j           * dx[1]; // face center
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
 

--- a/Source/Prob/ERF_InitCustomPertVels_EkmanSpiral.H
+++ b/Source/Prob/ERF_InitCustomPertVels_EkmanSpiral.H
@@ -28,25 +28,25 @@
         const Real a = one / DE;
 
         // Set the x-velocity
-        ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(xbx, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             const auto dx = geomdata.CellSize();
-            const Real z = (k + myhalf) * dx[2];
+            const Real z = (k + myhalf_d) * dx[2];
 
             // Set the x-velocity
-            x_vel_pert(i, j, k) = u_0 * (one - std::exp(-a * z) * std::cos(-a * z));
+            x_vel_pert(i, j, k) = u_0 * (one_d - std::exp(-a * z) * std::cos(-a * z));
         });
 
         // Set the y-velocity
-        ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             const auto dx = geomdata.CellSize();
-            const Real z = (k + myhalf) * dx[2];
+            const Real z = (k + myhalf_d) * dx[2];
 
             // Set the y-velocity
             y_vel_pert(i, j, k) = -u_0 * std::exp(-a * z) * std::sin(-a * z);
         });
 
         // Set the z-velocity
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            z_vel_pert(i, j, k) = zero;
+        ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            z_vel_pert(i, j, k) = zero_d;
         });
     } // end if uniform

--- a/Source/Prob/ERF_InitCustomPertVels_IsentropicVortex.H
+++ b/Source/Prob/ERF_InitCustomPertVels_IsentropicVortex.H
@@ -21,13 +21,13 @@
     amrex::Real a_inf = std::sqrt(gamma * R_d * T_inf);
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(xbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
         const Real x =  i        * dx[0]; // face center
-        const Real y = (j + myhalf) * dx[1]; // cell center
+        const Real y = (j + myhalf_d) * dx[1]; // cell center
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
 
         x_vel_pert(i, j, k) = (M_inf * std::cos(alpha)
@@ -35,12 +35,12 @@
     });
 
     // Set the y-velocity
-    ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(ybx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
-        const Real x = (i + myhalf) * dx[0]; // cell center
+        const Real x = (i + myhalf_d) * dx[0]; // cell center
         const Real y =  j        * dx[1]; // face center
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
 

--- a/Source/Prob/ERF_InitCustomPertVels_MovingTerrain.H
+++ b/Source/Prob/ERF_InitCustomPertVels_MovingTerrain.H
@@ -8,13 +8,13 @@
     Real omega       = std::sqrt(g * kp);
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(xbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const auto prob_lo  = geomdata.ProbLo();
         const auto dx       = geomdata.CellSize();
 
         const Real x = prob_lo[0] + i * dx[0];
-        Real z = fourth * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
+        Real z = fourth_d * (z_nd(i,j,k) + z_nd(i,j+1,k) + z_nd(i,j,k+1) + z_nd(i,j+1,k+1));
 
         Real z_base = Ampl * std::sin(kp * x);
         z -= z_base;
@@ -25,12 +25,12 @@
     });
 
     // Set the z-velocity from impenetrable condition
-    ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(zbx, [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const auto dx         = geomdata.CellSize();
 
-        Real x   = (i + myhalf) * dx[0];
-        Real z   = fourth * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k) );
+        Real x   = (i + myhalf_d) * dx[0];
+        Real z   = fourth_d * ( z_nd(i,j,k) + z_nd(i+1,j,k) + z_nd(i,j+1,k) + z_nd(i+1,j+1,k) );
         Real z_base = Ampl * std::sin(kp * x);
 
         z -= z_base;

--- a/Source/Prob/ERF_InitCustomPertVels_ParticleTests.H
+++ b/Source/Prob/ERF_InitCustomPertVels_ParticleTests.H
@@ -20,9 +20,9 @@
   dxInv[2] = one / dx[2];
 
   // Set the z-velocity from impenetrable condition
-  ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+  ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
-      z_vel_pert(i, j, k) = WFromOmega(i, j, k, zero,
+      z_vel_pert(i, j, k) = WFromOmega(i, j, k, zero_d,
                                        x_vel_pert, y_vel_pert,
                                        mf_u, mf_v, z_nd, dxInv);
   });

--- a/Source/Prob/ERF_InitCustomPertVels_RICO.H
+++ b/Source/Prob/ERF_InitCustomPertVels_RICO.H
@@ -26,57 +26,57 @@
     Real vfac = pert_deltaV * std::exp(myhalf) / pert_ref_height;
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(xbx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = U_0;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
-        if (pert_deltaU != zero)
+        if (pert_deltaU != zero_d)
         {
             const amrex::Real yl = y - prob_lo[1];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             x_vel_pert(i, j, k) += ufac * damp * z * std::cos(aval * yl);
         }
     });
 
     // Set the y-velocity
-    ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(ybx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the y-velocity
         y_vel_pert(i, j, k) = V_0;
-        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+            Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
             y_vel_pert(i, j, k) += y_vel_prime;
         }
-        if (pert_deltaV != zero)
+        if (pert_deltaV != zero_d)
         {
             const amrex::Real xl = x - prob_lo[0];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
         }
     });
 
     // Set the z-velocity
-    ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         const int dom_lo_z = geomdata.Domain().smallEnd()[2];
         const int dom_hi_z = geomdata.Domain().bigEnd()[2];
@@ -84,12 +84,12 @@
         // Set the z-velocity
         if (k == dom_lo_z || k == dom_hi_z+1)
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         }
-        else if (W_0_Pert_Mag != zero)
+        else if (W_0_Pert_Mag != zero_d)
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+            Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
             z_vel_pert(i, j, k) = W_0 + z_vel_prime;
         }
     });

--- a/Source/Prob/ERF_InitCustomPertVels_SDMCongestus3D.H
+++ b/Source/Prob/ERF_InitCustomPertVels_SDMCongestus3D.H
@@ -30,57 +30,57 @@
     Real vfac = pert_deltaV * std::exp(myhalf) / pert_ref_height;
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(xbx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = U_0;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
-        if (pert_deltaU != zero)
+        if (pert_deltaU != zero_d)
         {
             const amrex::Real yl = y - prob_lo[1];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             x_vel_pert(i, j, k) += ufac * damp * z * std::cos(aval * yl);
         }
     });
 
     // Set the y-velocity
-    ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(ybx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the y-velocity
         y_vel_pert(i, j, k) = V_0;
-        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+            Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
             y_vel_pert(i, j, k) += y_vel_prime;
         }
-        if (pert_deltaV != zero)
+        if (pert_deltaV != zero_d)
         {
             const amrex::Real xl = x - prob_lo[0];
             const amrex::Real zl = z / pert_ref_height;
-            const amrex::Real damp = std::exp(-myhalf * zl * zl);
+            const amrex::Real damp = std::exp(-myhalf_d * zl * zl);
             y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
         }
     });
 
     // Set the z-velocity
-    ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const int dom_lo_z = geomdata.Domain().smallEnd()[2];
         const int dom_hi_z = geomdata.Domain().bigEnd()[2];
@@ -88,12 +88,12 @@
         // Set the z-velocity
         if (k == dom_lo_z || k == dom_hi_z+1)
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         }
-        else if (W_0_Pert_Mag != zero)
+        else if (W_0_Pert_Mag != zero_d)
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+            Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
             z_vel_pert(i, j, k) = W_0 + z_vel_prime;
         }
     });

--- a/Source/Prob/ERF_InitCustomPertVels_ScalarAdvDiff.H
+++ b/Source/Prob/ERF_InitCustomPertVels_ScalarAdvDiff.H
@@ -12,14 +12,14 @@
     int prob_type = -1; pp_for_pert_vels.query("prob_type", prob_type);
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(xbx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real*      dx = geomdata.CellSize();
-        const Real        z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real        z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
-        if (uRef != zero) {
+        if (uRef != zero_d) {
             x_vel_pert(i, j, k) = U_0 + uRef *
                                   std::log((z + z0)/z0) / std::log((zRef +z0)/z0);
         } else {

--- a/Source/Prob/ERF_InitCustomPertVels_TaylorGreenVortex.H
+++ b/Source/Prob/ERF_InitCustomPertVels_TaylorGreenVortex.H
@@ -3,26 +3,26 @@
     Real V_0   =   one; pp_for_pert_vels.query("V_0", V_0);
 
     // Set the x-velocity
-    ParallelFor(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(xbx, [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + zero) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + zero_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = V_0 * std::sin(x) * std::cos(y) * std::cos(z);
     });
 
     // Set the y-velocity
-    ParallelFor(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(ybx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + zero) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + zero_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the y-velocity
         y_vel_pert(i, j, k) = - V_0 * std::cos(x) * std::sin(y) * std::cos(z);

--- a/Source/Prob/ERF_InitCustomPertVels_Terrain3DHemisphere.H
+++ b/Source/Prob/ERF_InitCustomPertVels_Terrain3DHemisphere.H
@@ -26,46 +26,46 @@
     const bool use_terrain  = (SolverChoice::terrain_type != TerrainType::None);
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(xbx, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real z = use_terrain ? fourth*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+        const Real z = use_terrain ? fourth_d*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
                                           + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
-            : prob_lo[2] + (k + myhalf) * dx[2];
+            : prob_lo[2] + (k + myhalf_d) * dx[2];
 
-        x_vel_pert(i, j, k) = zero;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        x_vel_pert(i, j, k) = zero_d;
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
     });
 
     // Set the y-velocity
-    ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(ybx, [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real z = use_terrain ? fourth*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real z = use_terrain ? fourth_d*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
                                           + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
-            : prob_lo[2] + (k + myhalf) * dx[2];
+            : prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the y-velocity
-        y_vel_pert(i, j, k) = zero;
-        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+        y_vel_pert(i, j, k) = zero_d;
+        if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+            Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
             y_vel_pert(i, j, k) += y_vel_prime;
         }
-        if (pert_deltaV != zero)
+        if (pert_deltaV != zero_d)
         {
             const Real xl = x - prob_lo[0];
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
             y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
         }
     });
@@ -77,7 +77,7 @@
     dxInv[2] = one / dx[2];
 
     // Set the z-velocity from impenetrable condition
-    ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const int dom_lo_z = geomdata.Domain().smallEnd()[2];
         const int dom_hi_z = geomdata.Domain().bigEnd()[2];
@@ -85,12 +85,12 @@
         // Set the z-velocity
         if (k == dom_lo_z || k == dom_hi_z+1)
         {
-            z_vel_pert(i, j, k) = zero;
+            z_vel_pert(i, j, k) = zero_d;
         }
-        else if (W_0_Pert_Mag != zero)
+        else if (W_0_Pert_Mag != zero_d)
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+            Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
             z_vel_pert(i, j, k) = z_vel_prime;
         }
     });

--- a/Source/Prob/ERF_InitCustomPertVels_TurbulentInflow.H
+++ b/Source/Prob/ERF_InitCustomPertVels_TurbulentInflow.H
@@ -40,72 +40,72 @@
     const bool use_terrain  = (SolverChoice::terrain_type != TerrainType::None);
 
     // Set the x-velocity
-    ParallelForRNG(xbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(xbx, [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = use_terrain ? fourth*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = use_terrain ? fourth_d*( z_nd(i,j  ,k) + z_nd(i,j  ,k+1)
                                           + z_nd(i,j+1,k) + z_nd(i,j+1,k+1) )
-                                   : prob_lo[2] + (k + myhalf) * dx[2];
+                                   : prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Set the x-velocity
         x_vel_pert(i, j, k) = U_0;
-        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero))
+        if ((z <= pert_ref_height) && (U_0_Pert_Mag != zero_d))
         {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real x_vel_prime = (rand_double*two - one)*U_0_Pert_Mag;
+            Real x_vel_prime = (rand_double*two_d - one_d)*U_0_Pert_Mag;
             x_vel_pert(i, j, k) += x_vel_prime;
         }
-        if (pert_deltaU != zero)
+        if (pert_deltaU != zero_d)
         {
             const Real yl = y - prob_lo[1];
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
             x_vel_pert(i, j, k) += ufac * damp * z * std::cos(aval * yl);
         }
     });
 
   // Set the y-velocity
-  ParallelForRNG(ybx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(ybx, [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const Real* prob_lo = geomdata.ProbLo();
     const Real* dx = geomdata.CellSize();
-    const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-    const Real z = use_terrain ? fourth*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
+    const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+    const Real z = use_terrain ? fourth_d*( z_nd(i  ,j,k) + z_nd(i  ,j,k+1)
                                       + z_nd(i+1,j,k) + z_nd(i+1,j,k+1) )
-                               : prob_lo[2] + (k + myhalf) * dx[2];
+                               : prob_lo[2] + (k + myhalf_d) * dx[2];
 
     // Set the y-velocity
     y_vel_pert(i, j, k) = V_0;
-    if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero))
+    if ((z <= pert_ref_height) && (V_0_Pert_Mag != zero_d))
     {
         Real rand_double = amrex::Random(engine); // Between zero and one
-        Real y_vel_prime = (rand_double*two - one)*V_0_Pert_Mag;
+        Real y_vel_prime = (rand_double*two_d - one_d)*V_0_Pert_Mag;
         y_vel_pert(i, j, k) += y_vel_prime;
     }
-    if (pert_deltaV != zero)
+    if (pert_deltaV != zero_d)
     {
         const Real xl = x - prob_lo[0];
         const Real zl = z / pert_ref_height;
-        const Real damp = std::exp(-myhalf * zl * zl);
+        const Real damp = std::exp(-myhalf_d * zl * zl);
         y_vel_pert(i, j, k) += vfac * damp * z * std::cos(bval * xl);
     }
   });
 
   // Set the z-velocity
-  ParallelForRNG(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
+  ParallelForRNG(zbx, [=,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept {
     const int dom_lo_z = geomdata.Domain().smallEnd()[2];
     const int dom_hi_z = geomdata.Domain().bigEnd()[2];
 
     // Set the z-velocity
     if (k == dom_lo_z || k == dom_hi_z+1)
     {
-        z_vel_pert(i, j, k) = zero;
+        z_vel_pert(i, j, k) = zero_d;
     }
-    else if (W_0_Pert_Mag != zero)
+    else if (W_0_Pert_Mag != zero_d)
     {
         Real rand_double = amrex::Random(engine); // Between zero and one
-        Real z_vel_prime = (rand_double*two - one)*W_0_Pert_Mag;
+        Real z_vel_prime = (rand_double*two_d - one_d)*W_0_Pert_Mag;
         z_vel_pert(i, j, k) = W_0 + z_vel_prime;
     }
   });

--- a/Source/Prob/ERF_InitCustomPertVels_WitchOfAgnesi.H
+++ b/Source/Prob/ERF_InitCustomPertVels_WitchOfAgnesi.H
@@ -26,9 +26,9 @@
     // Set the z-velocity from impenetrable condition
     if (sc.terrain_type == TerrainType::StaticFittedMesh ||
         sc.terrain_type == TerrainType::MovingFittedMesh   ) {
-        ParallelFor(zbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(zbx, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            z_vel_pert(i, j, k) = WFromOmega(i, j, k, zero,
+            z_vel_pert(i, j, k) = WFromOmega(i, j, k, zero_d,
                                              x_vel_pert, y_vel_pert,
                                              mf_u, mf_v, z_nd, dxInv);
         });

--- a/Source/Prob/ERF_InitCustomPert_ABL.H
+++ b/Source/Prob/ERF_InitCustomPert_ABL.H
@@ -52,10 +52,10 @@
     }
 #endif
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
-        const Real x = prob_lo_x + (i + myhalf) * dx;
-        const Real y = prob_lo_y + (j + myhalf) * dy;
+        const Real x = prob_lo_x + (i + myhalf_d) * dx;
+        const Real y = prob_lo_y + (j + myhalf_d) * dy;
         const Real z = z_cc(i,j,k);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
@@ -88,4 +88,3 @@
             }
         }
     });
-

--- a/Source/Prob/ERF_InitCustomPert_Bomex.H
+++ b/Source/Prob/ERF_InitCustomPert_Bomex.H
@@ -15,27 +15,27 @@
 
     const Real rdOcp   = sc.rdOcp;
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         // Geometry
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
-        const Real xc = myhalf * (prob_lo[0] + prob_hi[0]);
-        const Real yc = myhalf * (prob_lo[1] + prob_hi[1]);
-        const Real zc = myhalf * (prob_lo[2] + prob_hi[2]);
+        const Real xc = myhalf_d * (prob_lo[0] + prob_hi[0]);
+        const Real yc = myhalf_d * (prob_lo[1] + prob_hi[1]);
+        const Real zc = myhalf_d * (prob_lo[2] + prob_hi[2]);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
         //
         // Add temperature perturbations -- we want to keep pressure constant
         //     so these effectively end up as density perturbations
         //
-        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero)) {
+        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero_d)) {
 
             Real rhotheta  = state(i,j,k,RhoTheta_comp);
             Real rho       = state(i,j,k,Rho_comp);
@@ -44,7 +44,7 @@
             Real P         = getPgivenRTh(rhotheta,qv);
 
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real Tpert    = (rand_double*two - one)*T_0_Pert_Mag;
+            Real Tpert    = (rand_double*two_d - one_d)*T_0_Pert_Mag;
             Real Tnew     = Told + Tpert;
 
             Real theta_new = getThgivenTandP(Tnew,P,rdOcp);
@@ -52,7 +52,7 @@
             state_pert(i, j, k, Rho_comp) = rhonew - rho;
 
             // Note we do not perturb this
-            state_pert(i, j, k, RhoTheta_comp) = zero;
+            state_pert(i, j, k, RhoTheta_comp) = zero_d;
 
             //  Instead of perturbing (rho theta) we perturb T and hold (rho theta) fixed,
             //  which ends up being stored as a perturbation in rho
@@ -64,15 +64,15 @@
 
         // Set an initial value for KE
         if (custom_TKE) {
-            state_pert(i, j, k, RhoKE_comp) = (one - z/prob_hi[2]) * r_hse(i,j,k);
+            state_pert(i, j, k, RhoKE_comp) = (one_d - z/prob_hi[2]) * r_hse(i,j,k);
         } else {
             state_pert(i, j, k, RhoKE_comp) = KE_0;
         }
 
         if (use_moisture) {
-            state_pert(i, j, k, RhoQ1_comp) = zero;
-            state_pert(i, j, k, RhoQ2_comp) = zero;
-            if ((z <= pert_ref_height) && (qv_0_Pert_Mag != zero))
+            state_pert(i, j, k, RhoQ1_comp) = zero_d;
+            state_pert(i, j, k, RhoQ2_comp) = zero_d;
+            if ((z <= pert_ref_height) && (qv_0_Pert_Mag != zero_d))
             {
                 Real rhoold = state(i,j,k,Rho_comp);
                 Real rhonew = rhoold + state_pert(i,j,k,Rho_comp);
@@ -80,7 +80,7 @@
                 Real qvold = state(i,j,k,RhoQ1_comp) / rhoold;
 
                 Real rand_double = amrex::Random(engine); // Between zero and one
-                Real qvnew = qvold + (rand_double*two - one)*qv_0_Pert_Mag;
+                Real qvnew = qvold + (rand_double*two_d - one_d)*qv_0_Pert_Mag;
 
                 state_pert(i, j, k, RhoQ1_comp) = rhonew * qvnew - rhoold * qvold;
             }

--- a/Source/Prob/ERF_InitCustomPert_Bubble.H
+++ b/Source/Prob/ERF_InitCustomPert_Bubble.H
@@ -77,46 +77,46 @@
             moisture_type = 2;
         }
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,PI_d=PI,two_d=two,R_d_d=R_d,Cp_d_d=Cp_d,R_v_d=R_v,tbgmin_d=tbgmin,a_bg_d=a_bg] AMREX_GPU_DEVICE(int i, int j, int k)
         {
             // Geometry (note we must include these here to get the data on device)
             const auto prob_lo  = geomdata.ProbLo();
             const auto dx       = geomdata.CellSize();
-            const Real x        = prob_lo[0] + (i + myhalf) * dx[0];
-            const Real y        = prob_lo[1] + (j + myhalf) * dx[1];
-            const Real z        = prob_lo[2] + (k + myhalf) * dx[2];
+            const Real x        = prob_lo[0] + (i + myhalf_d) * dx[0];
+            const Real y        = prob_lo[1] + (j + myhalf_d) * dx[1];
+            const Real z        = prob_lo[2] + (k + myhalf_d) * dx[2];
 
             Real rad, delta_theta, theta_total, rho, RH;
 
             // Introduce the warm bubble. Assume that the bubble is pressure matched with the background
-            rad = zero;
+            rad = zero_d;
             if (x_r > 0) rad += amrex::Math::powi<2>((x - x_c)/x_r);
             if (y_r > 0) rad += amrex::Math::powi<2>((y - y_c)/y_r);
             if (z_r > 0) rad += amrex::Math::powi<2>((z - z_c)/z_r);
             rad = std::sqrt(rad);
 
             if (rad <= amrex::Real(1)) {
-                delta_theta = theta_pert*amrex::Math::powi<2>(std::cos(PI*rad/two));
+                delta_theta = theta_pert*amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
             } else {
                  delta_theta = amrex::Real(0);
             }
 
             theta_total  = theta_back[k]*(delta_theta/amrex::Real(300.0) + 1);
-            Real T = getTgivenPandTh(p_back[k], theta_total, (R_d/Cp_d));
-            rho    = p_back[k]/(R_d*T*(amrex::Real(1) + (R_v/R_d)*q_v_back[k]));
+            Real T = getTgivenPandTh(p_back[k], theta_total, (R_d_d/Cp_d_d));
+            rho    = p_back[k]/(R_d_d*T*(amrex::Real(1) + (R_v_d/R_d_d)*q_v_back[k]));
             RH     = compute_relative_humidity(use_empirical);
             Real q_v_hot = vapor_mixing_ratio(p_back[k], T, RH);
 
             // Compute background quantities
-            Real T_back   = getTgivenPandTh(p_back[k], theta_back[k], (R_d/Cp_d));
-            Real rho_back = p_back[k]/(R_d*T_back*(amrex::Real(1) + (R_v/R_d)*q_v_back[k]));
+            Real T_back   = getTgivenPandTh(p_back[k], theta_back[k], (R_d_d/Cp_d_d));
+            Real rho_back = p_back[k]/(R_d_d*T_back*(amrex::Real(1) + (R_v_d/R_d_d)*q_v_back[k]));
 
             // This version perturbs rho but not p
-            state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*theta_back[k]*(amrex::Real(1) + (R_v/R_d)*q_v_back[k]);
+            state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*theta_back[k]*(amrex::Real(1) + (R_v_d/R_d_d)*q_v_back[k]);
             state_pert(i, j, k, Rho_comp)      = rho - rho_back*(amrex::Real(1) + qt_init);
 
             // Set scalar = 0 everywhere
-            state_pert(i, j, k, RhoScalar_comp) = zero;
+            state_pert(i, j, k, RhoScalar_comp) = zero_d;
 
             // mean states
             state_pert(i, j, k, RhoQ1_comp) = rho*q_v_hot;
@@ -127,11 +127,11 @@
             if (nstate == NVAR_max) {
                 Real omn;
                 if(moisture_type == 1) {
-                    omn = std::max(amrex::Real(0),std::min(amrex::Real(1),(T-tbgmin)*a_bg));
+                    omn = std::max(amrex::Real(0),std::min(amrex::Real(1),(T-tbgmin_d)*a_bg_d));
                 } else if(moisture_type == 2) {
                     omn = amrex::Real(1);
                 } else {
-                    omn = zero;
+                    omn = zero_d;
                     Abort("Invalid moisture type specified");
                 }
                 Real qn  = state_pert(i, j, k, RhoQ2_comp);
@@ -140,15 +140,15 @@
             }
         });
     } else {
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,PI_d=PI,two_d=two,R_d_d=R_d,p_0_d=p_0] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // Geometry (note we must include these here to get the data on device)
             const auto prob_lo         = geomdata.ProbLo();
             const auto dx              = geomdata.CellSize();
 
-            const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-            const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-            const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+            const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+            const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+            const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
             //perturb_rho_theta(x, y, z, p_hse(i,j,k), r_hse(i,j,k), rdOcp,
             //                  state_pert(i, j, k, Rho_comp),
@@ -158,29 +158,29 @@
             // - The bubble is either cylindrical (for 2-D problems, if two
             //   radial extents are specified) or an ellipsoid (if all three
             //   radial extents are specified).
-            Real L = zero;
+            Real L = zero_d;
             if (x_r > 0) L += amrex::Math::powi<2>((x - x_c)/x_r);
             if (y_r > 0) L += amrex::Math::powi<2>((y - y_c)/y_r);
             if (z_r > 0) L += amrex::Math::powi<2>((z - z_c)/z_r);
             L = std::sqrt(L);
             Real dT;
             if (L > amrex::Real(1)) {
-                dT = zero;
+                dT = zero_d;
             } else {
-                dT = T_pert * amrex::Math::powi<2>(std::cos(PI*L/two));
+                dT = T_pert * amrex::Math::powi<2>(std::cos(PI_d*L/two_d));
             }
 
             // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
-            const Real Tbar_hse = p_hse(i,j,k) / (R_d * r_hse(i,j,k));
+            const Real Tbar_hse = p_hse(i,j,k) / (R_d_d * r_hse(i,j,k));
 
             // Note: theta_perturbed is theta PLUS perturbation in theta
             Real theta_perturbed;
             if (T_pert_is_airtemp) {
                 // dT is air temperature
-                theta_perturbed = (Tbar_hse + dT)*std::pow(p_0/p_hse(i,j,k), rdOcp);
+                theta_perturbed = (Tbar_hse + dT)*std::pow(p_0_d/p_hse(i,j,k), rdOcp);
             } else {
                 // dT is potential temperature
-                theta_perturbed = Tbar_hse*std::pow(p_0/p_hse(i,j,k), rdOcp) + dT;
+                theta_perturbed = Tbar_hse*std::pow(p_0_d/p_hse(i,j,k), rdOcp) + dT;
             }
 
             if (perturb_rho)
@@ -189,12 +189,12 @@
                 // - hydrostatic rebalance is needed (TODO: is this true?)
                 // - this is the approach taken in the density current problem
                 state_pert(i,j,k,Rho_comp)      = getRhoThetagivenP(p_hse(i,j,k)) / theta_perturbed - r_hse(i,j,k);
-                state_pert(i,j,k,RhoTheta_comp) = zero; // i.e., hydrostatically balanced pressure stays const
+                state_pert(i,j,k,RhoTheta_comp) = zero_d; // i.e., hydrostatically balanced pressure stays const
             }
             else
             {
                 // this version perturbs rho*theta (i.e., p) but not rho
-                state_pert(i,j,k,Rho_comp)      = zero; // i.e., hydrostatically balanced density stays const
+                state_pert(i,j,k,Rho_comp)      = zero_d; // i.e., hydrostatically balanced density stays const
                 state_pert(i,j,k,RhoTheta_comp) = r_hse(i,j,k) * theta_perturbed - getRhoThetagivenP(p_hse(i,j,k));
             }
         });

--- a/Source/Prob/ERF_InitCustomPert_DataAssimilation_ISV.H
+++ b/Source/Prob/ERF_InitCustomPert_DataAssimilation_ISV.H
@@ -49,29 +49,29 @@
 
     const amrex::Real rdOcp = sc.rdOcp;
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,two_d=two,Gamma_d=Gamma,p_0_d=p_0,fourth_d=fourth,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
-        const Real x = (i + myhalf) * dx[0]; // cell center
-        const Real y = (j + myhalf) * dx[1]; // cell center
+        const Real x = (i + myhalf_d) * dx[0]; // cell center
+        const Real y = (j + myhalf_d) * dx[1]; // cell center
 
         // Calculate perturbation temperature
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
-        const Real deltaT = -(gamma - one)/(two*sigma*sigma) * Omg*Omg;
+        const Real deltaT = -(gamma - one_d)/(two_d*sigma*sigma) * Omg*Omg;
 
         // Set the perturbation density
-        const Real rho_norm = std::pow(one + deltaT, inv_gm1);
+        const Real rho_norm = std::pow(one_d + deltaT, inv_gm1);
         //state_pert(i, j, k, Rho_comp) = rho_norm * rho_0 - r_hse(i,j,k);
 
         // Initial _potential_ temperature
-        const Real T = (one + deltaT) * T_inf;
-        const Real p = std::pow(rho_norm, Gamma) / Gamma  // isentropic relation
+        const Real T = (one_d + deltaT) * T_inf;
+        const Real p = std::pow(rho_norm, Gamma_d) / Gamma_d  // isentropic relation
                               * rho_0*a_inf*a_inf;
-        const Real rho_theta = rho_0 * rho_norm * (T * std::pow(p_0 / p, rdOcp)); // T --> theta
+        const Real rho_theta = rho_0 * rho_norm * (T * std::pow(p_0_d / p, rdOcp)); // T --> theta
         state_pert(i, j, k, RhoTheta_comp) = rho_theta - getRhoThetagivenP(p_hse(i,j,k)); // Set the perturbation rho*theta
 
         const Real r2d_xy = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc));
-        state_pert(i, j, k, RhoScalar_comp) = fourth * (one + std::cos(PI * std::min(r2d_xy, R) / R));
+        state_pert(i, j, k, RhoScalar_comp) = fourth_d * (one_d + std::cos(PI_d * std::min(r2d_xy, R) / R));
     });

--- a/Source/Prob/ERF_InitCustomPert_DensityCurrent.H
+++ b/Source/Prob/ERF_InitCustomPert_DensityCurrent.H
@@ -10,27 +10,27 @@
 
     const Real rdOcp = sc.rdOcp;
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,PI_d=PI,two_d=two,R_d_d=R_d,p_0_d=p_0] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry (note we must include these here to get the data on device)
         const auto prob_lo = geomdata.ProbLo();
         const auto dx      = geomdata.CellSize();
 
-        const Real x = ( prob_lo[0] + (i + myhalf) * dx[0] ) / mf_m(i,j,0);
+        const Real x = ( prob_lo[0] + (i + myhalf_d) * dx[0] ) / mf_m(i,j,0);
         const Real z = z_cc(i,j,k);
 
         Real L = std::sqrt(
             amrex::Math::powi<2>((x - x_c)/x_r) +
             amrex::Math::powi<2>((z - z_c)/z_r));
 
-        if (L <= one)
+        if (L <= one_d)
         {
-            Real dT = T_pert * (std::cos(PI*L) + one)/two;
-            Real Tbar_hse = p_hse(i,j,k) / (R_d * r_hse(i,j,k));
+            Real dT = T_pert * (std::cos(PI_d*L) + one_d)/two_d;
+            Real Tbar_hse = p_hse(i,j,k) / (R_d_d * r_hse(i,j,k));
 
             // Note: dT is a perturbation in temperature, theta_perturbed is base state + perturbation
-            Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0/p_hse(i,j,k), rdOcp);
-            Real theta_0         = (Tbar_hse   )*std::pow(p_0/p_hse(i,j,k), rdOcp);
+            Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0_d/p_hse(i,j,k), rdOcp);
+            Real theta_0         = (Tbar_hse   )*std::pow(p_0_d/p_hse(i,j,k), rdOcp);
 
             if (const_rho) {
                 state_pert(i, j, k, RhoTheta_comp) = r_hse(i,j,k) * (theta_perturbed  - theta_0);

--- a/Source/Prob/ERF_InitCustomPert_EBPoiseuille.H
+++ b/Source/Prob/ERF_InitCustomPert_EBPoiseuille.H
@@ -18,16 +18,16 @@
     AMREX_ALWAYS_ASSERT(sc.terrain_type == TerrainType::EB);
 
     // Set the state_pert
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
 
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
         const Real xc = xc_frac * (prob_lo[0] + prob_hi[0]);
@@ -49,9 +49,9 @@
             state_pert(i, j, k, RhoScalar_comp) = A_0 * std::exp(-amrex::Real(0.1)*r2d_xz*r2d_xz) + B_0*std::sin(x);
 
         } else if (prob_type == 11) {
-            if (r2d_xz_nd < one)
+            if (r2d_xz_nd < one_d)
             {
-                state_pert(i, j, k, RhoScalar_comp) = myhalf * A_0 * (one + std::cos(PI*r2d_xz_nd));
+                state_pert(i, j, k, RhoScalar_comp) = myhalf_d * A_0 * (one_d + std::cos(PI_d*r2d_xz_nd));
             }
         } else {
             // Set scalar = A_0 in a ball of radius r0 and 0 elsewhere

--- a/Source/Prob/ERF_InitCustomPert_FlowInABox.H
+++ b/Source/Prob/ERF_InitCustomPert_FlowInABox.H
@@ -2,9 +2,9 @@
     Real T_0_Pert_Mag = zero; pp_prob.query("T_0_Pert_Mag", T_0_Pert_Mag);
 
     // Add temperature perturbations
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         Real rand_double = amrex::Random(engine); // Between zero and one
-        state_pert(i, j, k, RhoTheta_comp) = (rand_double*two - one)*T_0_Pert_Mag;
+        state_pert(i, j, k, RhoTheta_comp) = (rand_double*two_d - one_d)*T_0_Pert_Mag;
         state_pert(i, j, k, RhoTheta_comp) *= r_hse(i,j,k);
     });

--- a/Source/Prob/ERF_InitCustomPert_IsentropicVortex.H
+++ b/Source/Prob/ERF_InitCustomPert_IsentropicVortex.H
@@ -49,29 +49,29 @@
 
     const amrex::Real rdOcp = sc.rdOcp;
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,two_d=two,Gamma_d=Gamma,p_0_d=p_0,fourth_d=fourth,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const Real* dx = geomdata.CellSize();
 
         // Note that since we only use (x-xc) and (y-yc), we neglect the prob_lo offset in these
-        const Real x = (i + myhalf) * dx[0]; // cell center
-        const Real y = (j + myhalf) * dx[1]; // cell center
+        const Real x = (i + myhalf_d) * dx[0]; // cell center
+        const Real y = (j + myhalf_d) * dx[1]; // cell center
 
         // Calculate perturbation temperature
         const Real Omg = erf_vortex_Gaussian(x,y,xc,yc,R,beta,sigma);
-        const Real deltaT = -(gamma - one)/(two*sigma*sigma) * Omg*Omg;
+        const Real deltaT = -(gamma - one_d)/(two_d*sigma*sigma) * Omg*Omg;
 
         // Set the perturbation density
-        const Real rho_norm = std::pow(one + deltaT, inv_gm1);
+        const Real rho_norm = std::pow(one_d + deltaT, inv_gm1);
         state_pert(i, j, k, Rho_comp) = rho_norm * rho_0 - r_hse(i,j,k);
 
         // Initial _potential_ temperature
-        const Real T = (one + deltaT) * T_inf;
-        const Real p = std::pow(rho_norm, Gamma) / Gamma  // isentropic relation
+        const Real T = (one_d + deltaT) * T_inf;
+        const Real p = std::pow(rho_norm, Gamma_d) / Gamma_d  // isentropic relation
                               * rho_0*a_inf*a_inf;
-        const Real rho_theta = rho_0 * rho_norm * (T * std::pow(p_0 / p, rdOcp)); // T --> theta
+        const Real rho_theta = rho_0 * rho_norm * (T * std::pow(p_0_d / p, rdOcp)); // T --> theta
         state_pert(i, j, k, RhoTheta_comp) = rho_theta - getRhoThetagivenP(p_hse(i,j,k)); // Set the perturbation rho*theta
 
         const Real r2d_xy = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc));
-        state_pert(i, j, k, RhoScalar_comp) = fourth * (one + std::cos(PI * std::min(r2d_xy, R) / R));
+        state_pert(i, j, k, RhoScalar_comp) = fourth_d * (one_d + std::cos(PI_d * std::min(r2d_xy, R) / R));
     });

--- a/Source/Prob/ERF_InitCustomPert_KE.H
+++ b/Source/Prob/ERF_InitCustomPert_KE.H
@@ -11,7 +11,7 @@
                        << std::endl;
     }
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Set an initial value for SGS KE
         const Real z = z_cc(i,j,k);
@@ -20,7 +20,7 @@
             // scale initial SGS kinetic energy with height
             if (KE_decay_height > 0) {
                 state_pert(i, j, k, RhoKE_comp) *= max(
-                    std::pow(1 - min(z/KE_decay_height,one), KE_decay_order),
+                    std::pow(1 - min(z/KE_decay_height,one_d), KE_decay_order),
                     1e-12);
             }
         }

--- a/Source/Prob/ERF_InitCustomPert_MovingTerrain.H
+++ b/Source/Prob/ERF_InitCustomPert_MovingTerrain.H
@@ -9,11 +9,11 @@
     Real g           = CONST_GRAV;
     Real omega       = std::sqrt(g * kp);
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const auto prob_lo  = geomdata.ProbLo();
         const auto dx       = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
 
         Real z = z_cc(i,j,k);
         Real z_base = Ampl * std::sin(kp * x);

--- a/Source/Prob/ERF_InitCustomPert_MultiSpeciesBubble.H
+++ b/Source/Prob/ERF_InitCustomPert_MultiSpeciesBubble.H
@@ -91,59 +91,59 @@
 
         int which_zone = -1;
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,one_d=one,PI_d=PI,two_d=two,R_d_d=R_d,Cp_d_d=Cp_d,R_v_d=R_v] AMREX_GPU_DEVICE(int i, int j, int k)
         {
             // Geometry (note we must include these here to get the data on device)
             const auto prob_lo         = geomdata.ProbLo();
             const auto dx              = geomdata.CellSize();
 
-            const auto x = prob_lo[0] + (i + myhalf) * dx[0];
-            const auto y = prob_lo[1] + (j + myhalf) * dx[1];
-            const auto z = prob_lo[2] + (k + myhalf) * dx[2];
+            const auto x = prob_lo[0] + (i + myhalf_d) * dx[0];
+            const auto y = prob_lo[1] + (j + myhalf_d) * dx[1];
+            const auto z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
             Real rad, delta_theta, theta_total, rho, RH;
 
             // Introduce the warm bubble.
             // Assume that the bubble is pressure matched with the background
-            rad = zero;
+            rad = zero_d;
             if (x_r > 0) rad += amrex::Math::powi<2>((x - x_c)/x_r);
             if (y_r > 0) rad += amrex::Math::powi<2>((y - y_c)/y_r);
             if (z_r > 0) rad += amrex::Math::powi<2>((z - z_c)/z_r);
             rad = std::sqrt(rad);
 
-            if (rad <= one){
-                delta_theta = theta_pert*amrex::Math::powi<2>(std::cos(PI*rad/two));
+            if (rad <= one_d){
+                delta_theta = theta_pert*amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
             } else {
-                delta_theta = zero;
+                delta_theta = zero_d;
             }
 
             theta_total  = theta_back[k]*(delta_theta/amrex::Real(300.0) + 1);
-            Real T = getTgivenPandTh(p_back[k], theta_total, (R_d/Cp_d));
-            rho    = p_back[k]/(R_d*T*(one + (R_v/R_d)*q_v_back[k]));
-            RH     = one; // compute_relative_humidity();
+            Real T = getTgivenPandTh(p_back[k], theta_total, (R_d_d/Cp_d_d));
+            rho    = p_back[k]/(R_d_d*T*(one_d + (R_v_d/R_d_d)*q_v_back[k]));
+            RH     = one_d; // compute_relative_humidity();
             Real q_v_hot = HSEutils::vapor_mixing_ratio(p_back[k], T, RH, use_empirical, which_zone);
 
             // Compute background quantities
-            Real T_back   = getTgivenPandTh(p_back[k], theta_back[k], (R_d/Cp_d));
-            Real rho_back = p_back[k]/(R_d*T_back*(one + (R_v/R_d)*q_v_back[k]));
+            Real T_back   = getTgivenPandTh(p_back[k], theta_back[k], (R_d_d/Cp_d_d));
+            Real rho_back = p_back[k]/(R_d_d*T_back*(one_d + (R_v_d/R_d_d)*q_v_back[k]));
 
             // This version perturbs rho but not p
-            state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*theta_back[k]*(one + (R_v/R_d)*q_v_back[k]);
-            state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one + qt_init);
+            state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*theta_back[k]*(one_d + (R_v_d/R_d_d)*q_v_back[k]);
+            state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one_d + qt_init);
 
             // mean states
             state_pert(i, j, k, RhoQ1_comp) = rho*q_v_hot;
         });
     } else {
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,one_d=one,PI_d=PI,two_d=two,R_d_d=R_d,p_0_d=p_0] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             // Geometry (note we must include these here to get the data on device)
             const auto prob_lo         = geomdata.ProbLo();
             const auto dx              = geomdata.CellSize();
 
-            const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-            const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-            const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+            const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+            const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+            const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
             // perturb_rho_theta(x, y, z, p_hse(i,j,k), r_hse(i,j,k), rdOcp,
             //                   state_pert(i, j, k, Rho_comp),
@@ -153,30 +153,30 @@
             // - The bubble is either cylindrical (for 2-D problems, if two
             //   radial extents are specified) or an ellipsoid (if all three
             //   radial extents are specified).
-            Real L = zero;
+            Real L = zero_d;
             if (x_r > 0) L += amrex::Math::powi<2>((x - x_c)/x_r);
             if (y_r > 0) L += amrex::Math::powi<2>((y - y_c)/y_r);
             if (z_r > 0) L += amrex::Math::powi<2>((z - z_c)/z_r);
             L = std::sqrt(L);
             Real dT;
-            if (L > one) {
-                dT = zero;
+            if (L > one_d) {
+                dT = zero_d;
             }
             else {
-                dT = T_pert * amrex::Math::powi<2>(std::cos(PI*L/two));
+                dT = T_pert * amrex::Math::powi<2>(std::cos(PI_d*L/two_d));
             }
 
             // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
-            const Real Tbar_hse = p_hse(i,j,k) / (R_d * r_hse(i,j,k));
+            const Real Tbar_hse = p_hse(i,j,k) / (R_d_d * r_hse(i,j,k));
 
             // Note: theta_perturbed is theta PLUS perturbation in theta
             Real theta_perturbed;
             if (T_pert_is_airtemp) {
                 // dT is air temperature
-                theta_perturbed = (Tbar_hse + dT)*std::pow(p_0/p_hse(i,j,k), rdOcp);
+                theta_perturbed = (Tbar_hse + dT)*std::pow(p_0_d/p_hse(i,j,k), rdOcp);
             } else {
                 // dT is potential temperature
-                theta_perturbed = Tbar_hse*std::pow(p_0/p_hse(i,j,k), rdOcp) + dT;
+                theta_perturbed = Tbar_hse*std::pow(p_0_d/p_hse(i,j,k), rdOcp) + dT;
             }
 
             if (perturb_rho)
@@ -184,13 +184,13 @@
                 // this version perturbs rho but not p (i.e., rho*theta)
                 // - hydrostatic rebalance is needed (TODO: is this true?)
                 // - this is the approach taken in the density current problem
-                state_pert(i,j,k,RhoTheta_comp) = zero; // i.e., hydrostatically balanced pressure stays const
+                state_pert(i,j,k,RhoTheta_comp) = zero_d; // i.e., hydrostatically balanced pressure stays const
                 state_pert(i,j,k,Rho_comp     ) = getRhoThetagivenP(p_hse(i,j,k)) / theta_perturbed - r_hse(i,j,k);
             }
             else
             {
                 // this version perturbs rho*theta (i.e., p) but not rho
-                state_pert(i,j,k,Rho_comp)      = zero; // i.e., hydrostatically balanced density stays const
+                state_pert(i,j,k,Rho_comp)      = zero_d; // i.e., hydrostatically balanced density stays const
                 state_pert(i,j,k,RhoTheta_comp) = r_hse(i,j,k) * theta_perturbed - getRhoThetagivenP(p_hse(i,j,k));
             }
 
@@ -209,27 +209,27 @@
                qv_init_d.begin() );
     auto qv_arr = qv_init_d.data();
 
-    ParallelFor(bx, [=]
+    ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,one_d=one]
                 AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         const auto prob_lo         = geomdata.ProbLo();
         const auto dx              = geomdata.CellSize();
 
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
-        amrex::Real L = zero;
+        amrex::Real L = zero_d;
         if (x_r > 0) L += amrex::Math::powi<2>((x - x_c)/x_r);
         if (y_r > 0) L += amrex::Math::powi<2>((y - y_c)/y_r);
         if (z_r > 0) L += amrex::Math::powi<2>((z - z_c)/z_r);
         L = std::sqrt(L);
 
-        if (L < one) {
+        if (L < one_d) {
             auto rho = state(i,j,k,Rho_comp) + state_pert(i,j,k,Rho_comp);
             for (int ns = 0; ns < n_sp; ns++) {
                 state_pert(i, j, k, nstart+2*ns)   = rho*qv_arr[ns];
-                state_pert(i, j, k, nstart+2*ns+1) = zero;
+                state_pert(i, j, k, nstart+2*ns+1) = zero_d;
             }
         }
     });

--- a/Source/Prob/ERF_InitCustomPert_ParticleTests.H
+++ b/Source/Prob/ERF_InitCustomPert_ParticleTests.H
@@ -8,26 +8,26 @@
   // Overridden physical constants
   Real C_p = amrex::Real(1004.0);
 
-  ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+  ParallelFor(bx, [=,myhalf_d=myhalf,R_d_d=R_d,one_d=one,PI_d=PI,two_d=two,p_0_d=p_0] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
   {
     // Geometry (note we must include these here to get the data on device)
     const auto prob_lo  = geomdata.ProbLo();
     const auto dx       = geomdata.CellSize();
-    const Real x = prob_lo[0] + (i + myhalf) * dx[0];
+    const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
     const Real z = z_cc(i,j,k);
 
     // Temperature that satisfies the EOS given the hydrostatically balanced (r,p)
-    const Real Tbar_hse = p_hse(i,j,k) / (R_d * r_hse(i,j,k));
+    const Real Tbar_hse = p_hse(i,j,k) / (R_d_d * r_hse(i,j,k));
 
     Real L = std::sqrt(
         amrex::Math::powi<2>((x - x_c)/x_r) +
         amrex::Math::powi<2>((z - z_c)/z_r)
     );
-    if (L <= one) {
-        Real dT = T_pert * (std::cos(PI*L) + one)/two;
+    if (L <= one_d) {
+        Real dT = T_pert * (std::cos(PI_d*L) + one_d)/two_d;
 
         // Note: dT is a temperature perturbation, theta_perturbed is base state + perturbation in theta
-        Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0/p_hse(i,j,k), R_d/C_p);
+        Real theta_perturbed = (Tbar_hse+dT)*std::pow(p_0_d/p_hse(i,j,k), R_d_d/C_p);
 
         // This version perturbs rho but not p
         state_pert(i, j, k, Rho_comp) = getRhoThetagivenP(p_hse(i,j,k)) / theta_perturbed - r_hse(i,j,k);

--- a/Source/Prob/ERF_InitCustomPert_RICO.H
+++ b/Source/Prob/ERF_InitCustomPert_RICO.H
@@ -31,27 +31,27 @@
 
     const Real rdOcp   = sc.rdOcp;
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const RandomEngine& engine) noexcept
     {
         // Geometry
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
-        const Real xc = myhalf * (prob_lo[0] + prob_hi[0]);
-        const Real yc = myhalf * (prob_lo[1] + prob_hi[1]);
-        const Real zc = myhalf * (prob_lo[2] + prob_hi[2]);
+        const Real xc = myhalf_d * (prob_lo[0] + prob_hi[0]);
+        const Real yc = myhalf_d * (prob_lo[1] + prob_hi[1]);
+        const Real zc = myhalf_d * (prob_lo[2] + prob_hi[2]);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
         //
         // Add temperature perturbations -- we want to keep pressure constant
         //     so these effectively end up as density perturbations
         //
-        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero)) {
+        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero_d)) {
 
             Real rhotheta  = state(i,j,k,RhoTheta_comp);
             Real rho       = state(i,j,k,Rho_comp);
@@ -60,7 +60,7 @@
             Real P         = getPgivenRTh(rhotheta,qv);
 
             Real rand_double = amrex::Random(engine); // Between zero and one
-            Real Tpert    = (rand_double*two - one)*T_0_Pert_Mag;
+            Real Tpert    = (rand_double*two_d - one_d)*T_0_Pert_Mag;
             Real Tnew     = Told + Tpert;
 
             Real theta_new = getThgivenTandP(Tnew,P,rdOcp);
@@ -68,7 +68,7 @@
             state_pert(i, j, k, Rho_comp) = rhonew - rho;
 
             // Note we do not perturb this
-            state_pert(i, j, k, RhoTheta_comp) = zero;
+            state_pert(i, j, k, RhoTheta_comp) = zero_d;
 
             //  Instead of perturbing (rho theta) we perturb T and hold (rho theta) fixed,
             //  which ends up being stored as a perturbation in rho
@@ -80,13 +80,13 @@
 
         // Set an initial value for KE
         if (custom_TKE) {
-            state_pert(i, j, k, RhoKE_comp) = (one - z/prob_hi[2]) * r_hse(i,j,k);
+            state_pert(i, j, k, RhoKE_comp) = (one_d - z/prob_hi[2]) * r_hse(i,j,k);
         } else {
             state_pert(i, j, k, RhoKE_comp) = KE_0;
         }
 
         if (use_moisture) {
-            if ((z <= pert_ref_height) && (qv_0_Pert_Mag != zero))
+            if ((z <= pert_ref_height) && (qv_0_Pert_Mag != zero_d))
             {
                 Real rhoold = state(i,j,k,Rho_comp);
                 Real rhonew = rhoold + state_pert(i,j,k,Rho_comp);
@@ -94,17 +94,17 @@
                 Real qvold = state(i,j,k,RhoQ1_comp) / rhoold;
 
                 Real rand_double = amrex::Random(engine); // Between zero and one
-                Real qvnew = qvold + (rand_double*two - one)*qv_0_Pert_Mag;
+                Real qvnew = qvold + (rand_double*two_d - one_d)*qv_0_Pert_Mag;
 
                 state_pert(i, j, k, RhoQ1_comp) = rhonew * qvnew - rhoold * qvold;
             }
         }
 
         // sinusoidal variation of theta and qv for regression tests
-        if (pert_deltaT != zero)
+        if (pert_deltaT != zero_d)
         {
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
 
             Real rhotheta  = state(i,j,k,RhoTheta_comp);
             Real rho       = state(i,j,k,Rho_comp);
@@ -119,13 +119,13 @@
             Real rhonew    = getRhogivenThetaPress(theta_new,P,rdOcp,qv);
 
             state_pert(i, j, k, Rho_comp) = rhonew - rho;
-            state_pert(i, j, k, RhoTheta_comp) = zero;
+            state_pert(i, j, k, RhoTheta_comp) = zero_d;
         }
 
-        if (use_moisture && pert_deltaQV != zero)
+        if (use_moisture && pert_deltaQV != zero_d)
         {
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
 
             Real rhoold = state(i,j,k,Rho_comp);
             Real rhonew = rhoold + state_pert(i,j,k,Rho_comp);

--- a/Source/Prob/ERF_InitCustomPert_SDMCongestus3D.H
+++ b/Source/Prob/ERF_InitCustomPert_SDMCongestus3D.H
@@ -33,30 +33,30 @@
 
     const Real rdOcp   = sc.rdOcp;
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
-        const Real xc = myhalf * (prob_lo[0] + prob_hi[0]);
-        const Real yc = myhalf * (prob_lo[1] + prob_hi[1]);
-        const Real zc = myhalf * (prob_lo[2] + prob_hi[2]);
+        const Real xc = myhalf_d * (prob_lo[0] + prob_hi[0]);
+        const Real yc = myhalf_d * (prob_lo[1] + prob_hi[1]);
+        const Real zc = myhalf_d * (prob_lo[2] + prob_hi[2]);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
         // Add temperature perturbations
-        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero)) {
+        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero_d)) {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            state_pert(i, j, k, RhoTheta_comp) = (rand_double*two - one)*T_0_Pert_Mag;
+            state_pert(i, j, k, RhoTheta_comp) = (rand_double*two_d - one_d)*T_0_Pert_Mag;
         }
-        if ((z <= pert_ref_height) && (Q_0_Pert_Mag != zero)) {
+        if ((z <= pert_ref_height) && (Q_0_Pert_Mag != zero_d)) {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            state_pert(i, j, k, RhoQ1_comp) = (rand_double*two - one)*Q_0_Pert_Mag;
+            state_pert(i, j, k, RhoQ1_comp) = (rand_double*two_d - one_d)*Q_0_Pert_Mag;
         }
         // Set scalar = A_0*exp(-10r^2), where r is distance from center of domain
         state_pert(i, j, k, RhoScalar_comp) = A_0 * std::exp(-amrex::Real(10.)*r*r);
@@ -65,10 +65,10 @@
         state_pert(i, j, k, RhoKE_comp) = KE_0;
 
         // sinusoidal variation of theta and qv for regression tests
-        if (pert_deltaT != zero)
+        if (pert_deltaT != zero_d)
         {
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
 
             Real rhotheta  = state(i,j,k,RhoTheta_comp);
             Real rho       = state(i,j,k,Rho_comp);
@@ -83,13 +83,13 @@
             Real rhonew    = getRhogivenThetaPress(theta_new,P,rdOcp,qv);
 
             state_pert(i, j, k, Rho_comp) = rhonew - rho;
-            state_pert(i, j, k, RhoTheta_comp) = zero;
+            state_pert(i, j, k, RhoTheta_comp) = zero_d;
         }
 
-        if (use_moisture && pert_deltaQV != zero)
+        if (use_moisture && pert_deltaQV != zero_d)
         {
             const Real zl = z / pert_ref_height;
-            const Real damp = std::exp(-myhalf * zl * zl);
+            const Real damp = std::exp(-myhalf_d * zl * zl);
 
             Real rhoold = state(i,j,k,Rho_comp);
             Real rhonew = rhoold + state_pert(i,j,k,Rho_comp);

--- a/Source/Prob/ERF_InitCustomPert_ScalarAdvDiff.H
+++ b/Source/Prob/ERF_InitCustomPert_ScalarAdvDiff.H
@@ -11,15 +11,15 @@
     Real zc_frac = myhalf; pp.query("zc_frac", zc_frac);
 
     int prob_type = -1; pp.query("prob_type", prob_type);
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one,PI_d=PI,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry
         const Real* prob_lo = geomdata.ProbLo();
         const Real* prob_hi = geomdata.ProbHi();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Define a point (xc,yc,zc) at the center of the domain
         const Real xc = xc_frac * (prob_lo[0] + prob_hi[0]);
@@ -40,22 +40,22 @@
             state_pert(i, j, k, RhoScalar_comp) = A_0 * std::exp(-amrex::Real(10.)*r3d*r3d) + B_0*std::sin(x);
 
         } else if (prob_type == 11) {
-            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth * (one + std::cos(PI * std::min(r2d_xy, r0) / r0));
+            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth_d * (one_d + std::cos(PI_d * std::min(r2d_xy, r0) / r0));
         } else if (prob_type == 12) {
-            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth * (one + std::cos(PI * std::min(r2d_xz, r0) / r0));
+            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth_d * (one_d + std::cos(PI_d * std::min(r2d_xz, r0) / r0));
         } else if (prob_type == 13) {
             const Real r0_z = rad_0 * (prob_hi[2] - prob_lo[2]);
             //ellipse for mapfac shear validation
             const Real r2d_xz_ell = std::sqrt((x-xc)*(x-xc)/(r0*r0) + (z-zc)*(z-zc)/(r0_z*r0_z));
-            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth * (one + std::cos(PI * std::min(r2d_xz_ell, r0_z) / r0_z));
+            state_pert(i, j, k, RhoScalar_comp) = A_0 * fourth_d * (one_d + std::cos(PI_d * std::min(r2d_xz_ell, r0_z) / r0_z));
         } else if (prob_type == 14) {
-            state_pert(i, j, k, RhoScalar_comp) = std::cos(PI*x);
+            state_pert(i, j, k, RhoScalar_comp) = std::cos(PI_d*x);
         } else {
             // Set scalar = A_0 in a ball of radius r0 and 0 elsewhere
             if (r3d < r0) {
                state_pert(i, j, k, RhoScalar_comp) = A_0;
             } else {
-               state_pert(i, j, k, RhoScalar_comp) = zero;
+               state_pert(i, j, k, RhoScalar_comp) = zero_d;
             }
         }
 

--- a/Source/Prob/ERF_InitCustomPert_SquallLine.H
+++ b/Source/Prob/ERF_InitCustomPert_SquallLine.H
@@ -60,13 +60,13 @@
     Real* t   = d_t.data();
     Real* p   = d_p.data();
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,PI_d=PI,two_d=two,zero_d=zero,R_d_d=R_d,Cp_d_d=Cp_d,one_d=one,R_v_d=R_v] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry (note we must include these here to get the data on device)
         const auto prob_lo  = geomdata.ProbLo();
         const auto dx       = geomdata.CellSize();
-        const Real z        = prob_lo[2] + (k + myhalf) * dx[2];
-        const Real x        = prob_lo[0] + (i + myhalf) * dx[0];
+        const Real z        = prob_lo[2] + (k + myhalf_d) * dx[2];
+        const Real x        = prob_lo[0] + (i + myhalf_d) * dx[0];
         Real rad, delta_theta, theta_total, temperature, rho, RH, scalar;
 
         Real scaled_height = z / z_tr;
@@ -84,18 +84,18 @@
                          amrex::Math::powi<2>((z - z_c)/z_r) );
 
     if(rad <= r_c){
-        delta_theta = theta_c*amrex::Math::powi<2>(std::cos(PI*rad/two));
-        scalar = amrex::Math::powi<2>(std::cos(PI*rad/two));
+        delta_theta = theta_c*amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
+        scalar = amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
     }
     else{
-        delta_theta = zero;
-        scalar = zero;
+        delta_theta = zero_d;
+        scalar = zero_d;
     }
 
     theta_total     = t[k] + delta_theta;
 
-    temperature     = getTgivenPandTh(p[k], theta_total, (R_d/Cp_d));
-    Real T_b        = getTgivenPandTh(p[k], t[k]       , (R_d/Cp_d));
+    temperature     = getTgivenPandTh(p[k], theta_total, (R_d_d/Cp_d_d));
+    Real T_b        = getTgivenPandTh(p[k], t[k]       , (R_d_d/Cp_d_d));
 
     RH = HSEutils::compute_relative_humidity(p[k], T_b, use_empirical, which_zone, scaled_height);
 
@@ -106,11 +106,11 @@
         q_v_hot = HSEutils::vapor_mixing_ratio(p[k], T_b, RH, use_empirical, which_zone);
     }
 
-    rho = p[k]/(R_d*temperature*(one + (R_v/R_d)*q_v_hot));
+    rho = p[k]/(R_d_d*temperature*(one_d + (R_v_d/R_d_d)*q_v_hot));
 
     // Compute background quantities
-    Real temperature_back = getTgivenPandTh(p[k], t[k], (R_d/Cp_d));
-    Real T_back           = getTgivenPandTh(p[k], t[k], (R_d/Cp_d));
+    Real temperature_back = getTgivenPandTh(p[k], t[k], (R_d_d/Cp_d_d));
+    Real T_back           = getTgivenPandTh(p[k], t[k], (R_d_d/Cp_d_d));
 
     Real RH_back          = HSEutils::compute_relative_humidity(p[k], T_back, use_empirical, which_zone, scaled_height);
 
@@ -120,11 +120,11 @@
     } else {
         q_v_back = HSEutils::vapor_mixing_ratio(p[k], T_back, RH_back, use_empirical, which_zone);
     }
-    Real rho_back         = p[k]/(R_d*temperature_back*(one + (R_v/R_d)*q_v_back));
+    Real rho_back         = p[k]/(R_d_d*temperature_back*(one_d + (R_v_d/R_d_d)*q_v_back));
 
     // This version perturbs rho but not p
-    state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*t[k]*(one + (R_v/R_d)*q_v_back);// rho*d_t[k]*(one + R_v_by_R_d*q_v_hot);
-    state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one + q_v_back);
+    state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*t[k]*(one_d + (R_v_d/R_d_d)*q_v_back);// rho*d_t[k]*(one + R_v_by_R_d*q_v_hot);
+    state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one_d + q_v_back);
 
     // Set scalar = 0 everywhere
     state_pert(i, j, k, RhoScalar_comp) = rho*scalar;
@@ -132,8 +132,7 @@
     // mean states
     if (use_moisture) {
         state_pert(i, j, k, RhoQ1_comp) = rho*q_v_hot;
-        state_pert(i, j, k, RhoQ2_comp) = zero;
+        state_pert(i, j, k, RhoQ2_comp) = zero_d;
     }
 
   });
-

--- a/Source/Prob/ERF_InitCustomPert_StokesSecondProblem.H
+++ b/Source/Prob/ERF_InitCustomPert_StokesSecondProblem.H
@@ -1,5 +1,5 @@
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,one_d=one,Gamma_d=Gamma] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // This version perturbs rho but not p -- TODO: CHECK THIS
-        state_pert(i, j, k, RhoTheta_comp) = std::pow(one,one/Gamma) * amrex::Real(101325.0) / amrex::Real(287.0) - p_hse(i,j,k);
+        state_pert(i, j, k, RhoTheta_comp) = std::pow(one_d,one_d/Gamma_d) * amrex::Real(101325.0) / amrex::Real(287.0) - p_hse(i,j,k);
     });

--- a/Source/Prob/ERF_InitCustomPert_SuperCell.H
+++ b/Source/Prob/ERF_InitCustomPert_SuperCell.H
@@ -63,14 +63,14 @@
     Real* t   = d_t.data();
     Real* p   = d_p.data();
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,PI_d=PI,two_d=two,zero_d=zero,R_d_d=R_d,Cp_d_d=Cp_d,one_d=one,R_v_d=R_v] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry (note we must include these here to get the data on device)
         const auto prob_lo  = geomdata.ProbLo();
         const auto dx       = geomdata.CellSize();
-        const Real x        = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y        = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z        = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x        = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y        = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z        = prob_lo[2] + (k + myhalf_d) * dx[2];
         Real rad, delta_theta, theta_total, temperature, rho, RH, scalar;
 
         // Introduce the warm bubble. Assume that the bubble is pressure matched with the background
@@ -79,11 +79,11 @@
                          amrex::Math::powi<2>((z - z_c)/z_r) );
 
         if(rad <= r_c) {
-            delta_theta = theta_c * amrex::Math::powi<2>(std::cos(PI*rad/two));
-            scalar = amrex::Math::powi<2>(std::cos(PI*rad/two));
+            delta_theta = theta_c * amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
+            scalar = amrex::Math::powi<2>(std::cos(PI_d*rad/two_d));
         } else {
-            delta_theta = zero;
-            scalar = zero;
+            delta_theta = zero_d;
+            scalar = zero_d;
         }
 
         Real scaled_height = z / z_tr;
@@ -97,8 +97,8 @@
         }
 
         theta_total     = t[k] + delta_theta;
-        temperature     = getTgivenPandTh(p[k], theta_total, (R_d/Cp_d));
-        Real T_b        = getTgivenPandTh(p[k], t[k]       , (R_d/Cp_d));
+        temperature     = getTgivenPandTh(p[k], theta_total, (R_d_d/Cp_d_d));
+        Real T_b        = getTgivenPandTh(p[k], t[k]       , (R_d_d/Cp_d_d));
         RH              = HSEutils::compute_relative_humidity(p[k], T_b, use_empirical, which_zone, scaled_height);
 
         Real q_v_hot;
@@ -108,11 +108,11 @@
             q_v_hot = HSEutils::vapor_mixing_ratio(p[k], T_b, RH, use_empirical, which_zone);
         }
 
-        rho             = p[k]/(R_d*temperature*(one + (R_v/R_d)*q_v_hot));
+        rho             = p[k]/(R_d_d*temperature*(one_d + (R_v_d/R_d_d)*q_v_hot));
 
         // Compute background quantities
-        Real temperature_back = getTgivenPandTh(p[k], t[k], (R_d/Cp_d));
-        Real T_back           = getTgivenPandTh(p[k], t[k], (R_d/Cp_d));
+        Real temperature_back = getTgivenPandTh(p[k], t[k], (R_d_d/Cp_d_d));
+        Real T_back           = getTgivenPandTh(p[k], t[k], (R_d_d/Cp_d_d));
         Real RH_back          = HSEutils::compute_relative_humidity(p[k], T_back, use_empirical, which_zone, scaled_height);
 
         Real q_v_back;
@@ -125,8 +125,8 @@
         Real rho_back         = getRhogivenTandPress(temperature_back, p[k], q_v_back);
 
         // This version perturbs rho but not p
-        state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*t[k]*(one + (R_v/R_d)*q_v_back);// rho*d_t[k]*(one + R_v_by_R_d*q_v_hot);
-        state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one + q_v_back);
+        state_pert(i, j, k, RhoTheta_comp) = rho*theta_total - rho_back*t[k]*(one_d + (R_v_d/R_d_d)*q_v_back);// rho*d_t[k]*(one + R_v_by_R_d*q_v_hot);
+        state_pert(i, j, k, Rho_comp)      = rho - rho_back*(one_d + q_v_back);
 
         // Set scalar = 0 everywhere
         state_pert(i, j, k, RhoScalar_comp) = rho*scalar;
@@ -134,7 +134,7 @@
         // mean states
         if (use_moisture) {
             state_pert(i, j, k, RhoQ1_comp) = rho*q_v_hot;
-            state_pert(i, j, k, RhoQ2_comp) = zero;
+            state_pert(i, j, k, RhoQ2_comp) = zero_d;
         }
 
     });

--- a/Source/Prob/ERF_InitCustomPert_TaylorGreenVortex.H
+++ b/Source/Prob/ERF_InitCustomPert_TaylorGreenVortex.H
@@ -5,21 +5,21 @@
     Real M_0   =   one; pp.query("M_0", M_0);
     Real V_0   =   one; pp.query("V_0", V_0);
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one,Gamma_d=Gamma] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         // Geometry
         const Real* prob_lo = geomdata.ProbLo();
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
-        const Real z = prob_lo[2] + (k + myhalf) * dx[2];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
+        const Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
         // Initial potential temperature (actually rho*theta) perturbation
         const Real p = rho_0 * V_0*V_0*
-                              ( one / (Gamma * M_0 * M_0)
-                              + (one / amrex::Real(16.0)) * (std::cos(2 * x) + std::cos(2 * y)) * (std::cos(2 * z) + 2));
+                              ( one_d / (Gamma_d * M_0 * M_0)
+                              + (one_d / amrex::Real(16.0)) * (std::cos(2 * x) + std::cos(2 * y)) * (std::cos(2 * z) + 2));
         state_pert(i, j, k, RhoTheta_comp) = getRhoThetagivenP(p) - getRhoThetagivenP(p_hse(i,j,k));
 
         // Set scalar = 0 everywhere
-        state_pert(i, j, k, RhoScalar_comp) = one * rho_0;
+        state_pert(i, j, k, RhoScalar_comp) = one_d * rho_0;
     });

--- a/Source/Prob/ERF_InitCustomPert_TurbulentInflow.H
+++ b/Source/Prob/ERF_InitCustomPert_TurbulentInflow.H
@@ -58,24 +58,24 @@
         }
     }
 
-    ParallelForRNG(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
+    ParallelForRNG(bx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k, const amrex::RandomEngine& engine) noexcept
     {
         const Real* dx = geomdata.CellSize();
-        const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-        const Real y = prob_lo[1] + (j + myhalf) * dx[1];
+        const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+        const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
         const Real z = z_cc(i,j,k);
 
         // Define a point (xc,yc,zc) at the center of the domain
-        const Real xc = myhalf * (prob_lo[0] + prob_hi[0]);
-        const Real yc = myhalf * (prob_lo[1] + prob_hi[1]);
-        const Real zc = myhalf * (prob_lo[2] + prob_hi[2]);
+        const Real xc = myhalf_d * (prob_lo[0] + prob_hi[0]);
+        const Real yc = myhalf_d * (prob_lo[1] + prob_hi[1]);
+        const Real zc = myhalf_d * (prob_lo[2] + prob_hi[2]);
 
         const Real r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc) + (z-zc)*(z-zc));
 
         // Add temperature perturbations
-        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero)) {
+        if ((z <= pert_ref_height) && (T_0_Pert_Mag != zero_d)) {
             Real rand_double = amrex::Random(engine); // Between zero and one
-            state_pert(i, j, k, RhoTheta_comp) = (rand_double*two - one)*T_0_Pert_Mag;
+            state_pert(i, j, k, RhoTheta_comp) = (rand_double*two_d - one_d)*T_0_Pert_Mag;
             if (!pert_rhotheta) {
                 // we're perturbing theta, not rho*theta
                 state_pert(i, j, k, RhoTheta_comp) *= r_hse(i,j,k);
@@ -92,7 +92,7 @@
             if (KE_decay_height > 0) {
                 // scale initial SGS kinetic energy with height
                 state_pert(i, j, k, RhoKE_comp) *= max(
-                    std::pow(1 - min(z/KE_decay_height,one), KE_decay_order), Real(1e-12));
+                    std::pow(1 - min(z/KE_decay_height,one_d), KE_decay_order), Real(1e-12));
             }
         }
     });

--- a/Source/Prob/ERF_UpdateRhoQtSources_Bomex.H
+++ b/Source/Prob/ERF_UpdateRhoQtSources_Bomex.H
@@ -11,7 +11,7 @@
         const Array4<Real>& qsrc_arr = qsrc->array(mfi);
         if (box.length(0) == 1)
         {
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 const Real z_cc = d_zlevels_arr[k];
                 if (z_cc < moisture_cutoff) {
                     qsrc_arr(i, j, k) = advection_moisture_rate;
@@ -19,7 +19,7 @@
                     Real slope = -advection_moisture_rate / moisture_cutoff_transition;
                     qsrc_arr(i, j, k) = (z_cc-moisture_cutoff) * slope + advection_moisture_rate;
                 } else {
-                    qsrc_arr(i, j, k) = zero;
+                    qsrc_arr(i, j, k) = zero_d;
                 }
             });
         }

--- a/Source/Prob/ERF_UpdateRhoQtSources_SDMCongestus3D.H
+++ b/Source/Prob/ERF_UpdateRhoQtSources_SDMCongestus3D.H
@@ -19,11 +19,11 @@
         if (box.length(0) != 1)
         {
             // if z dimension size is 1, then src is a spatially varying function over x,y at k=0
-            ParallelFor( box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor( box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                auto x = prob_lo[0] + (i + myhalf) * dx[0];
-                auto y = prob_lo[1] + (j + myhalf) * dx[1];
-                auto z = prob_lo[2] + (k + myhalf) * dx[2];
+                auto x = prob_lo[0] + (i + myhalf_d) * dx[0];
+                auto y = prob_lo[1] + (j + myhalf_d) * dx[1];
+                auto z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
                 //const Real c = two*dx[0];
                 auto c = amrex::Real(1700.0)*amrex::Real(1700.0);
@@ -37,8 +37,8 @@
             });
         } else {
             // src is a function over Z
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                qsrc_arr(i, j, k) = zero;
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                qsrc_arr(i, j, k) = zero_d;
             });
         }
     }

--- a/Source/Prob/ERF_UpdateRhoQtSources_SineMassFlux.H
+++ b/Source/Prob/ERF_UpdateRhoQtSources_SineMassFlux.H
@@ -12,7 +12,7 @@
         {
             qsrc->setVal(0.0);
         } else {
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 const Real z_cc = d_zlevels_arr[k];
                 if (z_cc < moisture_cutoff) {
                     qsrc_arr(i, j, k) = advection_moisture_rate;
@@ -20,7 +20,7 @@
                     Real slope = -advection_moisture_rate / moisture_cutoff_transition;
                     qsrc_arr(i, j, k) = (z_cc-moisture_cutoff) * slope + advection_moisture_rate;
                 } else {
-                    qsrc_arr(i, j, k) = zero;
+                    qsrc_arr(i, j, k) = zero_d;
                 }
             });
         }

--- a/Source/Prob/ERF_UpdateRhoThetaSources_Bomex.H
+++ b/Source/Prob/ERF_UpdateRhoThetaSources_Bomex.H
@@ -13,7 +13,7 @@
         {
             src->setVal(0.0);
         } else {
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 const Real z_cc = d_zlevels_arr[k];
                 if (z_cc < cutoff) {
                     src_arr(i, j, k) = advection_heating_rate;
@@ -21,7 +21,7 @@
                     Real slope = -advection_heating_rate / cutoff_transition;
                     src_arr(i, j, k) = (z_cc-cutoff) * slope + advection_heating_rate;
                 } else {
-                    src_arr(i, j, k) = zero;
+                    src_arr(i, j, k) = zero_d;
                 }
             });
         }

--- a/Source/Prob/ERF_UpdateRhoThetaSources_SDMCongestus3D.H
+++ b/Source/Prob/ERF_UpdateRhoThetaSources_SDMCongestus3D.H
@@ -19,11 +19,11 @@
         if (box.length(0) != 1)
         {
             // if z dimension size is 1, then src is a spatially varying function over x,y at k=0
-            ParallelFor( box, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor( box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                auto x = prob_lo[0] + (i + myhalf) * dx[0];
-                auto y = prob_lo[1] + (j + myhalf) * dx[1];
-                auto z = prob_lo[2] + (k + myhalf) * dx[2];
+                auto x = prob_lo[0] + (i + myhalf_d) * dx[0];
+                auto y = prob_lo[1] + (j + myhalf_d) * dx[1];
+                auto z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
                 auto c = amrex::Real(2890000.0);
                 auto r  = std::sqrt((x-xc)*(x-xc) + (y-yc)*(y-yc));

--- a/Source/Prob/ERF_UpdateRhoThetaSources_SineMassFlux.H
+++ b/Source/Prob/ERF_UpdateRhoThetaSources_SineMassFlux.H
@@ -12,7 +12,7 @@
         {
             src->setVal(0.0);
         } else {
-            ParallelFor(box, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+            ParallelFor(box, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
                 const Real z_cc = d_zlevels_arr[k];
                 if (z_cc < cutoff) {
                     src_arr(i, j, k) = advection_heating_rate;
@@ -20,7 +20,7 @@
                     Real slope = -advection_heating_rate / cutoff_transition;
                     src_arr(i, j, k) = (z_cc-cutoff) * slope + advection_heating_rate;
                 } else {
-                    src_arr(i, j, k) = zero;
+                    src_arr(i, j, k) = zero_d;
                 }
             });
         }

--- a/Source/Refinement/ERF_RefineHurricane.cpp
+++ b/Source/Refinement/ERF_RefineHurricane.cpp
@@ -27,7 +27,7 @@ ERF::FindInitialEye(int levc,
         const Box& box = mfi.validbox();
         const Array4<const Real>& vel_arr = mf_cc_vel.const_array(mfi);
 
-        ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+        ParallelFor(box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
         {
             Real magnitude = std::sqrt(vel_arr(i,j,k,0) * vel_arr(i,j,k,0) +
                                        vel_arr(i,j,k,1) * vel_arr(i,j,k,1) +
@@ -35,15 +35,15 @@ ERF::FindInitialEye(int levc,
 
             magnitude *= Real(3.6);
 
-            Real z = prob_lo[2] + (k + myhalf) * dx[2];
+            Real z = prob_lo[2] + (k + myhalf_d) * dx[2];
 
             // Check if magnitude exceeds threshold
             if (z < Real(2000.) && magnitude > velmag_threshold) {
                 // Use atomic operations to set found flag and store coordinates
                 Gpu::Atomic::Add(&d_found_ptr[0], 1); // Mark as found
 
-                Real x = prob_lo[0] + (i + myhalf) * dx[0];
-                Real y = prob_lo[1] + (j + myhalf) * dx[1];
+                Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+                Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
 
                 // Store coordinates
                 Gpu::Atomic::Add(&d_coords_ptr[0],x); // Store x index
@@ -91,10 +91,10 @@ tag_on_distance_from_eye(const Geometry& cgeom, TagBoxArray* tags,
 
         const Box& tile_box = mfi.tilebox(); // The box for this tile
 
-        ParallelFor(tile_box, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        ParallelFor(tile_box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) {
             // Compute cell center coordinates
-            Real x = prob_lo[0] + (i + myhalf) * dx[0];
-            Real y = prob_lo[1] + (j + myhalf) * dx[1];
+            Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+            Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
 
             Real dist = std::sqrt((x - eye_x)*(x - eye_x) + (y - eye_y)*(y - eye_y));
 

--- a/Source/SourceTerms/ERF_ApplyBndryForcing_Forecast.cpp
+++ b/Source/SourceTerms/ERF_ApplyBndryForcing_Forecast.cpp
@@ -56,13 +56,13 @@ ApplyBndryForcing_Forecast (
     AMREX_ALWAYS_ASSERT(ylo_sponge_end   > ProbLoArr[1]);
     AMREX_ALWAYS_ASSERT(yhi_sponge_start < ProbHiArr[1]);
 
-    ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
         Real x = ProbLoArr[0] + ii * dx[0];
-        Real y = ProbLoArr[1] + (jj+myhalf) * dx[1];
+        Real y = ProbLoArr[1] + (jj+myhalf_d) * dx[1];
 
         Real rho_u_sponge = rho_u_initial_state(i,j,k)*cons_initial_state(i,j,k,0);
         // x lo sponge
@@ -88,12 +88,12 @@ ApplyBndryForcing_Forecast (
     });
 
 
-    ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tby, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
-        Real x = ProbLoArr[0] + (ii+myhalf) * dx[0];
+        Real x = ProbLoArr[0] + (ii+myhalf_d) * dx[0];
         Real y = ProbLoArr[1] + jj * dx[1];
 
         Real rho_v_sponge    = rho_v_initial_state(i,j,k)*cons_initial_state(i,j,k,0);
@@ -121,14 +121,14 @@ ApplyBndryForcing_Forecast (
             }
     });
 
-    ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         Real z = z_phys_nd(i,j,k);
 
         if(hindcast_zhi_sponge_damping){
             if (z > zhi_sponge_start) {
                 Real xi = (z - zhi_sponge_start) / hindcast_zhi_sponge_length;
-                rho_w_rhs(i, j, k) -= hindcast_zhi_sponge_strength * xi * xi * (rho_w(i, j, k) - zero);
+                rho_w_rhs(i, j, k) -= hindcast_zhi_sponge_strength * xi * xi * (rho_w(i, j, k) - zero_d);
             }
         }
     });

--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs.cpp
@@ -63,13 +63,13 @@ ApplySpongeZoneBCsForCC (const SpongeChoice& spongeChoice,
     if(use_zlo_sponge_damping)AMREX_ALWAYS_ASSERT(zlo_sponge_end   > ProbLoArr[2]);
     if(use_zhi_sponge_damping)AMREX_ALWAYS_ASSERT(zhi_sponge_start < ProbHiArr[2]);
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+    ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
-        Real x = ProbLoArr[0] + (ii+myhalf) * dx[0];
-        Real y = ProbLoArr[1] + (jj+myhalf) * dx[1];
+        Real x = ProbLoArr[0] + (ii+myhalf_d) * dx[0];
+        Real y = ProbLoArr[1] + (jj+myhalf_d) * dx[1];
         Real z = z_phys_cc(i,j,k);
 
         Real sponge_density = (use_base_density) ? r0(i,j,k) : sponge_density_tmp;
@@ -229,16 +229,16 @@ ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
     if(use_zlo_sponge_damping)AMREX_ALWAYS_ASSERT(zlo_sponge_end   > ProbLoArr[2]);
     if(use_zhi_sponge_damping)AMREX_ALWAYS_ASSERT(zhi_sponge_start < ProbHiArr[2]);
 
-    ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
         Real x = ProbLoArr[0] + ii * dx[0];
-        Real y = ProbLoArr[1] + (jj+myhalf) * dx[1];
+        Real y = ProbLoArr[1] + (jj+myhalf_d) * dx[1];
         Real z = z_phys_cc(i,j,k);
 
-        Real sponge_density = (use_base) ? myhalf * (r0(i,j,k) + r0(i-1,j,k)) : sponge_density_tmp;
+        Real sponge_density = (use_base) ? myhalf_d * (r0(i,j,k) + r0(i-1,j,k)) : sponge_density_tmp;
 
         // x lo sponge
         if(use_xlo_sponge_damping){
@@ -289,16 +289,16 @@ ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
     });
 
 
-    ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tby, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
-        Real x = ProbLoArr[0] + (ii+myhalf) * dx[0];
+        Real x = ProbLoArr[0] + (ii+myhalf_d) * dx[0];
         Real y = ProbLoArr[1] + jj * dx[1];
         Real z = z_phys_cc(i,j,k);
 
-        Real sponge_density = (use_base) ?  myhalf * (r0(i,j,k) + r0(i,j-1,k)) : sponge_density_tmp;
+        Real sponge_density = (use_base) ?  myhalf_d * (r0(i,j,k) + r0(i,j-1,k)) : sponge_density_tmp;
 
         // x lo sponge
         if(use_xlo_sponge_damping){
@@ -349,16 +349,16 @@ ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
     });
 
 
-    ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbz, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
-        Real x = ProbLoArr[0] + (ii+myhalf) * dx[0];
-        Real y = ProbLoArr[1] + (jj+myhalf) * dx[1];
+        Real x = ProbLoArr[0] + (ii+myhalf_d) * dx[0];
+        Real y = ProbLoArr[1] + (jj+myhalf_d) * dx[1];
         Real z = z_phys_nd(i,j,k);
 
-        Real sponge_density = (use_base) ? myhalf * (r0(i,j,k) + r0(i,j,k-1)) : sponge_density_tmp;
+        Real sponge_density = (use_base) ? myhalf_d * (r0(i,j,k) + r0(i,j,k-1)) : sponge_density_tmp;
 
         // x left sponge
         if(use_xlo_sponge_damping){
@@ -408,7 +408,6 @@ ApplySpongeZoneBCsForMom (const SpongeChoice& spongeChoice,
         }
     });
 }
-
 
 
 

--- a/Source/SourceTerms/ERF_ApplySpongeZoneBCs_ReadFromFile.cpp
+++ b/Source/SourceTerms/ERF_ApplySpongeZoneBCs_ReadFromFile.cpp
@@ -54,13 +54,13 @@ ApplySpongeZoneBCsForMom_ReadFromFile (const SpongeChoice& spongeChoice,
     if(use_zlo_sponge_damping)AMREX_ALWAYS_ASSERT(zlo_sponge_end   > ProbLoArr[2]);
     if(use_zhi_sponge_damping)AMREX_ALWAYS_ASSERT(zhi_sponge_start < ProbHiArr[2]);
 
-    ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
         Real x = ProbLoArr[0] + ii * dx[0];
-        Real y = ProbLoArr[1] + (jj+myhalf) * dx[1];
+        Real y = ProbLoArr[1] + (jj+myhalf_d) * dx[1];
         Real z = z_phys_cc(i,j,k);
 
         // x lo sponge
@@ -112,12 +112,12 @@ ApplySpongeZoneBCsForMom_ReadFromFile (const SpongeChoice& spongeChoice,
     });
 
 
-    ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tby, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
         int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
 
-        Real x = ProbLoArr[0] + (ii+myhalf) * dx[0];
+        Real x = ProbLoArr[0] + (ii+myhalf_d) * dx[0];
         Real y = ProbLoArr[1] + jj * dx[1];
         Real z = z_phys_cc(i,j,k);
 

--- a/Source/SourceTerms/ERF_ApplySurfaceTreatment_BulkCoeff.cpp
+++ b/Source/SourceTerms/ERF_ApplySurfaceTreatment_BulkCoeff.cpp
@@ -20,38 +20,38 @@ ApplySurfaceTreatment_BulkCoeff_Mom (
     Real Cd_sea = Real(0.001);
     Real Cd_land = Real(0.01);
 
-    ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tbx, [=,two_d=two,one_d=one,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
     {
         if(k <= ndrag) {
             Real dz = z_phys_nd(i,j,1) - z_phys_nd(i,j,0);
-            Real ls_mask = (surface_state_arr(i-1,j,0)+surface_state_arr(i,j,0))/two;
-            Real weight = one - Real(k)/ndrag;  // linear decrease
-            Real fac = k==0? one : zero;
-            Real Cd = fac*Cd_sea*(one-ls_mask) + Cd_land*ls_mask;
-            Real rho_for_u = (cons_state(i-1,j,k,0)+cons_state(i,j,k,0))/two;
-            Real rho_for_v = (cons_state(i,j-1,k,0)+cons_state(i,j,k,0))/two;
+            Real ls_mask = (surface_state_arr(i-1,j,0)+surface_state_arr(i,j,0))/two_d;
+            Real weight = one_d - Real(k)/ndrag;  // linear decrease
+            Real fac = k==0? one_d : zero_d;
+            Real Cd = fac*Cd_sea*(one_d-ls_mask) + Cd_land*ls_mask;
+            Real rho_for_u = (cons_state(i-1,j,k,0)+cons_state(i,j,k,0))/two_d;
+            Real rho_for_v = (cons_state(i,j-1,k,0)+cons_state(i,j,k,0))/two_d;
             Real uvel = rho_u(i,j,k)/rho_for_u;
             Real vvel = rho_v(i,j,k)/rho_for_v;
             Real velmag = std::sqrt(uvel*uvel + vvel*vvel);
-            rho_u_rhs(i, j, k) += -one*weight*Cd*velmag*rho_for_u*uvel/dz;
+            rho_u_rhs(i, j, k) += -one_d*weight*Cd*velmag*rho_for_u*uvel/dz;
         }
     });
 
 
-    ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+    ParallelFor(tby, [=,two_d=two,one_d=one,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
     {
        if(k <= ndrag) {
             Real dz = z_phys_nd(i,j,1) - z_phys_nd(i,j,0);
-            Real ls_mask = (surface_state_arr(i,j-1,0)+surface_state_arr(i,j,0))/two;
-            Real fac = k==0? one : zero;
-            Real Cd = fac*Cd_sea*(one-ls_mask) + Cd_land*ls_mask;
-            Real weight = one - Real(k)/ndrag;  // linear decrease
-            Real rho_for_u = (cons_state(i-1,j,k,0)+cons_state(i,j,k,0))/two;
-            Real rho_for_v = (cons_state(i,j-1,k,0)+cons_state(i,j,k,0))/two;
+            Real ls_mask = (surface_state_arr(i,j-1,0)+surface_state_arr(i,j,0))/two_d;
+            Real fac = k==0? one_d : zero_d;
+            Real Cd = fac*Cd_sea*(one_d-ls_mask) + Cd_land*ls_mask;
+            Real weight = one_d - Real(k)/ndrag;  // linear decrease
+            Real rho_for_u = (cons_state(i-1,j,k,0)+cons_state(i,j,k,0))/two_d;
+            Real rho_for_v = (cons_state(i,j-1,k,0)+cons_state(i,j,k,0))/two_d;
             Real uvel = rho_u(i,j,k)/rho_for_u;
             Real vvel = rho_v(i,j,k)/rho_for_v;
             Real velmag = std::sqrt(uvel*uvel + vvel*vvel);
-            rho_v_rhs(i, j, k) += -one*weight*Cd*velmag*rho_for_v*vvel/dz;
+            rho_v_rhs(i, j, k) += -one_d*weight*Cd*velmag*rho_for_v*vvel/dz;
         }
     });
 }
@@ -63,12 +63,12 @@ ApplySurfaceTreatment_BulkCoeff_CC (const Box& bx,
                          const Array4<const Real>& z_phys_cc,
                          const Array4<const Real>& surface_state_arr)
 {
-     ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+     ParallelFor(bx, [=,one_d=one,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
         if(k == 0) {
             Real dz = z_phys_cc(i,j,1)-z_phys_cc(i,j,0);
             Real ls_mask = surface_state_arr(i,j,0);
-            Real Ch = Real(0.0015)*(one-ls_mask);
-            Real Ce = Real(0.0015)*(one-ls_mask);
+            Real Ch = Real(0.0015)*(one_d-ls_mask);
+            Real Ce = Real(0.0015)*(one_d-ls_mask);
 
             Real rho = cons_state(i,j,k, Rho_comp);
             Real rhotheta = cons_state(i,j,k, RhoTheta_comp);
@@ -79,8 +79,8 @@ ApplySurfaceTreatment_BulkCoeff_CC (const Box& bx,
             Real uvel = cons_state(i,j,k,1)/cons_state(i,j,k,0);
             Real vvel = cons_state(i,j,k,2)/cons_state(i,j,k,0);
             Real velmag = std::sqrt(uvel*uvel + vvel*vvel);
-            Real dT = max(zero, Real(301.0) - temp);
-            Real dq = max(zero, Real(0.024) - qv);
+            Real dT = max(zero_d, Real(301.0) - temp);
+            Real dq = max(zero_d, Real(0.024) - qv);
             cell_rhs(i, j, k, RhoTheta_comp) += (theta/(Real(1005.0)*temp))*rho*Ch*velmag*dT/dz;
             cell_rhs(i, j, k, RhoQ1_comp) += rho*Ce*velmag*dq/dz;
         }

--- a/Source/SourceTerms/ERF_ForestDrag.cpp
+++ b/Source/SourceTerms/ERF_ForestDrag.cpp
@@ -100,14 +100,14 @@ ForestDrag::define_drag_field (const BoxArray& ba,
             const Array4<const Real>& z_cc = z_phys_cc->const_array(mfi);
             const Array4<const Real>& z_nd = z_phys_nd->const_array(mfi);
 
-            ParallelFor(gtbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(gtbx, [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 // Physical positions of cell-centers
-                const Real x = prob_lo[0] + (i + myhalf) * dx[0];
-                const Real y = prob_lo[1] + (j + myhalf) * dx[1];
+                const Real x = prob_lo[0] + (i + myhalf_d) * dx[0];
+                const Real y = prob_lo[1] + (j + myhalf_d) * dx[1];
 
                 // "z" is measured as distance from cell center to ground
-                const Real z_sfc = fourth * ( z_nd(i,j  ,0) + z_nd(i+1,j  ,0)
+                const Real z_sfc = fourth_d * ( z_nd(i,j  ,0) + z_nd(i+1,j  ,0)
                                            +z_nd(i,j+1,0) + z_nd(i+1,j+1,0));
                 const Real z = std::max((z_cc(i,j,k)-z_sfc),amrex::Real(0));
 
@@ -117,15 +117,15 @@ ForestDrag::define_drag_field (const BoxArray& ba,
 
                 // Hit for canopy region
                 Real factor = 1;
-                if ((z <= hf) && (radius <= (myhalf * df))) {
+                if ((z <= hf) && (radius <= (myhalf_d * df))) {
                     if (tf == 2) {
                         Real ratio = (hf - treeZm) / (hf - z);
                         if (z < treeZm) {
                             factor = amrex::Math::powi<6>(ratio) *
-                                     std::exp(Real(6.0) * (one - ratio));
+                                     std::exp(Real(6.0) * (one_d - ratio));
                         } else if (z <= hf) {
-                            factor = std::pow(ratio, myhalf) *
-                                     std::exp(myhalf * (one - ratio));
+                            factor = std::pow(ratio, myhalf_d) *
+                                     std::exp(myhalf_d * (one_d - ratio));
                         }
                     }
                     levelDrag(i, j, k) = cdf * af * factor;
@@ -138,4 +138,3 @@ ForestDrag::define_drag_field (const BoxArray& ba,
     m_forest_drag->FillBoundary(geom.periodicity());
 
 } // init_drag_field
-

--- a/Source/SourceTerms/ERF_MakeBuoyancy.cpp
+++ b/Source/SourceTerms/ERF_MakeBuoyancy.cpp
@@ -199,9 +199,9 @@ void make_buoyancy (int lev,
             if ( anelastic && (solverChoice.moisture_type == MoistureType::None) ) {
 
                 if (grav_gpu[2]==0) {
-                    ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
-                        buoyancy_fab(i, j, k) = zero;
+                        buoyancy_fab(i, j, k) = zero_d;
                     });
                 } else {
 
@@ -217,9 +217,9 @@ void make_buoyancy (int lev,
             else
             {
                 if (grav_gpu[2]==0) {
-                    ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
-                        buoyancy_fab(i, j, k) = zero;
+                        buoyancy_fab(i, j, k) = zero_d;
                     });
                 } else {
                     // Currently, only dry compressible is supported

--- a/Source/SourceTerms/ERF_MakeGradP.cpp
+++ b/Source/SourceTerms/ERF_MakeGradP.cpp
@@ -66,9 +66,9 @@ void make_gradp_pert (int level,
             if (gbx.smallEnd(2) < 0) gbx.setSmall(2,0);
             const Array4<const Real>& cell_data = S_data[Vars::cons].array(mfi);
             const Array4<      Real>& pp_arr = p.array(mfi);
-            ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                Real qv_for_p = (l_use_moisture) ? cell_data(i,j,k,RhoQ1_comp)/cell_data(i,j,k,Rho_comp) : zero;
+                Real qv_for_p = (l_use_moisture) ? cell_data(i,j,k,RhoQ1_comp)/cell_data(i,j,k,Rho_comp) : zero_d;
                 pp_arr(i,j,k) = getPgivenRTh(cell_data(i,j,k,RhoTheta_comp),qv_for_p);
             });
         }
@@ -162,7 +162,7 @@ compute_gradp_xy (const MultiFab& p,
         if (solverChoice.terrain_type != TerrainType::EB) {
 
             ParallelFor(tbx, tby,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 //Note : mx/my == 1, so no map factor needed here
                 Real gpx = dxInv[0] * (p_arr(i,j,k) - p_arr(i-1,j,k));
@@ -188,7 +188,7 @@ compute_gradp_xy (const MultiFab& p,
                         gpz_hi  = (p_arr(i  ,j,k+1) - p_arr(i  ,j,k-1)) / dz_phys_hi;
                         gpz_lo  = (p_arr(i-1,j,k+1) - p_arr(i-1,j,k-1)) / dz_phys_lo;
                     }
-                    Real gpx_metric = met_h_xi * myhalf * (gpz_hi + gpz_lo);
+                    Real gpx_metric = met_h_xi * myhalf_d * (gpz_hi + gpz_lo);
                     gpx -= gpx_metric;
                 }
                 gpx_arr(i,j,k) = gpx;
@@ -196,7 +196,7 @@ compute_gradp_xy (const MultiFab& p,
                 // NOTE that the gradp array now carries the map factor!
                 gpx_arr(i,j,k) *= mf_ux_arr(i,j,0);
             },
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 //Note : mx/my == 1, so no map factor needed here
                 Real gpy = dxInv[1] * (p_arr(i,j,k) - p_arr(i,j-1,k));
@@ -222,7 +222,7 @@ compute_gradp_xy (const MultiFab& p,
                         gpz_hi  = (p_arr(i,j  ,k+1) - p_arr(i,j  ,k-1)) / dz_phys_hi;
                         gpz_lo  = (p_arr(i,j-1,k+1) - p_arr(i,j-1,k-1)) / dz_phys_lo;
                     }
-                    Real gpy_metric = met_h_eta * myhalf * (gpz_hi + gpz_lo);
+                    Real gpy_metric = met_h_eta * myhalf_d * (gpz_hi + gpz_lo);
                     gpy -= gpy_metric;
                 }
                 gpy_arr(i,j,k) = gpy;
@@ -259,9 +259,9 @@ compute_gradp_xy (const MultiFab& p,
             if (l_fitting) {
 
                 ParallelFor(tbx, tby,
-                [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
-                    if (u_volfrac(i,j,k) > zero) {
+                    if (u_volfrac(i,j,k) > zero_d) {
 
                         if (u_cellflg(i,j,k).isSingleValued()) {
 
@@ -275,12 +275,12 @@ compute_gradp_xy (const MultiFab& p,
                         }
 
                     } else {
-                        gpx_arr(i,j,k) = zero;
+                        gpx_arr(i,j,k) = zero_d;
                     }
                 },
-                [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
-                    if (v_volfrac(i,j,k) > zero) {
+                    if (v_volfrac(i,j,k) > zero_d) {
 
                         if (v_cellflg(i,j,k).isSingleValued()) {
 
@@ -293,7 +293,7 @@ compute_gradp_xy (const MultiFab& p,
                             gpy_arr(i,j,k) = dxInv[1] * (p_arr(i,j,k) - p_arr(i,j-1,k));
                         }
                     } else {
-                        gpy_arr(i,j,k) = zero;
+                        gpy_arr(i,j,k) = zero_d;
                     }
                 });
 
@@ -302,32 +302,32 @@ compute_gradp_xy (const MultiFab& p,
                 // Simple calculation: assuming pressures at cell centers
 
                 ParallelFor(tbx, tby,
-                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    if (u_volfrac(i,j,k) > zero) {
+                    if (u_volfrac(i,j,k) > zero_d) {
                         if (cellflg(i,j,k).isCovered()) {
-                            gpx_arr(i,j,k) = dxInv[0] * (p_arr(i-3,j,k) - three*p_arr(i-2,j,k) + two*p_arr(i-1,j,k));
+                            gpx_arr(i,j,k) = dxInv[0] * (p_arr(i-3,j,k) - three_d*p_arr(i-2,j,k) + two_d*p_arr(i-1,j,k));
                         } else if (cellflg(i-1,j,k).isCovered()) {
-                            gpx_arr(i,j,k) = dxInv[0] * (three*p_arr(i+1,j,k) - p_arr(i+2,j,k) - two*p_arr(i,j,k));
+                            gpx_arr(i,j,k) = dxInv[0] * (three_d*p_arr(i+1,j,k) - p_arr(i+2,j,k) - two_d*p_arr(i,j,k));
                         } else {
                             gpx_arr(i,j,k) = dxInv[0] * (p_arr(i,j,k) - p_arr(i-1,j,k));
                         }
                     } else {
-                        gpx_arr(i,j,k) = zero;
+                        gpx_arr(i,j,k) = zero_d;
                     }
                 },
-                [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    if (v_volfrac(i,j,k) > zero) {
+                    if (v_volfrac(i,j,k) > zero_d) {
                         if (cellflg(i,j,k).isCovered()) {
-                            gpy_arr(i,j,k) = dxInv[1] * (p_arr(i,j-3,k) - three*p_arr(i,j-2,k) + two*p_arr(i,j-1,k));
+                            gpy_arr(i,j,k) = dxInv[1] * (p_arr(i,j-3,k) - three_d*p_arr(i,j-2,k) + two_d*p_arr(i,j-1,k));
                         } else if (cellflg(i,j-1,k).isCovered()) {
-                            gpy_arr(i,j,k) = dxInv[1] * (three*p_arr(i,j+1,k) - p_arr(i,j+2,k) - two*p_arr(i,j,k));
+                            gpy_arr(i,j,k) = dxInv[1] * (three_d*p_arr(i,j+1,k) - p_arr(i,j+2,k) - two_d*p_arr(i,j,k));
                         } else {
                             gpy_arr(i,j,k) = dxInv[1] * (p_arr(i,j,k) - p_arr(i,j-1,k));
                         }
                     } else {
-                        gpy_arr(i,j,k) = zero;
+                        gpy_arr(i,j,k) = zero_d;
                     }
                 });
 
@@ -406,9 +406,9 @@ compute_gradp_z (const MultiFab& p,
 
             if (l_fitting) {
 
-                ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k)
+                ParallelFor(tbz, [=,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k)
                 {
-                    if (w_volfrac(i,j,k) > zero) {
+                    if (w_volfrac(i,j,k) > zero_d) {
 
                         if (w_cellflg(i,j,k).isSingleValued()) {
 
@@ -421,7 +421,7 @@ compute_gradp_z (const MultiFab& p,
                             gpz_arr(i,j,k) = dxInv[2] * (p_arr(i,j,k) - p_arr(i,j,k-1));
                         }
                     } else {
-                        gpz_arr(i,j,k) = zero;
+                        gpz_arr(i,j,k) = zero_d;
                     }
                 });
 
@@ -429,18 +429,18 @@ compute_gradp_z (const MultiFab& p,
 
                 // Simple calculation: assuming pressures at cell centers
 
-                ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+                ParallelFor(tbz, [=,zero_d=zero,three_d=three,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
                 {
-                    if (w_volfrac(i,j,k) > zero) {
+                    if (w_volfrac(i,j,k) > zero_d) {
                         if (cellflg(i,j,k).isCovered()) {
-                            gpz_arr(i,j,k) = dxInv[2] * ( p_arr(i,j,k-3) - three*p_arr(i,j,k-2) + two*p_arr(i,j,k-1) );
+                            gpz_arr(i,j,k) = dxInv[2] * ( p_arr(i,j,k-3) - three_d*p_arr(i,j,k-2) + two_d*p_arr(i,j,k-1) );
                         } else if (cellflg(i,j,k-1).isCovered()) {
-                            gpz_arr(i,j,k) = dxInv[2] * ( three*p_arr(i,j,k+1) - p_arr(i,j,k+2) - two*p_arr(i,j,k) );
+                            gpz_arr(i,j,k) = dxInv[2] * ( three_d*p_arr(i,j,k+1) - p_arr(i,j,k+2) - two_d*p_arr(i,j,k) );
                         } else {
                             gpz_arr(i,j,k) = dxInv[2] * ( p_arr(i,j,k)-p_arr(i,j,k-1) );
                         }
                     } else {
-                        gpz_arr(i,j,k) = zero;
+                        gpz_arr(i,j,k) = zero_d;
                     }
                 });
 
@@ -499,12 +499,12 @@ compute_gradp_interpz (const MultiFab& p,
         const Array4<const Real>& mf_vy_arr = mapfac[MapFacType::v_y]->const_array(mfi);
 
         ParallelFor(tbx, tby, tbz,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             if (l_use_terrain_fitted_coords) {
                 Real p_lo = p_arr(i-1,j,k);
                 Real p_hi = p_arr(i,j,k);
-                Real dz_int = myhalf * (z_cc_arr(i,j,k) - z_cc_arr(i-1,j,k));
+                Real dz_int = myhalf_d * (z_cc_arr(i,j,k) - z_cc_arr(i-1,j,k));
                 if (dz_int > 0) {
                     // Klemp 2011, Eqn. 16: s = 1/2
                     if (k==domain_klo) {
@@ -554,12 +554,12 @@ compute_gradp_interpz (const MultiFab& p,
             // NOTE that the gradp array now carries the map factor!
             gpx_arr(i,j,k) *= mf_ux_arr(i,j,0);
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
             if (l_use_terrain_fitted_coords) {
                 Real p_lo = p_arr(i,j-1,k);
                 Real p_hi = p_arr(i,j,k);
-                Real dz_int = myhalf * (z_cc_arr(i,j,k) - z_cc_arr(i,j-1,k));
+                Real dz_int = myhalf_d * (z_cc_arr(i,j,k) - z_cc_arr(i,j-1,k));
                 if (dz_int > 0) {
                     // Klemp 2011, Eqn. 16: s = 1/2
                     if (k==domain_klo) {

--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -331,51 +331,51 @@ void make_mom_sources (double time_d,
             if(solverChoice.init_type == InitType::HindCast) {
                 const Array4<const Real>& latlon_arr = (*forecast_state_at_lev)[4].array(mfi);
                 ParallelFor(tbx, tby, tbz,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                [=,myhalf_d=myhalf,fourth_d=fourth,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
-                    Real v_loc = fourth * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
-                    Real w_loc = fourth * (w(i,j,k+1) + w(i,j,k) + w(i,j-1,k+1) + w(i,j-1,k));
+                    Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                    Real v_loc = fourth_d * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
+                    Real w_loc = fourth_d * (w(i,j,k+1) + w(i,j,k) + w(i,j-1,k+1) + w(i,j-1,k));
                     Real latitude = latlon_arr(i,j,k,0);
-                    Real sphi_loc = std::sin(latitude*PI/Real(180.0));
-                    Real cphi_loc = std::cos(latitude*PI/Real(180.0));
+                    Real sphi_loc = std::sin(latitude*PI_d/Real(180.0));
+                    Real cphi_loc = std::cos(latitude*PI_d/Real(180.0));
                     xmom_src_arr(i, j, k) += coriolis_factor * rho_on_u_face * (v_loc * sphi_loc - w_loc * cphi_loc);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
-                    Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
+                [=,myhalf_d=myhalf,fourth_d=fourth,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                    Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
                     Real latitude = latlon_arr(i,j,k,0);
-                    Real sphi_loc = std::sin(latitude*PI/Real(180.0));
+                    Real sphi_loc = std::sin(latitude*PI_d/Real(180.0));
                     ymom_src_arr(i, j, k) += -coriolis_factor * rho_on_v_face * u_loc * sphi_loc;
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
-                    Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
+                [=,myhalf_d=myhalf,fourth_d=fourth,PI_d=PI] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
                     Real latitude = latlon_arr(i,j,k,0);
-                    Real cphi_loc = std::cos(latitude*PI/Real(180.0));
+                    Real cphi_loc = std::cos(latitude*PI_d/Real(180.0));
                     zmom_src_arr(i, j, k) += coriolis_factor * rho_on_w_face * u_loc * cphi_loc;
                 });
             }
             else if (var_coriolis && (sinPhi_mf) && (cosPhi_mf)) {
                 ParallelFor(tbx, tby, tbz,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
-                    Real v_loc = fourth * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
-                    Real w_loc = fourth * (w(i,j,k+1) + w(i,j,k) + w(i-1,j,k+1) + w(i-1,j,k));
-                    Real sphi_loc  = myhalf  * (sphi_arr(i,j,0) + sphi_arr(i-1,j,0));
-                    Real cphi_loc  = myhalf  * (cphi_arr(i,j,0) + cphi_arr(i-1,j,0));
+                    Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                    Real v_loc = fourth_d * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
+                    Real w_loc = fourth_d * (w(i,j,k+1) + w(i,j,k) + w(i-1,j,k+1) + w(i-1,j,k));
+                    Real sphi_loc  = myhalf_d  * (sphi_arr(i,j,0) + sphi_arr(i-1,j,0));
+                    Real cphi_loc  = myhalf_d  * (cphi_arr(i,j,0) + cphi_arr(i-1,j,0));
                     xmom_src_arr(i, j, k) += coriolis_factor * rho_on_u_face * (v_loc * sphi_loc - w_loc * cphi_loc);
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
-                    Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
-                    Real sphi_loc  = myhalf  * (sphi_arr(i,j,0) + sphi_arr(i,j-1,0));
+                [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                    Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
+                    Real sphi_loc  = myhalf_d  * (sphi_arr(i,j,0) + sphi_arr(i,j-1,0));
                     ymom_src_arr(i, j, k) += -coriolis_factor * rho_on_v_face * u_loc * sphi_loc;
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
-                    Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
+                [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
                     zmom_src_arr(i, j, k) += coriolis_factor * rho_on_w_face * u_loc * cphi_arr(i,j,0);
                 });
             } else {
@@ -383,12 +383,12 @@ void make_mom_sources (double time_d,
                     Array4<const Real> u_volfrac = (ebfact.get_u_const_factory())->getVolFrac().const_array(mfi);
                     Array4<const Real> v_volfrac = (ebfact.get_v_const_factory())->getVolFrac().const_array(mfi);
                     Array4<const Real> w_volfrac = (ebfact.get_w_const_factory())->getVolFrac().const_array(mfi);
-                    ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
                         Real v_loc = 0.0;
                         Real w_loc = 0.0;
                         Real v_vol = v_volfrac(i,j+1,k) + v_volfrac(i,j,k) + v_volfrac(i-1,j+1,k) + v_volfrac(i-1,j,k);
                         Real w_vol = w_volfrac(i,j,k+1) + w_volfrac(i,j,k) + w_volfrac(i-1,j,k+1) + w_volfrac(i-1,j,k);
-                        Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                        Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                         if (v_vol > 0.0) {
                             v_loc = ( v_volfrac(i  ,j+1,k) * v(i  ,j+1,k) + v_volfrac(i  ,j,k) * v(i  ,j,k)
                                     + v_volfrac(i-1,j+1,k) * v(i-1,j+1,k) + v_volfrac(i-1,j,k) * v(i-1,j,k)) / v_vol;
@@ -399,20 +399,20 @@ void make_mom_sources (double time_d,
                         }
                         xmom_src_arr(i, j, k) += coriolis_factor * rho_on_u_face * (v_loc * sinphi - w_loc * cosphi);
                     });
-                    ParallelFor(tby, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    ParallelFor(tby, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
                         Real u_loc = 0.0;
                         Real u_vol = u_volfrac(i+1,j,k) + u_volfrac(i,j,k) + u_volfrac(i+1,j-1,k) + u_volfrac(i,j-1,k);
-                        Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                        Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
                         if (u_vol > 0.0) {
                             u_loc = ( u_volfrac(i+1,j  ,k) * u(i+1,j  ,k) + u_volfrac(i,j  ,k) * u(i,j  ,k)
                                     + u_volfrac(i+1,j-1,k) * u(i+1,j-1,k) + u_volfrac(i,j-1,k) * u(i,j-1,k)) / u_vol;
                         }
                         ymom_src_arr(i, j, k) += -coriolis_factor * rho_on_v_face * u_loc * sinphi;
                     });
-                    ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    ParallelFor(tbz, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
                         Real u_loc = 0.0;
                         Real u_vol = u_volfrac(i+1,j,k) + u_volfrac(i,j,k) + u_volfrac(i+1,j,k-1) + u_volfrac(i,j,k-1);
-                        Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                        Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                         if (u_vol > 0.0) {
                             u_loc = ( u_volfrac(i+1,j,k  ) * u(i+1,j,k  ) + u_volfrac(i,j,k)   * u(i,j,k  )
                                     + u_volfrac(i+1,j,k-1) * u(i+1,j,k-1) + u_volfrac(i,j,k-1) * u(i,j,k-1)) / u_vol;
@@ -421,21 +421,21 @@ void make_mom_sources (double time_d,
                     });
                 } else {
                     ParallelFor(tbx, tby, tbz,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
                     {
-                        Real v_loc = fourth * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
-                        Real w_loc = fourth * (w(i,j,k+1) + w(i,j,k) + w(i-1,j,k+1) + w(i-1,j,k));
-                        Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                        Real v_loc = fourth_d * (v(i,j+1,k) + v(i,j,k) + v(i-1,j+1,k) + v(i-1,j,k));
+                        Real w_loc = fourth_d * (w(i,j,k+1) + w(i,j,k) + w(i-1,j,k+1) + w(i-1,j,k));
+                        Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                         xmom_src_arr(i, j, k) += rho_on_u_face * ( coriolis_factor * (v_loc * sinphi - w_loc * cosphi) );
                     },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
-                        Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
+                    [=,myhalf_d=myhalf,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) {
+                        Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                        Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j-1,k) + u(i,j-1,k));
                         ymom_src_arr(i, j, k) += rho_on_v_face * ( -coriolis_factor * u_loc * sinphi );
                     },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                        Real u_loc = fourth * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
-                        Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                        Real u_loc = fourth_d * (u(i+1,j,k) + u(i,j,k) + u(i+1,j,k-1) + u(i,j,k-1));
+                        Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                         zmom_src_arr(i, j, k) += rho_on_w_face * ( coriolis_factor * u_loc * cosphi );
                     });
                 }
@@ -449,9 +449,9 @@ void make_mom_sources (double time_d,
 
         if ( (is_slow_step && !use_Rayleigh_fast_uv) || (!is_slow_step && use_Rayleigh_fast_uv)) {
             if (rayleigh_damp_U) {
-                ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                    Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                     Real uu = rho_u(i,j,k) / rho_on_u_face;
                     Real sinesq = d_sinesq_at_lev[k];
                     xmom_src_arr(i, j, k) -= dampcoef*sinesq * (uu - ubar[k]) * rho_on_u_face;
@@ -459,9 +459,9 @@ void make_mom_sources (double time_d,
             }
 
             if (rayleigh_damp_V) {
-                ParallelFor(tby, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(tby, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                    Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
                     Real vv = rho_v(i,j,k) / rho_on_v_face;
                     Real sinesq = d_sinesq_at_lev[k];
                     ymom_src_arr(i, j, k) -= dampcoef*sinesq * (vv - vbar[k]) * rho_on_v_face;
@@ -471,9 +471,9 @@ void make_mom_sources (double time_d,
 
         if ( (is_slow_step && !use_Rayleigh_fast_w) || (!is_slow_step && use_Rayleigh_fast_w)) {
             if (rayleigh_damp_W) {
-                    ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                    ParallelFor(tbz, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                     Real ww = rho_w(i,j,k) / rho_on_w_face;
                     Real sinesq = d_sinesq_stag_at_lev[k];
                     zmom_src_arr(i, j, k) -= dampcoef*sinesq * (ww - wbar[k]) * rho_on_w_face;
@@ -486,19 +486,19 @@ void make_mom_sources (double time_d,
         // *****************************************************************************
         if (is_slow_step) {
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                 xmom_src_arr(i, j, k) += rho_on_u_face * abl_geo_forcing[0];
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
                 ymom_src_arr(i, j, k) += rho_on_v_face * abl_geo_forcing[1];
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                 zmom_src_arr(i, j, k) += rho_on_w_face * abl_geo_forcing[2];
             });
         }
@@ -508,14 +508,14 @@ void make_mom_sources (double time_d,
         // *****************************************************************************
         if (geo_wind_profile && is_slow_step) {
             ParallelFor(tbx, tby,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real rho_on_u_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                 xmom_src_arr(i, j, k) -= coriolis_factor * rho_on_u_face * dptr_v_geos[k] * sinphi;
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
             {
-                Real rho_on_v_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
                 ymom_src_arr(i, j, k) += coriolis_factor * rho_on_v_face * dptr_u_geos[k] * sinphi;
             });
         } // geo_wind_profile
@@ -527,68 +527,68 @@ void make_mom_sources (double time_d,
             if (solverChoice.custom_forcing_prim_vars) {
                 const int nr = Rho_comp;
                 ParallelFor(tbx, tby,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = myhalf*dxInv[2];
+                    Real dzInv = myhalf_d*dxInv[2];
                     if (z_nd_arr) {
-                        Real z_xf_lo = fourth * ( z_nd_arr(i,j,k  ) + z_nd_arr(i,j+1,k  )
+                        Real z_xf_lo = fourth_d * ( z_nd_arr(i,j,k  ) + z_nd_arr(i,j+1,k  )
                                               + z_nd_arr(i,j,k-1) + z_nd_arr(i,j+1,k-1) );
-                        Real z_xf_hi = fourth * ( z_nd_arr(i,j,k+1) + z_nd_arr(i,j+1,k+1)
+                        Real z_xf_hi = fourth_d * ( z_nd_arr(i,j,k+1) + z_nd_arr(i,j+1,k+1)
                                               + z_nd_arr(i,j,k+2) + z_nd_arr(i,j+1,k+2) );
-                        dzInv = one / (z_xf_hi - z_xf_lo);
+                        dzInv = one_d / (z_xf_hi - z_xf_lo);
                     }
-                    Real rho_on_u_face = myhalf * ( cell_data(i,j,k,nr) + cell_data(i-1,j,k,nr) );
+                    Real rho_on_u_face = myhalf_d * ( cell_data(i,j,k,nr) + cell_data(i-1,j,k,nr) );
                     Real U_hi = dptr_u_plane(k+1) / dptr_r_plane(k+1);
                     Real U_lo = dptr_u_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_xf = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_xf = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     xmom_src_arr(i, j, k) -= rho_on_u_face * wbar_xf * (U_hi - U_lo) * dzInv;
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = myhalf*dxInv[2];
+                    Real dzInv = myhalf_d*dxInv[2];
                     if (z_nd_arr) {
-                        Real z_yf_lo = fourth * ( z_nd_arr(i,j,k  ) + z_nd_arr(i+1,j,k  )
+                        Real z_yf_lo = fourth_d * ( z_nd_arr(i,j,k  ) + z_nd_arr(i+1,j,k  )
                                               + z_nd_arr(i,j,k-1) + z_nd_arr(i+1,j,k-1) );
-                        Real z_yf_hi = fourth * ( z_nd_arr(i,j,k+1) + z_nd_arr(i+1,j,k+1)
+                        Real z_yf_hi = fourth_d * ( z_nd_arr(i,j,k+1) + z_nd_arr(i+1,j,k+1)
                                               + z_nd_arr(i,j,k+2) + z_nd_arr(i+1,j,k+2) );
-                        dzInv = one / (z_yf_hi - z_yf_lo);
+                        dzInv = one_d / (z_yf_hi - z_yf_lo);
                     }
-                    Real rho_on_v_face = myhalf * ( cell_data(i,j,k,nr) + cell_data(i,j-1,k,nr) );
+                    Real rho_on_v_face = myhalf_d * ( cell_data(i,j,k,nr) + cell_data(i,j-1,k,nr) );
                     Real V_hi = dptr_v_plane(k+1) / dptr_r_plane(k+1);
                     Real V_lo = dptr_v_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_yf = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_yf = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     ymom_src_arr(i, j, k) -= rho_on_v_face * wbar_yf * (V_hi - V_lo) * dzInv;
                 });
             } else {
                 ParallelFor(tbx, tby,
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = myhalf*dxInv[2];
+                    Real dzInv = myhalf_d*dxInv[2];
                     if (z_nd_arr) {
-                        Real z_xf_lo = fourth * ( z_nd_arr(i,j,k  ) + z_nd_arr(i,j+1,k  )
+                        Real z_xf_lo = fourth_d * ( z_nd_arr(i,j,k  ) + z_nd_arr(i,j+1,k  )
                                               + z_nd_arr(i,j,k-1) + z_nd_arr(i,j+1,k-1) );
-                        Real z_xf_hi = fourth * ( z_nd_arr(i,j,k+1) + z_nd_arr(i,j+1,k+1)
+                        Real z_xf_hi = fourth_d * ( z_nd_arr(i,j,k+1) + z_nd_arr(i,j+1,k+1)
                                               + z_nd_arr(i,j,k+2) + z_nd_arr(i,j+1,k+2) );
-                        dzInv = one / (z_xf_hi - z_xf_lo);
+                        dzInv = one_d / (z_xf_hi - z_xf_lo);
                     }
                     Real U_hi = dptr_u_plane(k+1) / dptr_r_plane(k+1);
                     Real U_lo = dptr_u_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_xf = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_xf = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     xmom_src_arr(i, j, k) -= wbar_xf * (U_hi - U_lo) * dzInv;
                 },
-                [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                [=,myhalf_d=myhalf,fourth_d=fourth,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = myhalf*dxInv[2];
+                    Real dzInv = myhalf_d*dxInv[2];
                     if (z_nd_arr) {
-                        Real z_yf_lo = fourth * ( z_nd_arr(i,j,k  ) + z_nd_arr(i+1,j,k  )
+                        Real z_yf_lo = fourth_d * ( z_nd_arr(i,j,k  ) + z_nd_arr(i+1,j,k  )
                                               + z_nd_arr(i,j,k-1) + z_nd_arr(i+1,j,k-1) );
-                        Real z_yf_hi = fourth * ( z_nd_arr(i,j,k+1) + z_nd_arr(i+1,j,k+1)
+                        Real z_yf_hi = fourth_d * ( z_nd_arr(i,j,k+1) + z_nd_arr(i+1,j,k+1)
                                               + z_nd_arr(i,j,k+2) + z_nd_arr(i+1,j,k+2) );
-                        dzInv = one / (z_yf_hi - z_yf_lo);
+                        dzInv = one_d / (z_yf_hi - z_yf_lo);
                     }
                     Real V_hi = dptr_v_plane(k+1) / dptr_r_plane(k+1);
                     Real V_lo = dptr_v_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_yf = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_yf = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     ymom_src_arr(i, j, k) -= wbar_yf * (V_hi - V_lo) * dzInv;
                 });
             }
@@ -702,37 +702,37 @@ void make_mom_sources (double time_d,
         if (solverChoice.do_forest_drag &&
            ((is_slow_step && !use_canopy_fast) || (!is_slow_step && use_canopy_fast))) {
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const Real ux = u(i, j, k);
-                const Real uy = fourth * ( v(i, j  , k  ) + v(i-1, j  , k  )
+                const Real uy = fourth_d * ( v(i, j  , k  ) + v(i-1, j  , k  )
                                        + v(i, j+1, k  ) + v(i-1, j+1, k  ) );
-                const Real uz = fourth * ( w(i, j  , k  ) + w(i-1, j  , k  )
+                const Real uz = fourth_d * ( w(i, j  , k  ) + w(i-1, j  , k  )
                                        + w(i, j  , k+1) + w(i-1, j  , k+1) );
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real f_drag = myhalf * (f_drag_arr(i, j, k) + f_drag_arr(i-1, j, k));
+                const Real f_drag = myhalf_d * (f_drag_arr(i, j, k) + f_drag_arr(i-1, j, k));
                 xmom_src_arr(i, j, k) -= f_drag * ux * windspeed;
             },
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real ux = fourth * ( u(i  , j  , k  ) + u(i  , j-1, k  )
+                const Real ux = fourth_d * ( u(i  , j  , k  ) + u(i  , j-1, k  )
                                        + u(i+1, j  , k  ) + u(i+1, j-1, k  ) );
                 const Real uy = v(i, j, k);
-                const Real uz = fourth * ( w(i  , j  , k  ) + w(i  , j-1, k  )
+                const Real uz = fourth_d * ( w(i  , j  , k  ) + w(i  , j-1, k  )
                                        + w(i  , j  , k+1) + w(i  , j-1, k+1) );
                 const amrex::Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real f_drag = myhalf * (f_drag_arr(i, j, k) + f_drag_arr(i, j-1, k));
+                const Real f_drag = myhalf_d * (f_drag_arr(i, j, k) + f_drag_arr(i, j-1, k));
                 ymom_src_arr(i, j, k) -= f_drag * uy * windspeed;
             },
-            [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const amrex::Real ux = fourth * ( u(i  , j  , k  ) + u(i+1, j  , k  )
+                const amrex::Real ux = fourth_d * ( u(i  , j  , k  ) + u(i+1, j  , k  )
                                               + u(i  , j  , k-1) + u(i+1, j  , k-1) );
-                const amrex::Real uy = fourth * ( v(i  , j  , k  ) + v(i  , j+1, k  )
+                const amrex::Real uy = fourth_d * ( v(i  , j  , k  ) + v(i  , j+1, k  )
                                               + v(i  , j  , k-1) + v(i  , j+1, k-1) );
                 const amrex::Real uz = w(i, j, k);
                 const amrex::Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real f_drag = myhalf * (f_drag_arr(i, j, k) + f_drag_arr(i, j, k-1));
+                const Real f_drag = myhalf_d * (f_drag_arr(i, j, k) + f_drag_arr(i, j, k-1));
                 zmom_src_arr(i, j, k) -= f_drag * uz * windspeed;
             });
         }
@@ -761,34 +761,34 @@ void make_mom_sources (double time_d,
             const Real Olen_in            = solverChoice.if_Olen_in;
             const bool l_use_most         = solverChoice.if_use_most;
 
-            ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbx, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const Real ux = u(i, j, k);
-                const Real uy = fourth * ( v(i, j  , k  ) + v(i-1, j  , k  )
+                const Real uy = fourth_d * ( v(i, j  , k  ) + v(i-1, j  , k  )
                                        + v(i, j+1, k  ) + v(i-1, j+1, k  ) );
-                const Real uz = fourth * ( w(i, j  , k  ) + w(i-1, j  , k  )
+                const Real uz = fourth_d * ( w(i, j  , k  ) + w(i-1, j  , k  )
                                        + w(i, j  , k+1) + w(i-1, j  , k+1) );
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
-                const Real t_blank_above = myhalf * (t_blank_arr(i, j, k+1) + t_blank_arr(i-1, j, k+1));
+                const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
+                const Real t_blank_above = myhalf_d * (t_blank_arr(i, j, k+1) + t_blank_arr(i-1, j, k+1));
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_xface = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                const Real rho_xface = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
 
-                if ((t_blank > 0 && (t_blank_above == zero)) && l_use_most) { // force to MOST value
+                if ((t_blank > 0 && (t_blank_above == zero_d)) && l_use_most) { // force to MOST value
                     // calculate tangential velocity one cell above
                     const Real ux2r = u(i, j, k+1) ;
-                    const Real uy2r = fourth * ( v(i, j  , k+1) + v(i-1, j  , k+1)
+                    const Real uy2r = fourth_d * ( v(i, j  , k+1) + v(i-1, j  , k+1)
                                        + v(i, j+1, k+1) + v(i-1, j+1, k+1) ) ;
                     const Real h_windspeed2r = std::sqrt(ux2r * ux2r + uy2r * uy2r);
 
                     // MOST
-                    const Real theta_xface = (myhalf * (cell_data(i,j,k  ,RhoTheta_comp) + cell_data(i-1,j,k, RhoTheta_comp))) / rho_xface;
-                    const Real rho_xface_below    = myhalf * ( cell_data(i,j,k-1,Rho_comp) + cell_data(i-1,j,k-1,Rho_comp) );
-                    const Real theta_xface_below  = (myhalf * (cell_data(i,j,k-1,RhoTheta_comp) + cell_data(i-1,j,k-1, RhoTheta_comp))) / rho_xface_below;
+                    const Real theta_xface = (myhalf_d * (cell_data(i,j,k  ,RhoTheta_comp) + cell_data(i-1,j,k, RhoTheta_comp))) / rho_xface;
+                    const Real rho_xface_below    = myhalf_d * ( cell_data(i,j,k-1,Rho_comp) + cell_data(i-1,j,k-1,Rho_comp) );
+                    const Real theta_xface_below  = (myhalf_d * (cell_data(i,j,k-1,RhoTheta_comp) + cell_data(i-1,j,k-1, RhoTheta_comp))) / rho_xface_below;
                     const Real theta_surf         = theta_xface_below;
 
-                    Real psi_m = zero;
-                    Real psi_h = zero;
+                    Real psi_m = zero_d;
+                    Real psi_h = zero_d;
                     Real ustar = h_windspeed2r * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_m); // calculated from bottom of cell. Maintains flexibility for different Vf values
                     Real tflux = (tflux_in != Real(1e-8)) ? tflux_in : -(theta_xface - theta_surf) * ustar * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_h);
                     Real Olen  = (Olen_in  != Real(1e-8)) ? Olen_in  : -ustar * ustar * ustar * theta_xface / (kappa * ggg * tflux + tiny);
@@ -800,12 +800,12 @@ void make_mom_sources (double time_d,
                     ustar = h_windspeed2r * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_m);
 
                     // prevent some unphysical math
-                    if (!(ustar > zero && !std::isnan(ustar))) { ustar = zero; }
-                    if (!(ustar < two && !std::isnan(ustar))) { ustar = two; }
-                    if (psi_m > std::log(myhalf * dx_z / z0)) { psi_m = std::log(myhalf * dx_z / z0); }
+                    if (!(ustar > zero_d && !std::isnan(ustar))) { ustar = zero_d; }
+                    if (!(ustar < two_d && !std::isnan(ustar))) { ustar = two_d; }
+                    if (psi_m > std::log(myhalf_d * dx_z / z0)) { psi_m = std::log(myhalf_d * dx_z / z0); }
 
                     // determine target velocity
-                    const Real uTarget  = ustar / kappa * (std::log(myhalf * dx_z / z0) - psi_m);
+                    const Real uTarget  = ustar / kappa * (std::log(myhalf_d * dx_z / z0) - psi_m);
                     Real uxTarget = uTarget * ux2r / (tiny + h_windspeed2r);
                     const Real bc_forcing_x = -(uxTarget - ux); // BC forcing pushes nonrelative velocity toward target velocity
                     xmom_src_arr(i, j, k) -= (1-t_blank) * rho_xface * CdM * U_s * bc_forcing_x; // if Vf low, force more strongly to MOST. If high, less forcing.
@@ -813,34 +813,34 @@ void make_mom_sources (double time_d,
                     xmom_src_arr(i, j, k) -= t_blank * rho_xface * CdM * ux * windspeed;
                 }
             });
-            ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tby, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real ux = fourth * ( u(i  , j  , k  ) + u(i  , j-1, k  )
+                const Real ux = fourth_d * ( u(i  , j  , k  ) + u(i  , j-1, k  )
                                        + u(i+1, j  , k  ) + u(i+1, j-1, k  ) );
                 const Real uy = v(i, j, k);
-                const Real uz = fourth * ( w(i  , j  , k  ) + w(i  , j-1, k  )
+                const Real uz = fourth_d * ( w(i  , j  , k  ) + w(i  , j-1, k  )
                                        + w(i  , j  , k+1) + w(i  , j-1, k+1) );
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
-                const Real t_blank_above = myhalf * (t_blank_arr(i, j, k+1) + t_blank_arr(i, j-1, k+1));
+                const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
+                const Real t_blank_above = myhalf_d * (t_blank_arr(i, j, k+1) + t_blank_arr(i, j-1, k+1));
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_yface =  myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                const Real rho_yface =  myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
 
-                if ((t_blank > 0 && (t_blank_above == zero)) && l_use_most) { // force to MOST value
+                if ((t_blank > 0 && (t_blank_above == zero_d)) && l_use_most) { // force to MOST value
                     // calculate tangential velocity one cell above
-                    const Real ux2r = fourth * ( u(i  , j  , k+1) + u(i  , j-1, k+1)
+                    const Real ux2r = fourth_d * ( u(i  , j  , k+1) + u(i  , j-1, k+1)
                                        + u(i+1, j  , k+1) + u(i+1, j-1, k+1) );
                     const Real uy2r = v(i, j, k+1) ;
                     const Real h_windspeed2r = std::sqrt(ux2r * ux2r + uy2r * uy2r);
 
                     // MOST
-                    const Real theta_yface = (myhalf * (cell_data(i,j,k  ,RhoTheta_comp) + cell_data(i,j-1,k, RhoTheta_comp))) / rho_yface;
-                    const Real rho_yface_below    =  myhalf * ( cell_data(i,j,k-1,Rho_comp) + cell_data(i,j-1,k-1,Rho_comp) );
-                    const Real theta_yface_below  = (myhalf * (cell_data(i,j,k-1,RhoTheta_comp) + cell_data(i,j-1,k-1, RhoTheta_comp))) / rho_yface_below;
+                    const Real theta_yface = (myhalf_d * (cell_data(i,j,k  ,RhoTheta_comp) + cell_data(i,j-1,k, RhoTheta_comp))) / rho_yface;
+                    const Real rho_yface_below    =  myhalf_d * ( cell_data(i,j,k-1,Rho_comp) + cell_data(i,j-1,k-1,Rho_comp) );
+                    const Real theta_yface_below  = (myhalf_d * (cell_data(i,j,k-1,RhoTheta_comp) + cell_data(i,j-1,k-1, RhoTheta_comp))) / rho_yface_below;
                     const Real theta_surf         = theta_yface_below;
 
-                    Real psi_m = zero;
-                    Real psi_h = zero;
+                    Real psi_m = zero_d;
+                    Real psi_h = zero_d;
                     Real ustar = h_windspeed2r * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_m); // calculated from bottom of cell. Maintains flexibility for different Vf values
                     Real tflux = (tflux_in != Real(1e-8)) ? tflux_in : -(theta_yface - theta_surf) * ustar * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_h);
                     Real Olen  = (Olen_in  != Real(1e-8)) ? Olen_in  : -ustar * ustar * ustar * theta_yface / (kappa * ggg * tflux + tiny);
@@ -852,12 +852,12 @@ void make_mom_sources (double time_d,
                     ustar = h_windspeed2r * kappa / (std::log(Real(1.5) * dx_z / z0) - psi_m);
 
                     // prevent some unphysical math
-                    if (!(ustar > zero && !std::isnan(ustar))) { ustar = zero; }
-                    if (!(ustar < two && !std::isnan(ustar))) { ustar = two; }
-                    if (psi_m > std::log(myhalf * dx_z / z0)) { psi_m = std::log(myhalf * dx_z / z0); }
+                    if (!(ustar > zero_d && !std::isnan(ustar))) { ustar = zero_d; }
+                    if (!(ustar < two_d && !std::isnan(ustar))) { ustar = two_d; }
+                    if (psi_m > std::log(myhalf_d * dx_z / z0)) { psi_m = std::log(myhalf_d * dx_z / z0); }
 
                     // determine target velocity
-                    const Real uTarget  = ustar / kappa * (std::log(myhalf * dx_z / z0) - psi_m);
+                    const Real uTarget  = ustar / kappa * (std::log(myhalf_d * dx_z / z0) - psi_m);
                     Real uyTarget = uTarget * uy2r / (tiny + h_windspeed2r);
                     const Real bc_forcing_y = -(uyTarget - uy);  // BC forcing pushes nonrelative velocity toward target velocity
                     ymom_src_arr(i, j, k) -= (1 - t_blank) * rho_yface * CdM * U_s * bc_forcing_y; // if Vf low, force more strongly to MOST. If high, less forcing.
@@ -865,17 +865,17 @@ void make_mom_sources (double time_d,
                     ymom_src_arr(i, j, k) -= t_blank * rho_yface * CdM * uy * windspeed;
                 }
             });
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbz, [=,fourth_d=fourth,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real ux = fourth * ( u(i  , j  , k  ) + u(i+1, j  , k  )
+                const Real ux = fourth_d * ( u(i  , j  , k  ) + u(i+1, j  , k  )
                                        + u(i  , j  , k-1) + u(i+1, j  , k-1) );
-                const Real uy = fourth * ( v(i  , j  , k  ) + v(i  , j+1, k  )
+                const Real uy = fourth_d * ( v(i  , j  , k  ) + v(i  , j+1, k  )
                                        + v(i  , j  , k-1) + v(i  , j+1, k-1) );
                 const Real uz = w(i, j, k);
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
-                const Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
+                const Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_zface =  myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                const Real rho_zface =  myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                 zmom_src_arr(i, j, k) -= t_blank * rho_zface * CdM * uz * windspeed;
             });
         }
@@ -895,55 +895,55 @@ void make_mom_sources (double time_d,
             const Real tiny             = std::numeric_limits<amrex::Real>::epsilon();
             const Real min_t_blank      = Real(0.005); // threshold for where immersed forcing acts
 
-            ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbx, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,one_d=one,three_d=three] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const Real ux = u(i, j, k);
-                const Real uy = fourth * ( v(i, j  , k  ) + v(i-1, j  , k  )
+                const Real uy = fourth_d * ( v(i, j  , k  ) + v(i-1, j  , k  )
                                        + v(i, j+1, k  ) + v(i-1, j+1, k  ) );
-                const Real uz = fourth * ( w(i, j  , k  ) + w(i-1, j  , k  )
+                const Real uz = fourth_d * ( w(i, j  , k  ) + w(i-1, j  , k  )
                                        + w(i, j  , k+1) + w(i-1, j  , k+1) );
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
 
-                Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
-                if (t_blank < min_t_blank) { t_blank = zero; }
+                Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i-1, j, k));
+                if (t_blank < min_t_blank) { t_blank = zero_d; }
                 const Real dx_z    = (z_cc_arr) ? (z_cc_arr(i,j,k) - z_cc_arr(i,j,k-1)) : dx_arr[2];
-                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one/three);
+                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one_d/three_d);
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_xface = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
+                const Real rho_xface = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
                 xmom_src_arr(i, j, k) -= t_blank * rho_xface * CdM * ux * windspeed;
             });
-            ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tby, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,one_d=one,three_d=three] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real ux = fourth * ( u(i  , j  , k  ) + u(i  , j-1, k  )
+                const Real ux = fourth_d * ( u(i  , j  , k  ) + u(i  , j-1, k  )
                                        + u(i+1, j  , k  ) + u(i+1, j-1, k  ) );
                 const Real uy = v(i, j, k);
-                const Real uz = fourth * ( w(i  , j  , k  ) + w(i  , j-1, k  )
+                const Real uz = fourth_d * ( w(i  , j  , k  ) + w(i  , j-1, k  )
                                        + w(i  , j  , k+1) + w(i  , j-1, k+1) );
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
 
-                Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
-                if (t_blank < min_t_blank) { t_blank = zero; }
+                Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j-1, k));
+                if (t_blank < min_t_blank) { t_blank = zero_d; }
                 const Real dx_z    = (z_cc_arr) ? (z_cc_arr(i,j,k) - z_cc_arr(i,j,k-1)) : dx_arr[2];
-                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one/three);
+                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one_d/three_d);
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_yface =  myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
+                const Real rho_yface =  myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j-1,k,Rho_comp) );
                 ymom_src_arr(i, j, k) -= t_blank * rho_yface * CdM * uy * windspeed;
             });
-            ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(tbz, [=,fourth_d=fourth,myhalf_d=myhalf,zero_d=zero,one_d=one,three_d=three] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
-                const Real ux = fourth * ( u(i  , j  , k  ) + u(i+1, j  , k  )
+                const Real ux = fourth_d * ( u(i  , j  , k  ) + u(i+1, j  , k  )
                                        + u(i  , j  , k-1) + u(i+1, j  , k-1) );
-                const Real uy = fourth * ( v(i  , j  , k  ) + v(i  , j+1, k  )
+                const Real uy = fourth_d * ( v(i  , j  , k  ) + v(i  , j+1, k  )
                                        + v(i  , j  , k-1) + v(i  , j+1, k-1) );
                 const Real uz = w(i, j, k);
                 const Real windspeed = std::sqrt(ux * ux + uy * uy + uz * uz);
 
-                Real t_blank = myhalf * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
-                if (t_blank < min_t_blank) { t_blank = zero; }
+                Real t_blank = myhalf_d * (t_blank_arr(i, j, k) + t_blank_arr(i, j, k-1));
+                if (t_blank < min_t_blank) { t_blank = zero_d; }
                 const Real dx_z    = (z_nd_arr) ? (z_nd_arr(i,j,k) - z_nd_arr(i,j,k-1)) : dx_arr[2]; // ASW double check
-                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one/three);
+                const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one_d/three_d);
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
-                const Real rho_zface =  myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                const Real rho_zface =  myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                 zmom_src_arr(i, j, k) -= t_blank * rho_zface * CdM * uz * windspeed;
             });
         }

--- a/Source/SourceTerms/ERF_MakeSources.cpp
+++ b/Source/SourceTerms/ERF_MakeSources.cpp
@@ -349,21 +349,21 @@ void make_sources (int level,
             const int n = RhoTheta_comp;
             if (solverChoice.custom_forcing_prim_vars) {
                 const int nr = Rho_comp;
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = (z_cc_arr) ? one/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf*dxInv[2];
+                    Real dzInv = (z_cc_arr) ? one_d/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf_d*dxInv[2];
                     Real T_hi = dptr_t_plane(k+1) / dptr_r_plane(k+1);
                     Real T_lo = dptr_t_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_cc = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_cc = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     cell_src(i, j, k, n) -= cell_data(i,j,k,nr) * wbar_cc * (T_hi - T_lo) * dzInv;
                 });
             } else {
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = (z_cc_arr) ? one/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf*dxInv[2];
+                    Real dzInv = (z_cc_arr) ? one_d/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf_d*dxInv[2];
                     Real T_hi = dptr_t_plane(k+1) / dptr_r_plane(k+1);
                     Real T_lo = dptr_t_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_cc = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_cc = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     cell_src(i, j, k, n) -= wbar_cc * (T_hi - T_lo) * dzInv;
                 });
             }
@@ -376,26 +376,26 @@ void make_sources (int level,
             const int nv = RhoQ1_comp;
             if (solverChoice.custom_forcing_prim_vars) {
                 const int nr = Rho_comp;
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = (z_cc_arr) ? one/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf*dxInv[2];
+                    Real dzInv = (z_cc_arr) ? one_d/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf_d*dxInv[2];
                     Real Qv_hi = dptr_qv_plane(k+1) / dptr_r_plane(k+1);
                     Real Qv_lo = dptr_qv_plane(k-1) / dptr_r_plane(k-1);
                     Real Qc_hi = dptr_qc_plane(k+1) / dptr_r_plane(k+1);
                     Real Qc_lo = dptr_qc_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_cc = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_cc = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     cell_src(i, j, k, nv  ) -= cell_data(i,j,k,nr) * wbar_cc * (Qv_hi - Qv_lo) * dzInv;
                     cell_src(i, j, k, nv+1) -= cell_data(i,j,k,nr) * wbar_cc * (Qc_hi - Qc_lo) * dzInv;
                 });
             } else {
-                ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(bx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    Real dzInv = (z_cc_arr) ? one/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf*dxInv[2];
+                    Real dzInv = (z_cc_arr) ? one_d/ (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1)) : myhalf_d*dxInv[2];
                     Real Qv_hi = dptr_qv_plane(k+1) / dptr_r_plane(k+1);
                     Real Qv_lo = dptr_qv_plane(k-1) / dptr_r_plane(k-1);
                     Real Qc_hi = dptr_qc_plane(k+1) / dptr_r_plane(k+1);
                     Real Qc_lo = dptr_qc_plane(k-1) / dptr_r_plane(k-1);
-                    Real wbar_cc = myhalf * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
+                    Real wbar_cc = myhalf_d * (dptr_wbar_sub[k] + dptr_wbar_sub[k+1]);
                     cell_src(i, j, k, nv  ) -= wbar_cc * (Qv_hi - Qv_lo) * dzInv;
                     cell_src(i, j, k, nv+1) -= wbar_cc * (Qc_hi - Qc_lo) * dzInv;
                 });
@@ -524,20 +524,20 @@ void make_sources (int level,
 
             const Real Olen_in            = solverChoice.if_Olen_in;
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(bx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 const Real t_blank       = t_blank_arr(i, j, k);
                 const Real t_blank_above = t_blank_arr(i, j, k+1);
-                const Real ux_cc_2r = myhalf * (u(i  ,j  ,k+1) + u(i+1,j  ,k+1));
-                const Real uy_cc_2r = myhalf * (v(i  ,j  ,k+1) + v(i  ,j+1,k+1));
+                const Real ux_cc_2r = myhalf_d * (u(i  ,j  ,k+1) + u(i+1,j  ,k+1));
+                const Real uy_cc_2r = myhalf_d * (v(i  ,j  ,k+1) + v(i  ,j+1,k+1));
                 const Real h_windspeed2r  = std::sqrt(ux_cc_2r * ux_cc_2r + uy_cc_2r * uy_cc_2r);
 
                 const Real theta          = cell_data(i,j,k  ,RhoTheta_comp) / cell_data(i,j,k  ,Rho_comp);
                 const Real theta_neighbor = cell_data(i,j,k+1,RhoTheta_comp) / cell_data(i,j,k+1,Rho_comp);
 
                 // SURFACE TEMP AND HEATING/COOLING RATE
-                if (init_surf_temp > zero) {
-                    if (t_blank > 0 && (t_blank_above == zero)) { // force to MOST value
+                if (init_surf_temp > zero_d) {
+                    if (t_blank > 0 && (t_blank_above == zero_d)) { // force to MOST value
                         const Real surf_temp    = init_surf_temp + surf_heating_rate*time;
                         const Real bc_forcing_rt_srf = -(cell_data(i,j,k-1,Rho_comp) * surf_temp - cell_data(i,j,k-1,RhoTheta_comp));
                         cell_src(i, j, k-1, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf; // k-1
@@ -546,13 +546,13 @@ void make_sources (int level,
 
                 // SURFACE HEAT FLUX
                 if (tflux != Real(1e-8)){
-                    if (t_blank > 0 && (t_blank_above == zero)) { // force to MOST value
-                        Real psi_m           = zero;
-                        Real psi_h           = zero;
-                        Real psi_h_neighbor  = zero;
+                    if (t_blank > 0 && (t_blank_above == zero_d)) { // force to MOST value
+                        Real psi_m           = zero_d;
+                        Real psi_h           = zero_d;
+                        Real psi_h_neighbor  = zero_d;
                         Real ustar = h_windspeed2r * kappa / (std::log((Real(1.5)) * dx_z / z0) - psi_m);
                         const Real Olen  = -ustar * ustar * ustar * theta / (kappa * ggg * tflux + tiny);
-                        const Real zeta          = (myhalf) * dx_z / Olen;
+                        const Real zeta          = (myhalf_d) * dx_z / Olen;
                         const Real zeta_neighbor = (Real(1.5)) * dx_z / Olen;
 
                         // similarity functions
@@ -562,15 +562,15 @@ void make_sources (int level,
                         ustar = h_windspeed2r * kappa / (std::log((Real(1.5)) * dx_z / z0) - psi_m);
 
                         // prevent some unphysical math
-                        if (!(ustar > zero && !std::isnan(ustar))) { ustar = zero; }
-                        if (!(ustar < two && !std::isnan(ustar))) { ustar = two; }
+                        if (!(ustar > zero_d && !std::isnan(ustar))) { ustar = zero_d; }
+                        if (!(ustar < two_d && !std::isnan(ustar))) { ustar = two_d; }
                         if (psi_h_neighbor > std::log(Real(1.5) * dx_z / z0)) { psi_h_neighbor = std::log(Real(1.5) * dx_z / z0); }
-                        if (psi_h > std::log(myhalf * dx_z / z0)) { psi_h = std::log(myhalf * dx_z / z0); }
+                        if (psi_h > std::log(myhalf_d * dx_z / z0)) { psi_h = std::log(myhalf_d * dx_z / z0); }
 
                         // We do not know the actual temperature so use cell above
                         const Real thetastar    = theta * ustar * ustar / (kappa * ggg * Olen);
                         const Real surf_temp    = theta_neighbor - thetastar / kappa * (std::log((Real(1.5)) * dx_z / z0) - psi_h_neighbor);
-                        const Real tTarget      = surf_temp + thetastar / kappa * (std::log((myhalf) * dx_z / z0) - psi_h);
+                        const Real tTarget      = surf_temp + thetastar / kappa * (std::log((myhalf_d) * dx_z / z0) - psi_h);
 
                         const Real bc_forcing_rt = -(cell_data(i,j,k,Rho_comp) * tTarget - cell_data(i,j,k,RhoTheta_comp));
                         cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt;
@@ -579,9 +579,9 @@ void make_sources (int level,
 
                 // OBUKHOV LENGTH
                 if (Olen_in != Real(1e-8)){
-                    if (t_blank > 0 && (t_blank_above == zero)) { // force to MOST value
+                    if (t_blank > 0 && (t_blank_above == zero_d)) { // force to MOST value
                         const Real Olen  = Olen_in;
-                        const Real zeta          = (myhalf) * dx_z / Olen;
+                        const Real zeta          = (myhalf_d) * dx_z / Olen;
                         const Real zeta_neighbor = (Real(1.5)) * dx_z / Olen;
 
                         // similarity functions
@@ -593,7 +593,7 @@ void make_sources (int level,
                         // We do not know the actual temperature so use cell above
                         const Real thetastar    = theta * ustar * ustar / (kappa * ggg * Olen);
                         const Real surf_temp    = theta_neighbor - thetastar / kappa * (std::log((Real(1.5)) * dx_z / z0) - psi_h_neighbor);
-                        const Real tTarget      = surf_temp + thetastar / kappa * (std::log((myhalf) * dx_z / z0) - psi_h);
+                        const Real tTarget      = surf_temp + thetastar / kappa * (std::log((myhalf_d) * dx_z / z0) - psi_h);
 
                         const Real bc_forcing_rt = -(cell_data(i,j,k,Rho_comp) * tTarget - cell_data(i,j,k,RhoTheta_comp));
                         cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt;
@@ -623,7 +623,7 @@ void make_sources (int level,
             // Note this has been converted to K / s when it was read in;
             const Real surf_heating_rate  = solverChoice.if_surf_heating_rate;
 
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero,one_d=one,three_d=three] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
                 Real t_blank       = t_blank_arr(i, j, k);
                 Real t_blank_below = t_blank_arr(i, j, k-1);
@@ -632,50 +632,50 @@ void make_sources (int level,
                 Real t_blank_south  = t_blank_arr(i  , j-1, k);
                 Real t_blank_east   = t_blank_arr(i+1, j  , k);
                 Real t_blank_west   = t_blank_arr(i-1, j  , k);
-                if (t_blank < min_t_blank) { t_blank = zero; } // deal with situations where very small volfrac exist
-                if (t_blank_below < min_t_blank) { t_blank_below = zero; }
-                if (t_blank_north < min_t_blank) { t_blank_north = zero; }
-                if (t_blank_south < min_t_blank) { t_blank_south = zero; }
-                if (t_blank_east < min_t_blank) { t_blank_east = zero; }
-                if (t_blank_west < min_t_blank) { t_blank_west = zero; }
+                if (t_blank < min_t_blank) { t_blank = zero_d; } // deal with situations where very small volfrac exist
+                if (t_blank_below < min_t_blank) { t_blank_below = zero_d; }
+                if (t_blank_north < min_t_blank) { t_blank_north = zero_d; }
+                if (t_blank_south < min_t_blank) { t_blank_south = zero_d; }
+                if (t_blank_east < min_t_blank) { t_blank_east = zero_d; }
+                if (t_blank_west < min_t_blank) { t_blank_west = zero_d; }
 
                 Real dx_z    = (z_cc_arr) ? (z_cc_arr(i,j,k) - z_cc_arr(i,j,k-1)) : dx[2];
-                Real drag_coefficient = alpha_h / std::pow(dx_x*dx_y*dx_z, one/three);
+                Real drag_coefficient = alpha_h / std::pow(dx_x*dx_y*dx_z, one_d/three_d);
 
                 // SURFACE TEMP AND HEATING/COOLING RATE
-                if (init_surf_temp > zero) {
+                if (init_surf_temp > zero_d) {
                     const Real surf_temp    = init_surf_temp + surf_heating_rate*time;
-                    if (t_blank > 0 && (t_blank_above == zero) && (t_blank_below == one)) { // building roof
+                    if (t_blank > 0 && (t_blank_above == zero_d) && (t_blank_below == one_d)) { // building roof
                         const Real bc_forcing_rt_srf = -(cell_data(i,j,k,Rho_comp) * surf_temp - cell_data(i,j,k,RhoTheta_comp));
                         cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf;
 
-                    } else if (((t_blank > 0 && t_blank < t_blank_west && t_blank_east == zero) ||
-                                (t_blank > 0 && t_blank < t_blank_east && t_blank_west == zero) ||
-                                (t_blank > 0 && t_blank < t_blank_north && t_blank_south == zero) ||
-                                (t_blank > 0 && t_blank < t_blank_south && t_blank_north == zero))) {
+                    } else if (((t_blank > 0 && t_blank < t_blank_west && t_blank_east == zero_d) ||
+                                (t_blank > 0 && t_blank < t_blank_east && t_blank_west == zero_d) ||
+                                (t_blank > 0 && t_blank < t_blank_north && t_blank_south == zero_d) ||
+                                (t_blank > 0 && t_blank < t_blank_south && t_blank_north == zero_d))) {
                         // this should enter for just building walls
                         // walls are currently separated to allow for flexible in the future to heat walls differently
 
                         // south face
-                        if ((t_blank < t_blank_north) && (t_blank_north == one)) {
+                        if ((t_blank < t_blank_north) && (t_blank_north == one_d)) {
                             const Real bc_forcing_rt_srf = -(cell_data(i,j,k,Rho_comp) * surf_temp - cell_data(i,j,k,RhoTheta_comp));
                             cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf;
                         }
 
                         // north face
-                        if ((t_blank < t_blank_south) && (t_blank_south == one)) {
+                        if ((t_blank < t_blank_south) && (t_blank_south == one_d)) {
                             const Real bc_forcing_rt_srf = -(cell_data(i,j,k,Rho_comp) * surf_temp - cell_data(i,j,k,RhoTheta_comp));
                             cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf;
                         }
 
                         // west face
-                        if ((t_blank < t_blank_east) && (t_blank_east == one)) {
+                        if ((t_blank < t_blank_east) && (t_blank_east == one_d)) {
                             const Real bc_forcing_rt_srf = -(cell_data(i,j,k,Rho_comp) * surf_temp - cell_data(i,j,k,RhoTheta_comp));
                             cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf;
                         }
 
                         // east face
-                        if ((t_blank < t_blank_west) && (t_blank_west == one)) {
+                        if ((t_blank < t_blank_west) && (t_blank_west == one_d)) {
                             const Real bc_forcing_rt_srf = -(cell_data(i,j,k,Rho_comp) * surf_temp - cell_data(i,j,k,RhoTheta_comp));
                             cell_src(i, j, k, RhoTheta_comp) -= drag_coefficient * U_s * bc_forcing_rt_srf;
                         }
@@ -698,22 +698,22 @@ void make_sources (int level,
             Real qt_i = Real(0.008);
 
             Box xybx = makeSlab(bx,2,klo);
-            ParallelFor(xybx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+            ParallelFor(xybx, [=,zero_d=zero,myhalf_d=myhalf,Cp_d_d=Cp_d,three_d=three,one_d=one,R_d_d=R_d] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
             {
                 // Inclusive scan at w-faces for the Q integral (also find "i" values)
-                q_int[0] = zero;
-                Real zi   = myhalf * (z_cc_arr(i,j,khi) + z_cc_arr(i,j,khi-1));
-                Real rhoi = myhalf * (cell_data(i,j,khi,Rho_comp) + cell_data(i,j,khi-1,Rho_comp));
+                q_int[0] = zero_d;
+                Real zi   = myhalf_d * (z_cc_arr(i,j,khi) + z_cc_arr(i,j,khi-1));
+                Real rhoi = myhalf_d * (cell_data(i,j,khi,Rho_comp) + cell_data(i,j,khi-1,Rho_comp));
                 for (int k(klo+1); k<=khi+1; ++k) {
                     int lk    = k - klo;
                     // Average to w-faces when looping w-faces
-                    Real dz    = (z_cc_arr) ? myhalf * (z_cc_arr(i,j,k) - z_cc_arr(i,j,k-2)) : dx[2];
+                    Real dz    = (z_cc_arr) ? myhalf_d * (z_cc_arr(i,j,k) - z_cc_arr(i,j,k-2)) : dx[2];
                     q_int[lk]  = q_int[lk-1] + krad * cell_data(i,j,k-1,Rho_comp) * cell_data(i,j,k-1,RhoQ2_comp) * dz;
                     Real qt_hi = cell_data(i,j,k  ,RhoQ1_comp) + cell_data(i,j,k  ,RhoQ2_comp);
                     Real qt_lo = cell_data(i,j,k-1,RhoQ1_comp) + cell_data(i,j,k-1,RhoQ2_comp);
                     if ( (qt_lo > qt_i) && (qt_hi < qt_i) ) {
-                        zi   = myhalf * (z_cc_arr(i,j,k) + z_cc_arr(i,j,k-1));
-                        rhoi = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp));
+                        zi   = myhalf_d * (z_cc_arr(i,j,k) + z_cc_arr(i,j,k-1));
+                        rhoi = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp));
                     }
                 }
 
@@ -721,10 +721,10 @@ void make_sources (int level,
                 Real q_int_inf = q_int[khi+1];
                 for (int k(klo); k<=khi+1; ++k) {
                     int lk       = k - klo;
-                    Real z       = myhalf * (z_cc_arr(i,j,k) + z_cc_arr(i,j,k-1));
+                    Real z       = myhalf_d * (z_cc_arr(i,j,k) + z_cc_arr(i,j,k-1));
                     rad_flux[lk] = F1*std::exp(-q_int[lk]) + F0*std::exp(-(q_int_inf - q_int[lk]));
                     if (z > zi) {
-                      rad_flux[lk] += rhoi * Cp_d * D * ( std::pow(z-zi,Real(4.)/three)/Real(4.) + zi*std::pow(z-zi,one/three) ) ;
+                      rad_flux[lk] += rhoi * Cp_d_d * D * ( std::pow(z-zi,Real(4.)/three_d)/Real(4.) + zi*std::pow(z-zi,one_d/three_d) ) ;
                     }
                 }
 
@@ -732,12 +732,12 @@ void make_sources (int level,
                 for (int k(klo); k<=khi; ++k) {
                     int lk       = k - klo;
                     // Average to w-faces when looping CC
-                    Real dzInv   = (z_cc_arr) ? one/ (myhalf * (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1))) : dxInv[2];
+                    Real dzInv   = (z_cc_arr) ? one_d/ (myhalf_d * (z_cc_arr(i,j,k+1) - z_cc_arr(i,j,k-1))) : dxInv[2];
                     // NOTE: Fnet  = Up - Dn (all fluxes are up here)
                     //       dT/dt = dF/dz * (1/(-rho*Cp))
-                    Real dTdt    = (rad_flux[lk+1] - rad_flux[lk]) * dzInv / (-cell_data(i,j,k,Rho_comp)*Cp_d);
+                    Real dTdt    = (rad_flux[lk+1] - rad_flux[lk]) * dzInv / (-cell_data(i,j,k,Rho_comp)*Cp_d_d);
                     Real qv      = cell_data(i,j,k,RhoQ1_comp)/cell_data(i,j,k,Rho_comp);
-                    Real iexner  = one/getExnergivenRTh(cell_data(i,j,k,RhoTheta_comp), R_d/Cp_d, qv);
+                    Real iexner  = one_d/getExnergivenRTh(cell_data(i,j,k,RhoTheta_comp), R_d_d/Cp_d_d, qv);
                     // Convert dT/dt to dTheta/dt and multiply rho
                     cell_src(i,j,k,RhoTheta_comp) += cell_data(i,j,k,Rho_comp) * dTdt * iexner;
                 }

--- a/Source/SourceTerms/ERF_NumericalDiffusion.cpp
+++ b/Source/SourceTerms/ERF_NumericalDiffusion.cpp
@@ -32,36 +32,36 @@ NumericalDiffusion_Scal (const Box& bx,
     Real coeff6 = num_diff_coeff / (two * static_cast<Real>(dt));
 
     // Compute 5th order derivative and augment RHS
-    ParallelFor(bx, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int m) noexcept
+    ParallelFor(bx, num_comp, [=,one_d=one,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int m) noexcept
     {
         int n   = start_comp + m;     // conserved index
         int nm1 = (n==0) ? 0 : n - 1; // prim index
-        Real rho_x_lo = (n==0) ? one : myhalf * ( cell_data(i-1,j,k,Rho_comp) + cell_data(i  ,j,k,Rho_comp) );
+        Real rho_x_lo = (n==0) ? one_d : myhalf_d * ( cell_data(i-1,j,k,Rho_comp) + cell_data(i  ,j,k,Rho_comp) );
         Real xflux_lo = rho_x_lo * calc_fifth_order_deriv(prim_data(i+2,j,k,nm1), prim_data(i+1,j,k,nm1),
                                                           prim_data(i  ,j,k,nm1), prim_data(i-1,j,k,nm1),
                                                           prim_data(i-2,j,k,nm1), prim_data(i-3,j,k,nm1));
-        if ( (xflux_lo * (prim_data(i,j,k,nm1) - prim_data(i-1,j,k,nm1)) ) < zero) xflux_lo = zero;
+        if ( (xflux_lo * (prim_data(i,j,k,nm1) - prim_data(i-1,j,k,nm1)) ) < zero_d) xflux_lo = zero_d;
 
 
-        Real rho_x_hi = (n==0) ? one : myhalf * ( cell_data(i+1,j,k,Rho_comp) + cell_data(i  ,j,k,Rho_comp) );
+        Real rho_x_hi = (n==0) ? one_d : myhalf_d * ( cell_data(i+1,j,k,Rho_comp) + cell_data(i  ,j,k,Rho_comp) );
         Real xflux_hi = rho_x_hi * calc_fifth_order_deriv(prim_data(i+3,j,k,nm1), prim_data(i+2,j,k,nm1),
                                                           prim_data(i+1,j,k,nm1), prim_data(i  ,j,k,nm1),
                                                           prim_data(i-1,j,k,nm1), prim_data(i-2,j,k,nm1));
-        if ( (xflux_hi * (prim_data(i+1,j,k,nm1) - prim_data(i,j,k,nm1)) ) < zero) xflux_hi = zero;
+        if ( (xflux_hi * (prim_data(i+1,j,k,nm1) - prim_data(i,j,k,nm1)) ) < zero_d) xflux_hi = zero_d;
 
 
-        Real rho_y_lo = (n==0) ? one : myhalf * ( cell_data(i,j-1,k,Rho_comp) + cell_data(i,j  ,k,Rho_comp) );
+        Real rho_y_lo = (n==0) ? one_d : myhalf_d * ( cell_data(i,j-1,k,Rho_comp) + cell_data(i,j  ,k,Rho_comp) );
         Real yflux_lo = rho_y_lo * calc_fifth_order_deriv(prim_data(i,j+2,k,nm1), prim_data(i,j+1,k,nm1),
                                                           prim_data(i,j  ,k,nm1), prim_data(i,j-1,k,nm1),
                                                           prim_data(i,j-2,k,nm1), prim_data(i,j-3,k,nm1));
-        if ( (yflux_lo * (prim_data(i,j,k,nm1) - prim_data(i,j-1,k,nm1)) ) < zero) yflux_lo = zero;
+        if ( (yflux_lo * (prim_data(i,j,k,nm1) - prim_data(i,j-1,k,nm1)) ) < zero_d) yflux_lo = zero_d;
 
 
-        Real rho_y_hi = (n==0) ? one : myhalf * ( cell_data(i,j+1,k,Rho_comp) + cell_data(i,j  ,k,Rho_comp) );
+        Real rho_y_hi = (n==0) ? one_d : myhalf_d * ( cell_data(i,j+1,k,Rho_comp) + cell_data(i,j  ,k,Rho_comp) );
         Real yflux_hi = rho_y_hi * calc_fifth_order_deriv(prim_data(i,j+3,k,nm1), prim_data(i,j+2,k,nm1),
                                                           prim_data(i,j+1,k,nm1), prim_data(i,j  ,k,nm1),
                                                           prim_data(i,j-1,k,nm1), prim_data(i,j-2,k,nm1));
-        if ( (yflux_hi * (prim_data(i,j+1,k,nm1) - prim_data(i,j,k,nm1)) ) < zero) yflux_hi = zero;
+        if ( (yflux_hi * (prim_data(i,j+1,k,nm1) - prim_data(i,j,k,nm1)) ) < zero_d) yflux_hi = zero_d;
 
 
         rhs(i,j,k,n) += coeff6 * ( mfx_arr(i,j,0) * (xflux_hi - xflux_lo)
@@ -97,36 +97,36 @@ NumericalDiffusion_Xmom (const Box& bx,
     Real coeff6 = num_diff_coeff / (two * static_cast<Real>(dt));
 
     // Compute 5th order derivative and augment RHS
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx, [=,zero_d=zero,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         Real rho_x_lo = cell_data(i-1,j,k,Rho_comp);
         Real xflux_lo = rho_x_lo * calc_fifth_order_deriv(prim_data(i+2,j,k), prim_data(i+1,j,k),
                                                           prim_data(i  ,j,k), prim_data(i-1,j,k),
                                                           prim_data(i-2,j,k), prim_data(i-3,j,k));
-        if ( (xflux_lo * (prim_data(i,j,k) - prim_data(i-1,j,k)) ) < zero) xflux_lo = zero;
+        if ( (xflux_lo * (prim_data(i,j,k) - prim_data(i-1,j,k)) ) < zero_d) xflux_lo = zero_d;
 
 
         Real rho_x_hi = cell_data(i  ,j,k,Rho_comp);
         Real xflux_hi = rho_x_hi * calc_fifth_order_deriv(prim_data(i+3,j,k), prim_data(i+2,j,k),
                                                           prim_data(i+1,j,k), prim_data(i  ,j,k),
                                                           prim_data(i-1,j,k), prim_data(i-2,j,k));
-        if ( (xflux_hi * (prim_data(i+1,j,k) - prim_data(i,j,k)) ) < zero) xflux_hi = zero;
+        if ( (xflux_hi * (prim_data(i+1,j,k) - prim_data(i,j,k)) ) < zero_d) xflux_hi = zero_d;
 
 
-        Real rho_y_lo = fourth * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i-1,j  ,k,Rho_comp)
+        Real rho_y_lo = fourth_d * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i-1,j  ,k,Rho_comp)
                                + cell_data(i  ,j-1,k,Rho_comp) + cell_data(i-1,j-1,k,Rho_comp) );
         Real yflux_lo = rho_y_lo * calc_fifth_order_deriv(prim_data(i,j+2,k), prim_data(i,j+1,k),
                                                           prim_data(i,j  ,k), prim_data(i,j-1,k),
                                                           prim_data(i,j-2,k), prim_data(i,j-3,k));
-        if ( (yflux_lo * (prim_data(i,j,k) - prim_data(i,j-1,k)) ) < zero) yflux_lo = zero;
+        if ( (yflux_lo * (prim_data(i,j,k) - prim_data(i,j-1,k)) ) < zero_d) yflux_lo = zero_d;
 
 
-        Real rho_y_hi = fourth * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i-1,j  ,k,Rho_comp)
+        Real rho_y_hi = fourth_d * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i-1,j  ,k,Rho_comp)
                                + cell_data(i  ,j+1,k,Rho_comp) + cell_data(i-1,j+1,k,Rho_comp) );
         Real yflux_hi = rho_y_hi * calc_fifth_order_deriv(prim_data(i,j+3,k), prim_data(i,j+2,k),
                                                           prim_data(i,j+1,k), prim_data(i,j  ,k),
                                                           prim_data(i,j-1,k), prim_data(i,j-2,k));
-        if ( (yflux_hi * (prim_data(i,j+1,k) - prim_data(i,j,k)) ) < zero) yflux_hi = zero;
+        if ( (yflux_hi * (prim_data(i,j+1,k) - prim_data(i,j,k)) ) < zero_d) yflux_hi = zero_d;
 
 
         rhs(i,j,k,0) += coeff6 * ( mfx_arr(i,j,0) * (xflux_hi - xflux_lo)
@@ -163,36 +163,36 @@ NumericalDiffusion_Ymom (const Box& bx,
     Real coeff6 = num_diff_coeff / (two * static_cast<Real>(dt));
 
     // Compute 5th order derivative and augment RHS
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx, [=,fourth_d=fourth,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        Real rho_x_lo = fourth * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i  ,j-1,k,Rho_comp)
+        Real rho_x_lo = fourth_d * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i  ,j-1,k,Rho_comp)
                                + cell_data(i-1,j  ,k,Rho_comp) + cell_data(i-1,j-1,k,Rho_comp) );
         Real xflux_lo = rho_x_lo * calc_fifth_order_deriv(prim_data(i+2,j,k), prim_data(i+1,j,k),
                                                           prim_data(i  ,j,k), prim_data(i-1,j,k),
                                                           prim_data(i-2,j,k), prim_data(i-3,j,k));
-        if ( (xflux_lo * (prim_data(i,j,k) - prim_data(i-1,j,k)) ) < zero) xflux_lo = zero;
+        if ( (xflux_lo * (prim_data(i,j,k) - prim_data(i-1,j,k)) ) < zero_d) xflux_lo = zero_d;
 
 
-        Real rho_x_hi = fourth * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i  ,j-1,k,Rho_comp)
+        Real rho_x_hi = fourth_d * ( cell_data(i  ,j  ,k,Rho_comp) + cell_data(i  ,j-1,k,Rho_comp)
                                + cell_data(i+1,j  ,k,Rho_comp) + cell_data(i+1,j-1,k,Rho_comp) );
         Real xflux_hi = rho_x_hi * calc_fifth_order_deriv(prim_data(i+3,j,k), prim_data(i+2,j,k),
                                                           prim_data(i+1,j,k), prim_data(i  ,j,k),
                                                           prim_data(i-1,j,k), prim_data(i-2,j,k));
-        if ( (xflux_hi * (prim_data(i+1,j,k) - prim_data(i,j,k)) ) < zero) xflux_hi = zero;
+        if ( (xflux_hi * (prim_data(i+1,j,k) - prim_data(i,j,k)) ) < zero_d) xflux_hi = zero_d;
 
 
         Real rho_y_lo = cell_data(i,j-1,k,Rho_comp);
         Real yflux_lo = rho_y_lo * calc_fifth_order_deriv(prim_data(i,j+2,k), prim_data(i,j+1,k),
                                                           prim_data(i,j  ,k), prim_data(i,j-1,k),
                                                           prim_data(i,j-2,k), prim_data(i,j-3,k));
-        if ( (yflux_lo * (prim_data(i,j,k) - prim_data(i,j-1,k)) ) < zero) yflux_lo = zero;
+        if ( (yflux_lo * (prim_data(i,j,k) - prim_data(i,j-1,k)) ) < zero_d) yflux_lo = zero_d;
 
 
         Real rho_y_hi = cell_data(i,j  ,k,Rho_comp);
         Real yflux_hi = rho_y_hi * calc_fifth_order_deriv(prim_data(i,j+3,k), prim_data(i,j+2,k),
                                                           prim_data(i,j+1,k), prim_data(i,j  ,k),
                                                           prim_data(i,j-1,k), prim_data(i,j-2,k));
-        if ( (yflux_hi * (prim_data(i,j ,k) - prim_data(i,j,k)) ) < zero) yflux_hi = zero;
+        if ( (yflux_hi * (prim_data(i,j ,k) - prim_data(i,j,k)) ) < zero_d) yflux_hi = zero_d;
 
 
         rhs(i,j,k,0) += coeff6 * ( mfx_arr(i,j,0) * (xflux_hi - xflux_lo)

--- a/Source/TimeIntegration/ERF_ComputeTimestep.cpp
+++ b/Source/TimeIntegration/ERF_ComputeTimestep.cpp
@@ -105,9 +105,9 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                                    Array4<Real const> const& vf) -> Real
         {
            Real new_comp_dt = -bogus_large_value;
-           amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
+           amrex::Loop(b, [=,&new_comp_dt,zero_d=zero,Gamma_d=Gamma] (int i, int j, int k) noexcept
            {
-               if (vf(i,j,k) > zero)
+               if (vf(i,j,k) > zero_d)
                {
                    const Real rho      = s(i, j, k, Rho_comp);
                    const Real rhotheta = s(i, j, k, RhoTheta_comp);
@@ -116,7 +116,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                    //       we only use the partial pressure of the dry air
                    //       to compute the soundspeed
                    Real pressure = getPgivenRTh(rhotheta);
-                   Real c = std::sqrt(Gamma * pressure / rho);
+                   Real c = std::sqrt(Gamma_d * pressure / rho);
 
                    // If we are doing implicit acoustic substepping, then the z-direction does not contribute
                    //    to the computation of the time step
@@ -165,7 +165,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                                   Array4<Real const> const& dJ) -> Real
        {
            Real new_comp_dt = -bogus_large_value;
-           amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
+           amrex::Loop(b, [=,&new_comp_dt,Gamma_d=Gamma] (int i, int j, int k) noexcept
            {
                {
                    const Real rho      = s(i, j, k, Rho_comp);
@@ -177,7 +177,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                    //       we only use the partial pressure of the dry air
                    //       to compute the soundspeed
                    Real pressure = getPgivenRTh(rhotheta);
-                   Real c = std::sqrt(Gamma * pressure / rho);
+                   Real c = std::sqrt(Gamma_d * pressure / rho);
 
                    // If we are doing implicit acoustic substepping, then the z-direction is not constrained
                    //    by the speed of sound for the computation of the time step
@@ -249,7 +249,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                                     Array4<Real const> const& u) -> Real
          {
              Real new_comp_dt = -bogus_large_value;
-             amrex::Loop(b, [=,&new_comp_dt] (int i, int j, int k) noexcept
+             amrex::Loop(b, [=,&new_comp_dt,Gamma_d=Gamma] (int i, int j, int k) noexcept
              {
                  {
                      const Real rho      = s(i, j, k, Rho_comp);
@@ -259,7 +259,7 @@ ERF::estTimeStep (int level, long& dt_fast_ratio) const
                      //       we only use the partial pressure of the dry air
                      //       to compute the soundspeed
                      Real pressure = getPgivenRTh(rhotheta);
-                     Real c = std::sqrt(Gamma * pressure / rho);
+                     Real c = std::sqrt(Gamma_d * pressure / rho);
 
                      // Look at z-direction only
                      new_comp_dt = amrex::max((amrex::Math::abs(u(i,j,k,2)) + c) * dzinv, new_comp_dt);

--- a/Source/TimeIntegration/ERF_MakeFastCoeffs.cpp
+++ b/Source/TimeIntegration/ERF_MakeFastCoeffs.cpp
@@ -110,7 +110,7 @@ void make_fast_coeffs (int /*level*/,
         //Note we don't act on the bottom or top boundaries of the domain
         if (mesh_type != MeshType::ConstantDz)
         {
-            ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bx_shrunk_in_k, [=,myhalf_d=myhalf,one_d=one,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 Real rhobar_lo, rhobar_hi, pibar_lo, pibar_hi;
                 rhobar_lo =  r0_ca(i,j,k-1);
@@ -118,48 +118,48 @@ void make_fast_coeffs (int /*level*/,
                  pibar_lo = pi0_ca(i,j,k-1);
                  pibar_hi = pi0_ca(i,j,k  );
 
-                 Real pi_c =  myhalf * (pi_stage_ca(i,j,k-1) + pi_stage_ca(i,j,k));
+                 Real pi_c =  myhalf_d * (pi_stage_ca(i,j,k-1) + pi_stage_ca(i,j,k));
 
-                 Real     detJ_on_kface = myhalf * (detJ(i,j,k) + detJ(i,j,k-1));
-                 Real inv_detJ_on_kface = one / detJ_on_kface;
+                 Real     detJ_on_kface = myhalf_d * (detJ(i,j,k) + detJ(i,j,k-1));
+                 Real inv_detJ_on_kface = one_d / detJ_on_kface;
 
-                 Real qv_p = (l_use_moisture) ? prim(i,j,k  ,PrimQ1_comp) : zero;
-                 Real qv_q = (l_use_moisture) ? prim(i,j,k-1,PrimQ1_comp) : zero;
+                 Real qv_p = (l_use_moisture) ? prim(i,j,k  ,PrimQ1_comp) : zero_d;
+                 Real qv_q = (l_use_moisture) ? prim(i,j,k-1,PrimQ1_comp) : zero_d;
 
-                 Real coeff_P = -Gamma * R_d * dzi * inv_detJ_on_kface * pi_c * (one + RvOverRd*qv_p)
-                              +  halfg * R_d * rhobar_hi * pi_stage_ca(i,j,k) /
+                 Real coeff_P = -Gamma_d * R_d_d * dzi * inv_detJ_on_kface * pi_c * (one_d + RvOverRd*qv_p)
+                              +  halfg * R_d_d * rhobar_hi * pi_stage_ca(i,j,k) /
                                (  c_v * pibar_hi * stage_cons(i,j,k,RhoTheta_comp) );
 
-                 Real coeff_Q =  Gamma * R_d * dzi * inv_detJ_on_kface * pi_c * (one + RvOverRd*qv_q)
-                              + halfg * R_d * rhobar_lo * pi_stage_ca(i,j,k-1) /
+                 Real coeff_Q =  Gamma_d * R_d_d * dzi * inv_detJ_on_kface * pi_c * (one_d + RvOverRd*qv_q)
+                              + halfg * R_d_d * rhobar_lo * pi_stage_ca(i,j,k-1) /
                                ( c_v  * pibar_lo * stage_cons(i,j,k-1,RhoTheta_comp) );
 
                  coeffP_a(i,j,k) = coeff_P;
                  coeffQ_a(i,j,k) = coeff_Q;
 
                 if (l_use_moisture) {
-                    Real q = myhalf * ( prim(i,j,k,PrimQ1_comp) + prim(i,j,k-1,PrimQ1_comp)
+                    Real q = myhalf_d * ( prim(i,j,k,PrimQ1_comp) + prim(i,j,k-1,PrimQ1_comp)
                                       + prim(i,j,k,PrimQ2_comp) + prim(i,j,k-1,PrimQ2_comp) );
-                    coeff_P /= (one + q);
-                    coeff_Q /= (one + q);
+                    coeff_P /= (one_d + q);
+                    coeff_Q /= (one_d + q);
                 }
 
-                Real theta_t_lo  = myhalf * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
-                Real theta_t_mid = myhalf * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
-                Real theta_t_hi  = myhalf * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
+                Real theta_t_lo  = myhalf_d * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
+                Real theta_t_mid = myhalf_d * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
+                Real theta_t_hi  = myhalf_d * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
 
                 // LHS for tri-diagonal system
                 Real D = beta_2 * beta_2 * dzi * static_cast<Real>(dtau * dtau);
-                coeffA_a(i,j,k) = D * (one/detJ(i,j,k-1)) * ( halfg - coeff_Q * theta_t_lo );
-                coeffC_a(i,j,k) = D * (one/detJ(i,j,k  )) * (-halfg + coeff_P * theta_t_hi );
+                coeffA_a(i,j,k) = D * (one_d/detJ(i,j,k-1)) * ( halfg - coeff_Q * theta_t_lo );
+                coeffC_a(i,j,k) = D * (one_d/detJ(i,j,k  )) * (-halfg + coeff_P * theta_t_hi );
 
-                coeffB_a(i,j,k) = one + D * ( (coeff_Q/detJ(i,j,k-1) - coeff_P/detJ(i,j,k)) * theta_t_mid
+                coeffB_a(i,j,k) = one_d + D * ( (coeff_Q/detJ(i,j,k-1) - coeff_P/detJ(i,j,k)) * theta_t_mid
                                             + halfg * (Real(1.0)/detJ(i,j,k) - Real(1.0)/detJ(i,j,k-1)) );
             });
 
         } else {
 
-            ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bx_shrunk_in_k, [=,myhalf_d=myhalf,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 Real rhobar_lo, rhobar_hi, pibar_lo, pibar_hi;
                 rhobar_lo =  r0_ca(i,j,k-1);
@@ -167,39 +167,39 @@ void make_fast_coeffs (int /*level*/,
                  pibar_lo = pi0_ca(i,j,k-1);
                  pibar_hi = pi0_ca(i,j,k  );
 
-                 Real pi_c =  myhalf * (pi_stage_ca(i,j,k-1) + pi_stage_ca(i,j,k));
+                 Real pi_c =  myhalf_d * (pi_stage_ca(i,j,k-1) + pi_stage_ca(i,j,k));
 
-                 Real qv_p = (l_use_moisture) ? prim(i,j,k  ,PrimQ1_comp) : zero;
-                 Real qv_q = (l_use_moisture) ? prim(i,j,k-1,PrimQ1_comp) : zero;
+                 Real qv_p = (l_use_moisture) ? prim(i,j,k  ,PrimQ1_comp) : zero_d;
+                 Real qv_q = (l_use_moisture) ? prim(i,j,k-1,PrimQ1_comp) : zero_d;
 
-                 Real coeff_P = -Gamma * R_d * dzi * pi_c * (one + RvOverRd*qv_p)
-                              +  halfg * R_d * rhobar_hi * pi_stage_ca(i,j,k) /
+                 Real coeff_P = -Gamma_d * R_d_d * dzi * pi_c * (one_d + RvOverRd*qv_p)
+                              +  halfg * R_d_d * rhobar_hi * pi_stage_ca(i,j,k) /
                               (  c_v * pibar_hi * stage_cons(i,j,k,RhoTheta_comp) );
 
-                 Real coeff_Q = Gamma * R_d * dzi * pi_c * (one + RvOverRd*qv_q)
-                              + halfg * R_d * rhobar_lo * pi_stage_ca(i,j,k-1) /
+                 Real coeff_Q = Gamma_d * R_d_d * dzi * pi_c * (one_d + RvOverRd*qv_q)
+                              + halfg * R_d_d * rhobar_lo * pi_stage_ca(i,j,k-1) /
                               ( c_v  * pibar_lo * stage_cons(i,j,k-1,RhoTheta_comp) );
 
                  coeffP_a(i,j,k) = coeff_P;
                  coeffQ_a(i,j,k) = coeff_Q;
 
                 if (l_use_moisture) {
-                    Real q = myhalf * ( prim(i,j,k,PrimQ1_comp) + prim(i,j,k-1,PrimQ1_comp)
+                    Real q = myhalf_d * ( prim(i,j,k,PrimQ1_comp) + prim(i,j,k-1,PrimQ1_comp)
                                       + prim(i,j,k,PrimQ2_comp) + prim(i,j,k-1,PrimQ2_comp) );
-                    coeff_P /= (one + q);
-                    coeff_Q /= (one + q);
+                    coeff_P /= (one_d + q);
+                    coeff_Q /= (one_d + q);
                 }
 
-                Real theta_t_lo  = myhalf * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
-                Real theta_t_mid = myhalf * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
-                Real theta_t_hi  = myhalf * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
+                Real theta_t_lo  = myhalf_d * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
+                Real theta_t_mid = myhalf_d * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
+                Real theta_t_hi  = myhalf_d * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
 
                 // LHS for tri-diagonal system
                 Real D = beta_2 * beta_2 * dzi * static_cast<Real>(dtau * dtau);
                 coeffA_a(i,j,k) = D * ( halfg - coeff_Q * theta_t_lo );
                 coeffC_a(i,j,k) = D * (-halfg + coeff_P * theta_t_hi );
 
-                coeffB_a(i,j,k) = one + D * (coeff_Q - coeff_P) * theta_t_mid;
+                coeffB_a(i,j,k) = one_d + D * (coeff_Q - coeff_P) * theta_t_mid;
             });
         }
 
@@ -214,30 +214,30 @@ void make_fast_coeffs (int /*level*/,
         {
         BL_PROFILE("make_coeffs_b2d_loop");
 #ifdef AMREX_USE_GPU
-        ParallelFor(b2d, [=] AMREX_GPU_DEVICE (int i, int j, int) {
+        ParallelFor(b2d, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int) {
 
             // If at the bottom of the grid, we will set w to a specified Dirichlet value
-            coeffA_a(i,j,lo.z) =  zero;
-            coeffB_a(i,j,lo.z) =  one;
-            coeffC_a(i,j,lo.z) =  zero;
+            coeffA_a(i,j,lo.z) =  zero_d;
+            coeffB_a(i,j,lo.z) =  one_d;
+            coeffC_a(i,j,lo.z) =  zero_d;
 
             // If at the top of the grid, we will set w to a specified Dirichlet value
-            coeffA_a(i,j,hi.z+1) =  zero;
-            coeffB_a(i,j,hi.z+1) =  one;
-            coeffC_a(i,j,hi.z+1) =  zero;
+            coeffA_a(i,j,hi.z+1) =  zero_d;
+            coeffB_a(i,j,hi.z+1) =  one_d;
+            coeffC_a(i,j,hi.z+1) =  zero_d;
 
             // UNLESS if at the top of the domain and the boundary is outflow,
             //     we will use a homogeneous Neumann condition
             if ( (hi.z == domhi.z) &&
                  (phys_bc_type[5] == ERF_BC::outflow or phys_bc_type[5] == ERF_BC::ho_outflow) )
             {
-                coeffA_a(i,j,hi.z+1) =  -one;
+                coeffA_a(i,j,hi.z+1) =  -one_d;
             }
 
             // w = specified Dirichlet value at k = lo.z
             gam_a(i,j,lo.z) = coeffC_a(i,j,lo.z) / coeffB_a(i,j,lo.z);
             for (int k = lo.z+1; k <= hi.z+1; k++) {
-                coeffB_a(i,j,k) = one / ( coeffB_a(i,j,k) - coeffA_a(i,j,k)*gam_a(i,j,k-1) );
+                coeffB_a(i,j,k) = one_d / ( coeffB_a(i,j,k) - coeffA_a(i,j,k)*gam_a(i,j,k-1) );
                 gam_a(i,j,k)    = coeffC_a(i,j,k) * coeffB_a(i,j,k);
             }
         });

--- a/Source/TimeIntegration/ERF_MakeTauTerms.cpp
+++ b/Source/TimeIntegration/ERF_MakeTauTerms.cpp
@@ -389,9 +389,9 @@ void erf_make_tau_terms (int level, int nrk,
 
                 // First create Omega using velocity (not momentum)
                 Array4<Real> omega_arr = Omega.array();
-                ParallelFor(gbxo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(gbxo, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
-                    omega_arr(i,j,k) = (k == 0) ? zero : OmegaFromW(i,j,k,w(i,j,k),u,v,
+                    omega_arr(i,j,k) = (k == 0) ? zero_d : OmegaFromW(i,j,k,w(i,j,k),u,v,
                                                                   mf_ux,mf_vy,z_nd,dxInv);
                 });
 
@@ -533,9 +533,9 @@ void erf_make_tau_terms (int level, int nrk,
                                         (w(i  , j  , k+1) - w(i, j, k))*dxInv[2];
                     });
                 } else {
-                    ParallelFor(bxcc, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                    ParallelFor(bxcc, [=,one_d=one,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         if (cflag(i,j,k).isSingleValued()) {
-                            er_arr(i,j,k) = (one/vfrac(i,j,k)) * (
+                            er_arr(i,j,k) = (one_d/vfrac(i,j,k)) * (
                             dxInv[0] * ( apx(i+1,j,k)*u(i+1,j,k) - apx(i,j,k)*u(i,j,k) )
                             + dxInv[1] * ( apy(i,j+1,k)*v(i,j+1,k) - apy(i,j,k)*v(i,j,k) )
                             + dxInv[2] * ( apz(i,j,k+1)*w(i,j,k+1) - apz(i,j,k)*w(i,j,k) ) );
@@ -544,7 +544,7 @@ void erf_make_tau_terms (int level, int nrk,
                                             (v(i  , j+1, k  ) - v(i, j, k))*dxInv[1] +
                                             (w(i  , j  , k+1) - w(i, j, k))*dxInv[2];
                         } else {
-                            er_arr(i,j,k) = zero;
+                            er_arr(i,j,k) = zero_d;
                         }
                     });
                 }

--- a/Source/TimeIntegration/ERF_SlowRhsPost.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPost.cpp
@@ -521,7 +521,7 @@ void erf_slow_rhs_post (int level, int finest_level,
                 } else if (l_anelastic && (nrk == 1)) { // not moving and ( (anelastic) and second RK stage) )
 
                     ParallelFor(tbx, num_comp,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int nn) noexcept {
+                    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k, int nn) noexcept {
                         const int n = start_comp + nn;
                         cell_rhs(i,j,k,n) += src_arr(i,j,k,n);
 
@@ -529,7 +529,7 @@ void erf_slow_rhs_post (int level, int finest_level,
                         Real dt_times_old_cell_rhs = cur_cons(i,j,k,n) - old_cons(i,j,k,n);
 
                         // Add the time-averaged RHS to the old state
-                        cur_cons(i,j,k,n) = old_cons(i,j,k,n) + myhalf * (dt_times_old_cell_rhs + dt * cell_rhs(i,j,k,n));
+                        cur_cons(i,j,k,n) = old_cons(i,j,k,n) + myhalf_d * (dt_times_old_cell_rhs + dt * cell_rhs(i,j,k,n));
 
                         if (ivar == RhoKE_comp) {
                             cur_cons(i,j,k,n) = amrex::max(cur_cons(i,j,k,n), eps);

--- a/Source/TimeIntegration/ERF_SlowRhsPre.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPre.cpp
@@ -320,8 +320,8 @@ void erf_slow_rhs_pre (int level, int finest_level,
             Box gbxo_lo = gbxo; gbxo_lo.setBig(2,domain.smallEnd(2));
             int lo_z_face = domain.smallEnd(2);
             if (gbxo_lo.smallEnd(2) <= lo_z_face) {
-                ParallelFor(gbxo_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                    omega_arr(i,j,k) = zero;
+                ParallelFor(gbxo_lo, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                    omega_arr(i,j,k) = zero_d;
                 });
             }
             Box gbxo_hi = gbxo; gbxo_hi.setSmall(2,gbxo.bigEnd(2));
@@ -340,9 +340,9 @@ void erf_slow_rhs_pre (int level, int finest_level,
                 Box gbxo_mid = gbxo; gbxo_mid.setSmall(2,1); gbxo_mid.setBig(2,gbxo.bigEnd(2)-1);
                       Array4<const Real> z_t        = z_t_mf->array(mfi);
                 const Array4<const Real>& cell_data = S_data[IntVars::cons].array(mfi);
-                ParallelFor(gbxo_mid, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                ParallelFor(gbxo_mid, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                     // We define rho on the z-face the same way as in MomentumToVelocity/VelocityToMomentum
-                    Real rho_at_face = myhalf * (cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp));
+                    Real rho_at_face = myhalf_d * (cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp));
                     omega_arr(i,j,k) = OmegaFromW(i,j,k,rho_w(i,j,k),
                                                   rho_u,rho_v,mf_ux,mf_vy,z_nd,dxInv) -
                         rho_at_face * z_t(i,j,k);
@@ -721,10 +721,10 @@ void erf_slow_rhs_pre (int level, int finest_level,
         // If anelastic and in second RK stage, take average of old-time and new-time source
         if ( l_anelastic && (nrk == 1) )
         {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
-                cell_rhs(i,j,k,     Rho_comp) *= myhalf;
-                cell_rhs(i,j,k,RhoTheta_comp) *= myhalf;
+                cell_rhs(i,j,k,     Rho_comp) *= myhalf_d;
+                cell_rhs(i,j,k,RhoTheta_comp) *= myhalf_d;
 
                 cell_rhs(i,j,k,     Rho_comp) += half_dt * (cell_data(i,j,k,     Rho_comp) - cell_old(i,j,k,     Rho_comp));
                 cell_rhs(i,j,k,RhoTheta_comp) += half_dt * (cell_data(i,j,k,RhoTheta_comp) - cell_old(i,j,k,RhoTheta_comp));
@@ -784,14 +784,14 @@ void erf_slow_rhs_pre (int level, int finest_level,
         auto abl_pressure_grad    = solverChoice.abl_pressure_grad;
 
         ParallelFor(tbx, tby,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         { // x-momentum equation
 
             // Note that gradp arrays now carry the map factor in them
 
-            Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero;
+            Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero_d;
 
-            rho_u_rhs(i, j, k) += (-gpx_arr(i,j,k) - abl_pressure_grad[0]) / (one + q) + xmom_src_arr(i,j,k);
+            rho_u_rhs(i, j, k) += (-gpx_arr(i,j,k) - abl_pressure_grad[0]) / (one_d + q) + xmom_src_arr(i,j,k);
 
             if (l_moving_terrain) {
                 Real h_zeta = Compute_h_zeta_AtIface(i, j, k, dxInv, z_nd);
@@ -799,18 +799,18 @@ void erf_slow_rhs_pre (int level, int finest_level,
             }
 
             if ( l_anelastic && (nrk == 1) ) {
-                rho_u_rhs(i,j,k) *= myhalf;
+                rho_u_rhs(i,j,k) *= myhalf_d;
                 rho_u_rhs(i,j,k) += half_dt * (rho_u(i,j,k) - rho_u_old(i,j,k));
             }
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         { // y-momentum equation
 
             // Note that gradp arrays now carry the map factor in them
 
-            Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero;
+            Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero_d;
 
-            rho_v_rhs(i, j, k) += (-gpy_arr(i,j,k) - abl_pressure_grad[1]) / (one + q) + ymom_src_arr(i,j,k);
+            rho_v_rhs(i, j, k) += (-gpy_arr(i,j,k) - abl_pressure_grad[1]) / (one_d + q) + ymom_src_arr(i,j,k);
 
             if (l_moving_terrain) {
                 Real h_zeta = Compute_h_zeta_AtJface(i, j, k, dxInv, z_nd);
@@ -818,7 +818,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
             }
 
             if ( l_anelastic && (nrk == 1) ) {
-                rho_v_rhs(i,j,k) *= myhalf;
+                rho_v_rhs(i,j,k) *= myhalf_d;
                 rho_v_rhs(i,j,k) += half_dt * (rho_v(i,j,k) - rho_v_old(i,j,k));
             }
         });
@@ -831,13 +831,13 @@ void erf_slow_rhs_pre (int level, int finest_level,
         if (bx.smallEnd(0) == domain.smallEnd(0)) {
             Box lo_x_dom_face(bx); lo_x_dom_face.setBig(0,bx.smallEnd(0));
             if (bc_ptr_h[BCVars::xvel_bc].lo(0) == ERFBCType::ext_dir) {
-                ParallelFor(lo_x_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    rho_u_rhs(i,j,k) = zero;
+                ParallelFor(lo_x_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    rho_u_rhs(i,j,k) = zero_d;
                 });
             } else if (bc_ptr_h[BCVars::xvel_bc].lo(0) == ERFBCType::ext_dir_upwind) {
-                ParallelFor(lo_x_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (u(i,j,k) >= zero) {
-                        rho_u_rhs(i,j,k) = zero;
+                ParallelFor(lo_x_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (u(i,j,k) >= zero_d) {
+                        rho_u_rhs(i,j,k) = zero_d;
                     }
                 });
             }
@@ -845,13 +845,13 @@ void erf_slow_rhs_pre (int level, int finest_level,
         if (bx.bigEnd(0) == domain.bigEnd(0)) {
             Box hi_x_dom_face(bx); hi_x_dom_face.setSmall(0,bx.bigEnd(0)+1); hi_x_dom_face.setBig(0,bx.bigEnd(0)+1);
             if (bc_ptr_h[BCVars::xvel_bc].hi(0) == ERFBCType::ext_dir) {
-                ParallelFor(hi_x_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    rho_u_rhs(i,j,k) = zero;
+                ParallelFor(hi_x_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    rho_u_rhs(i,j,k) = zero_d;
                 });
             } else if (bc_ptr_h[BCVars::xvel_bc].hi(0) == ERFBCType::ext_dir_upwind) {
-                ParallelFor(hi_x_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (u(i,j,k) <= zero) {
-                        rho_u_rhs(i,j,k) = zero;
+                ParallelFor(hi_x_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (u(i,j,k) <= zero_d) {
+                        rho_u_rhs(i,j,k) = zero_d;
                     }
                 });
             }
@@ -859,13 +859,13 @@ void erf_slow_rhs_pre (int level, int finest_level,
         if (bx.smallEnd(1) == domain.smallEnd(1)) {
             Box lo_y_dom_face(bx); lo_y_dom_face.setBig(1,bx.smallEnd(1));
             if (bc_ptr_h[BCVars::yvel_bc].lo(1) == ERFBCType::ext_dir) {
-                ParallelFor(lo_y_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    rho_v_rhs(i,j,k) = zero;
+                ParallelFor(lo_y_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    rho_v_rhs(i,j,k) = zero_d;
                 });
             } else if (bc_ptr_h[BCVars::yvel_bc].lo(1) == ERFBCType::ext_dir_upwind) {
-                ParallelFor(lo_y_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (v(i,j,k) >= zero) {
-                        rho_v_rhs(i,j,k) = zero;
+                ParallelFor(lo_y_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (v(i,j,k) >= zero_d) {
+                        rho_v_rhs(i,j,k) = zero_d;
                     }
                 });
             }
@@ -873,29 +873,29 @@ void erf_slow_rhs_pre (int level, int finest_level,
         if (bx.bigEnd(1) == domain.bigEnd(1)) {
             Box hi_y_dom_face(bx); hi_y_dom_face.setSmall(1,bx.bigEnd(1)+1); hi_y_dom_face.setBig(1,bx.bigEnd(1)+1);
             if (bc_ptr_h[BCVars::yvel_bc].hi(1) == ERFBCType::ext_dir) {
-                ParallelFor(hi_y_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    rho_v_rhs(i,j,k) = zero;
+                ParallelFor(hi_y_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    rho_v_rhs(i,j,k) = zero_d;
                 });
             } else if (bc_ptr_h[BCVars::yvel_bc].hi(1) == ERFBCType::ext_dir_upwind) {
-                ParallelFor(hi_y_dom_face, [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (v(i,j,k) <= zero) {
-                        rho_v_rhs(i,j,k) = zero;
+                ParallelFor(hi_y_dom_face, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (v(i,j,k) <= zero_d) {
+                        rho_v_rhs(i,j,k) = zero_d;
                     }
                 });
             }
         }
 
-        ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(tbz, [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         { // z-momentum equation
 
             Real gpz = gpz_arr(i,j,k);
 
-            Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i,j,k-1)) : zero;
+            Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i,j,k-1)) : zero_d;
 
-            rho_w_rhs(i, j, k) += (-gpz - abl_pressure_grad[2] + buoyancy_arr(i,j,k)) / (one + q) + zmom_src_arr(i,j,k);
+            rho_w_rhs(i, j, k) += (-gpz - abl_pressure_grad[2] + buoyancy_arr(i,j,k)) / (one_d + q) + zmom_src_arr(i,j,k);
 
             if (l_moving_terrain) {
-                 rho_w_rhs(i, j, k) *= myhalf * (detJ_arr(i,j,k) + detJ_arr(i,j,k-1));
+                 rho_w_rhs(i, j, k) *= myhalf_d * (detJ_arr(i,j,k) + detJ_arr(i,j,k-1));
             }
         });
 

--- a/Source/TimeIntegration/ERF_Substep_MT.cpp
+++ b/Source/TimeIntegration/ERF_Substep_MT.cpp
@@ -209,8 +209,8 @@ void erf_substep_MT (int step, int /*nrk*/,
         {
         BL_PROFILE("fast_MT_making_omega");
         Box gbxo_lo = gbxo; gbxo_lo.setBig(2,0);
-        ParallelFor(gbxo_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            omega_arr(i,j,k) = zero;
+        ParallelFor(gbxo_lo, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            omega_arr(i,j,k) = zero_d;
         });
         Box gbxo_hi = gbxo; gbxo_hi.setSmall(2,gbxo.bigEnd(2));
         ParallelFor(gbxo_hi, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
@@ -238,7 +238,7 @@ void erf_substep_MT (int step, int /*nrk*/,
 
         if (step == 0) {
             ParallelFor(gbx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 cur_cons(i,j,k,Rho_comp)      = prev_cons(i,j,k,Rho_comp);
                 cur_cons(i,j,k,RhoTheta_comp) = prev_cons(i,j,k,RhoTheta_comp);
 
@@ -246,8 +246,8 @@ void erf_substep_MT (int step, int /*nrk*/,
                 theta_extrap(i,j,k) = delta_rt;
 
                 // NOTE: qv is not changing over the fast steps so we use the stage data
-                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-                theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero_d;
+                theta_extrap(i,j,k) *= (one_d + RvOverRd*qv);
 
                 // We define lagged_delta_rt for our next step as the current delta_rt
                 lagged(i,j,k) = delta_rt;
@@ -255,13 +255,13 @@ void erf_substep_MT (int step, int /*nrk*/,
         } else if (use_lagged_delta_rt) {
             // This is the default for cases with no or static terrain
             ParallelFor(gbx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 Real delta_rt = cur_cons(i,j,k,RhoTheta_comp) - stg_cons(i,j,k,RhoTheta_comp);
                 theta_extrap(i,j,k) = delta_rt + beta_d * (delta_rt - lagged(i,j,k));
 
                 // NOTE: qv is not changing over the fast steps so we use the stage data
-                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-                theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero_d;
+                theta_extrap(i,j,k) *= (one_d + RvOverRd*qv);
 
                 // We define lagged_delta_rt for our next step as the current delta_rt
                 lagged(i,j,k) = delta_rt;
@@ -269,12 +269,12 @@ void erf_substep_MT (int step, int /*nrk*/,
         } else {
             // For the moving wave problem, this choice seems more robust
             ParallelFor(gbx,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                 theta_extrap(i,j,k) = cur_cons(i,j,k,RhoTheta_comp) - stg_cons(i,j,k,RhoTheta_comp);
 
                 // NOTE: qv is not changing over the fast steps so we use the stage data
-                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-                theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+                Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero_d;
+                theta_extrap(i,j,k) *= (one_d + RvOverRd*qv);
             });
         } // if step
 
@@ -298,48 +298,48 @@ void erf_substep_MT (int step, int /*nrk*/,
         {
         BL_PROFILE("substep_xymom_T");
         ParallelFor(tbx, tby,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real h_xi_old   = Compute_h_xi_AtIface(i, j, k, dxInv, z_nd_old);
                 Real h_zeta_old = Compute_h_zeta_AtIface(i, j, k, dxInv, z_nd_old);
                 Real gp_xi = (theta_extrap(i,j,k) - theta_extrap(i-1,j,k)) * dxi;
                 Real gp_zeta_on_iface = (k == 0) ?
-                   myhalf  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
+                   myhalf_d  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
                                    - theta_extrap(i-1,j,k  ) - theta_extrap(i,j,k  ) ) :
-                   fourth  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
+                   fourth_d  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
                                    - theta_extrap(i-1,j,k-1) - theta_extrap(i,j,k-1) );
                 Real gpx = h_zeta_old * gp_xi - h_xi_old * gp_zeta_on_iface;
                 gpx *= mf_ux(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i-1,j,k) + qt_arr(i,j,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i-1,j,k) + qt_arr(i,j,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i-1,j,k) + pi_stage_ca(i  ,j,k));
-                Real fast_rhs_rho_u = -Gamma * R_d * pi_c * gpx / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i-1,j,k) + pi_stage_ca(i  ,j,k));
+                Real fast_rhs_rho_u = -Gamma_d * R_d_d * pi_c * gpx / (one_d + q);
 
                 // We have already scaled the source terms to have the extra factor of dJ
                 cur_xmom(i,j,k) = h_zeta_old * prev_xmom(i,j,k) + dtau * fast_rhs_rho_u
                                                                 + dtau * slow_rhs_rho_u(i,j,k)
                                                                 + dtau * xmom_src_arr(i,j,k);
         },
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real h_eta_old  = Compute_h_eta_AtJface(i, j, k, dxInv, z_nd_old);
                 Real h_zeta_old = Compute_h_zeta_AtJface(i, j, k, dxInv, z_nd_old);
                 Real gp_eta = (theta_extrap(i,j,k) -theta_extrap(i,j-1,k)) * dyi;
                 Real gp_zeta_on_jface = (k == 0) ?
-                    myhalf  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
+                    myhalf_d  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
                                     - theta_extrap(i,j,k  ) - theta_extrap(i,j-1,k  ) ) :
-                    fourth  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
+                    fourth_d  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
                                     - theta_extrap(i,j,k-1) - theta_extrap(i,j-1,k-1) );
                 Real gpy = h_zeta_old * gp_eta - h_eta_old  * gp_zeta_on_jface;
                 gpy *= mf_vy(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j-1,k) + qt_arr(i,j,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j-1,k) + qt_arr(i,j,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i,j-1,k) + pi_stage_ca(i,j  ,k));
-                Real fast_rhs_rho_v = -Gamma * R_d * pi_c * gpy / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i,j-1,k) + pi_stage_ca(i,j  ,k));
+                Real fast_rhs_rho_v = -Gamma_d * R_d_d * pi_c * gpy / (one_d + q);
 
                 // We have already scaled the source terms to have the extra factor of dJ
                 cur_ymom(i, j, k) = h_zeta_old * prev_ymom(i,j,k) + dtau * fast_rhs_rho_v
@@ -361,7 +361,7 @@ void erf_substep_MT (int step, int /*nrk*/,
         // *********************************************************************
         {
         BL_PROFILE("fast_T_making_rho_rhs");
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real h_zeta_stg_xlo = Compute_h_zeta_AtIface(i,  j  , k, dxInv, z_nd_stg);
             Real h_zeta_stg_xhi = Compute_h_zeta_AtIface(i+1,j  , k, dxInv, z_nd_stg);
@@ -378,22 +378,22 @@ void erf_substep_MT (int step, int /*nrk*/,
             temp_rhs_arr(i,j,k,1) = (( xflux_hi * (prim(i,j,k,0) + prim(i+1,j,k,0)) -
                                        xflux_lo * (prim(i,j,k,0) + prim(i-1,j,k,0)) ) * dxi +
                                      ( yflux_hi * (prim(i,j,k,0) + prim(i,j+1,k,0)) -
-                                       yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi) * myhalf;
+                                       yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi) * myhalf_d;
 
             if (l_reflux) {
                 (flx_arr[0])(i,j,k,0) = xflux_lo;
-                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i-1,j,k,0));
+                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i-1,j,k,0));
 
                 (flx_arr[1])(i,j,k,0) = yflux_lo;
-                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j-1,k,0));
+                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j-1,k,0));
 
                 if (i == vbx_hi.x) {
                     (flx_arr[0])(i+1,j,k,0) = xflux_hi;
-                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i+1,j,k,0));
+                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i+1,j,k,0));
                 }
                 if (j == vbx_hi.y) {
                     (flx_arr[1])(i,j+1,k,0) = yflux_hi;
-                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j+1,k,0));
+                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j+1,k,0));
                 }
             }
         });
@@ -427,18 +427,18 @@ void erf_substep_MT (int step, int /*nrk*/,
         {
         BL_PROFILE("fast_loop_on_shrunk_t");
         //Note we don't act on the bottom or top boundaries of the domain
-        ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx_shrunk_in_k, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real     dJ_old_kface = myhalf * (detJ_old(i,j,k) + detJ_old(i,j,k-1));
-            Real     dJ_new_kface = myhalf * (detJ_new(i,j,k) + detJ_new(i,j,k-1));
-            Real     dJ_stg_kface = myhalf * (detJ_stg(i,j,k) + detJ_stg(i,j,k-1));
+            Real     dJ_old_kface = myhalf_d * (detJ_old(i,j,k) + detJ_old(i,j,k-1));
+            Real     dJ_new_kface = myhalf_d * (detJ_new(i,j,k) + detJ_new(i,j,k-1));
+            Real     dJ_stg_kface = myhalf_d * (detJ_stg(i,j,k) + detJ_stg(i,j,k-1));
 
             Real coeff_P = coeffP_a(i,j,k);
             Real coeff_Q = coeffQ_a(i,j,k);
 
-            Real theta_t_lo  = myhalf * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
-            Real theta_t_mid = myhalf * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
-            Real theta_t_hi  = myhalf * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
+            Real theta_t_lo  = myhalf_d * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
+            Real theta_t_mid = myhalf_d * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
+            Real theta_t_hi  = myhalf_d * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
 
             // line 2 last two terms (order dtau)
             Real R0_tmp  = coeff_P * cur_cons(i,j,k  ,RhoTheta_comp)
@@ -495,10 +495,10 @@ void erf_substep_MT (int step, int /*nrk*/,
         BL_PROFILE("substep_b2d_loop_t");
 
 #ifdef AMREX_USE_GPU
-        ParallelFor(b2d, [=] AMREX_GPU_DEVICE (int i, int j, int)
+        ParallelFor(b2d, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int)
         {
             // Moving terrain
-            Real rho_on_bdy = myhalf * ( prev_cons(i,j,lo.z) + prev_cons(i,j,lo.z-1) );
+            Real rho_on_bdy = myhalf_d * ( prev_cons(i,j,lo.z) + prev_cons(i,j,lo.z-1) );
             RHS_a(i,j,lo.z) = rho_on_bdy * zp_t_arr(i,j,lo.z);
 
             soln_a(i,j,lo.z) = RHS_a(i,j,lo.z) * inv_coeffB_a(i,j,lo.z);
@@ -564,24 +564,24 @@ void erf_substep_MT (int step, int /*nrk*/,
         {
         BL_PROFILE("substep_new_drhow");
         tbz.setBig(2,hi.z);
-        ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(tbz, [=,myhalf_d=myhalf,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real rho_on_face = myhalf * (cur_cons(i,j,k,Rho_comp) + cur_cons(i,j,k-1,Rho_comp));
+            Real rho_on_face = myhalf_d * (cur_cons(i,j,k,Rho_comp) + cur_cons(i,j,k-1,Rho_comp));
 
             if (k == lo.z) {
                 cur_zmom(i,j,k) = WFromOmega(i,j,k,rho_on_face*(z_t_arr(i,j,k)+zp_t_arr(i,j,k)),
                                              cur_xmom,cur_ymom,mf_ux,mf_vy,z_nd_new,dxInv);
 
                 // We need to set this here because it is used to define zflux_lo below
-                soln_a(i,j,k) = zero;
+                soln_a(i,j,k) = zero_d;
 
             } else {
 
-                Real UppVpp = WFromOmega(i,j,k,zero,cur_xmom,cur_ymom,mf_ux,mf_vy,z_nd_new,dxInv)
-                            - WFromOmega(i,j,k,zero,stg_xmom,stg_ymom,mf_ux,mf_vy,z_nd_stg,dxInv);
+                Real UppVpp = WFromOmega(i,j,k,zero_d,cur_xmom,cur_ymom,mf_ux,mf_vy,z_nd_new,dxInv)
+                            - WFromOmega(i,j,k,zero_d,stg_xmom,stg_ymom,mf_ux,mf_vy,z_nd_stg,dxInv);
                 Real wpp = soln_a(i,j,k) + UppVpp;
-                Real dJ_old_kface = myhalf * (detJ_old(i,j,k) + detJ_old(i,j,k-1));
-                Real dJ_new_kface = myhalf * (detJ_new(i,j,k) + detJ_new(i,j,k-1));
+                Real dJ_old_kface = myhalf_d * (detJ_old(i,j,k) + detJ_old(i,j,k-1));
+                Real dJ_new_kface = myhalf_d * (detJ_new(i,j,k) + detJ_new(i,j,k-1));
 
                 cur_zmom(i,j,k) = dJ_old_kface * (stg_zmom(i,j,k) + wpp);
                 cur_zmom(i,j,k) /= dJ_new_kface;
@@ -593,7 +593,7 @@ void erf_substep_MT (int step, int /*nrk*/,
 
             if (l_rayleigh_impl_for_w && k > 0) {
               Real damping_coeff = l_damp_coef * dtau * sinesq_stag_d[k];
-              cur_zmom(i,j,k) /= (one + damping_coeff);
+              cur_zmom(i,j,k) /= (one_d + damping_coeff);
             }
         });
         } // end profile
@@ -603,7 +603,7 @@ void erf_substep_MT (int step, int /*nrk*/,
         // **************************************************************************
         {
         BL_PROFILE("fast_rho_final_update");
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
               Real zflux_lo = beta_2 * soln_a(i,j,k  ) + beta_1 * omega_arr(i,j,k);
               Real zflux_hi = beta_2 * soln_a(i,j,k+1) + beta_1 * omega_arr(i,j,k+1);
@@ -619,7 +619,7 @@ void erf_substep_MT (int step, int /*nrk*/,
               // when we multiply old and new by detJ_old and detJ_new , respectively
               // We have already scaled the slow source term to have the extra factor of dJ
               Real fast_rhs_rho = -(temp_rhs_arr(i,j,k,0) + ( zflux_hi - zflux_lo ) * dzi);
-              Real fast_rhs_rhotheta = -( temp_rhs_arr(i,j,k,1) + myhalf *
+              Real fast_rhs_rhotheta = -( temp_rhs_arr(i,j,k,1) + myhalf_d *
                                         ( zflux_hi * (prim(i,j,k) + prim(i,j,k+1))
                                         - zflux_lo * (prim(i,j,k) + prim(i,j,k-1)) ) * dzi );
 
@@ -630,14 +630,14 @@ void erf_substep_MT (int step, int /*nrk*/,
               cur_cons(i,j,k,1) += dtau * ( slow_rhs_cons(i,j,k,1) + fast_rhs_rhotheta / detJ_new(i,j,k));
 
               if (l_reflux) {
-                  (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf * (prim(i,j,k) + prim(i,j,k-1));
+                  (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k-1));
               }
 
               if (k == vbx_hi.z) {
                   avg_zmom_arr(i,j,k+1)      += facinv * zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
                   if (l_reflux) {
                       (flx_arr[2])(i,j,k+1,0) =          zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
-                      (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf * (prim(i,j,k) + prim(i,j,k+1));
+                      (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k+1));
                   }
               }
 

--- a/Source/TimeIntegration/ERF_Substep_NS.cpp
+++ b/Source/TimeIntegration/ERF_Substep_NS.cpp
@@ -158,7 +158,7 @@ void erf_substep_NS (int step, int nrk,
         const Array4<const Real>& prim      = S_stage_prim.const_array(mfi);
 
         Box gbx = mfi.growntilebox(1);
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(gbx, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             prev_drho_theta(i,j,k) = prev_cons(i,j,k,RhoTheta_comp) - stage_cons(i,j,k,RhoTheta_comp);
 
@@ -170,8 +170,8 @@ void erf_substep_NS (int step, int nrk,
             }
 
             // NOTE: qv is not changing over the fast steps so we use the stage data
-            Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-            theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+            Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero_d;
+            theta_extrap(i,j,k) *= (one_d + RvOverRd*qv);
 
             // We define lagged_delta_rt for our next step as the current delta_rt
             // (after using it above to extrapolate theta for this step)
@@ -246,17 +246,17 @@ void erf_substep_NS (int step, int nrk,
             });
         } else {
             ParallelFor(tbx, tby,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real gpx = (l_real_bc && (level==0) && (i==ilo || i==ihi)) ? Real(0.) :
                   (theta_extrap(i,j,k) - theta_extrap(i-1,j,k))*dxi;
                 gpx *= mf_ux(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i-1,j,k,0) + pi_stage_ca(i,j,k,0));
-                Real fast_rhs_rho_u = -Gamma * R_d * pi_c * gpx / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i-1,j,k,0) + pi_stage_ca(i,j,k,0));
+                Real fast_rhs_rho_u = -Gamma_d * R_d_d * pi_c * gpx / (one_d + q);
 
                 Real new_drho_u = prev_xmom(i,j,k) - stage_xmom(i,j,k)
                                 + dtau * fast_rhs_rho_u + dtau * slow_rhs_rho_u(i,j,k)
@@ -266,17 +266,17 @@ void erf_substep_NS (int step, int nrk,
 
                 temp_cur_xmom_arr(i,j,k) = stage_xmom(i,j,k) + new_drho_u;
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real gpy = (l_real_bc && (level==0) && (j==jlo || j==jhi)) ? Real(0.) :
                   (theta_extrap(i,j,k) - theta_extrap(i,j-1,k))*dyi;
                 gpy *= mf_vy(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i,j-1,k,0) + pi_stage_ca(i,j,k,0));
-                Real fast_rhs_rho_v = -Gamma * R_d * pi_c * gpy / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i,j-1,k,0) + pi_stage_ca(i,j,k,0));
+                Real fast_rhs_rho_v = -Gamma_d * R_d_d * pi_c * gpy / (one_d + q);
 
                 Real new_drho_v = prev_ymom(i,j,k) - stage_ymom(i,j,k)
                                 + dtau * fast_rhs_rho_v + dtau * slow_rhs_rho_v(i,j,k)
@@ -360,7 +360,7 @@ void erf_substep_NS (int step, int nrk,
             flx_arr{{AMREX_D_DECL(flux[0].array(), flux[1].array(), flux[2].array())}};
 
         // *********************************************************************
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             Real xflux_lo = (temp_cur_xmom_arr(i  ,j,k) - stage_xmom(i  ,j,k)) / mf_uy(i  ,j,0);
             Real xflux_hi = (temp_cur_xmom_arr(i+1,j,k) - stage_xmom(i+1,j,k)) / mf_uy(i+1,j,0);
             Real yflux_lo = (temp_cur_ymom_arr(i,j  ,k) - stage_ymom(i,j  ,k)) / mf_vx(i,j  ,0);
@@ -373,22 +373,22 @@ void erf_substep_NS (int step, int nrk,
             temp_rhs_arr(i,j,k,RhoTheta_comp) = (( xflux_hi * (prim(i,j,k,0) + prim(i+1,j,k,0)) -
                                                    xflux_lo * (prim(i,j,k,0) + prim(i-1,j,k,0)) ) * dxi * mfsq +
                                                  ( yflux_hi * (prim(i,j,k,0) + prim(i,j+1,k,0)) -
-                                                   yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi * mfsq) * myhalf;
+                                                   yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi * mfsq) * myhalf_d;
 
             if (l_reflux) {
                 (flx_arr[0])(i,j,k,0) = xflux_lo;
-                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i-1,j,k,0));
+                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i-1,j,k,0));
 
                 (flx_arr[1])(i,j,k,0) = yflux_lo;
-                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j-1,k,0));
+                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j-1,k,0));
 
                 if (i == vbx_hi.x) {
                     (flx_arr[0])(i+1,j,k,0) = xflux_hi;
-                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i+1,j,k,0));
+                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i+1,j,k,0));
                 }
                 if (j == vbx_hi.y) {
                     (flx_arr[1])(i,j+1,k,0) = yflux_hi;
-                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j+1,k,0));
+                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j+1,k,0));
                 }
             }
         });
@@ -408,14 +408,14 @@ void erf_substep_NS (int step, int nrk,
         // fast_loop_on_shrunk
         // *********************************************************************
         //Note we don't act on the bottom or top boundaries of the domain
-        ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx_shrunk_in_k, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             Real coeff_P = coeffP_a(i,j,k);
             Real coeff_Q = coeffQ_a(i,j,k);
 
-            Real theta_t_lo  = myhalf * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
-            Real theta_t_mid = myhalf * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
-            Real theta_t_hi  = myhalf * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
+            Real theta_t_lo  = myhalf_d * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
+            Real theta_t_mid = myhalf_d * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
+            Real theta_t_hi  = myhalf_d * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
 
             Real Omega_kp1 = prev_zmom(i,j,k+1) - stage_zmom(i,j,k+1);
             Real Omega_k   = prev_zmom(i,j,k  ) - stage_zmom(i,j,k  );
@@ -512,10 +512,10 @@ void erf_substep_NS (int step, int nrk,
         }
 #endif
         if (l_rayleigh_impl_for_w) {
-            ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            ParallelFor(bx_shrunk_in_k, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
               Real damping_coeff = l_damp_coef * dtau * sinesq_stag_d[k];
-              cur_zmom(i,j,k) /= (one + damping_coeff);
+              cur_zmom(i,j,k) /= (one_d + damping_coeff);
             });
         }
 
@@ -523,7 +523,7 @@ void erf_substep_NS (int step, int nrk,
         // Define updates in the RHS of rho and (rho theta)
         // **************************************************************************
         const Array4<Real>&  prev_drho_w = Delta_rho_w.array(mfi);
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
             Real zflux_lo = beta_2 * soln_a(i,j,k  ) + beta_1 * prev_drho_w(i,j,k  );
             Real zflux_hi = beta_2 * soln_a(i,j,k+1) + beta_1 * prev_drho_w(i,j,k+1);
@@ -531,20 +531,20 @@ void erf_substep_NS (int step, int nrk,
             avg_zmom_arr(i,j,k)      += facinv*zflux_lo / (mf_mx(i,j,0) * mf_my(i,j,0));
             if (l_reflux) {
                 (flx_arr[2])(i,j,k,0) =        zflux_lo / (mf_mx(i,j,0) * mf_my(i,j,0));
-                (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf * (prim(i,j,k) + prim(i,j,k-1));
+                (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k-1));
             }
 
             if (k == vbx_hi.z) {
                 avg_zmom_arr(i,j,k+1)      += facinv * zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
                 if (l_reflux) {
                     (flx_arr[2])(i,j,k+1,0) =          zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
-                    (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf * (prim(i,j,k) + prim(i,j,k+1));
+                    (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k+1));
                 }
             }
 
-            Real dz_inv = one / dz_ptr[k];
+            Real dz_inv = one_d / dz_ptr[k];
             temp_rhs_arr(i,j,k,Rho_comp     ) += dz_inv * ( zflux_hi - zflux_lo );
-            temp_rhs_arr(i,j,k,RhoTheta_comp) += myhalf * dz_inv * ( zflux_hi * (prim(i,j,k) + prim(i,j,k+1))
+            temp_rhs_arr(i,j,k,RhoTheta_comp) += myhalf_d * dz_inv * ( zflux_hi * (prim(i,j,k) + prim(i,j,k+1))
                                                                    - zflux_lo * (prim(i,j,k) + prim(i,j,k-1)) );
         });
 

--- a/Source/TimeIntegration/ERF_Substep_T.cpp
+++ b/Source/TimeIntegration/ERF_Substep_T.cpp
@@ -196,7 +196,7 @@ void erf_substep_T (int step, int /*nrk*/,
         const Array4<Real>& theta_extrap = extrap.array(mfi);
         const Array4<const Real>& prim   = S_stage_prim.const_array(mfi);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,zero_d=zero,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
             old_drho(i,j,k)       = cur_cons(i,j,k,Rho_comp)      - stage_cons(i,j,k,Rho_comp);
             old_drho_theta(i,j,k) = cur_cons(i,j,k,RhoTheta_comp) - stage_cons(i,j,k,RhoTheta_comp);
             if (step == 0) {
@@ -207,8 +207,8 @@ void erf_substep_T (int step, int /*nrk*/,
             }
 
             // NOTE: qv is not changing over the fast steps so we use the stage data
-            Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-            theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+            Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero_d;
+            theta_extrap(i,j,k) *= (one_d + RvOverRd*qv);
         });
     } // mfi
 
@@ -288,26 +288,26 @@ void erf_substep_T (int step, int /*nrk*/,
         const auto& bx_hi = ubound(bx);
 
         ParallelFor(tbx, tby,
-        [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real met_h_xi   = Compute_h_xi_AtIface  (i, j, k, dxInv, z_nd);
                 Real met_h_zeta = Compute_h_zeta_AtIface(i, j, k, dxInv, z_nd);
                 Real gp_xi = (theta_extrap(i,j,k) - theta_extrap(i-1,j,k)) * dxi;
                 Real gp_zeta_on_iface = (k == 0) ?
-                   myhalf  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
+                   myhalf_d  * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
                                    - theta_extrap(i-1,j,k  ) - theta_extrap(i,j,k  ) ) :
-                   fourth * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
+                   fourth_d * dzi * ( theta_extrap(i-1,j,k+1) + theta_extrap(i,j,k+1)
                                   - theta_extrap(i-1,j,k-1) - theta_extrap(i,j,k-1) );
                 Real gpx = (l_real_bc && (level==0) && (i==ilo || i==ihi)) ? Real(0.) :
                   gp_xi - (met_h_xi / met_h_zeta) * gp_zeta_on_iface;
 
                 gpx *= mf_ux(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i-1,j,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i-1,j,k,0) + pi_stage_ca(i  ,j,k,0));
-                Real fast_rhs_rho_u = -Gamma * R_d * pi_c * gpx / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i-1,j,k,0) + pi_stage_ca(i  ,j,k,0));
+                Real fast_rhs_rho_u = -Gamma_d * R_d_d * pi_c * gpx / (one_d + q);
 
                 new_drho_u(i, j, k) = old_drho_u(i,j,k) + dtau * fast_rhs_rho_u
                                                         + dtau * slow_rhs_rho_u(i,j,k)
@@ -322,26 +322,26 @@ void erf_substep_T (int step, int /*nrk*/,
 
                 cur_xmom(i,j,k) = stage_xmom(i,j,k) + new_drho_u(i,j,k);
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k)
+            [=,myhalf_d=myhalf,fourth_d=fourth,zero_d=zero,Gamma_d=Gamma,R_d_d=R_d,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
             {
                 // Add (negative) gradient of (rho theta) multiplied by lagged "pi"
                 Real met_h_eta  = Compute_h_eta_AtJface(i, j, k, dxInv, z_nd);
                 Real met_h_zeta = Compute_h_zeta_AtJface(i, j, k, dxInv, z_nd);
                 Real gp_eta = (theta_extrap(i,j,k) -theta_extrap(i,j-1,k)) * dyi;
                 Real gp_zeta_on_jface = (k == 0) ?
-                    myhalf  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
+                    myhalf_d  * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
                                     - theta_extrap(i,j,k  ) - theta_extrap(i,j-1,k  ) ) :
-                    fourth * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
+                    fourth_d * dzi * ( theta_extrap(i,j,k+1) + theta_extrap(i,j-1,k+1)
                                    - theta_extrap(i,j,k-1) - theta_extrap(i,j-1,k-1) );
                 Real gpy = (l_real_bc && (level==0) && (j==jlo || j==jhi)) ? Real(0.) :
                   gp_eta - (met_h_eta / met_h_zeta) * gp_zeta_on_jface;
 
                 gpy *= mf_vy(i,j,0);
 
-                Real q = (l_use_moisture) ? myhalf * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero;
+                Real q = (l_use_moisture) ? myhalf_d * (qt_arr(i,j,k) + qt_arr(i,j-1,k)) : zero_d;
 
-                Real pi_c =  myhalf * (pi_stage_ca(i,j-1,k,0) + pi_stage_ca(i,j  ,k,0));
-                Real fast_rhs_rho_v = -Gamma * R_d * pi_c * gpy / (one + q);
+                Real pi_c =  myhalf_d * (pi_stage_ca(i,j-1,k,0) + pi_stage_ca(i,j  ,k,0));
+                Real fast_rhs_rho_v = -Gamma_d * R_d_d * pi_c * gpy / (one_d + q);
 
                 new_drho_v(i, j, k) = old_drho_v(i,j,k) + dtau * fast_rhs_rho_v
                                                         + dtau * slow_rhs_rho_v(i,j,k)
@@ -449,20 +449,20 @@ void erf_substep_T (int step, int /*nrk*/,
         // *********************************************************************
         {
         BL_PROFILE("fast_T_making_rho_rhs");
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-            Real h_zeta_cc_xface_hi = myhalf * dzi *
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+            Real h_zeta_cc_xface_hi = myhalf_d * dzi *
               (  z_nd(i+1,j  ,k+1) + z_nd(i+1,j+1,k+1)
                 -z_nd(i+1,j  ,k  ) - z_nd(i+1,j+1,k  ) );
 
-            Real h_zeta_cc_xface_lo = myhalf * dzi *
+            Real h_zeta_cc_xface_lo = myhalf_d * dzi *
               (  z_nd(i  ,j  ,k+1) + z_nd(i  ,j+1,k+1)
                 -z_nd(i  ,j  ,k  ) - z_nd(i  ,j+1,k  ) );
 
-            Real h_zeta_cc_yface_hi = myhalf * dzi *
+            Real h_zeta_cc_yface_hi = myhalf_d * dzi *
               (  z_nd(i  ,j+1,k+1) + z_nd(i+1,j+1,k+1)
                 -z_nd(i  ,j+1,k  ) - z_nd(i+1,j+1,k  ) );
 
-            Real h_zeta_cc_yface_lo = myhalf * dzi *
+            Real h_zeta_cc_yface_lo = myhalf_d * dzi *
               (  z_nd(i  ,j  ,k+1) + z_nd(i+1,j  ,k+1)
                 -z_nd(i  ,j  ,k  ) - z_nd(i+1,j  ,k  ) );
 
@@ -479,22 +479,22 @@ void erf_substep_T (int step, int /*nrk*/,
             temp_rhs_arr(i,j,k,1) = (( xflux_hi * (prim(i,j,k,0) + prim(i+1,j,k,0)) -
                                        xflux_lo * (prim(i,j,k,0) + prim(i-1,j,k,0)) ) * dxi * mfsq+
                                      ( yflux_hi * (prim(i,j,k,0) + prim(i,j+1,k,0)) -
-                                       yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi * mfsq) * myhalf;
+                                       yflux_lo * (prim(i,j,k,0) + prim(i,j-1,k,0)) ) * dyi * mfsq) * myhalf_d;
 
             if (l_reflux) {
                 (flx_arr[0])(i,j,k,0) = xflux_lo;
-                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i-1,j,k,0));
+                (flx_arr[0])(i,j,k,1) = (flx_arr[0])(i  ,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i-1,j,k,0));
 
                 (flx_arr[1])(i,j,k,0) = yflux_lo;
-                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j-1,k,0));
+                (flx_arr[1])(i,j,k,1) = (flx_arr[1])(i,j  ,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j-1,k,0));
 
                 if (i == vbx_hi.x) {
                     (flx_arr[0])(i+1,j,k,0) = xflux_hi;
-                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf * (prim(i,j,k,0) + prim(i+1,j,k,0));
+                    (flx_arr[0])(i+1,j,k,1) = (flx_arr[0])(i+1,j,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i+1,j,k,0));
                 }
                 if (j == vbx_hi.y) {
                     (flx_arr[1])(i,j+1,k,0) = yflux_hi;
-                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf * (prim(i,j,k,0) + prim(i,j+1,k,0));
+                    (flx_arr[1])(i,j+1,k,1) = (flx_arr[1])(i,j+1,k,0) * myhalf_d * (prim(i,j,k,0) + prim(i,j+1,k,0));
                 }
             }
         });
@@ -508,8 +508,8 @@ void erf_substep_T (int step, int /*nrk*/,
         if (gbxo.smallEnd(2) == domlo.z) {
             Box gbxo_lo = gbxo; gbxo_lo.setBig(2,gbxo.smallEnd(2));
             gbxo_mid.setSmall(2,gbxo.smallEnd(2)+1);
-            ParallelFor(gbxo_lo, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                omega_arr(i,j,k) = zero;
+            ParallelFor(gbxo_lo, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                omega_arr(i,j,k) = zero_d;
             });
         }
         if (gbxo.bigEnd(2) == domhi.z+1) {
@@ -541,14 +541,14 @@ void erf_substep_T (int step, int /*nrk*/,
         {
         BL_PROFILE("fast_loop_on_shrunk_t");
         //Note we don't act on the bottom or top boundaries of the domain
-        ParallelFor(bx_shrunk_in_k, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx_shrunk_in_k, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             Real coeff_P = coeffP_a(i,j,k);
             Real coeff_Q = coeffQ_a(i,j,k);
 
-            Real theta_t_lo  = myhalf * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
-            Real theta_t_mid = myhalf * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
-            Real theta_t_hi  = myhalf * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
+            Real theta_t_lo  = myhalf_d * ( prim(i,j,k-2,PrimTheta_comp) + prim(i,j,k-1,PrimTheta_comp) );
+            Real theta_t_mid = myhalf_d * ( prim(i,j,k-1,PrimTheta_comp) + prim(i,j,k  ,PrimTheta_comp) );
+            Real theta_t_hi  = myhalf_d * ( prim(i,j,k  ,PrimTheta_comp) + prim(i,j,k+1,PrimTheta_comp) );
 
             // line 2 last two terms (order dtau)
             Real R0_tmp  =  -halfg * old_drho(i,j,k  ) + coeff_P * old_drho_theta(i,j,k  )
@@ -578,7 +578,7 @@ void erf_substep_T (int step, int /*nrk*/,
             RHS_a(i,j,k) = old_drho_w(i,j,k) + dtau * (slow_rhs_rho_w(i,j,k) + zmom_src_arr(i,j,k) + R0_tmp + dtau*beta_2*R1_tmp);
 
             // We cannot use omega_arr here since that was built with old_rho_u and old_rho_v ...
-            RHS_a(i,j,k) += OmegaFromW(i,j,k,zero,
+            RHS_a(i,j,k) += OmegaFromW(i,j,k,zero_d,
                                        new_drho_u,new_drho_v,
                                        mf_ux,mf_vy,z_nd,dxInv);
         });
@@ -670,7 +670,7 @@ void erf_substep_T (int step, int /*nrk*/,
         if (hi.z == domhi.z) {
             tbz.setBig(2,domhi.z);
         }
-        ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(tbz, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
         {
             Real wpp = WFromOmega(i,j,k,soln_a(i,j,k),
                                   new_drho_u,new_drho_v,
@@ -680,7 +680,7 @@ void erf_substep_T (int step, int /*nrk*/,
 
             if (l_rayleigh_impl_for_w) {
               Real damping_coeff = l_damp_coef * dtau * sinesq_stag_d[k];
-              cur_zmom(i,j,k) /= (one + damping_coeff);
+              cur_zmom(i,j,k) /= (one_d + damping_coeff);
             }
         });
 
@@ -689,7 +689,7 @@ void erf_substep_T (int step, int /*nrk*/,
         // **************************************************************************
         {
         BL_PROFILE("fast_rho_final_update");
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
               Real zflux_lo = beta_2 * soln_a(i,j,k  ) + beta_1 * omega_arr(i,j,k);
               Real zflux_hi = beta_2 * soln_a(i,j,k+1) + beta_1 * omega_arr(i,j,k+1);
@@ -705,7 +705,7 @@ void erf_substep_T (int step, int /*nrk*/,
                   avg_zmom_arr(i,j,k+1)      += facinv * zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
                   if (l_reflux) {
                       (flx_arr[2])(i,j,k+1,0) =      zflux_hi / (mf_mx(i,j,0) * mf_my(i,j,0));
-                      (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf * (prim(i,j,k) + prim(i,j,k+1));
+                      (flx_arr[2])(i,j,k+1,1) = (flx_arr[2])(i,j,k+1,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k+1));
                   }
               }
 
@@ -713,14 +713,14 @@ void erf_substep_T (int step, int /*nrk*/,
 
               cur_cons(i,j,k,0) += dtau * (slow_rhs_cons(i,j,k,0) + fast_rhs_rho);
 
-              Real fast_rhs_rhotheta = -( temp_rhs_arr(i,j,k,1) + myhalf *
+              Real fast_rhs_rhotheta = -( temp_rhs_arr(i,j,k,1) + myhalf_d *
                 ( zflux_hi * (prim(i,j,k) + prim(i,j,k+1)) -
                   zflux_lo * (prim(i,j,k) + prim(i,j,k-1)) ) * dzi ) / detJ(i,j,k);
 
               cur_cons(i,j,k,1) += dtau * (slow_rhs_cons(i,j,k,1) + fast_rhs_rhotheta);
 
               if (l_reflux) {
-                  (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf * (prim(i,j,k) + prim(i,j,k-1));
+                  (flx_arr[2])(i,j,k,1) = (flx_arr[2])(i,j,k,0) * myhalf_d * (prim(i,j,k) + prim(i,j,k-1));
               }
 
               // add in source terms for cell-centered conserved variables

--- a/Source/TimeIntegration/ERF_TI_no_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_no_substep_fun.H
@@ -1,7 +1,7 @@
 /**
  *  Wrapper for advancing the solution with the slow RHS in the absence of acoustic substepping
  */
-    auto no_substep_fun = [&](Vector<MultiFab>& S_sum,
+    auto no_substep_fun = [&,bogus_large_value_d=bogus_large_value](Vector<MultiFab>& S_sum,
                               Vector<MultiFab>& S_old,
                               Vector<MultiFab>& F_slow,
                               const double time_for_fp, const double slow_dt_d,
@@ -96,7 +96,7 @@
                                                      + slow_dt * fslow[IntVars::ymom](i,j,k) ) / h_zeta_new;
                     });
                     ParallelFor(tbz,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                    [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
                         if (k == 0) {
                             // Here we take advantage of the fact that moving terrain has a slip wall
                             // so we can just use the new value at (i,j,0).
@@ -105,8 +105,8 @@
                                                                     ssum[IntVars::xmom], ssum[IntVars::ymom],
                                                                     mf_u, mf_v, z_nd_new,dxInv);
                         } else {
-                            Real dJ_old_kface = myhalf * (dJ_old(i,j,k) + dJ_old(i,j,k-1));
-                            Real dJ_new_kface = myhalf * (dJ_new(i,j,k) + dJ_new(i,j,k-1));
+                            Real dJ_old_kface = myhalf_d * (dJ_old(i,j,k) + dJ_old(i,j,k-1));
+                            Real dJ_new_kface = myhalf_d * (dJ_new(i,j,k) + dJ_new(i,j,k-1));
                             ssum[IntVars::zmom](i,j,k) = ( dJ_old_kface *  sold[IntVars::zmom](i,j,k)
                                                          + slow_dt * fslow[IntVars::zmom](i,j,k) ) / dJ_new_kface;
                         }
@@ -115,9 +115,9 @@
                 } else { // Fixed or no terrain
                     const Array4<const Real>& dJ_old = detJ_cc[level]->const_array(mfi);
                     ParallelFor(bx, ncomp_fast[IntVars::cons],
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int nn) {
+                    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int nn) {
                         const int n = scomp_fast[IntVars::cons] + nn;
-                        if (dJ_old(i,j,k) > zero) {
+                        if (dJ_old(i,j,k) > zero_d) {
                             ssum[IntVars::cons](i,j,k,n) = sold[IntVars::cons](i,j,k,n) + slow_dt *
                                ( fslow[IntVars::cons](i,j,k,n) );
                         } else {
@@ -133,8 +133,8 @@
                         const Array4<const Real>& vfrac_w = (get_eb(level).get_w_const_factory())->getVolFrac().const_array(mfi);
 
                         ParallelFor(tbx, tby, tbz,
-                        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            if (vfrac_u(i,j,k) > zero) {
+                        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            if (vfrac_u(i,j,k) > zero_d) {
                                 // ssum[IntVars::xmom](i,j,k) = sold[IntVars::xmom](i,j,k);
                                 ssum[IntVars::xmom](i,j,k) = sold[IntVars::xmom](i,j,k)
                                                            + slow_dt * fslow[IntVars::xmom](i,j,k);
@@ -142,8 +142,8 @@
                                 ssum[IntVars::xmom](i,j,k) = sold[IntVars::xmom](i,j,k);
                             }
                         },
-                        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            if (vfrac_v(i,j,k) > zero) {
+                        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            if (vfrac_v(i,j,k) > zero_d) {
                                 // ssum[IntVars::ymom](i,j,k) = sold[IntVars::ymom](i,j,k);
                                 ssum[IntVars::ymom](i,j,k) = sold[IntVars::ymom](i,j,k)
                                                            + slow_dt * fslow[IntVars::ymom](i,j,k);
@@ -151,8 +151,8 @@
                                 ssum[IntVars::ymom](i,j,k) = sold[IntVars::ymom](i,j,k);
                             }
                         },
-                        [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                            if (vfrac_w(i,j,k) > zero) {
+                        [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                            if (vfrac_w(i,j,k) > zero_d) {
                                 // ssum[IntVars::zmom](i,j,k) = sold[IntVars::zmom](i,j,k);
                                 ssum[IntVars::zmom](i,j,k) = sold[IntVars::zmom](i,j,k)
                                                            + slow_dt * fslow[IntVars::zmom](i,j,k);
@@ -192,7 +192,7 @@
                 for (int i = 0; i <= AMREX_SPACEDIM; ++i) {
                     dUdt[i].setVal(0, 0, ncomp_fast[i], dUdt[i].nGrow());
                     MultiFab::Copy(dUdt[i], F_slow[i], 0, 0, F_slow[i].nComp(), 0);
-                    dUdt[i].setDomainBndry(bogus_large_value, 0, ncomp_fast[i], fine_geom);
+                    dUdt[i].setDomainBndry(bogus_large_value_d, 0, ncomp_fast[i], fine_geom);
                     dUdt[i].FillBoundary(fine_geom.periodicity());
                 }
 
@@ -260,10 +260,10 @@
                     // const Array4<const Real>& vfrac_c = detJ_cc[level]->const_array(mfi);
                     const Array4<const Real>& vfrac_c = (get_eb(level).get_const_factory())->getVolFrac().const_array(mfi);
 
-                    ParallelFor(bx, ncomp_fast[IntVars::cons], [=] AMREX_GPU_DEVICE (int i, int j, int k, int nn)
+                    ParallelFor(bx, ncomp_fast[IntVars::cons], [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int nn)
                     {
                         const int n = scomp_fast[IntVars::cons] + nn;
-                        if (vfrac_c(i,j,k) > zero) {
+                        if (vfrac_c(i,j,k) > zero_d) {
                             ssum[IntVars::cons](i,j,k,n) = sold[IntVars::cons](i,j,k,n) + slow_dt *
                                 ( fslow[IntVars::cons](i,j,k,n) );
                         }
@@ -274,20 +274,20 @@
                     const Array4<const Real>& vfrac_w = (get_eb(level).get_w_const_factory())->getVolFrac().const_array(mfi);
 
                     ParallelFor(tbx, tby, tbz,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                        if (vfrac_u(i,j,k) > zero) {
+                    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        if (vfrac_u(i,j,k) > zero_d) {
                             ssum[IntVars::xmom](i,j,k) = sold[IntVars::xmom](i,j,k)
                             + slow_dt * fslow[IntVars::xmom](i,j,k);
                         }
                     },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                        if (vfrac_v(i,j,k) > zero) {
+                    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        if (vfrac_v(i,j,k) > zero_d) {
                             ssum[IntVars::ymom](i,j,k) = sold[IntVars::ymom](i,j,k)
                                                     + slow_dt * fslow[IntVars::ymom](i,j,k);
                         }
                     },
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
-                        if (vfrac_w(i,j,k) > zero) {
+                    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
+                        if (vfrac_w(i,j,k) > zero_d) {
                             ssum[IntVars::zmom](i,j,k) = sold[IntVars::zmom](i,j,k)
                                                     + slow_dt * fslow[IntVars::zmom](i,j,k);
 

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_post.H
@@ -1,6 +1,6 @@
 #include "ERF_SrcHeaders.H"
 
-    auto slow_rhs_fun_post = [&](Vector<MultiFab>& S_rhs,
+    auto slow_rhs_fun_post = [&,bogus_large_value_d=bogus_large_value](Vector<MultiFab>& S_rhs,
                                  Vector<MultiFab>& S_old,
                                  Vector<MultiFab>& S_new,
                                  Vector<MultiFab>& S_data,
@@ -92,7 +92,7 @@
                 }
             }
             dUdt_tmp.FillBoundary(fine_geom.periodicity());
-            dUdt_tmp.setDomainBndry(bogus_large_value, 0, num_comp_total, fine_geom);
+            dUdt_tmp.setDomainBndry(bogus_large_value_d, 0, num_comp_total, fine_geom);
 
             const BCRec* bc_ptr_d = domain_bcs_type_d.data();
 
@@ -123,9 +123,9 @@
                             num_comp = NSCALARS;
                         }
                         Real sdt = static_cast<Real>(slow_dt);
-                        ParallelFor(tbx, num_comp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int nn)
+                        ParallelFor(tbx, num_comp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int nn)
                         {
-                            if (detJ_arr(i,j,k) > zero) {
+                            if (detJ_arr(i,j,k) > zero_d) {
                                 const int n = start_comp + nn;
                                 snew(i,j,k,n) = sold(i,j,k,n) + sdt * srhs(i,j,k,n);
                             }

--- a/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
+++ b/Source/TimeIntegration/ERF_TI_slow_rhs_pre.H
@@ -3,7 +3,7 @@
 /**
  *  Wrapper for calling the routine that creates the slow RHS
  */
-    auto slow_rhs_fun_pre = [&](Vector<MultiFab>& S_rhs,
+    auto slow_rhs_fun_pre = [&,zero_d=zero,one_d=one](Vector<MultiFab>& S_rhs,
                                 Vector<MultiFab>& S_old,
                                 Vector<MultiFab>& S_data,
                                 const double old_step_time,
@@ -198,7 +198,7 @@
 
         Real sdt = static_cast<Real>(slow_dt);
 
-        if ((solverChoice.vert_implicit_fac[level][nrk] > zero) && solverChoice.implicit_before_substep) {
+        if ((solverChoice.vert_implicit_fac[level][nrk] > zero_d) && solverChoice.implicit_before_substep) {
             MultiFab scratch(S_data[IntVars::cons].boxArray(),S_data[IntVars::cons].DistributionMap(), 2,
                              S_data[IntVars::cons].nGrowVect());
             MultiFab::Copy(scratch, S_old[IntVars::cons], 0, 0, 2, S_data[IntVars::cons].nGrowVect()); // scratch := S_old               (for rho, rhotheta)
@@ -233,21 +233,21 @@
 
 #include "ERF_ImplicitPre.H"
 
-            MultiFab::Saxpy(scratch, -one, S_old[IntVars::cons], 1, 1, 1, 0); // scratch  := (S_new - S_old)           (for rhotheta only)
-            scratch.mult(one / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
+            MultiFab::Saxpy(scratch, -one_d, S_old[IntVars::cons], 1, 1, 1, 0); // scratch  := (S_new - S_old)           (for rhotheta only)
+            scratch.mult(one_d / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
             MultiFab::Copy(S_rhs[IntVars::cons], scratch, 1, 1, 1, 0);        // slow_rhs := (S_new - S_old) / slow_dt (for rhotheta only)
 
             if (solverChoice.implicit_momentum_diffusion) {
-                MultiFab::Saxpy(scratch_xmom, -one, S_old[IntVars::xmom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
-                scratch_xmom.mult(one / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
+                MultiFab::Saxpy(scratch_xmom, -one_d, S_old[IntVars::xmom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
+                scratch_xmom.mult(one_d / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
                 MultiFab::Copy(S_rhs[IntVars::xmom], scratch_xmom, 0, 0, 1, 0);        // slow_rhs := (S_new - S_old) / slow_dt
 
-                MultiFab::Saxpy(scratch_ymom, -one, S_old[IntVars::ymom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
-                scratch_ymom.mult(one / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
+                MultiFab::Saxpy(scratch_ymom, -one_d, S_old[IntVars::ymom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
+                scratch_ymom.mult(one_d / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
                 MultiFab::Copy(S_rhs[IntVars::ymom], scratch_ymom, 0, 0, 1, 0);        // slow_rhs := (S_new - S_old) / slow_dt
 #ifdef ERF_IMPLICIT_W
-                MultiFab::Saxpy(scratch_zmom, -one, S_old[IntVars::zmom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
-                scratch_zmom.mult(one / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
+                MultiFab::Saxpy(scratch_zmom, -one_d, S_old[IntVars::zmom], 0, 0, 1, 0); // scratch  := (S_new - S_old)
+                scratch_zmom.mult(one_d / sdt);                                      // scratch  := (S_new - S_old) / slow_dt
                 MultiFab::Copy(S_rhs[IntVars::zmom], scratch_zmom, 0, 0, 1, 0);        // slow_rhs := (S_new - S_old) / slow_dt
 #endif
             }
@@ -326,15 +326,15 @@
                });
 
                Box gbx2 = mfi.growntilebox({1,1,0});
-               amrex::ParallelFor(gbx2, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+               amrex::ParallelFor(gbx2, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                {
-                   Real zflux_r_lo = -z_t_arr(i,j,k  ) * myhalf * (r0_tmp_arr(i,j,k) + r0_tmp_arr(i,j,k-1));
-                   Real zflux_r_hi = -z_t_arr(i,j,k+1) * myhalf * (r0_tmp_arr(i,j,k) + r0_tmp_arr(i,j,k+1));
+                   Real zflux_r_lo = -z_t_arr(i,j,k  ) * myhalf_d * (r0_tmp_arr(i,j,k) + r0_tmp_arr(i,j,k-1));
+                   Real zflux_r_hi = -z_t_arr(i,j,k+1) * myhalf_d * (r0_tmp_arr(i,j,k) + r0_tmp_arr(i,j,k+1));
 
-                   Real zflux_rt_lo = zflux_r_lo * myhalf * (rt0_tmp_arr(i,j,k)/r0_tmp_arr(i,j,k) + rt0_tmp_arr(i,j,k-1)/r0_tmp_arr(i,j,k-1));
-                   Real zflux_rt_hi = zflux_r_hi * myhalf * (rt0_tmp_arr(i,j,k)/r0_tmp_arr(i,j,k) + rt0_tmp_arr(i,j,k+1)/r0_tmp_arr(i,j,k+1));
+                   Real zflux_rt_lo = zflux_r_lo * myhalf_d * (rt0_tmp_arr(i,j,k)/r0_tmp_arr(i,j,k) + rt0_tmp_arr(i,j,k-1)/r0_tmp_arr(i,j,k-1));
+                   Real zflux_rt_hi = zflux_r_hi * myhalf_d * (rt0_tmp_arr(i,j,k)/r0_tmp_arr(i,j,k) + rt0_tmp_arr(i,j,k+1)/r0_tmp_arr(i,j,k+1));
 
-                   Real invdetJ = one / dJ_src_arr(i,j,k);
+                   Real invdetJ = one_d / dJ_src_arr(i,j,k);
 
                    Real src_r  = - invdetJ * ( zflux_r_hi  - zflux_r_lo  ) * dxInv[2];
                    Real src_rt = - invdetJ * ( zflux_rt_hi - zflux_rt_lo ) * dxInv[2];

--- a/Source/TimeIntegration/ERF_TI_substep_fun.H
+++ b/Source/TimeIntegration/ERF_TI_substep_fun.H
@@ -3,7 +3,7 @@
 /**
  *  Wrapper for calling the routine that creates the fast RHS
  */
-auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
+auto acoustic_substepping_fun = [&,one_d=one,zero_d=zero](int fast_step, int n_sub, int nrk,
                                     Vector<MultiFab>& S_slow_rhs,
                                     const Vector<MultiFab>& S_old,
                                     Vector<MultiFab>& S_stage,
@@ -29,7 +29,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
         if (solverChoice.substepping_type[level] == SubsteppingType::Implicit) {
             beta_s = solverChoice.beta_s;
         } else { // Fully explicit
-            beta_s = -one;
+            beta_s = -one_d;
         }
 
         const GpuArray<Real, AMREX_SPACEDIM> dxInv = fine_geom.InvCellSizeArray();
@@ -170,7 +170,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
         // Even if we update all the conserved variables we don't need
         // to fillpatch the slow ones every acoustic substep
 
-        if ( (solverChoice.vert_implicit_fac[level][nrk] > zero) && !solverChoice.implicit_before_substep &&
+        if ( (solverChoice.vert_implicit_fac[level][nrk] > zero_d) && !solverChoice.implicit_before_substep &&
              (fast_step == n_sub-1) )
         {
             MultiFab scratch(S_data[IntVars::cons], make_alias, 0, 2);
@@ -200,7 +200,7 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
                 const Array4<const Real>& cell_data = S_data[IntVars::cons].const_array(mfi);
                 const Array4<      Real>& rho_w     = S_data[IntVars::zmom].array(mfi);
 
-                ParallelFor(tbz, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(tbz, [=,myhalf_d=myhalf,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     Real dzInv;
                     if (z_nd_arr) {
@@ -235,14 +235,14 @@ auto acoustic_substepping_fun = [&](int fast_step, int n_sub, int nrk,
                     Real dampcoef = (w_damping_const > 0) ? w_damping_const
                                   : w_damping_coeff / (dzInv * dt_adv * dt_adv);
 
-                    Real rho_on_w_face = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
+                    Real rho_on_w_face = myhalf_d * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
                     Real wmag = std::abs(rho_w(i,j,k) / rho_on_w_face);
 
                     // This is the dynamics timestep, not the slow or fast dt
                     Real cflw = wmag * dt_adv * dzInv;
 
                     if (cflw > cflw_lim) {
-                        Real sgn_w = (rho_w(i,j,k) > 0) ? one : -one;
+                        Real sgn_w = (rho_w(i,j,k) > 0) ? one_d : -one_d;
                         rho_w(i, j, k) -= rho_on_w_face * sgn_w * dampcoef * (cflw - cflw_lim) * dt_adv;
                         // Note: These prints are not immediately flushed to screen
 #ifdef AMREX_USE_GPU

--- a/Source/TimeIntegration/ERF_TI_utils.H
+++ b/Source/TimeIntegration/ERF_TI_utils.H
@@ -20,9 +20,9 @@
           const Real rdOcp = solverChoice.rdOcp;
           const bool l_use_moisture  = (solverChoice.moisture_type != MoistureType::None);
 
-          amrex::ParallelFor(gbx1, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+          amrex::ParallelFor(gbx1, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
           {
-              auto qv_for_p = (l_use_moisture) ? cons_arr(i,j,k,RhoQ1_comp)/cons_arr(i,j,k,Rho_comp) : zero;
+              auto qv_for_p = (l_use_moisture) ? cons_arr(i,j,k,RhoQ1_comp)/cons_arr(i,j,k,Rho_comp) : zero_d;
               pi_stage_arr(i,j,k) = getExnergivenRTh(cons_arr(i,j,k,RhoTheta_comp), rdOcp, qv_for_p);
           });
       } // mfi
@@ -122,7 +122,7 @@
                               ng_cons_to_use, ng_vel, cons_only, scomp_cons, ncomp_cons);
     };
 
-    auto update_terrain_stage = [&](int lev, const double old_step_time,
+    auto update_terrain_stage = [&,one_d=one](int lev, const double old_step_time,
                                              const double old_stage_time,
                                              const double new_stage_time,
                                              const double slow_dt)
@@ -173,7 +173,7 @@
             make_terrain_fitted_coords(lev,fine_geom,*z_phys_nd_new[lev], zlevels_stag[lev], phys_bc_type);
             make_J             (fine_geom, *z_phys_nd_new[lev], *detJ_cc_new[lev]);
 
-            Real inv_dt  = one/static_cast<Real>(slow_dt);
+            Real inv_dt  = one_d/static_cast<Real>(slow_dt);
 
 #ifdef _OPENMP
 #pragma omp parallel if (amrex::Gpu::notInLaunchRegion())
@@ -187,10 +187,10 @@
                 const Array4<Real const>& z_nd_old_arr =  z_phys_nd[lev]->const_array(mfi);
 
                 // Loop over horizontal plane
-                amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                amrex::ParallelFor(gbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     // Evaluate between RK stages assuming the geometry is linear between old and new time
-                    z_t_arr(i,j,k) = fourth * inv_dt * (z_nd_new_arr(i+1,j+1,k) - z_nd_old_arr(i+1,j+1,k)
+                    z_t_arr(i,j,k) = fourth_d * inv_dt * (z_nd_new_arr(i+1,j+1,k) - z_nd_old_arr(i+1,j+1,k)
                                                      +z_nd_new_arr(i  ,j+1,k) - z_nd_old_arr(  i,j+1,k)
                                                      +z_nd_new_arr(i+1,j  ,k) - z_nd_old_arr(i+1,j  ,k)
                                                      +z_nd_new_arr(i  ,j  ,k) - z_nd_old_arr(i  ,j  ,k));
@@ -199,7 +199,7 @@
             } // mfi
     };
 
-    auto update_terrain_substep = [&](int lev, const double old_substep_time, const double new_substep_time, const double dtau,
+    auto update_terrain_substep = [&,one_d=one](int lev, const double old_substep_time, const double new_substep_time, const double dtau,
                                       Vector<MultiFab>& S_data, std::unique_ptr<MultiFab>& z_t_pert)
     {
         // Make "old" fast geom -- store in z_phys_nd for convenience
@@ -230,7 +230,7 @@
         make_terrain_fitted_coords(lev,fine_geom,*z_phys_nd_new[lev], zlevels_stag[lev], phys_bc_type);
         make_J             (fine_geom,*z_phys_nd_new[lev], *detJ_cc_new[lev]);
 
-        Real inv_dt   = one/static_cast<Real>(dtau);
+        Real inv_dt   = one_d/static_cast<Real>(dtau);
 
         z_t_pert = std::make_unique<MultiFab>(S_data[IntVars::zmom].boxArray(), S_data[IntVars::zmom].DistributionMap(), 1, 1);
 
@@ -245,10 +245,10 @@
             const Array4<Real const>& z_nd_old_arr =  z_phys_nd[lev]->const_array(mfi);
 
             // Loop over horizontal plane
-            amrex::ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            amrex::ParallelFor(gbx, [=,fourth_d=fourth] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 // Evaluate between RK stages assuming the geometry is linear between old and new time
-                zp_t_arr(i,j,k) = fourth * inv_dt * (z_nd_new_arr(i+1,j+1,k) - z_nd_old_arr(i+1,j+1,k)
+                zp_t_arr(i,j,k) = fourth_d * inv_dt * (z_nd_new_arr(i+1,j+1,k) - z_nd_old_arr(i+1,j+1,k)
                                                   +z_nd_new_arr(i  ,j+1,k) - z_nd_old_arr(  i,j+1,k)
                                                   +z_nd_new_arr(i+1,j  ,k) - z_nd_old_arr(i+1,j  ,k)
                                                   +z_nd_new_arr(i  ,j  ,k) - z_nd_old_arr(i  ,j  ,k));

--- a/Source/Utils/ERF_AverageDown.cpp
+++ b/Source/Utils/ERF_AverageDown.cpp
@@ -166,9 +166,9 @@ ERF::AverageDownTo (int crse_lev, int scomp, int ncomp, bool do_perturbational_a
                 const Array4<      Real> cons_new = vars_new[lev][Vars::cons].array(mfi);
                 const Array4<const Real> cons_old = vars_old[lev][Vars::cons].array(mfi);
                 const Array4<const Real> detJ_arr = detJ_cc[lev]->const_array(mfi);
-                ParallelFor(bx, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+                ParallelFor(bx, ncomp, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
                 {
-                    if (detJ_arr(i,j,k) == zero) {
+                    if (detJ_arr(i,j,k) == zero_d) {
                         cons_new(i,j,k,scomp+n) = cons_old(i,j,k,scomp+n);
                     }
                 });

--- a/Source/Utils/ERF_ConvertForProjection.cpp
+++ b/Source/Utils/ERF_ConvertForProjection.cpp
@@ -100,8 +100,8 @@ ConvertForProjection (const MultiFab& den_div, const MultiFab& den_mlt,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momx(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momx(i,j,k) >= zero_d) {
                         momx(i,j,k) *= den_mlt_arr(i-1,j,k,Rho_comp) / den_div_arr(i-1,j,k,Rho_comp) ;
                     } else {
                         momx(i,j,k) *= ( den_mlt_arr(i,j,k,Rho_comp) + den_mlt_arr(i-1,j,k,Rho_comp) )
@@ -120,8 +120,8 @@ ConvertForProjection (const MultiFab& den_div, const MultiFab& den_mlt,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.bigEnd(0)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momx(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.bigEnd(0)+1), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momx(i,j,k) <= zero_d) {
                         momx(i,j,k) *= den_mlt_arr(i,j,k,Rho_comp) / den_div_arr(i,j,k,Rho_comp) ;
                     } else {
                         momx(i,j,k) *= ( den_mlt_arr(i,j,k,Rho_comp) + den_mlt_arr(i-1,j,k,Rho_comp) )
@@ -140,8 +140,8 @@ ConvertForProjection (const MultiFab& den_div, const MultiFab& den_mlt,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momy(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momy(i,j,k) >= zero_d) {
                         momy(i,j,k) *= den_mlt_arr(i,j-1,k,Rho_comp) / den_div_arr(i,j-1,k,Rho_comp) ;
                     } else {
                         momy(i,j,k) *= ( den_mlt_arr(i,j,k,Rho_comp) + den_mlt_arr(i,j-1,k,Rho_comp) )
@@ -160,8 +160,8 @@ ConvertForProjection (const MultiFab& den_div, const MultiFab& den_mlt,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.bigEnd(1)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momy(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tby,1,domain.bigEnd(1)+1), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momy(i,j,k) <= zero_d) {
                         momy(i,j,k) *= den_mlt_arr(i,j,k,Rho_comp) / den_div_arr(i,j,k,Rho_comp) ;
                     } else {
                         momy(i,j,k) *= ( den_mlt_arr(i,j,k,Rho_comp) + den_mlt_arr(i,j-1,k,Rho_comp) )
@@ -201,14 +201,14 @@ void compute_influx_outflux(
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *vels_vec[0], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
             if ( (i == domlo.x   && vel_x[box_no](i,j,k) > zero) ||
                  (i == domhi.x+1 && vel_x[box_no](i,j,k) < zero) ) {
                 return { std::abs(vel_x[box_no](i,j,k)) * area_x[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -216,14 +216,14 @@ void compute_influx_outflux(
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *vels_vec[0], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
             if ( (i == domlo.x   && vel_x[box_no](i,j,k) < zero) ||
                  (i == domhi.x+1 && vel_x[box_no](i,j,k) > zero) ) {
                 return { std::abs(vel_x[box_no](i,j,k)) * area_x[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -234,14 +234,14 @@ void compute_influx_outflux(
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *vels_vec[1], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
             if ( (j == domlo.y   && vel_y[box_no](i,j,k) > zero) ||
                  (j == domhi.y+1 && vel_y[box_no](i,j,k) < zero) ) {
                 return { std::abs(vel_y[box_no](i,j,k)) * area_y[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -249,14 +249,14 @@ void compute_influx_outflux(
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *vels_vec[1], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
             if ( (j == domlo.y   && vel_y[box_no](i,j,k) < zero) ||
                  (j == domhi.y+1 && vel_y[box_no](i,j,k) > zero) ) {
                 return { std::abs(vel_y[box_no](i,j,k)) * area_y[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 

--- a/Source/Utils/ERF_EnforceConstraintOnBdy.cpp
+++ b/Source/Utils/ERF_EnforceConstraintOnBdy.cpp
@@ -44,17 +44,17 @@ scale_bdy_normal_by_rho0 (const MultiFab& rho0,
         // amrex::Print() << "MULTIPLYING BY RHO0 ON BX " << dir << " " << bx << std::endl;
 
         if (dir == 0) {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 const Real normal_vel = bdy_arr(i,j,k);
                 const bool use_xlo =
                     (i == domlo) &&
                     ((bc_lo == ERFBCType::ext_dir) ||
-                     (bc_lo == ERFBCType::ext_dir_upwind && normal_vel >= zero));
+                     (bc_lo == ERFBCType::ext_dir_upwind && normal_vel >= zero_d));
                 const bool use_xhi =
                     (i == domhi) &&
                     ((bc_hi == ERFBCType::ext_dir) ||
-                     (bc_hi == ERFBCType::ext_dir_upwind && normal_vel <= zero));
+                     (bc_hi == ERFBCType::ext_dir_upwind && normal_vel <= zero_d));
 
                 Real fac;
                 if (use_xlo) {
@@ -67,17 +67,17 @@ scale_bdy_normal_by_rho0 (const MultiFab& rho0,
                 tmp_arr(i,j,k) = multiply_by_rho0 ? normal_vel * fac : normal_vel / fac;
             });
         } else {
-            ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 const Real normal_vel = bdy_arr(i,j,k);
                 const bool use_ylo =
                     (j == domlo) &&
                     ((bc_lo == ERFBCType::ext_dir) ||
-                     (bc_lo == ERFBCType::ext_dir_upwind && normal_vel >= zero));
+                     (bc_lo == ERFBCType::ext_dir_upwind && normal_vel >= zero_d));
                 const bool use_yhi =
                     (j == domhi) &&
                     ((bc_hi == ERFBCType::ext_dir) ||
-                     (bc_hi == ERFBCType::ext_dir_upwind && normal_vel <= zero));
+                     (bc_hi == ERFBCType::ext_dir_upwind && normal_vel <= zero_d));
 
                 Real fac;
                 if (use_ylo) {
@@ -119,10 +119,10 @@ correct_bdy_outflow_on_face (FArrayBox& bdy_fab,
 
     // amrex::Print() << "OPERATING ON BX " << bx << std::endl;
 
-    ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    ParallelFor(bx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
-        if ((is_low && bdy_arr(i,j,k) < zero) ||
-           (!is_low && bdy_arr(i,j,k) > zero)) {
+        if ((is_low && bdy_arr(i,j,k) < zero_d) ||
+           (!is_low && bdy_arr(i,j,k) > zero_d)) {
             bdy_arr(i,j,k) *= alpha_fcf;
         }
     });
@@ -159,15 +159,15 @@ void compute_influx_outflux_bdy (FArrayBox& bdy_data_xlo, FArrayBox& bdy_data_xh
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *area_vec[0], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
-            if ( (i == domlo.x + n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxlo(i,j,k) > zero) {
+            if ( (i == domlo.x + n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxlo(i,j,k) > zero_d) {
                 return { std::abs(bdatxlo(i,j,k)) * area_x[box_no](i,j,k) };
-            } else if ( (i == domhi.x+1 - n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxhi(i,j,k) < zero) {
+            } else if ( (i == domhi.x+1 - n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxhi(i,j,k) < zero_d) {
                 return { std::abs(bdatxhi(i,j,k)) * area_x[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -175,15 +175,15 @@ void compute_influx_outflux_bdy (FArrayBox& bdy_data_xlo, FArrayBox& bdy_data_xh
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *area_vec[0], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
-            if (i == (domlo.x + n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxlo(i,j,k) < zero) {
+            if (i == (domlo.x + n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxlo(i,j,k) < zero_d) {
                 return { std::abs(bdatxlo(i,j,k)) * area_x[box_no](i,j,k) };
-            } else if ( (i == domhi.x+1 - n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxhi(i,j,k) > zero) {
+            } else if ( (i == domhi.x+1 - n) && (j >= domlo.y+n && j<= domhi.y-n) && bdatxhi(i,j,k) > zero_d) {
                 return { std::abs(bdatxhi(i,j,k)) * area_x[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -195,15 +195,15 @@ void compute_influx_outflux_bdy (FArrayBox& bdy_data_xlo, FArrayBox& bdy_data_xh
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *area_vec[1], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
-            if ( (j == domlo.y + n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatylo(i,j,k) > zero) {
+            if ( (j == domlo.y + n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatylo(i,j,k) > zero_d) {
                 return { std::abs(bdatylo(i,j,k)) * area_y[box_no](i,j,k) };
-            } else if ( (j == domhi.y+1 - n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatyhi(i,j,k) < zero) {
+            } else if ( (j == domhi.y+1 - n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatyhi(i,j,k) < zero_d) {
                 return { std::abs(bdatyhi(i,j,k)) * area_y[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 
@@ -211,15 +211,15 @@ void compute_influx_outflux_bdy (FArrayBox& bdy_data_xlo, FArrayBox& bdy_data_xh
         ParReduce(TypeList<ReduceOpSum>{},
                   TypeList<Real>{},
                   *area_vec[1], ngrow,
-        [=] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
+        [=,zero_d=zero] AMREX_GPU_DEVICE (int box_no, int i, int j, int k)
             noexcept -> GpuTuple<Real>
         {
-            if ( (j == domlo.y + n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatylo(i,j,k) < zero) {
+            if ( (j == domlo.y + n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatylo(i,j,k) < zero_d) {
                 return { std::abs(bdatylo(i,j,k)) * area_y[box_no](i,j,k) };
-            } else if ( (j == domhi.y+1 - n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatyhi(i,j,k) > zero) {
+            } else if ( (j == domhi.y+1 - n) && (i >= domlo.x+n && i<= domhi.x-n) && bdatyhi(i,j,k) > zero_d) {
                 return { std::abs(bdatyhi(i,j,k)) * area_y[box_no](i,j,k) };
             } else {
-                return { zero };
+                return { zero_d };
             }
         });
 

--- a/Source/Utils/ERF_HurricaneDiagnostics.cpp
+++ b/Source/Utils/ERF_HurricaneDiagnostics.cpp
@@ -282,10 +282,10 @@ ERF::HurricaneEyeTrackerNotInitial (const SolverChoice& sc,
         const Box& box = mfi.validbox();
         const Array4<Real const>& S_arr = S_data[IntVars::cons].const_array(mfi);
 
-        ParallelFor(box,[=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        ParallelFor(box,[=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) {
             if(k==0) {
-                Real x =  prob_lo[0] + (i+myhalf)*dx[0];
-                Real y =  prob_lo[1] + (j+myhalf)*dx[1];
+                Real x =  prob_lo[0] + (i+myhalf_d)*dx[0];
+                Real y =  prob_lo[1] + (j+myhalf_d)*dx[1];
                 Real dist = std::sqrt((x-tmp_x_eye)*(x-tmp_x_eye) + (y-tmp_y_eye)*(y-tmp_y_eye));
                 if(dist < 200e3) {
                     Real qv_for_p = (use_moisture && (ncomp > RhoQ1_comp)) ? S_arr(i,j,k,RhoQ1_comp)/S_arr(i,j,k,Rho_comp) : 0;
@@ -519,13 +519,13 @@ ERF::HurricaneMaxVelTracker(const Geometry& lev_geom,
         const Box& box = mfi.validbox();
         const auto& vel_arr = mf_cc_vel.const_array(mfi);
 
-        ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            Real x = prob_lo[0] + (i+myhalf)*dx[0];
-            Real y = prob_lo[1] + (j+myhalf)*dx[1];
+        ParallelFor(box, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            Real x = prob_lo[0] + (i+myhalf_d)*dx[0];
+            Real y = prob_lo[1] + (j+myhalf_d)*dx[1];
             Real dist = std::sqrt((x-x_eye)*(x-x_eye) +
                                          (y-y_eye)*(y-y_eye));
             if(k==1 && dist < 200e3) {
-                Real velmag = zero;
+                Real velmag = zero_d;
                 for (int comp = 0; comp < ncomp; ++comp) {
                     Real vel = vel_arr(i, j, k, comp);
                     velmag += vel * vel;
@@ -576,9 +576,9 @@ ERF::HurricaneMinPressureTracker (MoistureType moisture_type,
         const Box& box = mfi.validbox();
         const auto& S_arr = mf_cons_var.const_array(mfi);
 
-        ParallelFor(box, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
-            Real x = prob_lo[0] + (i+myhalf)*dx[0];
-            Real y = prob_lo[1] + (j+myhalf)*dx[1];
+        ParallelFor(box, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+            Real x = prob_lo[0] + (i+myhalf_d)*dx[0];
+            Real y = prob_lo[1] + (j+myhalf_d)*dx[1];
             Real dist2 = (x-x_last)*(x-x_last) +
                                 (y-y_last)*(y-y_last);
             if(k==1 && dist2 < 200e3*200e3) {

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -348,16 +348,16 @@ realbdy_compute_interior_ghost_rhs (const double& time,
 
             // Populate with interpolation (protect from ghost cells)
             ParallelFor(tbx_xlo, tbx_xhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 int ii = std::max(i , dom_lo.x); ii = std::min(ii, dom_lo.x+offset);
                 int jj = std::max(j , dom_lo.y); jj = std::min(jj, dom_hi.y);
 
                 Real rho_interp;
                 if (ivar==ivarU) {
-                    rho_interp = myhalf * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
                 } else if (ivar==ivarV) {
-                    rho_interp = myhalf * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
                 } else {
                     rho_interp = r_arr(i,j,k);
                 }
@@ -371,16 +371,16 @@ realbdy_compute_interior_ghost_rhs (const double& time,
                                                   + alpha * bdatxlo_np1(ii,jj,k,0) );
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 int ii = std::max(i , dom_hi.x-offset); ii = std::min(ii, dom_hi.x);
                 int jj = std::max(j , dom_lo.y);        jj = std::min(jj, dom_hi.y);
 
                 Real rho_interp;
                 if (ivar==ivarU) {
-                    rho_interp = myhalf * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
                 } else if (ivar==ivarV) {
-                    rho_interp = myhalf * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
                 } else {
                     rho_interp = r_arr(i,j,k);
                 }
@@ -396,16 +396,16 @@ realbdy_compute_interior_ghost_rhs (const double& time,
             });
 
             ParallelFor(tbx_ylo, tbx_yhi,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 int ii = std::max(i , dom_lo.x); ii = std::min(ii, dom_hi.x);
                 int jj = std::max(j , dom_lo.y); jj = std::min(jj, dom_lo.y+offset);
 
                 Real rho_interp;
                 if (ivar==ivarU) {
-                    rho_interp = myhalf * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
                 } else if (ivar==ivarV) {
-                    rho_interp = myhalf * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
                 } else {
                     rho_interp = r_arr(i,j,k);
                 }
@@ -419,16 +419,16 @@ realbdy_compute_interior_ghost_rhs (const double& time,
                                                   + alpha * bdatylo_np1(ii,jj,k,0) );
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 int ii = std::max(i , dom_lo.x);        ii = std::min(ii, dom_hi.x);
                 int jj = std::max(j , dom_hi.y-offset); jj = std::min(jj, dom_hi.y);
 
                 Real rho_interp;
                 if (ivar==ivarU) {
-                    rho_interp = myhalf * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i-1,j  ,k) + r_arr(i,j,k) );
                 } else if (ivar==ivarV) {
-                    rho_interp = myhalf * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
+                    rho_interp = myhalf_d * ( r_arr(i  ,j-1,k) + r_arr(i,j,k) );
                 } else {
                     rho_interp = r_arr(i,j,k);
                 }
@@ -712,10 +712,10 @@ fine_compute_interior_ghost_rhs (const double& time,
                 const Array4<const Real>& rho_arr  = fmf_p_v[0].const_array(mfi);
                 const Array4<const int>&  mask_arr = mask->const_array(mfi);
 
-                ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (mask_arr(i,j,k) == relax_mask_val) {
-                        Real rho_interp = myhalf * ( rho_arr(i-1,j,k) + rho_arr(i,j,k) );
+                        Real rho_interp = myhalf_d * ( rho_arr(i-1,j,k) + rho_arr(i,j,k) );
                         prim_arr(i,j,k) *= rho_interp;
                     }
                 });
@@ -739,10 +739,10 @@ fine_compute_interior_ghost_rhs (const double& time,
                 const Array4<const Real>& rho_arr  = fmf_p_v[0].const_array(mfi);
                 const Array4<const int>&  mask_arr = mask->const_array(mfi);
 
-                ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (mask_arr(i,j,k) == relax_mask_val) {
-                        Real rho_interp = myhalf * ( rho_arr(i,j-1,k) + rho_arr(i,j,k) );
+                        Real rho_interp = myhalf_d * ( rho_arr(i,j-1,k) + rho_arr(i,j,k) );
                         prim_arr(i,j,k) *= rho_interp;
                     }
                 });
@@ -766,10 +766,10 @@ fine_compute_interior_ghost_rhs (const double& time,
                 const Array4<const Real>& rho_arr  = fmf_p_v[0].const_array(mfi);
                 const Array4<const int>&  mask_arr = mask->const_array(mfi);
 
-                ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+                ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
                 {
                     if (mask_arr(i,j,k) == relax_mask_val) {
-                        Real rho_interp = myhalf * ( rho_arr(i,j,k-1) + rho_arr(i,j,k) );
+                        Real rho_interp = myhalf_d * ( rho_arr(i,j,k-1) + rho_arr(i,j,k) );
                         prim_arr(i,j,k) *= rho_interp;
                     }
                 });
@@ -790,10 +790,10 @@ fine_compute_interior_ghost_rhs (const double& time,
             const Array4<Real>& rhs_arr  = rhs.array(mfi);
             const Array4<const int>& mask_arr = mask->const_array(mfi);
 
-            ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+            ParallelFor(tbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 if (mask_arr(i,j,k) == set_mask_val) {
-                    rhs_arr(i,j,k) = zero;
+                    rhs_arr(i,j,k) = zero_d;
                 }
             });
         } // mfi
@@ -825,7 +825,7 @@ fine_compute_interior_ghost_rhs (const double& time,
             int Relax_z = width - Spec_z;
             Real num    = Real(Spec_z + Relax_z);
             Real denom  = Real(Relax_z - 1);
-            ParallelFor(tbx, num_var, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
+            ParallelFor(tbx, num_var, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept
             {
                if (mask_arr(i,j,k) == relax_mask_val) {
 
@@ -860,15 +860,15 @@ fine_compute_interior_ghost_rhs (const double& time,
 
                    // Found a nearby masked cell (valid n_ind)
                    if (mask_x_found && mask_y_found) {
-                       n_ind = std::min(ii,jj) + one;
+                       n_ind = std::min(ii,jj) + one_d;
                    } else if (mask_x_found) {
-                       n_ind = ii + one;
+                       n_ind = ii + one_d;
                    } else if (mask_y_found) {
-                       n_ind = jj + one;
+                       n_ind = jj + one_d;
                    // Pesky corner cell
                    } else {
                        if (near_x_lo_wall || near_x_hi_wall) {
-                           Real dj_min{width-one};
+                           Real dj_min{width-one_d};
                            int j_lb = std::max(vbx_lo.y,j-width);
                            int j_ub = std::min(vbx_hi.y,j+width);
                            int li   = (near_x_lo_wall) ? vbx_lo.x : vbx_hi.x;
@@ -880,12 +880,12 @@ fine_compute_interior_ghost_rhs (const double& time,
                            }
                            if (mask_y_found) {
                                Real mag = std::sqrt( Real(dj_min*dj_min + ii*ii) );
-                               n_ind = std::min(mag,width-one) + one;
+                               n_ind = std::min(mag,width-one_d) + one_d;
                            } else {
                                Abort("Mask not found near x wall!");
                            }
                        } else if (near_y_lo_wall || near_y_hi_wall) {
-                           Real di_min{width-one};
+                           Real di_min{width-one_d};
                            int i_lb = std::max(vbx_lo.x,i-width);
                            int i_ub = std::min(vbx_hi.x,i+width);
                            int lj   = (near_y_lo_wall) ? vbx_lo.y : vbx_hi.y;
@@ -897,7 +897,7 @@ fine_compute_interior_ghost_rhs (const double& time,
                            }
                            if (mask_x_found) {
                                Real mag = std::sqrt( Real(di_min*di_min + jj*jj) );
-                               n_ind = std::min(mag,width-one) + one;
+                               n_ind = std::min(mag,width-one_d) + one_d;
                            } else {
                                Abort("Mask not found near y wall!");
                            }

--- a/Source/Utils/ERF_MomentumToVelocity.cpp
+++ b/Source/Utils/ERF_MomentumToVelocity.cpp
@@ -60,38 +60,38 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
 
         if (c_vfrac==nullptr) {
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                velx(i,j,k) = momx(i,j,k) * two / (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
+            [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) {
+                velx(i,j,k) = momx(i,j,k) * two_d / (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                vely(i,j,k) = momy(i,j,k) * two / (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
+            [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) {
+                vely(i,j,k) = momy(i,j,k) * two_d / (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                velz(i,j,k) = momz(i,j,k) * two / (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
+            [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k) {
+                velz(i,j,k) = momz(i,j,k) * two_d / (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
             });
         } else {
             // EB
             const Array4<const Real>& c_vfrac_arr = c_vfrac->const_array(mfi);
 
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i-1,j,k) > zero) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i-1,j,k) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i-1,j,k) * dens_arr(i-1,j,k,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i-1,j,k));
                     velx(i,j,k) = momx(i,j,k) / rho;
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i,j-1,k) > zero) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i,j-1,k) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i,j-1,k) * dens_arr(i,j-1,k,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i,j-1,k));
                     vely(i,j,k) = momy(i,j,k) / rho;
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i,j,k-1) > zero) {
+            [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i,j,k-1) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i,j,k-1) * dens_arr(i,j,k-1,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i,j,k-1));
@@ -109,8 +109,8 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momx(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momx(i,j,k) >= zero_d) {
                         velx(i,j,k) = momx(i,j,k) / dens_arr(i-1,j,k,Rho_comp);
                     }
                 });
@@ -126,8 +126,8 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momx(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momx(i,j,k) <= zero_d) {
                         velx(i,j,k) = momx(i,j,k) / dens_arr(i,j,k,Rho_comp);
                     }
                 });
@@ -143,8 +143,8 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momy(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momy(i,j,k) >= zero_d) {
                         vely(i,j,k) = momy(i,j,k) / dens_arr(i,j-1,k,Rho_comp);
                     }
                 });
@@ -160,8 +160,8 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (momy(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (momy(i,j,k) <= zero_d) {
                         vely(i,j,k) = momy(i,j,k) / dens_arr(i,j,k,Rho_comp);
                     }
                 });

--- a/Source/Utils/ERF_PlaneAverage.H
+++ b/Source/Utils/ERF_PlaneAverage.H
@@ -211,7 +211,7 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
         const amrex::Array4<const amrex::Real>& fab_arr  = mfab.const_array(mfi);
         const amrex::Array4<const int        >& mask_arr = mask->const_array(mfi);
 
-        amrex::ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=]
+        amrex::ParallelFor(amrex::Gpu::KernelInfo().setReduction(true), pbx, [=,one_d=one,zero_d=zero]
                     AMREX_GPU_DEVICE( int p_i, int p_j, int p_k,
                                       amrex::Gpu::Handler const& handler) noexcept
         {
@@ -226,7 +226,7 @@ PlaneAverage::compute_averages (const IndexSelector& idxOp, const amrex::MultiFa
                         // NOTE: This factor is to avoid an if statement that will break
                         //       the devicereducesum since all threads won't participate.
                         //       This more performant than Gpu::Atomic::Add.
-                        amrex::Real fac = (mask_arr(i,j,k)) ? one : zero;
+                        amrex::Real fac = (mask_arr(i,j,k)) ? one_d : zero_d;
                         amrex::Gpu::deviceReduceSum(&cnt_avg[ind], fac, handler);
                         for (int n = 0; n < ncomp; ++n) {
                             amrex::Gpu::deviceReduceSum(&line_avg[ncomp * ind + n],

--- a/Source/Utils/ERF_Rebalance.cpp
+++ b/Source/Utils/ERF_Rebalance.cpp
@@ -39,7 +39,7 @@ rebalance_columns (MultiFab& rho,
 
         const Array4<const Real>&   z_arr = z_phys->const_array(mfi);
 
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
+        ParallelFor(bx, [=,zero_d=zero,p_0_d=p_0,R_d_d=R_d,Cp_d_d=Cp_d,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int /*k*/) noexcept
         {
             // integrate from surface to domain top
             Real dz, F, C;
@@ -54,7 +54,7 @@ rebalance_columns (MultiFab& rho,
 
             // Integrate from z=0
             if (use_sfc) {
-                z_lo = zero; // corresponding to p_0
+                z_lo = zero_d; // corresponding to p_0
                 z_hi = Real(0.125) * (z_arr(i,j,klo  ) + z_arr(i+1,j,klo  ) + z_arr(i,j+1,klo  ) + z_arr(i+1,j+1,klo  )
                                      +z_arr(i,j,klo+1) + z_arr(i+1,j,klo+1) + z_arr(i,j+1,klo+1) + z_arr(i+1,j+1,klo+1));
                 dz = z_hi - z_lo;
@@ -63,30 +63,30 @@ rebalance_columns (MultiFab& rho,
                 qt_lo = qt_arr(i,j,klo);
                 qv_lo = qv_arr(i,j,klo);
                 Th_lo = th_arr(i,j,klo);
-                P_lo  = p_0;
-                R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-                rho_tot_lo = R_lo * (one + qt_lo);
-                C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+                P_lo  = p_0_d;
+                R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
+                rho_tot_lo = R_lo * (one_d + qt_lo);
+                C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
                 // Initial guess and residual
                 qt_hi = qt_arr(i,j,klo);
                 qv_hi = qv_arr(i,j,klo);
                 Th_hi = th_arr(i,j,klo);
-                P_hi  = p_0;
-                T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-                R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-                rho_tot_hi = R_hi * (one + qt_hi);
-                F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+                P_hi  = p_0_d;
+                T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+                R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
+                rho_tot_hi = R_hi * (one_d + qt_hi);
+                F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
                 // Do iterations
-                HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+                HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                              grav, C, Th_hi, T_hi,
                                              qt_hi, qv_hi,
                                              P_hi, R_hi, F, maintain_Th);
 
                 // Assign data
                 rho_arr(i,j,klo) = R_hi;
-                if (!maintain_Th) { th_arr(i,j,klo)  = getThgivenTandP(T_hi, P_hi, R_d/Cp_d); }
+                if (!maintain_Th) { th_arr(i,j,klo)  = getThgivenTandP(T_hi, P_hi, R_d_d/Cp_d_d); }
                 P_lo = P_hi;
                 z_lo = z_hi;
 
@@ -108,28 +108,28 @@ rebalance_columns (MultiFab& rho,
               qt_lo = qt_arr(i,j,k-1);
               qv_lo = qv_arr(i,j,k-1);
               Th_lo = th_arr(i,j,k-1);
-              R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d/Cp_d, qv_lo);
-              rho_tot_lo = R_lo * (one + qt_lo);
-              C  = -P_lo + myhalf*rho_tot_lo*grav*dz;
+              R_lo  = getRhogivenThetaPress(Th_lo, P_lo, R_d_d/Cp_d_d, qv_lo);
+              rho_tot_lo = R_lo * (one_d + qt_lo);
+              C  = -P_lo + myhalf_d*rho_tot_lo*grav*dz;
 
               // Initial guess and residual
               qt_hi = qt_arr(i,j,k);
               qv_hi = qv_arr(i,j,k);
               Th_hi = th_arr(i,j,k);
-              T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d/Cp_d);
-              R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d/Cp_d, qv_hi);
-              rho_tot_hi = R_hi * (one + qt_hi);
-              F = P_hi + myhalf*rho_tot_hi*grav*dz + C;
+              T_hi  = getTgivenPandTh(P_hi, Th_hi, R_d_d/Cp_d_d);
+              R_hi  = getRhogivenThetaPress(Th_hi, P_hi, R_d_d/Cp_d_d, qv_hi);
+              rho_tot_hi = R_hi * (one_d + qt_hi);
+              F = P_hi + myhalf_d*rho_tot_hi*grav*dz + C;
 
               // Do iterations
-              HSEutils::Newton_Raphson_hse(tol, R_d/Cp_d, dz,
+              HSEutils::Newton_Raphson_hse(tol, R_d_d/Cp_d_d, dz,
                                            grav, C, Th_hi, T_hi,
                                            qt_hi, qv_hi,
                                            P_hi, R_hi, F, maintain_Th);
 
               // Assign data
               rho_arr(i,j,k) = R_hi;
-              if (!maintain_Th) { th_arr(i,j,k)  = getThgivenTandP(T_hi, P_hi, R_d/Cp_d); }
+              if (!maintain_Th) { th_arr(i,j,k)  = getThgivenTandP(T_hi, P_hi, R_d_d/Cp_d_d); }
               P_lo = P_hi;
               z_lo = z_hi;
             }

--- a/Source/Utils/ERF_SurfaceDataInterpolation.cpp
+++ b/Source/Utils/ERF_SurfaceDataInterpolation.cpp
@@ -109,11 +109,11 @@ ERF::FillSurfaceStateMultiFabs(const int lev,
         const Box gbx = mfi.growntilebox();
         const Array4<Real>& surf_arr = surface_state[lev].array(mfi);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
             if(k == 0) {
-                const Real x        = prob_lo[0] + (i + myhalf) * dx[0];
-                const Real y        = prob_lo[1] + (j + myhalf) * dx[1];
+                const Real x        = prob_lo[0] + (i + myhalf_d) * dx[0];
+                const Real y        = prob_lo[1] + (j + myhalf_d) * dx[1];
 
                 // First interpolate where the weather data is available from
                 Real tmp_ls_mask, tmp_sst;

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -32,9 +32,9 @@ init_default_zphys (int /*lev*/, const Geometry& geom, MultiFab& z_phys_nd, Mult
     {
         const Box& bx = mfi.growntilebox();
         const Array4< Real> z_cc_arr = z_phys_cc.array(mfi);
-        ParallelFor(bx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(bx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            z_cc_arr(i,j,k) = (k + myhalf) * dz - z_offset;
+            z_cc_arr(i,j,k) = (k + myhalf_d) * dz - z_offset;
         });
     }
 }
@@ -266,9 +266,9 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                 Array4<Real> const& z_arr = z_phys_nd.array(mfi);
 
                 // Fill lateral boundaries below the bottom surface
-                ParallelFor(makeSlab(gbx,2,0), [=] AMREX_GPU_DEVICE (int i, int j, int)
+                ParallelFor(makeSlab(gbx,2,0), [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int)
                 {
-                    z_arr(i,j,-1) = two*z_arr(i,j,0) - z_arr(i,j,1);
+                    z_arr(i,j,-1) = two_d*z_arr(i,j,0) - z_arr(i,j,1);
                 });
             }
         } // mfi
@@ -416,7 +416,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                 Array4<Real> const& h_s   = h_mf_old.array(mfi);
                 Array4<Real> const& z_arr = z_phys_nd.array(mfi);
 
-                ParallelFor(xybx, [=] AMREX_GPU_DEVICE (int i, int j, int) {
+                ParallelFor(xybx, [=,two_d=two] AMREX_GPU_DEVICE (int i, int j, int) {
 
                     // Location of nodes
                     Real z = z_lev_d[k];
@@ -426,7 +426,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
 
                     // Fill below the bottom surface
                     if (k == 1) {
-                        z_arr(i,j,k0-1) = two*z_arr(i,j,k0) - z_arr(i,j,k);
+                        z_arr(i,j,k0-1) = two_d*z_arr(i,j,k0) - z_arr(i,j,k);
                     }
                 });
             } // mfi
@@ -450,7 +450,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                 Array4<Real> const& z_arr = z_phys_nd.array(mfi);
                 auto const&         z_lev = z_levels_d.data();
 
-                ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(gbx, [=,one_d=one,two_d=two] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     // Vertical grid stretching
                     Real z =  z_lev[k];
@@ -460,14 +460,14 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
 
                     // Fill levels using model from Sullivan et. al. 2014
                     int omega = 3; //Used to adjust how rapidly grid lines level out. omega=1 is BTF!
-                    z_arr(i,j,k) = z + static_cast<Real>(std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
+                    z_arr(i,j,k) = z + static_cast<Real>(std::pow((one_d - (z/z_top)),omega) * z_arr(ii,jj,k0));
 
                     // Fill lateral boundaries and below the bottom surface
                     if (k == k0) {
                         z_arr(i,j,k0  ) = z_arr(ii,jj,k0);
                     }
                     if (k == 1) {
-                        z_arr(i,j,k0-1) = two*z_arr(ii,jj,k0) - z_arr(i,j,k);
+                        z_arr(i,j,k0-1) = two_d*z_arr(ii,jj,k0) - z_arr(i,j,k);
                     }
                 });
             } // mfi
@@ -487,7 +487,7 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                 Array4<Real> const& z_arr = z_phys_nd.array(mfi);
                 auto const&         z_lev = z_levels_d.data();
 
-                ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(gbx, [=,one_d=one] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
                     // Vertical grid stretching
                     Real z =  z_lev[k];
@@ -501,13 +501,13 @@ init_which_terrain_grid (int lev, Geometry const& geom, MultiFab& z_phys_nd,
                     } else {
                         // Fill levels using model from Sullivan et. al. 2014
                         int omega = 3; //Used to adjust how rapidly grid lines level out. omega=1 is BTF!
-                        z_arr(i,j,k) = z + static_cast<Real>(std::pow((one - (z/z_top)),omega) * z_arr(ii,jj,k0));
+                        z_arr(i,j,k) = z + static_cast<Real>(std::pow((one_d - (z/z_top)),omega) * z_arr(ii,jj,k0));
                     }
                 });
                 gbx.setBig(2,0);
-                ParallelFor(gbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+                ParallelFor(gbx, [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k)
                 {
-                    z_arr(i,j,k  ) = zero;
+                    z_arr(i,j,k  ) = zero_d;
                     z_arr(i,j,k-1) = -z_arr(i,j,k+1);
                 });
             } // mfi

--- a/Source/Utils/ERF_TimeAvgVel.cpp
+++ b/Source/Utils/ERF_TimeAvgVel.cpp
@@ -34,11 +34,11 @@ Time_Avg_Vel_atCC (double dt_d,
         // Time average at CC
         Array4<Real> vel_t_avg_arr = vel_t_avg->array(mfi);
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        ParallelFor(tbx, [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k)
         {
-            Real u_cc = myhalf * ( velx(i,j,k) + velx(i+1,j  ,k  ) );
-            Real v_cc = myhalf * ( vely(i,j,k) + vely(i  ,j+1,k  ) );
-            Real w_cc = myhalf * ( velz(i,j,k) + velz(i  ,j  ,k+1) );
+            Real u_cc = myhalf_d * ( velx(i,j,k) + velx(i+1,j  ,k  ) );
+            Real v_cc = myhalf_d * ( vely(i,j,k) + vely(i  ,j+1,k  ) );
+            Real w_cc = myhalf_d * ( velz(i,j,k) + velz(i  ,j  ,k+1) );
             Real umag_cc = std::sqrt(u_cc*u_cc + v_cc*v_cc + w_cc*w_cc);
             vel_t_avg_arr(i,j,k,0) += u_cc * dt;
             vel_t_avg_arr(i,j,k,1) += v_cc * dt;

--- a/Source/Utils/ERF_Utils.H
+++ b/Source/Utils/ERF_Utils.H
@@ -270,7 +270,7 @@ realbdy_compute_relaxation (const int& icomp,
     int nq = num_var;
 
     amrex::ParallelFor( bx_xlo, bx_xhi,
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         // Corners with x boxes
         amrex::Real x = ProbLo[0] + (i + ioff) * dx[0];
@@ -279,8 +279,8 @@ realbdy_compute_relaxation (const int& icomp,
         amrex::Real y_end  = ProbLo[1] + width * dx[1];
         amrex::Real y_strt = ProbHi[1] - width * dx[1];
         amrex::Real xi     = (x_end - x) / (x_end - ProbLo[0]);
-        amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : zero;
-        amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : zero;
+        amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : zero_d;
+        amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : zero_d;
         amrex::Real eta    = std::max(eta_lo,eta_hi);
         amrex::Real Factor = std::max(xi*xi,eta*eta) * F1;
 
@@ -314,7 +314,7 @@ realbdy_compute_relaxation (const int& icomp,
             }
         }
     },
-    [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+    [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
     {
         // Corners with x boxes
         amrex::Real x = ProbLo[0] + (i + ioff) * dx[0];
@@ -323,8 +323,8 @@ realbdy_compute_relaxation (const int& icomp,
         amrex::Real y_strt = ProbHi[1] - width * dx[1];
         amrex::Real y_end  = ProbLo[1] + width * dx[1];
         amrex::Real xi     = (x - x_strt) / (ProbHi[0] - x_strt);
-        amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : zero;
-        amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : zero;
+        amrex::Real eta_lo = (y < y_end ) ? (y_end  - y) / (y_end  - ProbLo[1]) : zero_d;
+        amrex::Real eta_hi = (y > y_strt) ? (y - y_strt) / (ProbHi[1] - y_strt) : zero_d;
         amrex::Real eta    = std::max(eta_lo,eta_hi);
         amrex::Real Factor = std::max(xi*xi,eta*eta) * F1;
 

--- a/Source/Utils/ERF_VelocityToMomentum.cpp
+++ b/Source/Utils/ERF_VelocityToMomentum.cpp
@@ -79,48 +79,48 @@ void VelocityToMomentum (const MultiFab& xvel_in,
 
         if (c_vfrac==nullptr) {
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                momx(i,j,k) = velx(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                momx(i,j,k) = velx(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                momy(i,j,k) = vely(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                momy(i,j,k) = vely(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                momz(i,j,k) = velz(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
+            [=,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                momz(i,j,k) = velz(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
             });
         } else {
             // EB
             const Array4<const Real>& c_vfrac_arr = c_vfrac->const_array(mfi);
 
             ParallelFor(tbx, tby, tbz,
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i-1,j,k) > zero) {
+            [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i-1,j,k) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i-1,j,k) * dens_arr(i-1,j,k,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i-1,j,k));
                     momx(i,j,k) = velx(i,j,k) * rho;
                 } else {
-                    momx(i,j,k) = velx(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
+                    momx(i,j,k) = velx(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i-1,j,k,Rho_comp));
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i,j-1,k) > zero) {
+            [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i,j-1,k) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i,j-1,k) * dens_arr(i,j-1,k,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i,j-1,k));
                     momy(i,j,k) = vely(i,j,k) * rho;
                 } else {
-                    momy(i,j,k) = vely(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
+                    momy(i,j,k) = vely(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j-1,k,Rho_comp));
                 }
             },
-            [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                if (c_vfrac_arr(i,j,k) > zero || c_vfrac_arr(i,j,k-1) > zero) {
+            [=,zero_d=zero,myhalf_d=myhalf] AMREX_GPU_DEVICE (int i, int j, int k) {
+                if (c_vfrac_arr(i,j,k) > zero_d || c_vfrac_arr(i,j,k-1) > zero_d) {
                     Real rho = (c_vfrac_arr(i,j,k) * dens_arr(i,j,k,Rho_comp)
                             + c_vfrac_arr(i,j,k-1) * dens_arr(i,j,k-1,Rho_comp))
                             / (c_vfrac_arr(i,j,k) + c_vfrac_arr(i,j,k-1));
                     momz(i,j,k) = velz(i,j,k) * rho;
                 } else {
-                    momz(i,j,k) = velz(i,j,k) * myhalf * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
+                    momz(i,j,k) = velz(i,j,k) * myhalf_d * (dens_arr(i,j,k,Rho_comp) + dens_arr(i,j,k-1,Rho_comp));
                 }
             });
         }
@@ -135,8 +135,8 @@ void VelocityToMomentum (const MultiFab& xvel_in,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (velx(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (velx(i,j,k) >= zero_d) {
                         momx(i,j,k) = velx(i,j,k) * dens_arr(i-1,j,k,Rho_comp);
                     }
                 });
@@ -152,8 +152,8 @@ void VelocityToMomentum (const MultiFab& xvel_in,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.bigEnd(0)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (velx(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tbx,0,domain.bigEnd(0)+1), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (velx(i,j,k) <= zero_d) {
                         momx(i,j,k) = velx(i,j,k) * dens_arr(i,j,k,Rho_comp);
                     }
                 });
@@ -169,8 +169,8 @@ void VelocityToMomentum (const MultiFab& xvel_in,
             }
             else if (bc_ptr_h[BCVars::cons_bc].lo(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (vely(i,j,k) >= zero) {
+                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (vely(i,j,k) >= zero_d) {
                         momy(i,j,k) = vely(i,j,k) * dens_arr(i,j-1,k,Rho_comp);
                     }
                 });
@@ -186,8 +186,8 @@ void VelocityToMomentum (const MultiFab& xvel_in,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.bigEnd(1)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
-                    if (vely(i,j,k) <= zero) {
+                ParallelFor(makeSlab(tby,1,domain.bigEnd(1)+1), [=,zero_d=zero] AMREX_GPU_DEVICE (int i, int j, int k) {
+                    if (vely(i,j,k) <= zero_d) {
                         momy(i,j,k) = vely(i,j,k) * dens_arr(i,j,k,Rho_comp);
                     }
                 });

--- a/Source/Utils/ERF_WeatherDataInterpolation.cpp
+++ b/Source/Utils/ERF_WeatherDataInterpolation.cpp
@@ -178,12 +178,12 @@ ERF::FillForecastStateMultiFabs(const int lev,
         const auto dx       = geom[lev].CellSizeArray();
        //const Box &gtbz = mfi.tilebox(IntVect(0,0,1));
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,myhalf_d=myhalf,two_d=two,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             // Geometry (note we must include these here to get the data on device)
-            const Real x        = prob_lo[0] + (i + myhalf) * dx[0];
-            const Real y        = prob_lo[1] + (j + myhalf) * dx[1];
+            const Real x        = prob_lo[0] + (i + myhalf_d) * dx[0];
+            const Real y        = prob_lo[1] + (j + myhalf_d) * dx[1];
             //const Real z        = prob_lo[2] + (k + myhalf) * dx[2];
-            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two;
+            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two_d;
 
             // First interpolate where the weather data is available from
             Real tmp_rho, tmp_theta, tmp_qv, tmp_qc, tmp_qr, tmp_lat, tmp_lon;
@@ -220,13 +220,13 @@ ERF::FillForecastStateMultiFabs(const int lev,
             bilinear_interpolation(xvec_d_ptr, yvec_d_ptr, zvec_d_ptr,
                                    dxvec, dyvec,
                                    nx, ny, 1,
-                                   x, y, zero,
+                                   x, y, zero_d,
                                    latvec_d_ptr, tmp_lat);
 
             bilinear_interpolation(xvec_d_ptr, yvec_d_ptr, zvec_d_ptr,
                                    dxvec, dyvec,
                                    nx, ny, 1,
-                                   x, y, zero,
+                                   x, y, zero_d,
                                    lonvec_d_ptr, tmp_lon);
 
             fine_cons_arr(i,j,k,Rho_comp) = tmp_rho;
@@ -235,12 +235,12 @@ ERF::FillForecastStateMultiFabs(const int lev,
         });
 
         ParallelFor(gtbx, gtby, gtbz,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        [=,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) {
              // Physical location of the fine node
             Real x = prob_lo_erf[0] + i       * dx_erf[0];
-            Real y = prob_lo_erf[1] + (j+myhalf) * dx_erf[1];
+            Real y = prob_lo_erf[1] + (j+myhalf_d) * dx_erf[1];
             //Real z = prob_lo_erf[2] + (k+myhalf) * dx_erf[2];
-            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two;
+            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two_d;
 
             Real tmp_uvel;
             bilinear_interpolation(xvec_d_ptr, yvec_d_ptr, zvec_d_ptr,
@@ -251,12 +251,12 @@ ERF::FillForecastStateMultiFabs(const int lev,
 
             fine_xvel_arr(i, j, k, 0) = tmp_uvel;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        [=,myhalf_d=myhalf,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) {
              // Physical location of the fine node
-            Real x = prob_lo_erf[0] + (i+myhalf) * dx_erf[0];
+            Real x = prob_lo_erf[0] + (i+myhalf_d) * dx_erf[0];
             Real y = prob_lo_erf[1] + j       * dx_erf[1];
             //Real z = prob_lo_erf[2] + (k+myhalf) * dx_erf[2];
-            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two;
+            const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two_d;
 
             Real tmp_vvel;
             bilinear_interpolation(xvec_d_ptr, yvec_d_ptr, zvec_d_ptr,
@@ -267,10 +267,10 @@ ERF::FillForecastStateMultiFabs(const int lev,
 
             fine_yvel_arr(i, j, k, 0) = tmp_vvel;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+        [=,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) {
              // Physical location of the fine node
-            Real x = prob_lo_erf[0] + (i+myhalf) * dx_erf[0];
-            Real y = prob_lo_erf[1] + (j+myhalf) * dx_erf[1];
+            Real x = prob_lo_erf[0] + (i+myhalf_d) * dx_erf[0];
+            Real y = prob_lo_erf[1] + (j+myhalf_d) * dx_erf[1];
             Real z = prob_lo_erf[2] + k       * dx_erf[2];
             //const Real z = (z_arr(i,j,k) + z_arr(i,j,k+1))/two;
 

--- a/Source/WindFarmParametrization/ERF_WindFarm.cpp
+++ b/Source/WindFarmParametrization/ERF_WindFarm.cpp
@@ -510,7 +510,7 @@ WindFarm::fill_SMark_multifab_mesoscale_models (const Geometry& geom,
         const Array4<const Real>& z_nd_arr = z_phys_nd->const_array(mfi);
         int k0 = gbx.smallEnd()[2];
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             if(Nturb_array(i,j,k,0) > 0) {
                 int li = amrex::min(amrex::max(i, i_lo), i_hi);
                 int lj = amrex::min(amrex::max(j, j_lo), j_hi);
@@ -521,7 +521,7 @@ WindFarm::fill_SMark_multifab_mesoscale_models (const Geometry& geom,
 
                 Real zturb = z_nd_arr(li,lj,k0) + d_hub_height;
                 if (zturb+1e-3 > z1 and zturb+1e-3 < z2) {
-                    SMark_array(i,j,k,0) = one;
+                    SMark_array(i,j,k,0) = one_d;
                 }
             }
         });
@@ -747,5 +747,4 @@ WindFarm::write_actuator_disks_vtk (const Geometry& geom,
         fclose(file_averaging_disks_in_dom);
     }
 }
-
 

--- a/Source/WindFarmParametrization/EWP/ERF_AdvanceEWP.cpp
+++ b/Source/WindFarmParametrization/EWP/ERF_AdvanceEWP.cpp
@@ -60,12 +60,12 @@ EWP::compute_power_output (const MultiFab& cons_in,
         auto w_vel          = W_old.array(mfi);
         Box tbx = mfi.nodaltilebox(0);
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(tbx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
-            if(SMark_array(i,j,k,0) == one) {
+            if(SMark_array(i,j,k,0) == one_d) {
                 Real avg_vel = std::pow(u_vel(i,j,k)*u_vel(i,j,k) +
                                         v_vel(i,j,k)*v_vel(i,j,k) +
-                                        w_vel(i,j,k)*w_vel(i,j,k),myhalf);
+                                        w_vel(i,j,k)*w_vel(i,j,k),myhalf_d);
                 Real turb_power = interpolate_1d(d_wind_speed_ptr, d_power_ptr, avg_vel, n_spec_table);
                 turb_power = turb_power*Nturb_array(i,j,k,0);
                 Gpu::Atomic::Add(d_total_power_ptr,turb_power);
@@ -109,13 +109,13 @@ EWP::update (const double& dt_advance,
         auto v_vel       = V_old.array(mfi);
 
         ParallelFor(tbx, tby, bx,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            u_vel(i,j,k) = u_vel(i,j,k) + (ewp_array(i-1,j,k,0) + ewp_array(i,j,k,0))/two*dt_advance;
+            u_vel(i,j,k) = u_vel(i,j,k) + (ewp_array(i-1,j,k,0) + ewp_array(i,j,k,0))/two_d*dt_advance;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            v_vel(i,j,k) = v_vel(i,j,k) + (ewp_array(i,j-1,k,1) + ewp_array(i,j,k,1))/two*dt_advance;
+            v_vel(i,j,k) = v_vel(i,j,k) + (ewp_array(i,j-1,k,1) + ewp_array(i,j,k,1))/two_d*dt_advance;
         },
         [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
@@ -173,33 +173,33 @@ EWP::source_terms_cellcentered (const Geometry& geom,
         const Real* thrust_coeff_d   = d_thrust_coeff.dataPtr();
         const int n_spec_table = static_cast<int>(d_wind_speed.size());
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,three_d=three,PI_d=PI] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
             int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
-            Real z = ProbLoArr[2] + (kk+myhalf) * dx[2];
+            Real z = ProbLoArr[2] + (kk+myhalf_d) * dx[2];
 
             // Compute Fitch source terms
 
             Real Vabs = std::pow(u_vel(i,j,k)*u_vel(i,j,k) +
                                  v_vel(i,j,k)*v_vel(i,j,k) +
-                                 w_vel(i,j,kk)*w_vel(i,j,kk), myhalf);
+                                 w_vel(i,j,kk)*w_vel(i,j,kk), myhalf_d);
 
             Real C_T = interpolate_1d(wind_speed_d, thrust_coeff_d, Vabs, n_spec_table);
 
-            Real C_TKE = zero;
+            Real C_TKE = zero_d;
             Real K_turb = Real(6.0);
 
-            Real L_wake = std::pow(dx[0]*dx[1],myhalf)/two;
-            Real sigma_e = Vabs/(three*K_turb*L_wake)*
-                           (std::pow(two*K_turb*L_wake/Vabs + std::pow(sigma_0,2),three/two) - amrex::Math::powi<3>(sigma_0));
+            Real L_wake = std::pow(dx[0]*dx[1],myhalf_d)/two_d;
+            Real sigma_e = Vabs/(three_d*K_turb*L_wake)*
+                           (std::pow(two_d*K_turb*L_wake/Vabs + std::pow(sigma_0,2),three_d/two_d) - amrex::Math::powi<3>(sigma_0));
 
             Real phi     = std::atan2(v_vel(i,j,k),u_vel(i,j,k)); // Wind direction w.r.t the x-dreiction
-            Real fac = -std::pow(PI/Real(8.0),myhalf)*C_T*amrex::Math::powi<2>(d_rotor_rad)*
+            Real fac = -std::pow(PI_d/Real(8.0),myhalf_d)*C_T*amrex::Math::powi<2>(d_rotor_rad)*
                         amrex::Math::powi<2>(Vabs)/(dx[0]*dx[1]*sigma_e)*
-                        std::exp(-myhalf*amrex::Math::powi<2>((z - d_hub_height)/sigma_e));
+                        std::exp(-myhalf_d*amrex::Math::powi<2>((z - d_hub_height)/sigma_e));
             ewp_array(i,j,k,0) = fac*std::cos(phi)*Nturb_array(i,j,k);
             ewp_array(i,j,k,1) = fac*std::sin(phi)*Nturb_array(i,j,k);
-            ewp_array(i,j,k,2) = C_TKE*zero;
+            ewp_array(i,j,k,2) = C_TKE*zero_d;
          });
     }
 }

--- a/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
+++ b/Source/WindFarmParametrization/Fitch/ERF_AdvanceFitch.cpp
@@ -83,13 +83,13 @@ Fitch::update (const double& dt_advance,
         auto v_vel       = V_old.array(mfi);
 
         ParallelFor(tbx, tby, bx,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            u_vel(i,j,k) = u_vel(i,j,k) + (fitch_array(i-1,j,k,2) + fitch_array(i,j,k,2))/two*dt_advance;
+            u_vel(i,j,k) = u_vel(i,j,k) + (fitch_array(i-1,j,k,2) + fitch_array(i,j,k,2))/two_d*dt_advance;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            v_vel(i,j,k) = v_vel(i,j,k) + (fitch_array(i,j-1,k,3) + fitch_array(i,j,k,3))/two*dt_advance;
+            v_vel(i,j,k) = v_vel(i,j,k) + (fitch_array(i,j-1,k,3) + fitch_array(i,j,k,3))/two_d*dt_advance;
         },
         [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
@@ -131,10 +131,10 @@ Fitch::compute_power_output (const MultiFab& cons_in,
         auto v_vel          = V_old.array(mfi);
         Box tbx = mfi.nodaltilebox(0);
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(tbx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
-            if(SMark_array(i,j,k,0) == one) {
-                Real avg_vel = std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf);
+            if(SMark_array(i,j,k,0) == one_d) {
+                Real avg_vel = std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf_d);
                 Real turb_power = interpolate_1d(d_wind_speed_ptr, d_power_ptr, avg_vel, n_spec_table);
                 turb_power = turb_power*Nturb_array(i,j,k,0);
                 Gpu::Atomic::Add(d_total_power_ptr,turb_power);
@@ -207,7 +207,7 @@ Fitch::source_terms_cellcentered (const Geometry& geom,
         const Real* thrust_coeff_d   = d_thrust_coeff.dataPtr();
         const int n_spec_table = static_cast<int>(d_wind_speed.size());
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,myhalf_d=myhalf,zero_d=zero] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
             Real z_k   = kk*dx[2];
@@ -219,16 +219,16 @@ Fitch::source_terms_cellcentered (const Geometry& geom,
 
             Real Vabs = std::pow(u_vel(i,j,k)*u_vel(i,j,k) +
                                  v_vel(i,j,k)*v_vel(i,j,k) +
-                                 w_vel(i,j,kk)*w_vel(i,j,kk), myhalf);
+                                 w_vel(i,j,kk)*w_vel(i,j,kk), myhalf_d);
 
             Real C_T = interpolate_1d(wind_speed_d, thrust_coeff_d, Vabs, n_spec_table);
-            Real C_TKE = zero;
+            Real C_TKE = zero_d;
 
             fitch_array(i,j,k,0) = Vabs;
-            fitch_array(i,j,k,1) =  -myhalf*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_T*Vabs*Vabs*A_ijk/(z_kp1 - z_k);
+            fitch_array(i,j,k,1) =  -myhalf_d*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_T*Vabs*Vabs*A_ijk/(z_kp1 - z_k);
             fitch_array(i,j,k,2) = u_vel(i,j,k)/Vabs*fitch_array(i,j,k,1);
             fitch_array(i,j,k,3) = v_vel(i,j,k)/Vabs*fitch_array(i,j,k,1);
-            fitch_array(i,j,k,4) = myhalf*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_TKE*amrex::Math::powi<3>(Vabs)*A_ijk/(z_kp1 - z_k);
+            fitch_array(i,j,k,4) = myhalf_d*Nturb_array(i,j,k)/(dx[0]*dx[1])*C_TKE*amrex::Math::powi<3>(Vabs)*A_ijk/(z_kp1 - z_k);
 
                  //amrex::Gpu::Atomic::Add(sum_area, A_ijk);
         });

--- a/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_AdvanceGeneralAD.cpp
+++ b/Source/WindFarmParametrization/GeneralActuatorDisk/ERF_AdvanceGeneralAD.cpp
@@ -77,17 +77,17 @@ GeneralAD::update (const double& dt_advance,
         auto w_vel       = W_old.array(mfi);
 
         ParallelFor(tbx, tby, tbz,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            u_vel(i,j,k) = u_vel(i,j,k) + (generalAD_array(i-1,j,k,0) + generalAD_array(i,j,k,0))/two*dt_advance;
+            u_vel(i,j,k) = u_vel(i,j,k) + (generalAD_array(i-1,j,k,0) + generalAD_array(i,j,k,0))/two_d*dt_advance;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            v_vel(i,j,k) = v_vel(i,j,k) + (generalAD_array(i,j-1,k,1) + generalAD_array(i,j,k,1))/two*dt_advance;
+            v_vel(i,j,k) = v_vel(i,j,k) + (generalAD_array(i,j-1,k,1) + generalAD_array(i,j,k,1))/two_d*dt_advance;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            w_vel(i,j,k) = w_vel(i,j,k) + (generalAD_array(i,j,k-1,2) + generalAD_array(i,j,k,2))/two*dt_advance;
+            w_vel(i,j,k) = w_vel(i,j,k) + (generalAD_array(i,j,k-1,2) + generalAD_array(i,j,k,2))/two_d*dt_advance;
         });
 
     }
@@ -125,13 +125,13 @@ void GeneralAD::compute_freestream_velocity (const MultiFab& cons_in,
         auto v_vel          = V_old.array(mfi);
         Box tbx = mfi.nodaltilebox(0);
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(tbx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
-            if(SMark_array(i,j,k,0) != -one) {
+            if(SMark_array(i,j,k,0) != -one_d) {
                 int turb_index = static_cast<int>(SMark_array(i,j,k,0));
                 Real phi = std::atan2(v_vel(i,j,k),u_vel(i,j,k)); // Wind direction w.r.t the x-direction
-                Gpu::Atomic::Add(&d_freestream_velocity_ptr[turb_index],std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf));
-                Gpu::Atomic::Add(&d_disk_cell_count_ptr[turb_index],one);
+                Gpu::Atomic::Add(&d_freestream_velocity_ptr[turb_index],std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf_d));
+                Gpu::Atomic::Add(&d_disk_cell_count_ptr[turb_index],one_d);
                 Gpu::Atomic::Add(&d_freestream_phi_ptr[turb_index],phi);
             }
         });
@@ -440,19 +440,19 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
         auto SMark_array    = mf_SMark.array(mfi);
         auto generalAD_array = mf_vars_generalAD.array(mfi);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,myhalf_d=myhalf,zero_d=zero,two_d=two,three_d=three,PI_d=PI,one_d=one] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
             int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
             int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
-            Real x   = ProbLoArr[0] + (ii+myhalf)*dx[0];
-            Real y   = ProbLoArr[1] + (jj+myhalf)*dx[1];
-            Real z   = ProbLoArr[2] + (kk+myhalf)*dx[2];
+            Real x   = ProbLoArr[0] + (ii+myhalf_d)*dx[0];
+            Real y   = ProbLoArr[1] + (jj+myhalf_d)*dx[1];
+            Real z   = ProbLoArr[2] + (kk+myhalf_d)*dx[2];
             // ?? Density needed here
 
             int check_int = 0;
 
-            Real source_x = zero, source_y = zero, source_z = zero;
+            Real source_x = zero_d, source_y = zero_d, source_z = zero_d;
             std::array<Real,2> Fn_and_Ft;
 
             for(long unsigned int it=0;it<nturbs;it++) {
@@ -466,14 +466,14 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
                     // Find radial distance of the point and the zeta angle
                     Real rad = std::pow( (x-d_xloc_ptr[it])*(x-d_xloc_ptr[it]) +
                                          (y-d_yloc_ptr[it])*(y-d_yloc_ptr[it]) +
-                                         (z-d_hub_height)*(z-d_hub_height), myhalf );
+                                         (z-d_hub_height)*(z-d_hub_height), myhalf_d );
 
                     int index = find_rad_loc_index(rad, bld_rad_loc_ptr, n_bld_sections);
 
                     // This if check makes sure it is a point with radial distance
                     // between the hub radius and the rotor radius.
                     // ?? hub radius needed here
-                    if(rad >= two and rad <= d_rotor_rad) {
+                    if(rad >= two_d and rad <= d_rotor_rad) {
                         //AMREX_ASSERT( (z-d_hub_height) <= rad );
                         // Consider the vector that joines the point and the turbine center.
                         // Dot it on to the vector that joins the turbine center and along
@@ -499,8 +499,8 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
                                                                d_blade_pitch_ptr,
                                                                n_spec_extra);
 
-                        Real Fn = three*Fn_and_Ft[0];
-                        Real Ft = three*Fn_and_Ft[1];
+                        Real Fn = three_d*Fn_and_Ft[0];
+                        Real Ft = three_d*Fn_and_Ft[1];
                         // Compute the source terms - pass in radial distance, free stream velocity
 
                         Real Fx = Fn*std::cos(phi) + Ft*std::sin(zeta)*std::sin(phi);
@@ -509,9 +509,9 @@ GeneralAD::source_terms_cellcentered (const Geometry& geom,
 
                         //Real dn = (
 
-                        source_x = -Fx/(two*PI*rad*dx[0])*one/std::pow(two*PI,myhalf);
-                        source_y = -Fy/(two*PI*rad*dx[0])*one/std::pow(two*PI,myhalf);
-                        source_z = -Fz/(two*PI*rad*dx[0])*one/std::pow(two*PI,myhalf);
+                        source_x = -Fx/(two_d*PI_d*rad*dx[0])*one_d/std::pow(two_d*PI_d,myhalf_d);
+                        source_y = -Fy/(two_d*PI_d*rad*dx[0])*one_d/std::pow(two_d*PI_d,myhalf_d);
+                        source_z = -Fz/(two_d*PI_d*rad*dx[0])*one_d/std::pow(two_d*PI_d,myhalf_d);
 
 
                         //printf("Val source_x, is %0.15g, %0.15g, %0.15g %0.15g %0.15g %0.15g\n", rad, Fn, Ft, source_x, source_y, source_z);

--- a/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
+++ b/Source/WindFarmParametrization/SimpleActuatorDisk/ERF_AdvanceSimpleAD.cpp
@@ -70,13 +70,13 @@ SimpleAD::update (const double& dt_advance,
         auto v_vel       = V_old.array(mfi);
 
         ParallelFor(tbx, tby,
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            u_vel(i,j,k) = u_vel(i,j,k) + (simpleAD_array(i-1,j,k,0) + simpleAD_array(i,j,k,0))/two*dt_advance;
+            u_vel(i,j,k) = u_vel(i,j,k) + (simpleAD_array(i-1,j,k,0) + simpleAD_array(i,j,k,0))/two_d*dt_advance;
         },
-        [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
+        [=,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
         {
-            v_vel(i,j,k) = v_vel(i,j,k) + (simpleAD_array(i,j-1,k,1) + simpleAD_array(i,j,k,1))/two*dt_advance;
+            v_vel(i,j,k) = v_vel(i,j,k) + (simpleAD_array(i,j-1,k,1) + simpleAD_array(i,j,k,1))/two_d*dt_advance;
         });
     }
 }
@@ -113,13 +113,13 @@ void SimpleAD::compute_freestream_velocity (const MultiFab& cons_in,
         auto v_vel          = V_old.array(mfi);
         Box tbx = mfi.nodaltilebox(0);
 
-        ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(tbx, [=,one_d=one,myhalf_d=myhalf] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
 
-            if(SMark_array(i,j,k,0) != -one) {
+            if(SMark_array(i,j,k,0) != -one_d) {
                 int turb_index = static_cast<int>(SMark_array(i,j,k,0));
                 Real phi = std::atan2(v_vel(i,j,k),u_vel(i,j,k)); // Wind direction w.r.t the x-direction
-                Gpu::Atomic::Add(&d_freestream_velocity_ptr[turb_index],std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf));
-                Gpu::Atomic::Add(&d_disk_cell_count_ptr[turb_index],one);
+                Gpu::Atomic::Add(&d_freestream_velocity_ptr[turb_index],std::pow(u_vel(i,j,k)*u_vel(i,j,k) + v_vel(i,j,k)*v_vel(i,j,k),myhalf_d));
+                Gpu::Atomic::Add(&d_disk_cell_count_ptr[turb_index],one_d);
                 Gpu::Atomic::Add(&d_freestream_phi_ptr[turb_index],phi);
             }
         });
@@ -221,14 +221,14 @@ SimpleAD::source_terms_cellcentered (const Geometry& geom,
         auto SMark_array    = mf_SMark.array(mfi);
         auto simpleAD_array = mf_vars_simpleAD.array(mfi);
 
-        ParallelFor(gbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
+        ParallelFor(gbx, [=,zero_d=zero,myhalf_d=myhalf,one_d=one,two_d=two] AMREX_GPU_DEVICE(int i, int j, int k) noexcept {
             int ii = amrex::min(amrex::max(i, domlo_x), domhi_x);
             int jj = amrex::min(amrex::max(j, domlo_y), domhi_y);
             int kk = amrex::min(amrex::max(k, domlo_z), domhi_z);
 
 
-            Real source_x = zero;
-            Real source_y = zero;
+            Real source_x = zero_d;
+            Real source_y = zero_d;
 
             int it = static_cast<int>(SMark_array(ii,jj,kk,1));
 
@@ -239,16 +239,16 @@ SimpleAD::source_terms_cellcentered (const Geometry& geom,
                 Real C_T = interpolate_1d(wind_speed_d, thrust_coeff_d, avg_vel, n_spec_table);
                 Real a;
                 if(C_T <= 1) {
-                    a = myhalf - myhalf*std::pow(one-C_T,myhalf);
+                    a = myhalf_d - myhalf_d*std::pow(one_d-C_T,myhalf_d);
                 }
                 Real Uinfty_dot_nhat = avg_vel*(std::cos(phi)*nx + std::sin(phi)*ny);
                     if(C_T <= 1) {
-                        source_x = -two*std::pow(Uinfty_dot_nhat, two)*a*(one-a)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::cos(phi);
-                        source_y = -two*std::pow(Uinfty_dot_nhat, two)*a*(one-a)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::sin(phi);
+                        source_x = -two_d*std::pow(Uinfty_dot_nhat, two_d)*a*(one_d-a)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::cos(phi);
+                        source_y = -two_d*std::pow(Uinfty_dot_nhat, two_d)*a*(one_d-a)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::sin(phi);
                     }
                     else {
-                        source_x = -myhalf*C_T*std::pow(Uinfty_dot_nhat, two)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::cos(phi);
-                        source_y = -myhalf*C_T*std::pow(Uinfty_dot_nhat, two)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::sin(phi);
+                        source_x = -myhalf_d*C_T*std::pow(Uinfty_dot_nhat, two_d)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::cos(phi);
+                        source_y = -myhalf_d*C_T*std::pow(Uinfty_dot_nhat, two_d)*dx[1]*dx[2]*std::cos(d_turb_disk_angle)/(dx[0]*dx[1]*dx[2])*std::sin(phi);
                     }
              }
 


### PR DESCRIPTION
# Summary
This PR introduces an explicit capture paradigm of `[=,constant_d = constant_h]` to avoid the **undefined in device code** error that arises from copying a host constant into a kernel that calls an inline function whose signature takes that constant by reference (it has no device address).

No change in functionality is expected.

## Tests

- [x] Pass CPU regtests (in addition to workflow)
- [x] Pass GPU regtests (in addition to workflow)