### PR TITLE
Fix restart issue with FFT

### DIFF
--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -743,6 +743,15 @@ ERF::InitData_post ()
             } // itime
         }
 #endif
+#ifdef ERF_USE_FFT
+        for (int lev = 0; lev <= finest_level; lev++) {
+            // rebuild fft solvers here in case mesh type was changed when reading the checkpoint file
+            if ( ( (solverChoice.anelastic[lev] == 1)               || (solverChoice.project_initial_velocity[lev] == 1) ) &&
+                 ( (solverChoice.mesh_type == MeshType::ConstantDz) || (solverChoice.mesh_type == MeshType::StretchedDz) ) ) {
+                build_fft_solvers(lev);
+            }
+        }
+#endif
     } // end restart
 
 #ifdef ERF_USE_PARTICLES


### PR DESCRIPTION
This fixes an issue where the FFT solvers would not be created when restarting with anelastic, `erf.use_fft = 1` and flat terrain.

When restarting, the existing call to `build_fft_solvers(lev)` in `init_stuff()` would be skipped because the mesh type was VariableDz, even though it is later changed to StretchedDz when reading the checkpoint file. This adds another call to `build_fft_solvers()` after the checkpoint file is read in case the mesh type was changed during restart.