### PR TITLE
Add implicit formulation for ImmersedForcing

### DIFF
--- a/Docs/sphinx_doc/theory/Forcings.rst
+++ b/Docs/sphinx_doc/theory/Forcings.rst
@@ -268,11 +268,14 @@ The following inputs are available when representing terrain using immersed forc
         erf.if_surf_heating_rate       = FLOAT
         erf.if_Olen                    = FLOAT
         erf.if_use_most                = BOOL
+        erf.if_implicit_drag           = BOOL
         erf.immersed_forcing_substep   = BOOL
 
 An example of using immersed forcing for a Witch of Agnesi hill is available in ``Exec/RegTests/ImmersedForcingTest``.
 
 .. note:: When using fully compressible simulations, it is recommended to apply immersed forcing on the substep for numerical stability.
+
+.. note:: By default (``erf.if_implicit_drag = false``) the momentum drag is applied with an explicit (forward-Euler) source term. Setting ``erf.if_implicit_drag = true`` switches to a point-implicit (linearly-implicit) formulation of the same drag, which is unconditionally stable and prevents momentum overshoot in stiff (high :math:`C_{d,m}`) or large-timestep regimes such as anelastic runs without acoustic substepping.
 
 Immersed forcing to represent buildings
 ---------------------------------------
@@ -339,6 +342,7 @@ Inputs that can be used with immersed forcing for buildings are as follows:
         erf.if_Olen                    = FLOAT
         erf.if_use_most                = BOOL
         erf.if_stability_correction    = BOOL
+        erf.if_implicit_drag           = BOOL
         erf.immersed_forcing_substep   = BOOL
 
 The default drag coefficients are different when using the fully compressible solver compared to the anelastic solver.

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -634,6 +634,7 @@ struct SolverChoice {
         // immersed forcing parameters
         pp.query("if_Cd_momentum", if_Cd_momentum);
         pp.query("if_Cd_scalar", if_Cd_scalar);
+        pp.query("if_implicit_drag", if_implicit_drag); // flag for implicit vs. explicit drag formulation
         pp.query("if_z0", if_z0);
         pp.query("if_surf_temp_flux", if_surf_temp_flux);
         pp.query("if_init_surf_temp", if_init_surf_temp);
@@ -1450,6 +1451,9 @@ struct SolverChoice {
     // immersed forcing parameters
     amrex::Real if_Cd_momentum        = amrex::Real(50.0);
     amrex::Real if_Cd_scalar          = amrex::Real(10.0);
+    // Use a point-implicit (linearly-implicit) formulation of the immersed-forcing
+    // drag. Defaults to false (explicit forward-Euler source).
+    bool        if_implicit_drag      = false;
     // immersed forcing MOST parameters.
     amrex::Real if_z0                    = amrex::Real(0.1);   // [m]
     amrex::Real if_surf_temp_flux        = amrex::Real(1e-8);  // [K m/s]

--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -785,6 +785,7 @@ void make_mom_sources (double time_d,
             const Real alpha_m = solverChoice.if_Cd_momentum;
             const Real tiny = std::numeric_limits<amrex::Real>::epsilon();
             const Real U_s = one; // unit velocity scale
+            const bool l_implicit_drag = solverChoice.if_implicit_drag;
 
             // MOST parameters
             similarity_funs sfuns;
@@ -846,9 +847,13 @@ void make_mom_sources (double time_d,
                     const Real uTarget  = ustar / kappa * (std::log(myhalf * dx_z / z0) - psi_m);
                     Real uxTarget = uTarget * ux2r / (tiny + h_windspeed2r);
                     const Real bc_forcing_x = -(uxTarget - ux); // BC forcing pushes nonrelative velocity toward target velocity
-                    xmom_src_arr(i, j, k) -= (1-t_blank) * rho_xface * CdM * U_s * bc_forcing_x; // if Vf low, force more strongly to MOST. If high, less forcing.
+                    const Real lambda = (1-t_blank) * CdM * U_s; // affine relaxation rate toward MOST target [1/s]
+                    const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt) : lambda; // point-implicit rescale (else explicit)
+                    xmom_src_arr(i, j, k) -= fac * rho_xface * bc_forcing_x; // if Vf low, force more strongly to MOST. If high, less forcing.
                 } else {
-                    xmom_src_arr(i, j, k) -= t_blank * rho_xface * CdM * ux * windspeed;
+                    const Real lambda = t_blank * CdM * windspeed; // linear drag rate [1/s]
+                    const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt) : lambda; // point-implicit rescale (else explicit)
+                    xmom_src_arr(i, j, k) -= fac * rho_xface * ux;
                 }
             });
             ParallelFor(tby, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -902,9 +907,13 @@ void make_mom_sources (double time_d,
                     const Real uTarget  = ustar / kappa * (std::log(myhalf * dx_z / z0) - psi_m);
                     Real uyTarget = uTarget * uy2r / (tiny + h_windspeed2r);
                     const Real bc_forcing_y = -(uyTarget - uy);  // BC forcing pushes nonrelative velocity toward target velocity
-                    ymom_src_arr(i, j, k) -= (1 - t_blank) * rho_yface * CdM * U_s * bc_forcing_y; // if Vf low, force more strongly to MOST. If high, less forcing.
+                    const Real lambda = (1 - t_blank) * CdM * U_s; // affine relaxation rate toward MOST target [1/s]
+                    const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt) : lambda; // point-implicit rescale (else explicit)
+                    ymom_src_arr(i, j, k) -= fac * rho_yface * bc_forcing_y; // if Vf low, force more strongly to MOST. If high, less forcing.
                 } else {
-                    ymom_src_arr(i, j, k) -= t_blank * rho_yface * CdM * uy * windspeed;
+                    const Real lambda = t_blank * CdM * windspeed; // linear drag rate [1/s]
+                    const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt) : lambda; // point-implicit rescale (else explicit)
+                    ymom_src_arr(i, j, k) -= fac * rho_yface * uy;
                 }
             });
             ParallelFor(tbz, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
@@ -922,7 +931,9 @@ void make_mom_sources (double time_d,
                 const Real CdM = std::min(drag_coefficient / (windspeed + tiny), drag_coefficient);
 
                 const Real rho_zface =  myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i,j,k-1,Rho_comp) );
