### PR TITLE
Implement multi-level PlaneSampler

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -913,6 +913,14 @@ prefixes "plt_line" and "plt_plane", respectively. Names for sampled data may op
 be provided with ``sample_line_name`` and/or ``sample_plane_name`` -- if provided, each
 line and/or plane must be named.
 
+Plane samples are written as true multi-level AMReX plotfiles: every refinement level
+whose grids intersect the plane is written (``Level_0``, ``Level_1``, ...), so a plane
+that cuts through static refinement patches retains the finer in-plane resolution there.
+By default all intersecting levels are written; ``erf.plane_sampling_max_level = <int>``
+caps the finest level (``0`` forces level-0-only output). The slice-normal direction is
+resolved natively on each level by replicating the sampled plane across the level's cells,
+so the resulting dataset has an isotropic refinement ratio and loads cleanly in yt/amrvis.
+
 Line and plane samples will be default be written to plotfiles, one plotfile per output
 snapshot, with all output variables in the same file. Alternatively, line sampling has
 the ``erf.line_sampling_text_output`` option, which writes one text file per output
@@ -981,6 +989,11 @@ List of Parameters
 +-----------------------------------+------------------+----------------+----------------+
 | **erf.plane_sampling_vars**       | Specify sampled  | List of strings| theta, magvel  |
 |                                   | variables        |                |                |
++-----------------------------------+------------------+----------------+----------------+
+| **erf.plane_sampling_max_level**  | Cap on finest    | Integer        | -1 (all        |
+|                                   | level written to |                | intersecting   |
+|                                   | the plane        |                | levels)        |
+|                                   | plotfile         |                |                |
 +-----------------------------------+------------------+----------------+----------------+
 
 .. _examples-of-usage-10b:

--- a/Source/IO/ERF_SampleData.H
+++ b/Source/IO/ERF_SampleData.H
@@ -627,10 +627,10 @@ struct PlaneSampler
                 }
             }
 
-            // Allocate space for level indicator
-            m_lev.resize(n_plane_dir,0);
+            // Optional cap on the finest level written (-1 => all intersecting levels)
+            pp.query("plane_sampling_max_level", m_max_level);
 
-            // Allocate space for MF pointers
+            // Allocate per-plane vectors of per-level MF pointers
             m_ps_mf.resize(n_plane_lo);
 
             // Get requested vars
@@ -714,8 +714,20 @@ struct PlaneSampler
             amrex::RealBox bnd_rbx  = m_bnd_rbx[iplane];
             amrex::Real point = bnd_rbx.lo(dir);
 
-            // Search each level to get the finest data possible
-            for (int ilev(nlev-1); ilev>=0; --ilev) {
+            // Collect every level 0..lev_cap whose grids intersect the plane.
+            int lev_cap = (m_max_level >= 0 && m_max_level < nlev-1) ? m_max_level : nlev-1;
+            m_ps_mf[iplane].clear();
+
+            for (int ilev(0); ilev<=lev_cap; ++ilev) {
+
+                // Stop ascending once a level's grids no longer touch the flattened plane
+                {
+                    amrex::Box plane_bx = getIndexBox(bnd_rbx, geom[ilev]);
+                    int k_l = static_cast<int>(std::floor((point - geom[ilev].ProbLo(dir))
+                                                          / geom[ilev].CellSize(dir)));
+                    plane_bx.setSmall(dir, k_l); plane_bx.setBig(dir, k_l);
+                    if (!vars_new[ilev][Vars::cons].boxArray().intersects(plane_bx)) { break; }
+                }
 
                 // Construct CC velocities
                 amrex::MultiFab mf_cc_vel;
@@ -863,14 +875,47 @@ struct PlaneSampler
                     mf_comp += 1;
                 }
 
-                  m_lev[iplane] = ilev;
-                m_ps_mf[iplane] = get_slice_data(dir, point, mf_cc_data, geom[ilev],
-                                                 0, ncomp, interpolate, bnd_rbx);
+                auto slice = get_slice_data(dir, point, mf_cc_data, geom[ilev],
+                                            0, ncomp, interpolate, bnd_rbx);
 
-                // We can stop if we got the entire plane
-                auto min_bnd_bx   = m_ps_mf[iplane]->boxArray().minimalBox();
-                amrex::Box bnd_bx = getIndexBox(bnd_rbx, geom[ilev]);
-                if (bnd_bx == min_bnd_bx) { break; }
+                // Defensive: an empty return means nothing was actually sampled.
+                if (!slice || slice->boxArray().size() == 0) { break; }
+
+                // Broadcast the single sampled plane across 2^ilev cells in dir so
+                // every level shares an isotropic refinement ratio. The dir extent
+                // becomes [0, 2^ilev-1]; each cell holds the interpolated plane value
+                // replicated across the shared level-0 slab thickness.
+                const int rr_l    = 1 << ilev;
+                const int k_slice = slice->boxArray().minimalBox().smallEnd(dir);
+                const int l_dir   = dir;
+
+                amrex::BoxList bl;
+                const amrex::BoxArray& slice_ba = slice->boxArray();
+                for (int ib(0); ib<static_cast<int>(slice_ba.size()); ++ib) {
+                    amrex::Box b = slice_ba[ib];
+                    b.setSmall(dir, 0);
+                    b.setBig(dir, rr_l - 1);
+                    bl.push_back(b);
+                }
+                amrex::BoxArray out_ba(std::move(bl));
+                auto out_mf = std::make_unique<amrex::MultiFab>(out_ba, slice->DistributionMap(),
+                                                                ncomp, 0);
+
+                for (amrex::MFIter mfi(*out_mf); mfi.isValid(); ++mfi) {
+                    const amrex::Box& obx = mfi.validbox();
+                    auto const& ofab = out_mf->array(mfi);
+                    auto const& sfab = slice->array(mfi);
+                    amrex::ParallelFor(obx, ncomp, [=] AMREX_GPU_DEVICE(int i, int j, int k, int n) noexcept
+                    {
+                        int si = i, sj = j, sk = k;
+                        if      (l_dir == 0) { si = k_slice; }
+                        else if (l_dir == 1) { sj = k_slice; }
+                        else                 { sk = k_slice; }
+                        ofab(i,j,k,n) = sfab(si,sj,sk,n);
+                    });
+                }
+
+                m_ps_mf[iplane].push_back(std::move(out_mf));
 
             } // ilev
         }// iplane
