### PR TITLE
[Data Assimilation] Pre-processing for data assimilation

### DIFF
--- a/.Exec_dev/DataAssimilation/PreProcessing/Makefile
+++ b/.Exec_dev/DataAssimilation/PreProcessing/Makefile
@@ -1,0 +1,42 @@
+#---------------------------
+# Makefile for AMReX project
+#---------------------------
+
+CXX = mpicxx
+CXXFLAGS = -O2 -std=c++17 -fopenmp -Wall
+
+# AMReX paths
+AMREX_INC = /pscratch/sd/n/nataraj2/AIModCon/GitHub/amrex_repos/amrex/include
+AMREX_LIB = /pscratch/sd/n/nataraj2/AIModCon/GitHub/amrex_repos/amrex/lib
+
+HDRS = ReadPlotFile.H
+
+LIBS = -lamrex -lpthread -lgfortran -ldl -lm -lstdc++
+
+# Executable
+EXE = out
+
+SRCS = main.cpp ReadPlotFile.cpp
+OBJS = $(SRCS:.cpp=.o)
+
+
+# Default target
+all: $(EXE)
+
+
+# Link executable
+$(EXE): $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $^ -L$(AMREX_LIB) $(LIBS)
+
+
+# Compile object files
+%.o: %.cpp $(HDRS)
+	$(CXX) $(CXXFLAGS) -I$(AMREX_INC) -c $< -o $@
+
+
+# Clean
+clean:
+	rm -f *.o $(EXE)
+
+
+.PHONY: all clean

--- a/.Exec_dev/DataAssimilation/PreProcessing/ReadPlotFile.H
+++ b/.Exec_dev/DataAssimilation/PreProcessing/ReadPlotFile.H
@@ -1,0 +1,64 @@
+#ifndef READ_PLOTFILE_H_
+#define READ_PLOTFILE_H_
+
+#include <string>
+#include <AMReX.H>
+#include <AMReX_Vector.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_PlotFileUtil.H>
+
+amrex::Vector<std::string> ReadVarNames(const std::string& filename);
+
+// ------------------------------------------------------------
+// ReadPlotFile
+//
+// var_filename  : text file containing variable names (one per line)
+// plot_filename : AMReX plotfile directory
+// mf            : MultiFab that will be defined and filled
+// ------------------------------------------------------------
+void ReadPlotFile(const std::string& var_filename,
+                  amrex::PlotFileData& pf,
+                  amrex::MultiFab& mf);
+
+void
+GetCoarseMultiFabOnFineDMap(const amrex::Geometry& geom_coarse,
+                            const amrex::Geometry& geom_fine,
+                            const amrex::MultiFab& multifab_coarse,
+                            const amrex::MultiFab& multifab_fine,
+                            amrex::MultiFab& coarse_multifab_on_fine_dmap);
+
+void
+CreateNodalMultiFabFromCellCenteredMultiFab (amrex::MultiFab& mf_nc,      // output nodal MF
+                    amrex::MultiFab& mf_cc,      // input cell-centered MF (coarse)
+                    const amrex::Geometry& geom);
+
+void
+CreateCellCenteredMultiFabFromNodalMultiFab(amrex::MultiFab& tmp_cc,   // cell-centered output
+                                            amrex::MultiFab& mf_nc);   // node-centered input
+
+// Populate a fine, cell-centered MultiFab from coarse nodal data using
+// trilinear interpolation at fine cell centers.
+// mf_cc_fine provides the fine BoxArray + DistributionMapping template.
+void
+PopulateFineCellCenteredFromCoarseNodal(const amrex::Geometry& geom_coarse,
+                                        const amrex::Geometry& geom_fine,
+                                        const amrex::MultiFab& coarse_multifab_on_fine_dmap,
+                                        const amrex::MultiFab& mf_cc_fine,
+                                        amrex::MultiFab& mf_cc_from_coarse);
+
+void
+check_large_values(const amrex::MultiFab& mf);
+
+void
+ApplyNeumannBCs(const amrex::Geometry& geom,
+                     amrex::MultiFab& mf_cc);
+
+void WriteCustomDataFile(const amrex::Geometry& geom,
+                         const amrex::MultiFab& mf_cc,
+                         const std::string& filename_custom);
+
+void AverageFineToCoarse(const amrex::MultiFab& mf_fine,
+                         amrex::MultiFab&       mf_coarse,
+                         const amrex::Geometry& geom_fine,
+                         const amrex::Geometry& geom_coarse);
+#endif

