### PR TITLE
Fix uninitialized ghost rings in wrf_PHB checkpoint write/read

### DIFF
--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -450,7 +450,7 @@ ERF::WriteCheckpointFile () const
 
                 MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,wrf_PHB->nGrowVect());
 
-                MultiFab::Copy(tmp3d,*wrf_PHB,0,0,1,ng);
+                MultiFab::Copy(tmp3d,*wrf_PHB,0,0,1,wrf_PHB->nGrowVect());
                 VisMF::Write(tmp3d, MultiFabFileFullPrefix(lev, checkpointname, "Level_", "PHB"));
             }
         }
@@ -1015,7 +1015,7 @@ ERF::ReadCheckpointFile ()
                 MultiFab tmp3d(convert(grids[0],IntVect(0,0,1)),dmap[0],1,wrf_PHB->nGrowVect());
 
                 VisMF::Read(tmp3d, MultiFabFileFullPrefix(lev, restart_chkfile, "Level_", "PHB"));
-                MultiFab::Copy(*wrf_PHB,tmp3d,0,0,1,ng);
+                MultiFab::Copy(*wrf_PHB,tmp3d,0,0,1,wrf_PHB->nGrowVect());
             }
         }
 #endif


### PR DESCRIPTION
wrf_PHB is allocated with CC+3 ghost cells but the MultiFab::Copy on checkpoint write (line 453) and read (line 1018) used the stale ng from vars_new[cons] ( CC+1), leaving the outer two ghost rings uninitialized. On write this produces byte-non-reproducible checkpoints (sNaN with init_snan=1); on restart wrf_PHB's outer ghosts stay uninitialized and propagate into WRF BDY updates. Use wrf_PHB- >nGrowVect() to match the sibling MUB copy.