### PR TITLE
Initialize sponge target velocities

### DIFF
--- a/Source/DataStructs/ERF_SpongeStruct.H
+++ b/Source/DataStructs/ERF_SpongeStruct.H
@@ -95,6 +95,8 @@ struct SpongeChoice {
     amrex::Real sponge_density = -one;
     amrex::Real sponge_rhotheta = -one;
     amrex::Real sponge_rhomoist = -one;
-    amrex::Real sponge_x_velocity, sponge_y_velocity, sponge_z_velocity;
+    amrex::Real sponge_x_velocity = zero;
+    amrex::Real sponge_y_velocity = zero;
+    amrex::Real sponge_z_velocity = zero;
 };
 #endif


### PR DESCRIPTION
SpongeChoice relied on static zero-initialization when the optional target velocity parameters were omitted. Automatic or independently constructed instances could instead retain indeterminate values because ParmParse query leaves missing parameters unchanged.

Initialize all sponge target velocities explicitly to zero, preserving the existing production behavior while making the structure safe and self-contained.