### PR TITLE
Fix signedness warning in native SHOC gold comparator

### DIFF
--- a/Tests/ShocGoldDifferential.cpp
+++ b/Tests/ShocGoldDifferential.cpp
@@ -155,7 +155,8 @@ bool check_inventory (const PlotFileData& plotfile,
 {
     const std::set<std::string> expected_set(expected.begin(), expected.end());
     const std::set<std::string> actual_set(plotfile.varNames().begin(), plotfile.varNames().end());
-    if (expected_set != actual_set || actual_set.size() != plotfile.varNames().size()) {
+    if (expected_set != actual_set ||
+        static_cast<amrex::Long>(actual_set.size()) != plotfile.varNames().size()) {
         std::cerr << label << " has an unexpected field inventory\n";
         for (const auto& field : expected_set) {
             if (actual_set.count(field) == 0) {


### PR DESCRIPTION
### Summary

Fixes the CI `-Wsign-compare` warning in `ShocGoldDifferential.cpp` by explicitly converting the standard-library set size to `amrex::Long` before comparing it with the AMReX variable-count type.

### Validation

- Rebuilt `erf_shoc_gold_differential` with 8-way parallel build.
- Build completed without warnings.
- `git diff --check` passed.
- No production code, fixtures, workflows, or gold files changed.