### PR TITLE
Enforce that if both erf.most.surf_temp and input_sounding are used, …

### DIFF
--- a/.Exec_dev/ASPIRE/PythonScripts/PlotARMData.py
+++ b/.Exec_dev/ASPIRE/PythonScripts/PlotARMData.py
@@ -98,7 +98,7 @@ def plot_function(varname, units):
     dpi=300,
     bbox_inches="tight"
     )
-    print(f"Saved {plt_filename:s}")    
+    print(f"Saved {plt_filename:s}")
 
 # ------------------------------------------------------
 # Plot accumulated precipitation

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -510,6 +510,8 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
         auto hfx3_arr = zheat_flux->array(mfi);
         auto qfx3_arr = (zqv_flux)  ? zqv_flux->array(mfi)   : Array4<Real>{};
 
+        auto olen_arr   = olen[lev]->array(mfi);
+
         // Rotated stress vars
         auto t11_arr = (m_rotate) ? Tau_lev[TauType::tau11]->array(mfi) : Array4<Real>{};
         auto t22_arr = (m_rotate) ? Tau_lev[TauType::tau22]->array(mfi) : Array4<Real>{};
@@ -770,6 +772,38 @@ SurfaceLayer::compute_SurfaceLayer_bcs (const int& lev,
                                      t23_arr, t32_arr);
                 });
         }
+
+        constexpr double eps = std::numeric_limits<float>::epsilon();
+        bool l_use_moisture = use_moisture;
+        ParallelFor(bx, [=] AMREX_GPU_DEVICE(int i, int j, int /*k*/)
+        {
+            int is_land = (lmask_arr) ? lmask_arr(i,j,0) : 1;
+            // Skip cells the LSM did not have a valid flux (lsm_undefined).
+            if (is_land && lsm_t_flux_arr && lsm_t_flux_arr(i,j,0) < lsm_undefined) {
+                Real rho = cons_arr(i,j,klo,Rho_comp);
+                Real Thd = cons_arr(i,j,klo,RhoTheta_comp) / rho;
+                Real qv  = (l_use_moisture) ? cons_arr(i,j,klo,RhoQ1_comp) / rho : zero;
+                Real Thv = Thd * (one + epsv*qv);
+
+                Real tau = std::sqrt( t13_arr(i,j,klo)*t13_arr(i,j,klo)
+                                    + t23_arr(i,j,klo)*t23_arr(i,j,klo) );
+                u_star_arr(i,j,0) = amrex::max(std::sqrt(tau),eps);
+
+                if (hfx3_arr(i,j,klo)>=zero) {
+                    t_star_arr(i,j,0) = amrex::min(-hfx3_arr(i,j,klo) / u_star_arr(i,j,0),-eps);
+                } else {
+                    t_star_arr(i,j,0) = amrex::max(-hfx3_arr(i,j,klo) / u_star_arr(i,j,0),eps);
+                }
+                if (qfx3_arr(i,j,klo)>=zero) {
+                    q_star_arr(i,j,0) = amrex::min(-qfx3_arr(i,j,klo) / u_star_arr(i,j,0),-eps);
+                } else {
+                    q_star_arr(i,j,0) = amrex::max(-qfx3_arr(i,j,klo) / u_star_arr(i,j,0),eps);
+                }
+                olen_arr(i,j,0)   = ( u_star_arr(i,j,0) * u_star_arr(i,j,0) * Thv ) /
+                                       ( KAPPA * CONST_GRAV * t_star_arr(i,j,0) );
+            }
+        });
+
     } // mfiter
 
     surface_diagnostic_source[lev]->FillBoundary(m_geom[lev].periodicity());

--- a/Source/DataStructs/ERF_InputSoundingData.H
+++ b/Source/DataStructs/ERF_InputSoundingData.H
@@ -121,8 +121,35 @@ public:
             U_inp_sound_tmp.push_back(0);
             V_inp_sound_tmp.push_back(0);
 
+            // *************************************************************************************************
+            // Make sure that if we specify surface values for temp in the inputs file and in the input sounding file,
+            //      those values must match
+            // *************************************************************************************************
+            amrex::ParmParse pp_erf("erf");
+
+            amrex::Real surf_temp;
+            bool surf_temp_specified = pp_erf.query("most.surf_temp", surf_temp);
+            if ( surf_temp_specified && (surf_temp != theta_inp_sound_tmp[0]) ) {
+                amrex::Print() << "Input sounding temp does not match most.surf_temp" << std::endl;
+                amrex::Print() << "Modify one or both to match." << std::endl;
+                amrex::Abort();
+            }
+
+            // *************************************************************************************************
+            // Make sure that if we specify surface values for qv in the inputs file and in the input sounding file,
+            //      those values must match
+            // *************************************************************************************************
+            amrex::Real surf_moist;
+            bool surf_moist_specified = pp_erf.query("most.surf_moist", surf_moist);
+            if ( surf_moist_specified && (surf_moist != qv_inp_sound_tmp[0]) ) {
+                amrex::Print() << "Input sounding qv does not match most.surf_moist" << std::endl;
+                amrex::Print() << "Modify one or both to match." << std::endl;
+                amrex::Abort();
+            }
+
             // Read the vertical profile at each given height
             amrex::Real z, theta, qv, U, V;
+
             while(std::getline(input_sounding_reader, line)) {
                 std::istringstream iss_z(line);
                 iss_z >> z >> theta >> qv >> U >> V;


### PR DESCRIPTION
…the values must be consistent.  Same for erf.most.surf_moist.