### PR TITLE
Fix float comparison warnings in source-term calculations that fail CI

### DIFF
--- a/Source/SourceTerms/ERF_MakeMomSources.cpp
+++ b/Source/SourceTerms/ERF_MakeMomSources.cpp
@@ -34,8 +34,8 @@ compute_if_most_target_vel(
     Real tang_windspeed2r       = std::sqrt(u1_2r * u1_2r + u2_2r * u2_2r);
 
     Real ustar = tang_windspeed2r * KAPPA / (std::log(1.5 * delta / z0) - psi_m);
-    Real tflux = (tflux_in != 1e-8) ? tflux_in : -(theta_xface - theta_surf) * ustar * KAPPA / (std::log(1.5 * delta / z0) - psi_h);
-    Real Olen  = (Olen_in != 1e-8)  ? Olen_in  : -ustar * ustar * ustar * theta_xface / (KAPPA * CONST_GRAV * tflux + tiny);
+    Real tflux = (tflux_in != Real(1.e-8)) ? tflux_in : -(theta_xface - theta_surf) * ustar * KAPPA / (std::log(1.5 * delta / z0) - psi_h);
+    Real Olen  = (Olen_in != Real(1.e-8))  ? Olen_in  : -ustar * ustar * ustar * theta_xface / (KAPPA * CONST_GRAV * tflux + tiny);
     Real zeta  = 1.5 * delta / Olen;
 
     // similarity functions

--- a/Source/SourceTerms/ERF_MakeSources.cpp
+++ b/Source/SourceTerms/ERF_MakeSources.cpp
@@ -705,7 +705,7 @@ void make_sources (int level,
                 }
 
                 // SURFACE HEAT FLUX
-                if (tflux != 1e-8){
+                if (tflux != Real(1.e-8)){
                     if (t_blank > zero && (t_blank_above == zero)) { // building roof
                         Real psi_m           = zero;
                         Real psi_h           = zero;


### PR DESCRIPTION
This patch changes three 1e-8 comparisons to use typed Real(1.e-8) literals. This prevents -Wliteral-range warnings when Real is float, allowing CI warning checks to pass. 