### PR TITLE
replace mesh spacing by grid spacing for consistency

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -446,7 +446,7 @@ Time Step
 
 The solver timestep can be fixed by the user or computed dynamically at each timestep based on the user-specified CFL
 number --- i.e., adaptive time stepping. For the compressible equations, the timestep calculation uses the acoustic CFL constraint.
-We note that when using implicit substepping, the vertical mesh spacing does not appear in the time step calculation.
+We note that when using implicit substepping, the vertical grid spacing does not appear in the time step calculation.
 The number of acoustic sub-steps per timestep can also be specified by the user as a fixed value or by specifying the
 number of substeps per RK stage.  For the anelastic equations, the timestep calculation uses the advective CFL constraint,
 which means it is determined by the fluid speed rather than the sound speed and thus allows much larger timesteps.

--- a/Docs/sphinx_doc/Meshing.rst
+++ b/Docs/sphinx_doc/Meshing.rst
@@ -17,9 +17,9 @@ See `WoA`_ for an example of a terrain-fitted grid; this one follows the Witch o
 
 .. _`WoA`: https://github.com/erf-model/validation/blob/main/JAMES_Paper/Flow_Over_Terrain/WoA_mesh.png
 
-As in many atmospheric modeling codes, variable mesh spacing in the vertical direction is allowed with or without terrain.
+As in many atmospheric modeling codes, variable grid spacing in the vertical direction is allowed with or without terrain.
 The heights of each level can be parsed from a text file as "z levels" (as in WRF), or calculated at run-time given an
-initial mesh spacing at the bottom surface and a specified growth rate.  In the presence of non-flat terrain, the mesh is
+initial grid spacing at the bottom surface and a specified growth rate.  In the presence of non-flat terrain, the mesh is
 modified so that it fits the specified terrain at the bottom of the computational domain, and relaxes to flat at the top of the domain.
 Three approaches to this are offered in ERF: Basic Terrain Following (BTF), in which the influence of the terrain decreases
 linearly with height;  Smoothed Terrain Following (STF), in which small-scale terrain structures are progressively smoothed out

--- a/Docs/sphinx_doc/theory/DNSvsLES.rst
+++ b/Docs/sphinx_doc/theory/DNSvsLES.rst
@@ -99,7 +99,7 @@ Smagorinsky Model
 .. math::
    \mu_{t} = (C_s \Delta)^2 (\sqrt{2 \tilde{S} \tilde{S}}) \overline{\rho}
 
-:math:`C_s` is the Smagorinsky constant and :math:`\Delta` is the cube root of cell volume, the representative mesh spacing.
+:math:`C_s` is the Smagorinsky constant and :math:`\Delta` is the cube root of cell volume, the representative grid spacing.
 
 .. math::
    \tau_{ij} = -2\mu_{t} \tilde{\sigma}_{ij} = -K \tilde{\sigma}_{ij}

--- a/Docs/sphinx_doc/theory/WindFarmModels.rst
+++ b/Docs/sphinx_doc/theory/WindFarmModels.rst
@@ -119,7 +119,7 @@ with
 .. math::
     \sigma_e = \frac{\overline{u}_0}{3KL}\left[\left(\frac{2KL}{\overline{u}_0} + \sigma_0^2\right)^{\frac{3}{2}} - \sigma_0^3\right]
 
