### PR TITLE
Sync momenta for anelastic EB.

### DIFF
--- a/Source/TimeIntegration/ERF_SlowRhsPost.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPost.cpp
@@ -219,6 +219,13 @@ void erf_slow_rhs_post (int level, int finest_level,
     //       components come from the LES model or are left as zero.
     // *************************************************************************
 
+    // EB Anelastic: Copy projected momentum with ghost-cell synchronization
+    if (l_anelastic && l_use_eb) {
+        avg_xmom.ParallelCopy(S_data[IntVars::xmom], 0, 0, 1, 0, 1, geom.periodicity());
+        avg_ymom.ParallelCopy(S_data[IntVars::ymom], 0, 0, 1, 0, 1, geom.periodicity());
+        avg_zmom.ParallelCopy(S_data[IntVars::zmom], 0, 0, 1, 0, 1, geom.periodicity());
+    }
+
     // *************************************************************************
     // Define updates and fluxes in the current RK stage
     // *************************************************************************
@@ -315,10 +322,8 @@ void erf_slow_rhs_post (int level, int finest_level,
             cur_cons(i,j,k,n) = new_cons(i,j,k,n);
         });
 
-        // We have projected the velocities stored in S_data but we will use
-        //    the velocities stored in {avg_xmom,avg_ymom,avg_zmom} to update the scalars,
-        //    so we need to copy from S_data (projected) into these
-        if (l_anelastic) {
+        // Non-EB Anelastic: Per-tile copy of projected momentum (EB done above)
+        if (l_anelastic && !l_use_eb) {
             Box tbx_inc = mfi.nodaltilebox(0);
             Box tby_inc = mfi.nodaltilebox(1);
             Box tbz_inc = mfi.nodaltilebox(2);


### PR DESCRIPTION
This PR address issue https://github.com/erf-model/ERF/issues/3549.

The current tile-based copy of momenta in `erf_slow_rhs_post` can cause decomposition-dependent errors for EB because scalar advection requires one additional ghost cell value. To resolve this, the tile copy is replaced by `ParallelCopy` only for EB cases.