@@ -882,49 +927,75 @@ struct PlaneSampler
                        amrex::Vector<amrex::IntVect>& ref_ratio,
                        amrex::Vector<amrex::Geometry>& geom)
     {
+        amrex::ignore_unused(ref_ratio);
         int nplane = m_ps_mf.size();
         for (int iplane(0); iplane<nplane; ++iplane) {
-            // Data members that can be used as-is
-            int dir = m_dir[iplane];
-            int lev = m_lev[iplane];
-            double m_time = time[lev];
-            amrex::Vector<int> m_level_steps = {level_steps[lev]};
-            amrex::Vector<amrex::IntVect> m_ref_ratio  = {ref_ratio[lev]};
+            int nlev_c = static_cast<int>(m_ps_mf[iplane].size());
+            if (nlev_c == 0) { continue; }
 
-            // Create modified geometry object corresponding to the plane
-            amrex::RealBox m_rb = m_bnd_rbx[iplane];
-            amrex::Box m_dom    = getIndexBox(m_rb, geom[lev]);
-            amrex::Real point   = m_rb.hi(dir);
+            int dir = m_dir[iplane];
+            amrex::RealBox bnd_rbx = m_bnd_rbx[iplane];
+            amrex::Real point = bnd_rbx.lo(dir);
+
+            // One shared physical RealBox for every level: full in-plane extent of the
+            // requested plane, and a dir-slab of level-0 thickness centered on the plane.
+            // Level 0 supplies prob_lo/hi to the writer, so this object must be shared.
+            amrex::Real dx0 = geom[0].CellSize(dir);
+            amrex::RealBox shared_rbx = bnd_rbx;
+            shared_rbx.setLo(dir, point - myhalf*dx0);
+            shared_rbx.setHi(dir, point + myhalf*dx0);
+
             amrex::Vector<int> is_per(AMREX_SPACEDIM,0);
-            for (int d(0); d<AMREX_SPACEDIM; ++d) {
-                if (d==dir) {
-                    m_rb.setLo(d,point-myhalf*geom[lev].CellSize(d));
-                    m_rb.setHi(d,point+myhalf*geom[lev].CellSize(d));
+            for (int d(0); d<AMREX_SPACEDIM; ++d) { is_per[d] = geom[0].isPeriodic(d); }
+
+            // Build the index chain by refining the level-0 plane box so that
+            // Domain_l == refine(Domain_{l-1},2) holds exactly in every axis.
+            amrex::Box B0 = getIndexBox(bnd_rbx, geom[0]);
+
+            amrex::Vector<const amrex::MultiFab*> mf(nlev_c);
+            amrex::Vector<amrex::Geometry>        m_geom(nlev_c);
+            amrex::Vector<int>                    m_level_steps(nlev_c);
+            amrex::Vector<amrex::IntVect>         m_ref_ratio(nlev_c-1, amrex::IntVect(2));
+
+            for (int l(0); l<nlev_c; ++l) {
+                const int rr_l = 1 << l;
+
+                // The nested plane plotfile stores a single scalar refinement
+                // ratio per level, so multi-level output requires factor-2
+                // isotropic refinement.
+                for (int d(0); d<AMREX_SPACEDIM; ++d) {
+                    amrex::Real ratio = geom[0].CellSize(d) / geom[l].CellSize(d);
+                    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+                        std::abs(ratio - static_cast<amrex::Real>(rr_l)) < amrex::Real(1.e-6) * rr_l,
+                        "PlaneSampler multi-level output requires factor-2 isotropic refinement (amr.ref_ratio = 2 2 2)");
                 }
-                is_per[d] = geom[lev].isPeriodic(d);
+
+                amrex::Box domain_l = amrex::refine(B0, rr_l);
+                domain_l.setSmall(dir, 0);
+                domain_l.setBig(dir, rr_l - 1);
+
+                mf[l] = m_ps_mf[iplane][l].get();
+                m_geom[l].define(domain_l, &shared_rbx, geom[l].Coord(), is_per.data());
+                m_level_steps[l] = level_steps[l];
+                AMREX_ASSERT(domain_l.contains(mf[l]->boxArray().minimalBox()));
             }
-            amrex::Vector<amrex::Geometry> m_geom; m_geom.resize(1);
-            m_geom[0].define(m_dom, &m_rb, geom[lev].Coord(), is_per.data());
 
             // Create plotfile name
             std::string name_plane = m_name[iplane];
             name_plane += "_step_";
             std::string plotfilename = amrex::Concatenate(name_plane, m_level_steps[0], 5);
 
-            // Get the data
-            amrex::Vector<const amrex::MultiFab*> mf = {m_ps_mf[iplane].get()};
-
-            // Write each plane
-            WriteMultiLevelPlotfile(plotfilename, 1, mf,
-                                    m_varnames, m_geom, static_cast<amrex::Real>(m_time),
+            // Write the nested multi-level plane plotfile
+            WriteMultiLevelPlotfile(plotfilename, nlev_c, mf,
+                                    m_varnames, m_geom, static_cast<amrex::Real>(time[0]),
                                     m_level_steps, m_ref_ratio);
         } // iplane
     }
 
+    int m_max_level = -1;
     amrex::Vector<int> m_dir;
-    amrex::Vector<int> m_lev;
     amrex::Vector<amrex::RealBox> m_bnd_rbx;
-    amrex::Vector<std::unique_ptr<amrex::MultiFab>> m_ps_mf;
+    amrex::Vector<amrex::Vector<std::unique_ptr<amrex::MultiFab>>> m_ps_mf;
     amrex::Vector<std::string> m_name;
 
     amrex::Vector<std::string> m_varnames {"magvel","theta"};


### PR DESCRIPTION
# Feature
The PlaneSampler currently flattens every sampled plane onto a single level. I was running a 3-level simulation, and as a result, data was only getting saved out on Level_0. This PR makes plane sampling write a true multi-level AMReX plotfile: every refinement level whose grids intersect the plane is emitted (Level_0, Level_1, …), so the sampled plane keeps native resolution inside refined regions and still loads cleanly in yt/Paraview. Users have the option to cap the maximum level at which data is written out (e.g., Level_1 even if there is Level_2 data). As implemented, this feature only works for isotropic mesh refinement zones, but breaks for anisotropic refinement (e.g., `2 1 2`) and will abort accordingly.

# What changed
* `ERF_SampleData.H`
   * I only modified `PlaneSampler`. I left `LineSampler` untouched.
   * The per-plane storage is now per-plane × per-level (`m_ps_mf`). `get_sample_data` walks levels 0 … lev_cap in ascending order and collects a level only if its grids actually intersect the flattened plane
* `inputs.rst`
   * Updated the docs

# Verification
I ran three tests.
1. I verified that if the plane does not intersect any refinement zones, it still only writes out level 0 data
2. I verified that `erf.plane_sampling_max_level` correctly caps the maximum level that is written out
3. Using `yt` and an urban simulation that I launched from a checkpoint, I verified that written out planar data matches the volumetric data to machine precession across all levels for [x-velocity](https://github.com/user-attachments/assets/f7ad710c-880f-4839-ad11-a30b8b6ebc2e) and [temperature](https://github.com/user-attachments/assets/8269a046-6658-428c-969c-5137196ba350).

I've attached two python scrips I used as part of the verification work.

[verify_plane_sampler.py](https://github.com/user-attachments/files/30317542/verify_plane_sampler.py)
[plot_plane_vs_3d.py](https://github.com/user-attachments/files/30317544/plot_plane_vs_3d.py)