-where :math:`N_{ij}` is the number of turbines in cell :math:`(i,j)`, :math:`c_t` is the thrust coefficient, :math:`r_0` is the rotor radius, :math:`\overline{u}_0` is the mean advection velocity at hub height, :math:`h` is the hub height, :math:`\sigma_0 \approx 1.7 r_0` [`Volker et al. 2017`_] is a length scale that accounts for near-wake expansion, :math:`L` is the downstream distance that the wake travels within the cell approximated as a fraction of the cell size, :math:`K` is the turbulence eddy diffusivity (:math:`m^2/s`), :math:`\Delta x` and :math:`\Delta y` are the mesh sizes in the horizontal directions, and :math:`\phi(k)` is the wind direction with respect to the x-axis. :math:`\overline{u}_{i,h}` and :math:`\overline{u'}_{i,h}` are the mean and the fluctuating values of the velocity components (subscript :math:`i` is the direction index) at the hub height :math:`h`, :math:`A_r = \pi r^2` is the swept area of the rotor and :math:`\rho` is the density of air.
+where :math:`N_{ij}` is the number of turbines in cell :math:`(i,j)`, :math:`c_t` is the thrust coefficient, :math:`r_0` is the rotor radius, :math:`\overline{u}_0` is the mean advection velocity at hub height, :math:`h` is the hub height, :math:`\sigma_0 \approx 1.7 r_0` [`Volker et al. 2017`_] is a length scale that accounts for near-wake expansion, :math:`L` is the downstream distance that the wake travels within the cell approximated as a fraction of the cell size, :math:`K` is the turbulence eddy diffusivity (:math:`m^2/s`), :math:`\Delta x` and :math:`\Delta y` are the cell sizes in the horizontal directions, and :math:`\phi(k)` is the wind direction with respect to the x-axis. :math:`\overline{u}_{i,h}` and :math:`\overline{u'}_{i,h}` are the mean and the fluctuating values of the velocity components (subscript :math:`i` is the direction index) at the hub height :math:`h`, :math:`A_r = \pi r^2` is the swept area of the rotor and :math:`\rho` is the density of air.
 
 The EWP model does not have a concept of intersected area by the turbine rotor like the Fitch model (see :ref:`Fitch model`). The exponential factor in the source terms for the velocities models the effect of the rotor for the momentum sinks (see Fig. :numref:`fig:WindTurbine_EWP`), and the turbulent kinetic energy source term only depends on the density, hub-height mean velocities and fluctuations, and the total swept area of the rotor :math:`A_r`.
 
