### PR TITLE
[IF]: Set bottom BC fluxes to 0 for immersed buildings/terrain

### DIFF
--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -1111,6 +1111,11 @@ selectable in every configuration.
      - Source code for the unified near-surface diagnostic bundle
 .. END ERF BUILT-IN 2D DIAGNOSTIC CATALOG
 
+.. note::
+
+   For the ``landmask`` variable, land is ``1`` and sea is ``0``. 
+   Buildings are ``2`` when using ImmersedForcing.
+
 If a requested fixed diagnostic is not selectable for the active configuration,
 ERF warns and skips it. The descriptor table above records metadata; it does
 not define request acceptance or guarantee a non-missing runtime value.

--- a/Docs/sphinx_doc/Plotfiles.rst
+++ b/Docs/sphinx_doc/Plotfiles.rst
@@ -1113,8 +1113,7 @@ selectable in every configuration.
 
 .. note::
 
-   For the ``landmask`` variable, land is ``1`` and sea is ``0``. 
-   Buildings are ``2`` when using ImmersedForcing.
+   For the ``landmask`` variable, land is ``1`` and sea is ``0``. Buildings are ``2`` when using ImmersedForcing.
 
 If a requested fixed diagnostic is not selectable for the active configuration,
 ERF warns and skips it. The descriptor table above records metadata; it does

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -581,11 +581,13 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
             int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
             const bool lsm_flux_is_valid = (lsm_t_flux_arr) ? (lsm_t_flux_arr(i,j,0) < lsm_undefined) :
                                                               false;
