### PR TITLE
Fix staggered-redistribution domain over-extension on low side

### DIFF
--- a/Source/EB/ERF_EBRedistribute.cpp
+++ b/Source/EB/ERF_EBRedistribute.cpp
@@ -82,7 +82,7 @@ redistribute_term ( int ncomp,
 
                 // Extended geometry domain
                 Box domain_grown = geom.Domain();
-                domain_grown.grow(igrid-1, 1); // Extend geometry domain by 1 in the staggering direction
+                domain_grown.growHi(igrid-1, 1); // Extend geometry domain by 1 in the staggering direction
                 geom_used = Geometry(domain_grown, geom.ProbDomain(), geom.Coord(), geom.isPeriodic());
             }
 


### PR DESCRIPTION
Use growHi instead of grow when extending geom_used for staggered-momentum redistribution. The working box bx_cc is already grown only on the high side (setBig +1) to span lo,hi+1; growing the domain on both sides to lo-1,hi+1 defeats AMReX's dUdt_in zeroing outside the passed domain (leaving the bogus_large_value=1e150 sentinel at i=lo-1 intact) and makes xdir_mns_ok wrongly true at i=lo in AMReX_EB_StateRedistItracker.cpp, allowing state merges across the physical wall.