### PR TITLE
Fix vertical ghost handling in boundary conditions

### DIFF
--- a/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
@@ -269,20 +269,12 @@ void ERFPhysBCFunct_base::impose_vertical_basestate_bcs (const Array4<Real>& des
     const auto& dom_lo = lbound(domain);
     const auto& dom_hi = ubound(domain);
 
-    Box bx_zlo1(bx); bx_zlo1.setBig(2,dom_lo.z-1); if (bx_zlo1.ok()) bx_zlo1.setSmall(2,dom_lo.z-1);
-    ParallelFor(
-        bx_zlo1, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
-        {
-            dest_arr(i,j,k,n) = dest_arr(i,j,dom_lo.z,n);
-        }
-    );
-
-    Box bx_zlo(bx); bx_zlo.setBig(2,dom_lo.z-2);
+    Box bx_zlo(bx); bx_zlo.setBig(2,dom_lo.z-1);
     Box bx_zhi(bx); bx_zhi.setSmall(2,dom_hi.z+1);
     ParallelFor(
         bx_zlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
         {
-            dest_arr(i,j,k,n) = dest_arr(i,j,dom_lo.z-1,n);
+            dest_arr(i,j,k,n) = dest_arr(i,j,dom_lo.z,n);
         },
         bx_zhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
         {

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsBaseState.cpp
@@ -259,12 +259,9 @@ void ERFPhysBCFunct_base::impose_vertical_basestate_bcs (const Array4<Real>& des
 
     Box bx_zlo1(bx); bx_zlo1.setBig(2,dom_lo.z-1); if (bx_zlo1.ok()) bx_zlo1.setSmall(2,dom_lo.z-1);
     ParallelFor(
-        bx_zlo1, [=] AMREX_GPU_DEVICE (int i, int j, int k)
+        bx_zlo1, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
         {
-            dest_arr(i,j,k,BaseState::r0_comp)  = dest_arr(i,j,dom_lo.z,BaseState::r0_comp);
-            dest_arr(i,j,k,BaseState::p0_comp)  = dest_arr(i,j,dom_lo.z,BaseState::p0_comp);
-            dest_arr(i,j,k,BaseState::pi0_comp) = dest_arr(i,j,dom_lo.z,BaseState::pi0_comp);
-            dest_arr(i,j,k,BaseState::th0_comp) = dest_arr(i,j,dom_lo.z,BaseState::th0_comp);
+            dest_arr(i,j,k,n) = dest_arr(i,j,dom_lo.z,n);
         }
     );
 

--- a/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
+++ b/Source/BoundaryConditions/ERF_BoundaryConditionsCons.cpp
@@ -86,6 +86,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_xlo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int k_profile = amrex::min(amrex::max(k, dom_lo.z), dom_hi.z) - dom_lo.z;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
@@ -95,14 +96,14 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                      (l_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_lo.x,j,k) >= zero) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][0];
                     }
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_lo.x,j,k,Rho_comp);
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][0];
                     }
@@ -111,6 +112,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_xhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int k_profile = amrex::min(amrex::max(k, dom_lo.z), dom_hi.z) - dom_lo.z;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
@@ -120,14 +122,14 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                      (h_bc_type == ERFBCType::ext_dir_upwind && xvel_arr(dom_hi.x+1,j,k) <= zero) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][3];
                     }
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(dom_hi.x,j,k,Rho_comp);
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][3];
                     }
@@ -152,6 +154,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_ylo, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int k_profile = amrex::min(amrex::max(k, dom_lo.z), dom_hi.z) - dom_lo.z;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
@@ -160,14 +163,14 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                      (l_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_lo.y,k) >= zero) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][1];
                     }
                 } else if (l_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_lo.y,k,Rho_comp);
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][1];
                     }
@@ -176,6 +179,7 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
             bx_yhi, ncomp, [=] AMREX_GPU_DEVICE (int i, int j, int k, int n)
             {
                 int dest_comp = icomp+n;
+                int k_profile = amrex::min(amrex::max(k, dom_lo.z), dom_hi.z) - dom_lo.z;
                 int bc_comp   = (dest_comp >= RhoScalar_comp && dest_comp < RhoScalar_comp+NSCALARS) ?
                                  BCVars::RhoScalar_bc_comp : dest_comp;
                 if (bc_comp > BCVars::RhoScalar_bc_comp) bc_comp -= (NSCALARS-1);
@@ -184,14 +188,14 @@ void ERFPhysBCFunct_cons::impose_lateral_cons_bcs (const Array4<Real>& dest_arr,
                      (h_bc_type == ERFBCType::ext_dir_upwind && yvel_arr(i,dom_hi.y+1,k) <= zero) )
                 {
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = l_bc_extdir_vals_d[bc_comp][4];
                     }
                 } else if (h_bc_type == ERFBCType::ext_dir_prim) {
                     Real rho = dest_arr(i,dom_hi.y,k,Rho_comp);
                     if ((dest_comp == RhoTheta_comp) && th_bc_ptr) {
-                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k];
+                        dest_arr(i,j,k,dest_comp) = rho * th_bc_ptr[k_profile];
                     } else {
                         dest_arr(i,j,k,dest_comp) = rho * l_bc_extdir_vals_d[bc_comp][4];
                     }


### PR DESCRIPTION
Clamp lateral theta-profile lookups to valid vertical indices to prevent out-of-bounds reads. Fill all base-state components in the first lower ghost layer so qv0 is extrapolated consistently.