-            const bool has_land_and_flux = (static_cast<bool>(is_land) && lsm_flux_is_valid);
+            const bool has_land_and_flux = (is_land == 1 && lsm_flux_is_valid);
             if (lsm_t_flux_arr && has_land_and_flux) {
                 // LSM flux MultiFabs store kinematic fluxes for MOST parameter
                 // updates. The applied hfx array stores the conservative RHS flux.
                 Tflux = cons_arr(i,j,k,Rho_comp) * lsm_t_flux_arr(i,j,0);
+            } else if (is_land == 2) { // no temperature flux within buildings
+                Tflux = zero;
             } else {
                 Tflux = flux_comp.compute_t_flux(i, j, k,
                                                  cons_arr, velx_arr, vely_arr,
@@ -620,11 +622,13 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
                 const bool lsm_flux_is_valid = (lsm_q_flux_arr) ? (lsm_q_flux_arr(i,j,0) < lsm_undefined) :
                                                                   false;
-                const bool has_land_and_flux = (static_cast<bool>(is_land) && lsm_flux_is_valid);
+                const bool has_land_and_flux = (is_land == 1 && lsm_flux_is_valid);
                 if (lsm_q_flux_arr && has_land_and_flux) {
                     // LSM flux MultiFabs store kinematic fluxes for MOST parameter
                     // updates. The applied qfx array stores the conservative RHS flux.
                     Qflux = cons_arr(i,j,k,Rho_comp) * lsm_q_flux_arr(i,j,0);
+                } else if (is_land == 2) { // no moisture flux within buildings
+                    Qflux = zero;
                 } else {
                     Qflux = flux_comp.compute_q_flux(i, j, k,
                                                      cons_arr, velx_arr, vely_arr,
@@ -658,13 +662,13 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 int is_land_hi = (lmask_arr) ? lmask_arr(i  ,j,0) : 1;
                 int is_land_lo = (lmask_arr) ? lmask_arr(i-1,j,0) : 1;
                 const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
-                    static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_hi),
+                    static_cast<bool>(lsm_tau13_arr), is_land_hi == 1,
                     lsm_tau13_arr ? lsm_tau13_arr(i  ,j,0) : zero, lsm_undefined);
                 const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
-                    static_cast<bool>(lsm_tau13_arr), static_cast<bool>(is_land_lo),
+                    static_cast<bool>(lsm_tau13_arr), is_land_lo == 1,
                     lsm_tau13_arr ? lsm_tau13_arr(i-1,j,0) : zero, lsm_undefined);
-                const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
-                const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
+                const bool has_land_and_flux_hi = (is_land_hi == 1 && lsm_hi_flux_is_valid);
+                const bool has_land_and_flux_lo = (is_land_lo == 1 && lsm_lo_flux_is_valid);
                 if (lsm_tau13_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
                     const Real rho_hi = cons_arr(i  ,j,k,Rho_comp);
                     const Real rho_lo = cons_arr(i-1,j,k,Rho_comp);
@@ -678,6 +682,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                     stressx = result.face_stress;
                     if (!has_land_and_flux_lo) { lsm_tau13_arr(i-1,j,0) = result.low_kinematic_cache; }
                     if (!has_land_and_flux_hi) { lsm_tau13_arr(i  ,j,0) = result.high_kinematic_cache; }
+                } else if (is_land_hi == 2 || is_land_lo == 2) { // no stress within buildings
+                    stressx = zero;
                 } else {
                     stressx = flux_comp.compute_u_flux(i, j, k,
                                                        cons_arr, velx_arr, vely_arr,
@@ -707,13 +713,13 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                 int is_land_hi = (lmask_arr) ? lmask_arr(i,j  ,0) : 1;
                 int is_land_lo = (lmask_arr) ? lmask_arr(i,j-1,0) : 1;
                 const bool lsm_hi_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
-                    static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_hi),
+                    static_cast<bool>(lsm_tau23_arr), is_land_hi == 1,
                     lsm_tau23_arr ? lsm_tau23_arr(i,j  ,0) : zero, lsm_undefined);
                 const bool lsm_lo_flux_is_valid = surface_layer_stress::lsm_flux_is_valid(
-                    static_cast<bool>(lsm_tau23_arr), static_cast<bool>(is_land_lo),
+                    static_cast<bool>(lsm_tau23_arr), is_land_lo == 1,
                     lsm_tau23_arr ? lsm_tau23_arr(i,j-1,0) : zero, lsm_undefined);
-                const bool has_land_and_flux_hi = (static_cast<bool>(is_land_hi) && lsm_hi_flux_is_valid);
-                const bool has_land_and_flux_lo = (static_cast<bool>(is_land_lo) && lsm_lo_flux_is_valid);
+                const bool has_land_and_flux_hi = (is_land_hi == 1 && lsm_hi_flux_is_valid);
+                const bool has_land_and_flux_lo = (is_land_lo == 1 && lsm_lo_flux_is_valid);
                 if (lsm_tau23_arr && (has_land_and_flux_hi || has_land_and_flux_lo)) {
                     const Real rho_hi = cons_arr(i,j  ,k,Rho_comp);
                     const Real rho_lo = cons_arr(i,j-1,k,Rho_comp);
@@ -727,6 +733,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                     stressy = result.face_stress;
                     if (!has_land_and_flux_lo) { lsm_tau23_arr(i,j-1,0) = result.low_kinematic_cache; }
                     if (!has_land_and_flux_hi) { lsm_tau23_arr(i,j  ,0) = result.high_kinematic_cache; }
+                } else if (is_land_hi == 2 || is_land_lo == 2) { // no stress within buildings
+                    stressy = zero;
                 } else {
                     stressy = flux_comp.compute_v_flux(i, j, k,
                                                        cons_arr, velx_arr, vely_arr,

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -791,6 +791,20 @@ ERF::init_zphys (int lev, double elapsed_time)
         MultiFab::Subtract(*terrain_blanking[lev], EBFactory(lev).getVolFrac(), 0, 0, 1, ComputeGhostCells(solverChoice) + 2);
         terrain_blanking[lev]->FillBoundary(geom[lev].periodicity());
         init_immersed_forcing(lev); // needed for real cases
+
+        // buildings are landmask = 2
+        for (MFIter mfi(*lmask_lev[lev][0]); mfi.isValid(); ++mfi) {
+            const Box& bx2d = mfi.growntilebox();
+            auto lmask_arr = lmask_lev[lev][0]->array(mfi);
+            const auto& t_blank_arr = terrain_blanking[lev]->array(mfi);
+
+            amrex::ParallelFor(bx2d, [=] AMREX_GPU_DEVICE(int i, int j, int k) {
+                // Use k=0 for the terrain_blanking field
+                if (t_blank_arr(i, j, 0) > 0.0) {
+                    lmask_arr(i, j, k) = 2;
+                }
+            });
+        }
     }
 
     // Compute the min dz and pass to the micro model


### PR DESCRIPTION
This PR utilizes the landmask to enforce 0 fluxes (temperature, moisture, momentum) within immersed cells (`terrain_IB_mask > 0`) to prevent any numerical instabilities from occurring where immersed forcing and the surface layer interact. We set `terrain_IB_mask = 2` for anywhere buildings/terrain exist, then we enforce zero flux using the logic in `ERF_SurfaceLayer.cpp`. 

Additionally, the logic is already in place so that we do not iterate the fluxes within immersed cells; therefore, the `*_star` arrays stay as their default values. As a result, some of the surface layer variables stay as a `bogus_large_value` (such as `u_star`, `w_star`, `olen`, and `pblh`). The fact that these variables default to the large value is important for logic elsewhere in the code. We could modify the values, but the logic is such that it does not matter when using immersed forcing for ideal cases (unless I'm missing something). 

I tested this using the immersed forcing building reg test but changing the bottom no slip BC to:

`zlo.type                    = "surface_layer"`
`erf.most.z0                 = 0.1`
`erf.most_zref = 2.5`
`erf.most.surf_temp_flux    = 0.05`

Here is how the landmask looks:

<img width="1093" height="665" alt="image" src="https://github.com/user-attachments/assets/e1b78319-c39e-4d3f-8ca1-3a3bb92170ce" />

Here is how the friction velocity looks, for example:

<img width="1096" height="668" alt="image" src="https://github.com/user-attachments/assets/963d289c-4298-4986-8275-0c71e95fdff2" />

Also confirmed that this PR works with restarts for the same case as well as the immersed forcing terrain reg test.  I ran the simulations for over 600s to confirm that everything looked physical.

Testing will still need to be done for real cases, but this PR should also provide the framework such that the land surface model is not applied within buildings.

Resubmitting this PR because I screwed up my branch for the previous one.