### PR TITLE
Cancel in-progress CI when a PR is closed or merged

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-ci
@@ -18,6 +19,8 @@ concurrency:
 jobs:
 
   Build-And-Test:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ${{matrix.os}}
     name: OS ${{matrix.os}} - Particles ${{matrix.particles}}
     env:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,9 @@
 name: codespell
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-codespell
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   codespell:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-22.04
 
     steps:

--- a/.github/workflows/cuda-ci.yml
+++ b/.github/workflows/cuda-ci.yml
@@ -10,6 +10,7 @@ on:
 
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-cuda-ci
@@ -17,6 +18,8 @@ concurrency:
 
 jobs:
   cuda-build:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-22.04
     name: CUDA v${{matrix.cuda_ver}} - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     strategy:
@@ -35,10 +38,6 @@ jobs:
             cuda_pkg: 12-2
             cuda_arch: "8.0"
     steps:
-      - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.13.1
-        with:
-          access_token: ${{github.token}}
       - uses: actions/checkout@v7
         with:
           submodules: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,9 @@
 name: DocHTML -- Build and Deploy
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-docs
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   build-and-deploy:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/gcc-rrtmgp.yml
+++ b/.github/workflows/gcc-rrtmgp.yml
@@ -1,6 +1,10 @@
 name: Linux GCC NetCDF RRTMGP
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc-rrtmgp
@@ -8,6 +12,8 @@ concurrency:
 
 jobs:
   library:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: GNU@9.3 C++17 Release - NetCDF ${{matrix.netcdf}} - Particles ${{matrix.particles}} - RRTMGP ${{matrix.rrtmgp}}
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -1,6 +1,9 @@
 name: Linux GCC
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-linux-gcc
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   library:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: GNU@9.3 C++17 Release - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     runs-on: ubuntu-22.04
     # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}

--- a/.github/workflows/hip.yml
+++ b/.github/workflows/hip.yml
@@ -10,6 +10,7 @@ on:
 
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-hip
@@ -20,6 +21,8 @@ jobs:
   # https://gitlab.kitware.com/cmake/cmake/-/issues/21968
   # https://github.com/ROCm-Developer-Tools/HIP/issues/2246
   Build-And-Test-HIP:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: HIP ROCm GFortran@9.3 C++17 - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     runs-on: ubuntu-22.04
     # Have to have -Wno-deprecated-declarations due to deprecated atomicAddNoRet

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,9 @@
 name: MacOS
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-macos
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   MacOS-Clang:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: Apple Clang@11.0 - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     runs-on: macos-latest
     # env: {CXXFLAGS: "-fno-operator-names -Werror -Wall -Wextra -Wpedantic -Wnull-dereference -Wfloat-conversion -Wshadow -Woverloaded-virtual"}

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,6 +1,9 @@
 name: Style
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-style
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   tabs:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
@@ -15,6 +20,8 @@ jobs:
         run: .github/workflows/style/check_tabs.sh
 
   trailing_whitespaces:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/sycl.yml
+++ b/.github/workflows/sycl.yml
@@ -10,6 +10,7 @@ on:
 
   pull_request:
     branches: [development]
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-sycl
@@ -17,6 +18,8 @@ concurrency:
 
 jobs:
   Build-And-Test-SYCL:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: oneAPI SYCL - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/windows-mpi.yml
+++ b/.github/workflows/windows-mpi.yml
@@ -1,6 +1,9 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows-mpi
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   WIN64-MSVC:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: WIN64-MSVC - MPI ${{ matrix.mpi }} - Mesh ${{ matrix.mesh_precision }} Particles ${{ matrix.particles }} ${{ matrix.particles_precision }}
     runs-on: windows-latest
     strategy:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,6 +1,9 @@
 name: Windows
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.head_ref }}-windows
@@ -8,6 +11,8 @@ concurrency:
 
 jobs:
   WIN32-MSVC10:
+    # The closed event exists only to cancel in-progress runs via concurrency.
+    if: github.event.action != 'closed'
     name: WIN32 MSVC@19.29 - Mesh ${{matrix.mesh_precision}} Particles ${{matrix.particles}} ${{matrix.particles_precision}}
     runs-on: windows-latest
     strategy:


### PR DESCRIPTION
Add `closed` to the pull_request types of the 12 workflows with a concurrency block, and guard every job with
`if: github.event.action != 'closed'`. The closed run joins the existing group, cancels what is in flight, then skips its jobs without ever provisioning a runner. Needs no token, so fork PRs work too.

Also drop the styfle/cancel-workflow-action step from cuda-ci.yml: it duplicates that workflow's own concurrency block and is a no-op for fork PRs.