### PR TITLE
Bugfix: Reading boundary planes when refinement levels are present

### DIFF
--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -83,9 +83,14 @@ void ReadBndryPlanes::define_level_data (int /*lev*/)
  * @param time Constant specifying the time for interpolation
  */
 Vector<std::unique_ptr<PlaneVector>>&
-ReadBndryPlanes::interp_in_time (const double& time)
+ReadBndryPlanes::interp_in_time (const double& time_in)
 {
-    AMREX_ALWAYS_ASSERT(m_tn <= time && time <= m_tnp2);
+    // A restart that lands exactly on a boundary-plane time can request a time a few
+    // ULP outside [m_tn, m_tnp2] because per-level t_new drifts under subcycling.
+    // Tolerate that drift, then clamp into the valid window before interpolating.
+    const double eps  = 1.0e-8 * (m_tnp2 - m_tn);
+    AMREX_ALWAYS_ASSERT(m_tn - eps <= time_in && time_in <= m_tnp2 + eps);
+    const double time = std::min(std::max(time_in, m_tn), m_tnp2);
 
     //Print() << "interp_in_time at time " << time << " given " << m_tn << " " << m_tnp1 << " " << m_tnp2 << std::endl;
     //Print() << "m_tinterp " << m_tinterp << std::endl;
@@ -143,9 +148,14 @@ ReadBndryPlanes::interp_in_time (const double& time)
  * @param time Constant specifying the time for interpolation
  */
 Vector<std::unique_ptr<PlaneVector>>&
-ReadBndryPlanes::get_tendency (const double& time)
+ReadBndryPlanes::get_tendency (const double& time_in)
 {
-    AMREX_ALWAYS_ASSERT(m_tn <= time && time <= m_tnp2);
+    // A restart that lands exactly on a boundary-plane time can request a time a few
+    // ULP outside [m_tn, m_tnp2] because per-level t_new drifts under subcycling.
+    // Tolerate that drift, then clamp into the valid window before interpolating.
+    const double eps  = 1.0e-8 * (m_tnp2 - m_tn);
+    AMREX_ALWAYS_ASSERT(m_tn - eps <= time_in && time_in <= m_tnp2 + eps);
+    const double time = std::min(std::max(time_in, m_tn), m_tnp2);
 
     if (time < m_tnp1) {
         Real idt = static_cast<Real>(1.0 / (m_tnp1 - m_tn));


### PR DESCRIPTION
# Problem
I ran an anelastic LES simulation with nested mesh refinement (`amr.max_level = 2`) and inflow boundary planes read from disk (`erf.input_bndry_planes = 1`), restarting from a checkpoint. The run aborted on the first boundary-plane read, at an `AMREX_ALWAYS_ASSERT` inside `ReadBndryPlanes::interp_in_time`. Historically I have been able to read boundary planes without issue at max_level = 0.

# Debugging
I turned on print statements around the failing assert and inspected the times involved. The checkpoint stores a per-level `t_new`, and under subcycling the fine levels drift a few ULP away from the coarse level:

```
t_new[0] = 4800
t_new[1] = 4799.9999999999527   (~5e-11 below 4800)
t_new[2] = 4800.0000000001019
```

On restart, `InitData_post`'s ghost-cell fill loop calls `FillPatchFineLevel(lev, t_new[lev])`. When the restart lands exactly on the first boundary-plane time (`m_tn = 4800`), the fine-level request `interp_in_time(4799.9999999999527)` falls a few ULP below `m_tn` and trips the strict guard:

```
AMREX_ALWAYS_ASSERT(m_tn <= time && time <= m_tnp2);
```

The same guard exists in `get_tendency`.

# Solution
Make `interp_in_time` and `get_tendency` tolerant of sub-ULP time drift: assert against a small tolerance, then clamp the requested time into `[m_tn, m_tnp2]` before interpolating. The tolerance reuses the relative `small_dt` convention already used for time comparisons in `ERF_FillPatch.cpp` (`1.e-8 × dt`), which is far larger than the ~5e-11 s drift but far smaller than the boundary-plane spacing (~0.1 s), so genuinely out-of-range requests still abort.

```
    Source/IO/ERF_ReadBndryPlanes.cpp
    // A restart that lands exactly on a boundary-plane time can request a time a few
    // ULP outside [m_tn, m_tnp2] because per-level t_new drifts under subcycling.
    // Tolerate that drift, then clamp into the valid window before interpolating. The
    // relative tolerance matches the small_dt convention used in ERF_FillPatch.cpp.
    const double eps  = 1.0e-8 * (m_tnp2 - m_tn);
    AMREX_ALWAYS_ASSERT(m_tn - eps <= time_in && time_in <= m_tnp2 + eps);
    const double time = std::min(std::max(time_in, m_tn), m_tnp2);
 ```

# Test and sanity check
After this modification, my simulation now reads the BC data, and it successfully ran for 60 seconds [without any obviously weird behavior](https://github.com/user-attachments/assets/87bd4635-1151-461d-aa34-ae4023fb83d8).

