### PR TITLE
Fix out-of-bounds dz_s read in TerrainIF at top domain boundary

### DIFF
--- a/Source/EB/ERF_EBIFTerrain.H
+++ b/Source/EB/ERF_EBIFTerrain.H
@@ -43,7 +43,8 @@ public:
           prob_hi_x(a_geom.ProbHi(0)),
           prob_hi_y(a_geom.ProbHi(1)),
           i_hi(static_cast<int>(std::round((a_geom.ProbHi(0)-a_geom.ProbLo(0))/a_geom.CellSize(0)))),
-          j_hi(static_cast<int>(std::round((a_geom.ProbHi(1)-a_geom.ProbLo(1))/a_geom.CellSize(1))))
+          j_hi(static_cast<int>(std::round((a_geom.ProbHi(1)-a_geom.ProbLo(1))/a_geom.CellSize(1)))),
+          k_hi(static_cast<int>(std::round((a_geom.ProbHi(2)-a_geom.ProbLo(2))/a_geom.CellSize(2))))
         {}
 
     /**
@@ -72,7 +73,7 @@ public:
         amrex::Real terr_z{amrex::Real(0.0)};
 
         // z_stretched
-        const int k1 = static_cast<int>(std::floor((z-prob_lo_z) / dz));
+        const int k1 = std::min(static_cast<int>(std::floor((z-prob_lo_z) / dz)), k_hi - 1);
         const amrex::Real z1 = prob_lo_z + k1*dz;
         const amrex::Real remainder_z = (z - z1)/dz;
         amrex::Real z_stretched = prob_lo_z;
@@ -159,6 +160,8 @@ protected:
     amrex::Real prob_hi_x, prob_hi_y;
     //! Highest terrain-array index in the x and y directions.
     int i_hi, j_hi;
+    //! Number of vertical cells (one past the highest valid dz_s index).
+    int k_hi;
     /**
      * \var TerrainIF::dy
      * \brief Uniform computational mesh spacing in y.

--- a/Source/EB/ERF_EBIFTerrain.H
+++ b/Source/EB/ERF_EBIFTerrain.H
@@ -73,7 +73,7 @@ public:
         amrex::Real terr_z{amrex::Real(0.0)};
 
         // z_stretched
-        const int k1 = std::min(static_cast<int>(std::floor((z-prob_lo_z) / dz)), k_hi - 1);
+        const int k1 = amrex::Clamp(static_cast<int>(std::floor((z-prob_lo_z) / dz)), 0, k_hi - 1);
         const amrex::Real z1 = prob_lo_z + k1*dz;
         const amrex::Real remainder_z = (z - z1)/dz;
         amrex::Real z_stretched = prob_lo_z;


### PR DESCRIPTION
When AMReX's EB2 fillFab samples the level set at z == prob_hi_z (nodal k=nz plane), k1 = floor((z-prob_lo_z)/dz) equals nz, but stretched_dz_d has only nz entries. The resulting one-past-the-end dz_s[nz] read is normally multiplied by remainder_z == 0, but IEEE-754 0*{NaN,Inf}==NaN, so NaN/Inf bits in the adjacent arena slot would propagate into the level set and corrupt EB geometry at the top boundary.

Add a k_hi member (= nz, matching the existing i_hi/j_hi pattern) and clamp k1 to k_hi-1. Mathematically equivalent at the boundary and eliminates the UB.