--- a/.Exec_dev/DataAssimilation/PreProcessing/ReadPlotFile.cpp
+++ b/.Exec_dev/DataAssimilation/PreProcessing/ReadPlotFile.cpp
@@ -1,0 +1,371 @@
+#include <fstream>
+#include <sstream>
+
+#include <AMReX.H>
+#include <AMReX_Vector.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_PlotFileUtil.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_BoxArray.H>
+
+#include "ReadPlotFile.H"
+
+#include <vector>
+#include <algorithm>  // for std::remove_if, std::isspace
+
+using namespace amrex;
+// ------------------------------------------------------------
+// Read variable names from a file
+// ------------------------------------------------------------
+Vector<std::string>
+ReadVarNames(const std::string& filename)
+{
+    Vector<std::string> varnames;
+    std::ifstream infile(filename);
+    if (!infile.is_open()) {
+        amrex::Abort("Cannot open variable file: " + filename);
+    }
+
+    std::string line;
+    while (std::getline(infile, line)) {
+        // trim whitespace
+        line.erase(line.begin(),
+                   std::find_if(line.begin(), line.end(),
+                                [](unsigned char ch){ return !std::isspace(ch); }));
+        line.erase(std::find_if(line.rbegin(), line.rend(),
+                                [](unsigned char ch){ return !std::isspace(ch); }).base(),
+                   line.end());
+
+        if (!line.empty()) varnames.push_back(line);
+    }
+
+    if (varnames.empty()) {
+        amrex::Abort("Variable file is empty: " + filename);
+    }
+
+    return varnames;
+}
+
+// Reads the plotfile data into cell cenetred multifab
+// Does not fill ghost cells
+void
+ReadPlotFile(const std::string& var_filename,
+             PlotFileData& pf,
+             amrex::MultiFab& mf)
+{
+    // ------------------------------------------------------------
+    // Read variable list from file
+    // ------------------------------------------------------------
+    Vector<std::string> varnames;
+    {
+        std::ifstream infile(var_filename);
+        if (!infile.is_open()) {
+            Abort("ReadPlotFile: Cannot open variable file: " + var_filename);
+        }
+
+        std::string line;
+        while (std::getline(infile, line)) {
+            if (!line.empty()) {
+                // trim whitespace
+                line.erase(0, line.find_first_not_of(" \t\r\n"));
+                line.erase(line.find_last_not_of(" \t\r\n") + 1);
+
+                if (!line.empty()) varnames.push_back(line);
+            }
+        }
+    }
+
+    if (varnames.empty()) {
+        Abort("ReadPlotFile: No variables found in " + var_filename);
+    }
+
+    // ------------------------------------------------------------
+    // Open plotfile
+    // ------------------------------------------------------------
+    const Vector<std::string>& var_names_pf = pf.varNames();
+
+    // ------------------------------------------------------------
+    // Validate requested variables
+    // ------------------------------------------------------------
+    for (auto const& v : varnames) {
+        bool found = false;
+        for (auto const& vpf : var_names_pf) {
+            if (v == vpf) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            Abort("ReadPlotFile: invalid variable name: " + v);
+        }
+    }
+
+    // ------------------------------------------------------------
+    // Define destination MultiFab (single level only)
+    // ------------------------------------------------------------
+    const int level = 0;
+
+    BoxArray ba = pf.boxArray(level);
+    DistributionMapping dm(ba);
+
+    int ncomp = varnames.size();
+    int ngrow = 1;
+
+    mf.define(ba, dm, ncomp, ngrow);
+
+    // ------------------------------------------------------------
+    // Copy plotfile data → mf
+    // ------------------------------------------------------------
+    for (int comp = 0; comp < ncomp; ++comp)
+    {
+        const MultiFab& src = pf.get(level, varnames[comp]);
+        MultiFab::Copy(mf, src, 0, comp, 1, 0);
+    }
+}
+
+void AverageFineToCoarse(
+    const MultiFab& mf_fine,
+    MultiFab&       mf_coarse,
+    const Geometry& geom_fine,
+    const Geometry& geom_coarse)
+{
+    AMREX_ALWAYS_ASSERT(mf_fine.nComp() == mf_coarse.nComp());
+
+    const int ncomp = mf_fine.nComp();
+
+    // Fine grid spacing
+    const Real* dx_f = geom_fine.CellSize();
+    const Real* plo_f = geom_fine.ProbLo();
+
+    // Coarse grid spacing
+    const Real* dx_c = geom_coarse.CellSize();
+    const Real* plo_c = geom_coarse.ProbLo();
+
+
+    // Store all fine cell centers and values
+    struct FineCell
+    {
+        Real x, y, z;
+        Vector<Real> val;
+    };
+
+    Vector<FineCell> fine_cells;
+
+
+    // Collect fine cell centers
+    for (MFIter mfi(mf_fine); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.validbox();
+        auto const& fine_arr = mf_fine.const_array(mfi);
+
+        for (int k = bx.smallEnd(2); k <= bx.bigEnd(2); ++k)
+        {
+            for (int j = bx.smallEnd(1); j <= bx.bigEnd(1); ++j)
+            {
+                for (int i = bx.smallEnd(0); i <= bx.bigEnd(0); ++i)
+                {
+                    FineCell cell;
+
+                    cell.x = plo_f[0] + (i + 0.5)*dx_f[0];
+                    cell.y = plo_f[1] + (j + 0.5)*dx_f[1];
+                    cell.z = plo_f[2] + (k + 0.5)*dx_f[2];
+
+                    cell.val.resize(ncomp);
+
+                    for (int n = 0; n < ncomp; ++n)
+                    {
+                        cell.val[n] = fine_arr(i,j,k,n);
+                    }
+
+                    fine_cells.push_back(std::move(cell));
+                }
+            }
+        }
+    }
+
+
+    Print() << "Number of fine cells = "
+            << fine_cells.size() << "\n";
+
+
+    // Loop over coarse cells
+    for (MFIter mfi(mf_coarse); mfi.isValid(); ++mfi)
+    {
+        const Box& bx = mfi.validbox();
+        auto const& coarse_arr = mf_coarse.array(mfi);
+
+
+        for (int k = bx.smallEnd(2); k <= bx.bigEnd(2); ++k)
+        {
+            for (int j = bx.smallEnd(1); j <= bx.bigEnd(1); ++j)
+            {
+                for (int i = bx.smallEnd(0); i <= bx.bigEnd(0); ++i)
+                {
+
+                    Real xlo = plo_c[0] + i*dx_c[0];
+                    Real xhi = xlo + dx_c[0];
+
+                    Real ylo = plo_c[1] + j*dx_c[1];
+                    Real yhi = ylo + dx_c[1];
+
+                    Real zlo = plo_c[2] + k*dx_c[2];
+                    Real zhi = zlo + dx_c[2];
+
+
+                    Vector<Real> sum(ncomp,0.0);
+                    int count = 0;
+
+
+                    // Search fine cells inside coarse cell
+                    for (const auto& fc : fine_cells)
+                    {
+                        if (fc.x >= xlo && fc.x < xhi &&
+                            fc.y >= ylo && fc.y < yhi &&
+                            fc.z >= zlo && fc.z < zhi)
+                        {
+                            for (int n = 0; n < ncomp; ++n)
+                            {
+                                sum[n] += fc.val[n];
+                            }
+
+                            count++;
+                        }
+                    }
+
+
+                    // Average
+                    if (count > 0)
+                    {
+                        for (int n = 0; n < ncomp; ++n)
+                        {
+                            coarse_arr(i,j,k,n)
+                                = sum[n]/Real(count);
+                        }
+                    }
+                    else
+                    {
+                        // no fine cell found
+                        for (int n = 0; n < ncomp; ++n)
+                        {
+                            coarse_arr(i,j,k,n) = 0.0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+void ApplyNeumannBCs(const Geometry& geom,
+                     MultiFab& mf_cc)
+{
+
+     // -------------------------------------------------
+    // 2. Fill interior + periodic ghost cells
+    // -------------------------------------------------
+    mf_cc.FillBoundary(geom.periodicity());
+    // -------------------------------------------------
+    // 3. Apply FOExtrap (Neumann) at domain boundaries
+    // -------------------------------------------------
+    const Box& domain = geom.Domain();
+
+    for (MFIter mfi(mf_cc, TilingIfNotGPU()); mfi.isValid(); ++mfi)
+    {
+        const Box& gbx = mfi.growntilebox();   // includes ghost cells
+        const Box& vbx = mfi.validbox();
+
+        auto const& arr = mf_cc.array(mfi);
+        int ncomp = mf_cc.nComp();
+
+        ParallelFor(gbx, ncomp,
+        [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
+        {
+            if (vbx.contains(i,j,k)) return;
+
+            int ii = i;
+            int jj = j;
+            int kk = k;
+
+            // Clamp to domain interior (FOExtrap)
+            ii = amrex::max(domain.smallEnd(0),
+                 amrex::min(i, domain.bigEnd(0)));
+
+            jj = amrex::max(domain.smallEnd(1),
+                 amrex::min(j, domain.bigEnd(1)));
+
+            kk = amrex::max(domain.smallEnd(2),
+                 amrex::min(k, domain.bigEnd(2)));
+
+            arr(i,j,k,n) = arr(ii,jj,kk,n);
+        });
+    }
+}
+
+void WriteCustomDataFile(const Geometry& geom,
+                         const MultiFab& mf_cc,
+                         const std::string& filename_custom)
+{
+    std::cout << "coarse box number is " << mf_cc.local_size() << std::endl;
+
+    AMREX_ALWAYS_ASSERT(mf_cc.nComp() >= 1);
+    AMREX_ALWAYS_ASSERT(mf_cc.local_size() == 1); // single box assumed
+
+    const int ncomp = mf_cc.nComp();
+    const int ng    = mf_cc.nGrow();
+
+    const Box grown_domain = amrex::grow(geom.Domain(), ng);
+    const auto lo = lbound(grown_domain);
+    const auto hi = ubound(grown_domain);
+
+    const auto problo = geom.ProbLoArray();
+    const auto probhi = geom.ProbHiArray();
+    const auto dx     = geom.CellSizeArray();
+
+    // extend physical domain to include ghosts
+    amrex::GpuArray<double,3> problo_ext, probhi_ext;
+    for (int d=0; d<3; ++d) {
+        problo_ext[d] = problo[d] - ng*dx[d];
+        probhi_ext[d] = probhi[d] + ng*dx[d];
+    }
+
+    std::ofstream ofs(filename_custom, std::ios::binary);
+    if (!ofs.is_open()) Abort("Failed to open file for writing");
+
+    // header
+    const int nx = hi.x - lo.x + 1;
+    const int ny = hi.y - lo.y + 1;
+    const int nz = hi.z - lo.z + 1;
+
+    ofs.write(reinterpret_cast<const char*>(&nx), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&ny), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&nz), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&ng), sizeof(int));
+    ofs.write(reinterpret_cast<const char*>(&ncomp), sizeof(int));
+
+    for (int d=0; d<3; ++d) ofs.write(reinterpret_cast<const char*>(&problo_ext[d]), sizeof(double));
+    for (int d=0; d<3; ++d) ofs.write(reinterpret_cast<const char*>(&probhi_ext[d]), sizeof(double));
+
+    // data
+    const auto& arr = mf_cc.const_array(0);
+    for (int k=lo.z; k<=hi.z; ++k)
+    for (int j=lo.y; j<=hi.y; ++j)
+    for (int i=lo.x; i<=hi.x; ++i)
+    {
+        double x = problo[0] + (i + 0.5) * dx[0];
+        double y = problo[1] + (j + 0.5) * dx[1];
+        double z = problo[2] + (k + 0.5) * dx[2];
+
+        ofs.write(reinterpret_cast<const char*>(&x), sizeof(double));
+        ofs.write(reinterpret_cast<const char*>(&y), sizeof(double));
+        ofs.write(reinterpret_cast<const char*>(&z), sizeof(double));
+
+        for (int n=0; n<ncomp; ++n)
+        {
+            double val = arr(i,j,k,n);
+            ofs.write(reinterpret_cast<const char*>(&val), sizeof(double));
+        }
+    }
+
+    ofs.close();
+}

--- a/.Exec_dev/DataAssimilation/PreProcessing/main.cpp
+++ b/.Exec_dev/DataAssimilation/PreProcessing/main.cpp
@@ -1,0 +1,107 @@
+#include <AMReX.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_PlotFileUtil.H>
+
+#include "ReadPlotFile.H"
+
+using namespace amrex;
+
+int main (int argc, char* argv[])
+{
+        std::cout << "Before reading data 0" << std::endl;
+    Initialize(argc, argv);
+
+    {
+        if (argc != 4)
+        {
+            Print() << "Usage: " << argv[0]
+                    << " <fine-mesh-plot-file> <coarse-mesh-plot-file>\n";
+            Finalize();
+            return 1;
+        }
+
+        std::string fine_plotfile   = argv[2];
+        std::string coarse_plotfile = argv[3];
+
+        MultiFab mf_cc_coarse;
+        MultiFab mf_cc_fine;
+
+        std::cout << "Before reading data" << std::endl;
+
+        // Read fine plotfile
+        PlotFileData pf_fine(fine_plotfile);
+        ReadPlotFile("vars.txt", pf_fine, mf_cc_fine);
+
+        std::cout << "Fine data read complete" << std::endl;
+
+        // Read coarse plotfile
+        PlotFileData pf_coarse(coarse_plotfile);
+        ReadPlotFile("vars.txt", pf_coarse, mf_cc_coarse);
+
+        std::cout << "Coarse data read complete" << std::endl;
+
+        Array<int,AMREX_SPACEDIM> is_periodic
+        {
+            AMREX_D_DECL(0,0,0)
+        };
+
+        Geometry geom_fine(
+            pf_fine.probDomain(0),
+            RealBox(pf_fine.probLo(),
+                    pf_fine.probHi()),
+            pf_fine.coordSys(),
+            is_periodic);
+
+        Geometry geom_coarse(
+            pf_coarse.probDomain(0),
+            RealBox(pf_coarse.probLo(),
+                    pf_coarse.probHi()),
+            pf_coarse.coordSys(),
+            is_periodic);
+
+        MultiFab mf_cc_coarse_avg(mf_cc_coarse.boxArray(),
+                                  mf_cc_coarse.DistributionMap(),
+                                  mf_cc_fine.nComp(),
+                                  0);
+
+        AverageFineToCoarse(mf_cc_fine,
+                            mf_cc_coarse_avg,
+                            geom_fine,
+                            geom_coarse);
+
+        std::cout << "Interpolation from fine to coarse is complete" << std::endl;
+
+        Vector<std::string> varnames = ReadVarNames("vars.txt");
+
+        WriteSingleLevelPlotfile("plt_coarse_avg",
+                                  mf_cc_coarse_avg,
+                                  varnames,
+                                  geom_coarse,
+                                  0.0,
+                                  0);
+
+        std::string filename_custom = "coarse_data.bin";
+
+        ApplyNeumannBCs(geom_coarse, mf_cc_coarse);
+
+        WriteCustomDataFile(
+            geom_coarse,
+            mf_cc_coarse_avg,
+            filename_custom);
+
+        // Example:
+        // WriteSingleLevelPlotfile("plt_final",
+        //                          mf_cc_fine_from_coarse,
+        //                          varnames,
+        //                          geom_fine,
+        //                          0.0,
+        //                          0);
+
+    }
+
+    Finalize();
+
+    return 0;
+}
+

--- a/.Exec_dev/DataAssimilation/PreProcessing/vars.txt
+++ b/.Exec_dev/DataAssimilation/PreProcessing/vars.txt
@@ -1,0 +1,8 @@
+density
+theta
+x_velocity
+y_velocity
+z_velocity
+qv
+qc
+qrain


### PR DESCRIPTION
This PR contains
 
1. pre-processing routines to interpolate fine mesh data to an arbitrary coarse mesh and 
2. write a custom binary file that can be read-in and interpolated onto the mesh during ensemble simulations. 

The idea is -

1. Fine mesh data is the ground truth and the coarse mesh data is similar to coarse satellite weather data,
3. Coarse mesh data will be interpolated onto the fine mesh used for ensemble simulations and used as background data for for data assimilation, 
4. Fine mesh data (serving as ground truth) will be used in the Kalman gain term during data assimilation. 

The test is to see if the EnKF data assimilation procedure (starting from interpolated coarse data) leads to an expected development of the 2d squall line.

The images below show the `z-velocity` and `qrain` for the initial phase of a 2d-squall line simulation interpolated onto a coarse mesh, ie. 10 times coarser in each direction.

<img width="1340" height="694" alt="Screen Shot 2026-07-21 at 12 10 33 PM" src="https://github.com/user-attachments/assets/9fd2a664-a129-4939-822e-5bafeada052a" />