-                zmom_src_arr(i, j, k) -= t_blank * rho_zface * CdM * uz * windspeed;
+                const Real lambda = t_blank * CdM * windspeed; // linear drag rate [1/s]
+                const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt) : lambda; // point-implicit rescale (else explicit)
+                zmom_src_arr(i, j, k) -= fac * rho_zface * uz;
             });
         }
 
@@ -953,6 +964,8 @@ void make_mom_sources (double time_d,
             // To limit stiffness of drag when using anelastic
             const Real ws_floor           = solverChoice.if_ws_floor;
             const Real damp_alpha         = solverChoice.if_damp_alpha;
+            // Point-implicit alternative to the clamp above; stabilizes both compressible and anelastic
+            const bool l_implicit_drag    = solverChoice.if_implicit_drag;
 
             ParallelFor(tbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
             {
@@ -1038,8 +1051,14 @@ void make_mom_sources (double time_d,
                 // interior cell forcing
                 drag               += interior_mask * rho_xface * CdM * ux * windspeed;
 
-                // limit drag term for anelastic for numerical stability
-                if (is_slow_step && !use_ImmersedForcing_fast) {
+                if (l_implicit_drag) {
+                    // point-implicit rescale of the aggregated drag
+                    const Real lambda = CdM * ( (roof_mask + south_mask + north_mask) * U_s
+                                               + wall_mask * t_blank * windspeed
+                                               + interior_mask * windspeed );
+                    xmom_src_arr(i,j,k) -= drag / (one + lambda*dt);
+                } else if (is_slow_step && !use_ImmersedForcing_fast) {
+                    // limit drag term for anelastic for numerical stability
                     Real d_drag = dt * -drag; // time step * acceleration like tendency
                     Real wsmax_change = damp_alpha * amrex::max(amrex::Math::abs(ux), ws_floor); // aims to prevent oscillations around 0.
                     if (amrex::Math::abs(ux) < 0.1){ // no damping for smaller velocities
@@ -1135,8 +1154,14 @@ void make_mom_sources (double time_d,
                 // interior cell forcing
                 drag               += interior_mask * rho_yface * CdM * uy * windspeed;
 
-                // limit drag term for anelastic for numerical stability
-                if (is_slow_step && !use_ImmersedForcing_fast) {
+                if (l_implicit_drag) {
+                    // point-implicit rescale of the aggregated drag
+                    const Real lambda = CdM * ( (roof_mask + west_mask + east_mask) * U_s
+                                               + wall_mask * t_blank * windspeed
+                                               + interior_mask * windspeed );
+                    ymom_src_arr(i,j,k) -= drag / (one + lambda*dt);
+                } else if (is_slow_step && !use_ImmersedForcing_fast) {
+                    // limit drag term for anelastic for numerical stability
                     Real d_drag = dt * -drag; // time step * acceleration like tendency
                     Real wsmax_change = damp_alpha * amrex::max(amrex::Math::abs(uy), ws_floor); // aims to prevent oscillations around 0.
                     if (amrex::Math::abs(uy) < 0.1){ // no damping for smaller velocities
@@ -1249,8 +1274,14 @@ void make_mom_sources (double time_d,
                 // interior cell forcing
                 drag               += interior_mask * rho_zface * CdM * uz * windspeed;
 
-                // limit drag term for anelastic for numerical stability
-                if (is_slow_step && !use_ImmersedForcing_fast) {
+                if (l_implicit_drag) {
+                    // point-implicit rescale of the aggregated drag
+                    const Real lambda = CdM * ( (south_mask + north_mask + west_mask + east_mask) * U_s
+                                               + wall_mask * t_blank * windspeed
+                                               + interior_mask * windspeed );
+                    zmom_src_arr(i,j,k) -= drag / (one + lambda*dt);
+                } else if (is_slow_step && !use_ImmersedForcing_fast) {
+                    // limit drag term for anelastic for numerical stability
                     Real d_drag = dt * -drag; // time step * acceleration like tendency
                     Real wsmax_change = damp_alpha * amrex::max(amrex::Math::abs(uz), ws_floor); // aims to prevent oscillations around 0.
                     if (amrex::Math::abs(uz) < 0.1){ // no damping for smaller velocities


### PR DESCRIPTION
I'm submitting this as a draft PR to get early feedback. I plan to integrate my changes after [Adam's IF changes](https://github.com/erf-model/ERF/pull/3478) get integrated.

# Problem
I ran an anelastic LES of flow around a building with immersed forcing and `amrex.fpe_trap_invalid = 1`. The run aborted after a few hundred steps with
```
RhoTheta is negative at ... 
amrex::Abort: Bad theta in check_for_negative_theta !!!
```

This crash was ultimately caused because of an ODE stiffness problem. One way to solve this problem was to further decrease my `dt` and drag coefficient. Another approach is to propose an implicit formulation for immersed forcing, which is what I do here.

# Derivation 
## The existing explicit drag, and how it is linear in momentum

The explicit immersed drag on the x-face momentum is (buildings block; the terrain block is analogous):

```cpp
const Real drag_coefficient = alpha_m / std::pow(dx_x*dx_y*dx_z, one/three);
const Real CdM = std::min(drag_coefficient / (windspeed + tiny), Real(1000.0));
const Real rho_xface = myhalf * ( cell_data(i,j,k,Rho_comp) + cell_data(i-1,j,k,Rho_comp) );
xmom_src_arr(i, j, k) -= t_blank * rho_xface * CdM * ux * windspeed;
```

This building drag source is added to the momentum equation `d m / dt = ... + S`, where the x-face momentum is `m = rho_xface * ux`, i.e. `m = rho u` and `ux = m / rho`. The drag contribution is therefore

$$
S = -\big(t_\text{blank} C_{dM} \lVert \mathbf u \rVert\big)
      \big(\rho_\text{xface} u_x\big)
  = -\underbrace{\big(t_\text{blank} C_{dM} \lVert \mathbf u \rVert\big)}_{\displaystyle \equiv\lambda} m .
$$

Although the code line *looks* quadratic (`CdM * ux * windspeed`), the definition of `CdM` removes one power of the speed. In the uncapped regime `CdM = drag_coefficient / windspeed`, so the `windspeed` factors cancel and

$$
\lambda = t_\text{blank}\\frac{\alpha_m}{\Delta},
\qquad
\Delta = (dx \ dy \ dz)^{1/3},
$$

which is **independent of the velocity magnitude** -- the drag is *linear* in the momentum `m`. Over one step `lambda >= 0` is thus a known constant, and the drag reduces to the scalar linear ODE

$$
\frac{dm}{dt} = -\lambda \ m .
$$

Everything below follows from integrating this one equation.

## Explicit (forward Euler) -- the current scheme
Generic forward Euler for `dm/dt = f(m)` is `m^{n+1} = m^n + dt * f(m^n)`; here `f(m) = -lambda m`, so `f(m^n) = -lambda m^n` and

$$
m^{n+1} = m^n - \lambda \ dt \ m^n = (1 - \lambda \ dt) \ m^n .
$$

## Backward Euler (point-implicit)

Generic backward Euler is `m^{n+1} = m^n + dt * f(m^{n+1})`

$$
\frac{m^{n+1} - m^n}{dt} = -\lambda \ m^{n+1}
\quad\Longrightarrow\quad
m^{n+1}(1 + \lambda \ dt) = m^n
\quad\Longrightarrow\quad
m^{n+1} = \frac{m^n}{1 + \lambda \ dt} .
$$

The multiplier `1/(1 + lambda dt)` lies in `(0,1)` for **every** `lambda dt > 0`: monotone, sign-preserving, unconditionally stable.

## Effective source

To implement backwards Euler, we do not change the integrator. We instead change the source term in the current update equation so that this explicit update lands on the backward-Euler answer `m^{n+1} = m^n / (1 + \lambda dt)`.

$$
m^{n+1} = m^n + dt \ S ,
$$

with $S$ being the value written into `xmom_src_arr`.

$$
m^n + dt \ S_\text{eff} = \frac{m^n}{1 + \lambda \ dt}
\quad\Longrightarrow\quad
dt \ S_\text{eff} = \frac{m^n}{1 + \lambda \ dt} - m^n
= -\frac{\lambda \ dt}{1 + \lambda \ dt} \ m^n
$$

and cancelling the `dt` (because that comes from the RK integrator later):

$$
\boxed{S_\text{eff} = -\frac{\lambda}{1 + \lambda \ dt} \ m^n}
\qquad\text{vs. explicit}\qquad
S_\text{expl} = -\lambda \ m^n .
$$

## MOST relaxation branch (terrain)

Where `erf.if_use_most = true`, the terrain drag is not `-lambda m` but a relaxation of velocity toward a MOST target `u_tgt`:

$$
\frac{dm}{dt} = -\lambda (m - m_{tgt}) = -\lambda \ \rho \ (u - u_\text{tgt}) .
$$

With `u_tgt` frozen over the step, backward Euler acts on the deviation `d = u - u_tgt`:

$$
d^{n+1} = \frac{d^n}{1 + \lambda \ dt},
\qquad
S_\text{eff} = -\frac{\lambda}{1 + \lambda \ dt} \ \rho \ (u^n - u_\text{tgt}) ,
$$

i.e. the identical `lambda / (1 + lambda dt)` rescale, now applied to the MOST forcing term. The same stability/monotonicity guarantees carry over.

# Solution

A new boolean `erf.if_implicit_drag` (default `false`) selects the formulation. The momentum-drag source now uses

```cpp
const Real lambda = t_blank * CdM * windspeed;                       // drag rate [1/s]
const Real fac    = l_implicit_drag ? lambda / (one + lambda*dt)     // point-implicit
                                    : lambda;                        // explicit (default)
xmom_src_arr(i,j,k) -= fac * rho_xface * ux;
```

Files changed:

- **`Source/SourceTerms/ERF_MakeMomSources.cpp`** — apply the   `lambda/(1+lambda dt)` rescale in the terrain block (incl. the MOST branch) and the buildings block, for all three momentum components. The timestep `dt` is now threaded into the routine so the rescale can use the same `dt` the integrator applies at that stage/substep (slow `dt` or acoustic `dtau`).
- **`Source/DataStructs/ERF_DataStruct.H`** — declare `if_implicit_drag = false` and `pp.query("if_implicit_drag", ...)`.
- **`Docs/sphinx_doc/theory/Forcings.rst`** — document `erf.if_implicit_drag` and the point-implicit formulation.

With `if_implicit_drag = false` the code path is identical to before, so no regression-test gold files change.

# Test and sanity check

I verified two properties for both the buildings and the terrain (with MOST) drag paths, using `fcompare` between explicit and implicit runs that are identical except for `erf.if_implicit_drag`. Input files for the first two test cases attached in the zip.

[implicit_if_verification.zip](https://github.com/user-attachments/files/30279134/implicit_if_verification.zip)

**1. Consistency (implicit -> explicit as `lambda*dt -> 0`).** For a Witch of Agnesi hill via `terrain_type = ImmersedForcing` (`if_use_most = true`), reducing `if_Cd_momentum` from 500 to 50 (i.e. cutting `lambda` 10x) shrank the explicit-vs-implicit differences by roughly the same order, e.g. `x_velocity` relative error `0.0263 -> 0.0030` and `z_velocity` `0.054 -> 0.0083`. The differences shrink as `lambda*dt -> 0`.

**2. Stability (explicit crashes for Cd that makes lambda > 2, implicit survives).** Running simulations with `if_Cd_momentum = 500` (`lambda*dt ~ 12.5`) reproduces the original `RhoTheta is negative` abort with the explicit scheme, while the implicit run stays bounded (factor `1/(1+12.5) = 0.074`) and completes.

**3. End-to-end.** My original anelastic building case that motivated this PR now runs for 10 min past the crash point with `erf.if_implicit_drag = true` and produces reasonable [x-velocity](https://github.com/user-attachments/assets/436ecdec-d1fe-4131-b814-2135369847a4) fields.