@@ -208,7 +208,7 @@ The generalized actuator model (GAD) based on blade element theory (`Mirocha et.
    \frac{\partial v}{\partial t} &= -\frac{F_y}{\rho \Delta x\Delta y\Delta z} \\
    \frac{\partial w}{\partial t} &= -\frac{F_z}{\rho \Delta x\Delta y\Delta z},
 
-where :math:`\rho` is the density of air in the cell, and :math:`\Delta x, \Delta y, \Delta z` are the mesh spacing in the x, y, and z directions. The forces on the GAD are given by:
+where :math:`\rho` is the density of air in the cell, and :math:`\Delta x, \Delta y, \Delta z` are the grid spacing in the x, y, and z directions. The forces on the GAD are given by:
 
 .. math::
    :label: GAD_forces

--- a/Source/Advection/ERF_AdvectionSrcForMom.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom.cpp
@@ -37,7 +37,7 @@ using namespace amrex;
  * @param[in] az   Area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation (= 1 if use_terrain_fitted_coords is false)
  * @param[in] stretched_dz_d device vector of vertical cell spacing
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_ux x map factor at x-faces
  * @param[in] mf_vx x map factor at y-faces
@@ -48,7 +48,7 @@ using namespace amrex;
  * @param[in] vert_adv_type  sets the spatial order to be used for vertical derivatives
  * @param[in] horiz_upw_frac horizontal upwind blending fraction
  * @param[in] vert_upw_frac vertical upwind blending fraction
- * @param[in] mesh_type mesh spacing type
+ * @param[in] mesh_type grid spacing type
  * @param[in] terrain_type terrain representation type
  * @param[in] ebfact EB factories for cell- and face-centered variables
  * @param[in,out] flx_u_arr container of fluxes for x-momentum

--- a/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_ConstantDz.cpp
@@ -22,7 +22,7 @@ using namespace amrex;
  * @param[in] rho_u x-component of the momentum
  * @param[in] rho_v y-component of the momentum
  * @param[in] omega component of the momentum normal to the z-coordinate surface
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] stretched_dz_d device vector of vertical cell spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_ux x map factor at x-faces

--- a/Source/Advection/ERF_AdvectionSrcForMom_EB.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_EB.cpp
@@ -27,7 +27,7 @@ using namespace amrex;
  * @param[in] rho_u x-component of the momentum
  * @param[in] rho_v y-component of the momentum
  * @param[in] omega component of the momentum normal to the z-coordinate surface
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_ux x map factor at x-faces
  * @param[in] mf_vx x map factor at y-faces

--- a/Source/Advection/ERF_AdvectionSrcForMom_N.H
+++ b/Source/Advection/ERF_AdvectionSrcForMom_N.H
@@ -18,9 +18,9 @@
  * @param[in] mf_ux_inv inverse x map factor on x-faces
  * @param[in] mf_uy_inv inverse y map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces
- * @param[in] dxInv inverse mesh spacing in x
- * @param[in] dyInv inverse mesh spacing in y
- * @param[in] dzInv inverse mesh spacing in z
+ * @param[in] dxInv inverse grid spacing in x
+ * @param[in] dyInv inverse grid spacing in y
+ * @param[in] dzInv inverse grid spacing in z
  * @return advective tendency for x-momentum
  */
 template<typename InterpType_H, typename InterpType_V>
@@ -100,9 +100,9 @@ AdvectionSrcForXMom_N (int i, int j, int k,
  * @param[in] mf_uy_inv inverse y map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces
  * @param[in] mf_vy_inv inverse y map factor on y-faces
- * @param[in] dxInv inverse mesh spacing in x
- * @param[in] dyInv inverse mesh spacing in y
- * @param[in] dzInv inverse mesh spacing in z
+ * @param[in] dxInv inverse grid spacing in x
+ * @param[in] dyInv inverse grid spacing in y
+ * @param[in] dzInv inverse grid spacing in z
  * @return advective tendency for y-momentum
  */
 template<typename InterpType_H, typename InterpType_V>
@@ -189,9 +189,9 @@ AdvectionSrcForYMom_N (int i, int j, int k,
  * @param[in] vert_adv_type vertical advection stencil
  * @param[in] lo_z_face minimum z-face k-index at this level
  * @param[in] hi_z_face maximum z-face k-index at this level
- * @param[in] dxInv inverse mesh spacing in x
- * @param[in] dyInv inverse mesh spacing in y
- * @param[in] dzInv inverse mesh spacing in z
+ * @param[in] dxInv inverse grid spacing in x
+ * @param[in] dyInv inverse grid spacing in y
+ * @param[in] dzInv inverse grid spacing in z
  * @return advective tendency for z-momentum
  */
 template<typename InterpType_H, typename InterpType_V, typename WallInterpType>
@@ -316,7 +316,7 @@ AdvectionSrcForZMom_N (int i, int j, int k,
  * @param[in] u x-component of velocity
  * @param[in] v y-component of velocity
  * @param[in] w z-component of velocity
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] stretched_dz_d device vector of vertical cell spacing
  * @param[in] mf_mx x map factor on cell centers
  * @param[in] mf_ux_inv inverse x map factor on x-faces
@@ -414,7 +414,7 @@ AdvectionSrcForMomWrapper_N (const amrex::Box& bxx, const amrex::Box& bxy, const
  * @param[in] u x-component of velocity
  * @param[in] v y-component of velocity
  * @param[in] w z-component of velocity
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] stretched_dz_d device vector of vertical cell spacing
  * @param[in] mf_mx x map factor on cell centers
  * @param[in] mf_ux_inv inverse x map factor on x-faces

--- a/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_StretchedDz.cpp
@@ -22,7 +22,7 @@ using namespace amrex;
  * @param[in] rho_u x-component of the momentum
  * @param[in] rho_v y-component of the momentum
  * @param[in] omega component of the momentum normal to the z-coordinate surface
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] stretched_dz_d device vector of vertical cell spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_ux x map factor at x-faces

--- a/Source/Advection/ERF_AdvectionSrcForMom_T.H
+++ b/Source/Advection/ERF_AdvectionSrcForMom_T.H
@@ -20,7 +20,7 @@
  * @param[in] detJ Jacobian of the metric transformation (= 1 if use_terrain is false)
  * @param[in] interp_u_h horizontal interpolator for x-component velocity
  * @param[in] interp_u_v vertical interpolator for x-component velocity
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_ux_inv inverse x map factor on x-faces
  * @param[in] mf_uy_inv inverse y map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces
@@ -125,7 +125,7 @@ AdvectionSrcForXMom (int i, int j, int k,
  * @param[in] detJ Jacobian of the metric transformation (= 1 if use_terrain is false)
  * @param[in] interp_v_h horizontal interpolator for y-component velocity
  * @param[in] interp_v_v vertical interpolator for y-component velocity
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_uy_inv inverse y map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces
  * @param[in] mf_vy_inv inverse y map factor on y-faces
@@ -232,7 +232,7 @@ AdvectionSrcForYMom (int i, int j, int k,
  * @param[in] interp_omega_h horizontal interpolator for z-coordinate-normal momentum
  * @param[in] interp_omega_v vertical interpolator for z-coordinate-normal momentum
  * @param[in] interp_omega_wall wall-aware vertical interpolator for z-coordinate-normal momentum
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor on cell centers
  * @param[in] mf_my y map factor on cell centers
  * @param[in] mf_uy_inv inverse y map factor on x-faces
@@ -396,7 +396,7 @@ AdvectionSrcForZMom (int i, int j, int k,
  * @param[in] ay area fractions on y-faces
  * @param[in] az area fractions on z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] mf_mx x map factor on cell centers
  * @param[in] mf_ux_inv inverse x map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces
@@ -491,7 +491,7 @@ AdvectionSrcForMomWrapper (const amrex::Box& bxx, const amrex::Box& bxy, const a
  * @param[in] ay area fractions on y-faces
  * @param[in] az area fractions on z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] mf_mx x map factor on cell centers
  * @param[in] mf_ux_inv inverse x map factor on x-faces
  * @param[in] mf_vx_inv inverse x map factor on y-faces

--- a/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
@@ -27,7 +27,7 @@ using namespace amrex;
  * @param[in] ay   Area fraction of y-faces
  * @param[in] az   Area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_ux x map factor at x-faces
  * @param[in] mf_vx x map factor at y-faces

--- a/Source/Advection/ERF_AdvectionSrcForOpenBC.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForOpenBC.cpp
@@ -10,7 +10,7 @@ using namespace amrex;
  * @param[out] rhs_arr tendency for the boundary-normal momentum equation
  * @param[in] vel_norm_arr velocity component normal to the open boundary
  * @param[in] cell_data_arr cell-centered conservative state
- * @param[in] dxInv inverse mesh spacing
+ * @param[in] dxInv inverse grid spacing
  * @param[in] do_lo flag for a low-side open boundary
  */
 void
@@ -58,7 +58,7 @@ AdvectionSrcForOpenBC_Normal (const Box& bx,
  * @param[in] ax area fraction of x-faces
  * @param[in] az area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] do_lo flag for a low-side open boundary
  */
 void
@@ -113,7 +113,7 @@ AdvectionSrcForOpenBC_Tangent_Xmom (const Box& bxx,
  * @param[in] ay area fraction of y-faces
  * @param[in] az area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] do_lo flag for a low-side open boundary
  */
 void
@@ -169,7 +169,7 @@ AdvectionSrcForOpenBC_Tangent_Ymom (const Box& bxy,
  * @param[in] ay area fraction of y-faces
  * @param[in] az area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] domhi_z maximum cell-centered k-index in the domain
  * @param[in] do_lo flag for a low-side open boundary
  */
@@ -245,7 +245,7 @@ AdvectionSrcForOpenBC_Tangent_Zmom (const Box& bxz,
  * @param[in] avg_ymom y-component of time-averaged momentum
  * @param[in] avg_zmom z-component of time-averaged momentum
  * @param[in] detJ Jacobian of the metric transformation
- * @param[in] cellSizeInv inverse mesh spacing
+ * @param[in] cellSizeInv inverse grid spacing
  * @param[in] do_lo flag for a low-side open boundary
  */
 void
@@ -315,7 +315,7 @@ AdvectionSrcForOpenBC_Tangent_Cons (const Box& bx,
  * @param[in] dir coordinate direction normal to the open boundary
  * @param[in] prim_tang_arr primitive variable tangent to the open boundary
  * @param[in] mom_norm_arr momentum component normal to the open boundary
- * @param[in] dxInv inverse mesh spacing in the open-boundary normal direction
+ * @param[in] dxInv inverse grid spacing in the open-boundary normal direction
  * @param[in] do_lo flag for a low-side open boundary
  * @return source contribution before the wrapper applies its sign convention
  */

--- a/Source/Advection/ERF_AdvectionSrcForState.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForState.cpp
@@ -22,7 +22,7 @@ using namespace amrex;
  * @param[in] ay_arr area fraction of y-faces
  * @param[in] az_arr area fraction of z-faces
  * @param[in] detJ Jacobian of the metric transformation (= 1 if use_terrain is false)
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_my y map factor at cell centers
  * @param[in] mf_uy y map factor at x-faces
@@ -113,7 +113,7 @@ AdvectionSrcForRho (const Box& bx,
  * @param[in] cell_prim primitive form of scalar variables, here only potential temperature theta
  * @param[out] advectionSrc tendency for the scalar update equation
  * @param[in] detJ Jacobian of the metric transformation (= 1 if use_terrain is false)
- * @param[in] cellSizeInv inverse of the mesh spacing
+ * @param[in] cellSizeInv inverse of the grid spacing
  * @param[in] mf_mx x map factor at cell centers
  * @param[in] mf_my y map factor at cell centers
  * @param[in] horiz_adv_type advection scheme to be used in horiz. directions for dry scalars

--- a/Source/Diffusion/ERF_ComputeStrain_S.cpp
+++ b/Source/Diffusion/ERF_ComputeStrain_S.cpp
@@ -25,7 +25,7 @@ using namespace amrex;
  * @param[out] tau31 31 strain
  * @param[out] tau32 32 strain
  * @param[in] bc_ptr container with boundary condition types
- * @param[in] stretched_dz_d array of vertical mesh spacings
+ * @param[in] stretched_dz_d array of vertical grid spacings
  * @param[in] dxInv inverse cell size array
  * @param[in] mf_mx map factor at cell center
  * @param[in] mf_ux map factor at x-face

--- a/Source/Diffusion/ERF_DiffusionSrcForMom.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForMom.cpp
@@ -23,7 +23,7 @@ using namespace amrex;
  * @param[in]  tau31 31 stress
  * @param[in]  tau32 32 stress
  * @param[in]  detJ Jacobian determinant
- * @param[in]  stretched_dz_d array of vertical mesh spacings
+ * @param[in]  stretched_dz_d array of vertical grid spacings
  * @param[in]  dxInv inverse cell size array
  * @param[in]  mf_mx x map factor at cell centers
  * @param[in]  mf_ux x map factor at x-faces

--- a/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
+++ b/Source/Diffusion/ERF_DiffusionSrcForState_S.cpp
@@ -19,7 +19,7 @@ using namespace amrex;
  * @param[in]  xflux flux in x-dir
  * @param[in]  yflux flux in y-dir
  * @param[in]  zflux flux in z-dir
- * @param[in]  stretched_dz_d array of vertical mesh spacings
+ * @param[in]  stretched_dz_d array of vertical grid spacings
  * @param[in]  cellSizeInv inverse cell size array
  * @param[in]  SmnSmn_a strain rate magnitude
  * @param[in]  mf_mx x map factor at cell centers

--- a/Source/EB/ERF_EBAdvectionSrcForState.cpp
+++ b/Source/EB/ERF_EBAdvectionSrcForState.cpp
@@ -34,7 +34,7 @@ using namespace amrex;
  * @param[in] fcy_arr Face centroid on y-faces.
  * @param[in] fcz_arr Face centroid on z-faces.
  * @param[in] detJ Jacobian of the metric transformation.
- * @param[in] cellSizeInv Inverse mesh spacing.
+ * @param[in] cellSizeInv Inverse grid spacing.
  * @param[in] mf_mx x-direction map factor at cell centers.
  * @param[in] mf_my y-direction map factor at cell centers.
  * @param[in] mf_uy Map factor used for x-momentum fluxes.
@@ -243,7 +243,7 @@ EBAdvectionSrcForRho (const Box& bx,
  * @param[in] fcy_arr Face centroid on y-faces.
  * @param[in] fcz_arr Face centroid on z-faces.
  * @param[in] detJ Jacobian of the metric transformation.
- * @param[in] cellSizeInv Inverse mesh spacing.
+ * @param[in] cellSizeInv Inverse grid spacing.
  * @param[in] mf_mx x-direction map factor at cell centers.
  * @param[in] mf_my y-direction map factor at cell centers.
  * @param[in] horiz_adv_type Horizontal advection scheme.

--- a/Source/EB/ERF_EBIFTerrain.H
+++ b/Source/EB/ERF_EBIFTerrain.H
@@ -27,7 +27,7 @@ public:
     /**
      * \brief Construct a terrain implicit function from height and geometry data.
      * \param a_z_terrain Terrain elevation values on the horizontal mesh.
-     * \param a_geom Geometry used for mesh spacing and problem bounds.
+     * \param a_geom Geometry used for grid spacing and problem bounds.
      * \param a_dz_stretched Device vector of stretched vertical cell sizes.
      */
     TerrainIF (amrex::FArrayBox const& a_z_terrain, amrex::Geometry const& a_geom,
@@ -152,7 +152,7 @@ protected:
     amrex::Array4<amrex::Real const> terr_arr;
     //! Device pointer to stretched vertical cell sizes.
     amrex::Real const* dz_s;
-    //! Uniform computational mesh spacing in each direction.
+    //! Uniform computational grid spacing in each direction.
     amrex::Real dx, dy, dz;
     //! Low problem bounds used for interpolation.
     amrex::Real prob_lo_x, prob_lo_y, prob_lo_z;
@@ -164,11 +164,11 @@ protected:
     int k_hi;
     /**
      * \var TerrainIF::dy
-     * \brief Uniform computational mesh spacing in y.
+     * \brief Uniform computational grid spacing in y.
      */
     /**
      * \var TerrainIF::dz
-     * \brief Uniform computational mesh spacing in z.
+     * \brief Uniform computational grid spacing in z.
      */
     /**
      * \var TerrainIF::prob_lo_y

--- a/Source/Utils/ERF_PlaneAverage.H
+++ b/Source/Utils/ERF_PlaneAverage.H
@@ -63,7 +63,7 @@ protected:
 
     amrex::Vector<amrex::Real> m_line_xcentroid; /** line storage for centroids of each cell along a line*/
 
-    amrex::Real m_dx;  /** mesh spacing in axis direction*/
+    amrex::Real m_dx;  /** grid spacing in axis direction*/
     amrex::Real m_xlo; /** bottom of domain in axis direction */
 
     int m_ncell_plane; /** number of cells in plane */

--- a/Source/WindFarmParametrization/ERF_WindFarm.cpp
+++ b/Source/WindFarmParametrization/ERF_WindFarm.cpp
@@ -402,7 +402,7 @@ WindFarm::fill_Nturb_multifab (const Geometry& geom,
     int j_lo = geom.Domain().smallEnd(1); int j_hi = geom.Domain().bigEnd(1);
     auto dx = geom.CellSizeArray();
     if(dx[0]<= 1e-3 or dx[1]<=1e-3 or dx[2]<= 1e-3) {
-        Abort("The value of mesh spacing for wind farm parametrization cannot be less than 1e-3 m. "
+        Abort("The value of grid spacing for wind farm parametrization cannot be less than 1e-3 m. "
               "It should be usually of order 1 m");
     }
     auto ProbLoArr = geom.ProbLoArray();


### PR DESCRIPTION
This enforces consistency of wording replacing "mesh spacing" by "grid spacing" -- changes commented lines and documentation only