### PR TITLE
Fix stable MOST heat stability coefficient

### DIFF
--- a/Source/BoundaryConditions/ERF_MOSTStress.H
+++ b/Source/BoundaryConditions/ERF_MOSTStress.H
@@ -78,7 +78,7 @@ struct similarity_funs
     {
         if (zeta > 0) {
             amrex::Real x = std::pow(one + std::pow(zeta, amrex::Real(1.1)), one/amrex::Real(1.1));
-            return ( -amrex::Real(6.1)*std::log(zeta + x) );
+            return ( -amrex::Real(5.3)*std::log(zeta + x) );
         } else {
             amrex::Real x = std::sqrt(one - amrex::Real(16.0)*zeta);
             amrex::Real psi_k_h = two * std::log(myhalf * (one + x));


### PR DESCRIPTION
The Cheng-Brutsaert/Jimenez stable similarity functions use 6.1 for momentum and 5.3 for heat. calc_psi_h2 incorrectly reused the momentum coefficient, overestimating the magnitude of psi_h and affecting surface heat and moisture transfer under stable stratification.

Use the correct heat coefficient of 5.3 with exponent 1.1.