### PR TITLE
Address issues recently identified

### DIFF
--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -1494,57 +1494,68 @@ private:
     int
     ComputeGhostCells (const SolverChoice& sc)
     {
-        int ngrow = 0;
+        // We never have fewer than 2 ghost cells
+        int ngrow = 2;
 
-        if (sc.use_num_diff)
-        {
+        // This sets the minimum to 3 if using num_diff but we might still need more 
+        if (sc.use_num_diff) {
             ngrow = 3;
-        } else {
-            if (
-                 (sc.advChoice.dycore_horiz_adv_type    == AdvType::Centered_6th)
-              || (sc.advChoice.dycore_vert_adv_type     == AdvType::Centered_6th)
-              || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Centered_6th)
-              || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Centered_6th)
-              || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Centered_6th)
-              || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Centered_6th) )
-            { ngrow = 3; }
-            else if (
-                 (sc.advChoice.dycore_horiz_adv_type    == AdvType::Upwind_5th)
-              || (sc.advChoice.dycore_vert_adv_type     == AdvType::Upwind_5th)
-              || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Upwind_5th)
-              || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Upwind_5th)
-              || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Upwind_5th)
-              || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Upwind_5th) )
-            { ngrow = 3; }
-            else if (
-                  (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_5)
-               || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_5)
-               || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_5)
-               || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_5)
-               || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_5Z)
-               || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_5Z)
-               || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_5Z)
-               || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_5Z) )
-            { ngrow = 3; }
-            else if (
-                  (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_7)
-               || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_7)
-               || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_7)
-               || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_7)
-               || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_7Z)
-               || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_7Z)
-               || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_7Z)
-               || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_7Z) )
-            { ngrow = 4; }
-            else
-            {
-                if (sc.terrain_type == TerrainType::EB){
-                    ngrow = 4;
-                } else {
-                    ngrow = 2;
-                }
-            }
         }
