### PR TITLE
Fix perturbational fill-patch ghost handling

### DIFF
--- a/Source/BoundaryConditions/ERF_FillPatch.cpp
+++ b/Source/BoundaryConditions/ERF_FillPatch.cpp
@@ -174,16 +174,16 @@ ERF::FillPatchFineLevel (int lev, double time_d,
         }
 
         if (!amrex::almostEqual(time,ftime[1])) {
-            MultiFab::Add(vars_old[lev][Vars::cons],base_state[lev  ],BaseState::r0_comp,Rho_comp,1,ngvect_cons);
-            MultiFab::Add(vars_old[lev][Vars::cons],base_state[lev  ],BaseState::th0_comp,RhoTheta_comp,1,ngvect_cons);
+            MultiFab::Add(vars_old[lev][Vars::cons],base_state[lev  ],BaseState::r0_comp,Rho_comp,1,IntVect{0});
+            MultiFab::Add(vars_old[lev][Vars::cons],base_state[lev  ],BaseState::th0_comp,RhoTheta_comp,1,IntVect{0});
             MultiFab::Multiply(vars_old[lev][Vars::cons], vars_old[lev][Vars::cons],
-                                   Rho_comp,RhoTheta_comp,1,ngvect_cons);
+                               Rho_comp,RhoTheta_comp,1,IntVect{0});
         }
         if (!amrex::almostEqual(time,ftime[0])) {
-            MultiFab::Add(vars_new[lev][Vars::cons], base_state[lev],BaseState::r0_comp,Rho_comp,1,ngvect_cons);
-            MultiFab::Add(vars_new[lev][Vars::cons], base_state[lev],BaseState::th0_comp,RhoTheta_comp,1,ngvect_cons);
+            MultiFab::Add(vars_new[lev][Vars::cons], base_state[lev],BaseState::r0_comp,Rho_comp,1,IntVect{0});
+            MultiFab::Add(vars_new[lev][Vars::cons], base_state[lev],BaseState::th0_comp,RhoTheta_comp,1,IntVect{0});
             MultiFab::Multiply(vars_new[lev][Vars::cons], vars_new[lev][Vars::cons],
-                               Rho_comp,RhoTheta_comp,1,ngvect_cons);
+                               Rho_comp,RhoTheta_comp,1,IntVect{0});
         }
 
         // Set values in the cells outside the domain boundary so that we can do the Add

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -31,7 +31,7 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     //
     // Here is where we set the number of ghost cells for the base state!
     // ********************************************************************************************
-    int ngb = (solverChoice.terrain_type == TerrainType::EB) ? ComputeGhostCells(solverChoice)+1 : 3;
+    int ngb = ComputeGhostCells(solverChoice) + 1;
     tmp_base_state.define(ba,dm,BaseState::num_comps,ngb);
     tmp_base_state.setVal(zero);
 


### PR DESCRIPTION
Allocate base-state ghosts to match the conserved-state stencil width, preventing out-of-bounds operations for high-order schemes. Restore fine perturbational source states over valid cells only to avoid corrupting untouched ghost data.