+
+        // With EB we always have 4 so no need to do further tests
+        if (sc.terrain_type == TerrainType::EB) {
+            ngrow = 4;
+            return ngrow;
+        }
+
+        if (
+             (sc.advChoice.dycore_horiz_adv_type    == AdvType::Centered_6th)
+          || (sc.advChoice.dycore_vert_adv_type     == AdvType::Centered_6th)
+          || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Centered_6th)
+          || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Centered_6th)
+          || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Centered_6th)
+          || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Centered_6th) )
+        { ngrow = 3; }
+        else if (
+             (sc.advChoice.dycore_horiz_adv_type    == AdvType::Upwind_5th)
+          || (sc.advChoice.dycore_vert_adv_type     == AdvType::Upwind_5th)
+          || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Upwind_5th)
+          || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Upwind_5th)
+          || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Upwind_5th)
+          || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Upwind_5th) )
+        { ngrow = 3; }
+        else if (
+              (sc.advChoice.dycore_horiz_adv_type    == AdvType::Weno_5)
+           || (sc.advChoice.dycore_vert_adv_type     == AdvType::Weno_5)
+           || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_5)
+           || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_5)
+           || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_5)
+           || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_5) )
+        { ngrow = 3; }
+        else if (
+              (sc.advChoice.dycore_horiz_adv_type    == AdvType::Weno_5Z)
+           || (sc.advChoice.dycore_vert_adv_type     == AdvType::Weno_5Z)
+           || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_5Z)
+           || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_5Z)
+           || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_5Z)
+           || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_5Z) )
+        { ngrow = 3; }
+        else if (
+              (sc.advChoice.dycore_horiz_adv_type    == AdvType::Weno_7)
+           || (sc.advChoice.dycore_vert_adv_type     == AdvType::Weno_7)
+           || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_7)
+           || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_7)
+           || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_7)
+           || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_7) )
+        { ngrow = 3; }
+        else if (
+              (sc.advChoice.dycore_horiz_adv_type    == AdvType::Weno_7Z)
+           || (sc.advChoice.dycore_vert_adv_type     == AdvType::Weno_7Z)
+           || (sc.advChoice.dryscal_horiz_adv_type   == AdvType::Weno_7Z)
+           || (sc.advChoice.dryscal_vert_adv_type    == AdvType::Weno_7Z)
+           || (sc.advChoice.moistscal_horiz_adv_type == AdvType::Weno_7Z)
+           || (sc.advChoice.moistscal_vert_adv_type  == AdvType::Weno_7Z) )
+        { ngrow = 4; }
 
         return ngrow;
     }

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -748,12 +748,11 @@ ERF::init_zphys (int lev, double elapsed_time)
         if (lev == 0) {
             Real zmax = z_phys_nd[0]->max(0,0,false);
             Real rel_diff = (zmax - zlevels_stag[0][zlevels_stag[0].size()-1]) / zmax;
-            if (rel_diff < Real(1.e-8)) {
+            if (rel_diff > Real(1.e-8)) {
                 amrex::Print() << "max of zphys_nd " << zmax << std::endl;
                 amrex::Print() << "max of zlevels  " << zlevels_stag[0][zlevels_stag[0].size()-1] << std::endl;
-                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(rel_diff < Real(1.e-8), "Terrain is taller than domain top!");
+                amrex::Abort("Terrain is taller than domain top!");
             }
-
 #if 0
             // This remains commented out until we verify that the stretched and variable dz pathways
             //   in fact give the same answer when appropriate
@@ -788,7 +787,8 @@ ERF::init_zphys (int lev, double elapsed_time)
     if (solverChoice.terrain_type == TerrainType::ImmersedForcing ||
         solverChoice.buildings_type == BuildingsType::ImmersedForcing) {
         terrain_blanking[lev]->setVal(one);
-        MultiFab::Subtract(*terrain_blanking[lev], EBFactory(lev).getVolFrac(), 0, 0, 1, ComputeGhostCells(solverChoice) + 2);
+        const int ng_sub = std::min(ComputeGhostCells(solverChoice) + 2, EBFactory(lev).getVolFrac().nGrow());
+        MultiFab::Subtract(*terrain_blanking[lev], EBFactory(lev).getVolFrac(), 0, 0, 1, ng_sub);
         terrain_blanking[lev]->FillBoundary(geom[lev].periodicity());
         init_immersed_forcing(lev); // needed for real cases
 

--- a/Source/LinearSolvers/ERF_PoissonSolve_tb.cpp
+++ b/Source/LinearSolvers/ERF_PoissonSolve_tb.cpp
@@ -112,7 +112,7 @@ void ERF::project_velocity_tb (int lev, double l_dt_d, Vector<MultiFab>& vmf)
         // Calculate u + dt*deltaf
         for (int idim = 0; idim < 3; ++idim) {
             MultiFab::Copy(u_plus_dtdf[0][idim], deltaf[0][idim], 0, 0, 1, 0);
-            u_plus_dtdf[0][0].mult(-l_dt,0,1,0);
+            u_plus_dtdf[0][idim].mult(-l_dt,0,1,0);
         }
         MultiFab::Add(u_plus_dtdf[0][0], vmf[Vars::xvel], 0, 0, 1, 0);
         MultiFab::Add(u_plus_dtdf[0][1], vmf[Vars::yvel], 0, 0, 1, 0);

--- a/Source/MaterialProperties/ERF_MaterialProperties.H
+++ b/Source/MaterialProperties/ERF_MaterialProperties.H
@@ -37,6 +37,7 @@ namespace saturation_funcs
     void compute_saturation_vapfrac_null ( amrex::MultiFab&,
                                            const amrex::MultiFab&,
                                            const amrex::MultiFab& );
+
     /*! \brief Compute saturation vapour fraction for moist air */
     AMREX_GPU_HOST
     void compute_saturation_vapfrac_H2O  ( amrex::MultiFab&,
@@ -174,6 +175,7 @@ struct MaterialProperties : public MaterialPropertiesCore {
 
     /*! pointer to function to compute saturation pressure */
     decltype(saturation_funcs::compute_saturation_pressure_null)* m_saturation_pressure_func = nullptr;
+
     /*! pointer to function to compute vapour fraction */
     decltype(saturation_funcs::compute_saturation_vapfrac_null)* m_saturation_vapfrac_func = nullptr;
 

--- a/Source/MaterialProperties/ERF_MaterialProperties.cpp
+++ b/Source/MaterialProperties/ERF_MaterialProperties.cpp
@@ -26,7 +26,7 @@ namespace saturation_funcs
     }
 
     AMREX_GPU_HOST
-    void compute_saturation_vapfrac_null ( MultiFab&, const MultiFab&) { }
+    void compute_saturation_vapfrac_null ( MultiFab&, const MultiFab&, const MultiFab&) { }
 
     AMREX_GPU_HOST
     void compute_saturation_vapfrac_H2O ( MultiFab&          a_mf_sat_vapfrac,

--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -49,7 +49,7 @@ Morrison::Init (const MultiFab& cons_in,
     }
 
 #ifdef ERF_USE_MORR_FORT
-    bool use_cpp;
+    bool use_cpp = true;
     amrex::ParmParse pp("erf");
     pp.query("use_morr_cpp_answer", use_cpp);
 

--- a/Source/Utils/ERF_ConvertForProjection.cpp
+++ b/Source/Utils/ERF_ConvertForProjection.cpp
@@ -38,9 +38,9 @@ ConvertForProjection (const MultiFab& den_div, const MultiFab& den_mlt,
         // We need velocity in the interior ghost cells (init == real)
         Box bx = mfi.tilebox();
 
-        Box tbx = surroundingNodes(bx,0);
-        Box tby = surroundingNodes(bx,1);
-        Box tbz = surroundingNodes(bx,2);
+        Box tbx = mfi.nodaltilebox(0);
+        Box tby = mfi.nodaltilebox(1);
+        Box tbz = mfi.nodaltilebox(2);
 
         if ( (bx.smallEnd(0) == domain.smallEnd(0)) &&
              ( (bc_ptr_h[BCVars::cons_bc].lo(0) == ERFBCType::ext_dir) ||

--- a/Source/Utils/ERF_MomentumToVelocity.cpp
+++ b/Source/Utils/ERF_MomentumToVelocity.cpp
@@ -126,7 +126,7 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(0) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tbx,0,domain.smallEnd(0)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                ParallelFor(makeSlab(tbx,0,domain.bigEnd(0)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                     if (momx(i,j,k) <= zero) {
                         velx(i,j,k) = momx(i,j,k) / dens_arr(i,j,k,Rho_comp);
                     }
@@ -160,7 +160,7 @@ MomentumToVelocity (MultiFab& xvel, MultiFab& yvel, MultiFab& zvel,
             }
             else if (bc_ptr_h[BCVars::cons_bc].hi(1) == ERFBCType::ext_dir_upwind)
             {
-                ParallelFor(makeSlab(tby,1,domain.smallEnd(1)), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
+                ParallelFor(makeSlab(tby,1,domain.bigEnd(1)+1), [=] AMREX_GPU_DEVICE (int i, int j, int k) {
                     if (momy(i,j,k) <= zero) {
                         vely(i,j,k) = momy(i,j,k) / dens_arr(i,j,k,Rho_comp);
                     }

--- a/Source/Utils/ERF_VolWgtSum.cpp
+++ b/Source/Utils/ERF_VolWgtSum.cpp
@@ -130,7 +130,7 @@ ERF::build_fine_mask (int level, MultiFab& fine_mask_lev)
     BoxArray cba            = grids[level-1];
     DistributionMapping cdm = dmap[level-1];
 
-    BoxArray fba            = fine_mask_lev.boxArray();
+    BoxArray fba            = grids[level];
 
     iMultiFab ifine_mask_lev = makeFineMask(cba, cdm, fba, ref_ratio[level-1], 1, 0);
 

--- a/Source/main.cpp
+++ b/Source/main.cpp
@@ -211,7 +211,11 @@ return code;
 #else
     amrex::Initialize(argc,argv,true,MPI_COMM_WORLD,add_par);
 #endif
-    CheckForDuplicateInputs(argv[1]);
+
+    // Only when argv[1] is actually an inputs file (same test the surrounding code uses).
+    if (argc > 1 && std::string(argv[1]).find('=') == std::string::npos) {
+        CheckForDuplicateInputs(argv[1]);
+    }
 
 #ifdef ERF_USE_KOKKOS
     // Initialize kokkos


### PR DESCRIPTION
This PR closes issues 3707, 3708, 3710, 3653, 3698, 3584, 3579, 3576, 3577, 3705.

Summary of effects:
3707 : fix for thin body Poisson solve
3708: fix for upwind boundary conditions as used in MomentumToVelocity
3653: fix for assertion hidden by wrong logic
3710: correct the test to determine number of ghost cells needed for WENO5/5Z/7/7Z
3698: fix for projection (only on conversion of velocity before actual projection)
3584: fix number of ghost cells in defining terrain_blanking
3579: uninitialized boolean in Morrison microphysics for using cpp vs fortran answer - set default to true
3576: wrap call to check for duplicates in main.cpp 
3577: matching call signature (no effect)
3705: fix for making fine mask used in multi-level volume-weighted averagin