### PR TITLE
Issue 3709

### DIFF
--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -2054,18 +2054,62 @@ init_terrain_from_wrfinput (int /*lev*/,
                                    z_slice_wrf.size(),
                                    ParallelContext::CommunicatorAll());
 
-            // Solve for node values that average to WRF z-face values
-            // while minimizing the first derivative
-            const Real tol = std::numeric_limits<Real>::epsilon();
+            // Solve for node values that reproduce the WRF z-face values as
+            // closely as a bounded, smooth nodal field can.  We deliberately do
+            // *not* invert the four-node averaging operator exactly: its symbol
+            // vanishes at the grid Nyquist mode, so exact de-averaging amplifies
+            // grid-scale content of the WRF terrain without bound and returns
+            // nodal heights that are kilometers away from the WRF terrain.
+            // See ERF_NodalReconstruction.H for the regularized least-squares
+            // formulation used instead.
+            const Real tol = Real(1.e-10);
             NodalReconstruction NR_solver(z_face_dom_slice, geom);
-            auto boundary = NR_solver.makeBoundaryFromT(z_slice_wrf);
-            std::pair<amrex::FArrayBox,SolveInfo> result = NR_solver.solve(z_slice_wrf, boundary,
-                                                                           VariationOperator::Laplacian, tol);
+            FArrayBox z_slice_ref = NR_solver.makeReference(z_slice_wrf);
+            std::pair<amrex::FArrayBox,SolveInfo> result = NR_solver.solve(z_slice_wrf, z_slice_ref,
+                                                                           VariationOperator::FirstDeriv, tol);
             const Array4<Real>& z_slice_erf_arr = result.first.array();
-            if (!result.second.converged) {
+            const SolveInfo& info = result.second;
+            if (!info.converged) {
                 Print() << "WARNING: Nodal reconstruction did not converge at k = " << k
-                        << "; residual is: " << result.second.final_residual
+                        << "; residual is: " << info.final_residual
                         << " and requested tolerance was: " << tol << "\n";
+            }
+
+            // Range check on the reconstructed heights.  This is the check that
+            // has teeth: comparing the four-node average against WRF (done at
+            // the end of this routine) is close to satisfied by construction and
+            // cannot detect a blown-up reconstruction.
+            {
+                Real wrf_min =  std::numeric_limits<Real>::max();
+                Real wrf_max = -std::numeric_limits<Real>::max();
+                LoopOnCpu(z_face_dom_slice, [=,&wrf_min,&wrf_max] (int i, int j, int /*k*/) noexcept
+                {
+                    wrf_min = amrex::min(wrf_min, z_slice_wrf_arr(i,j,0));
+                    wrf_max = amrex::max(wrf_max, z_slice_wrf_arr(i,j,0));
+                });
+
+                Print() << "Nodal reconstruction at k = " << k << ": "
+                        << info.iterations << " CG iterations, " << info.refinements
+                        << " refinements, regularization " << info.regularization
+                        << "\n    nodal heights in [" << info.min_value << ", " << info.max_value
+                        << "] m vs WRF z-faces in [" << wrf_min << ", " << wrf_max << "] m"
+                        << "\n    max |avg4(nodal) - WRF| = " << info.max_average_error
+                        << " m (direct interpolation gives " << info.interp_average_error << " m)"
+                        << "\n    max deviation from direct interpolation = " << info.deviation
+                        << " m (cap " << info.deviation_cap << " m)" << std::endl;
+
+                // Nodes may legitimately over/undershoot the cell values where
+                // the terrain is under-resolved, but only by a fraction of the
+                // relief of the layer itself.
+                const Real relief = amrex::max(wrf_max - wrf_min, Real(1.0));
+                const Real slack  = amrex::max(Real(0.5) * relief, Real(10.0));
+
+                if ( !std::isfinite(info.min_value) || !std::isfinite(info.max_value) ||
+                     (info.min_value < wrf_min - slack) || (info.max_value > wrf_max + slack) )
+                {
+                    Error("Nodal reconstruction produced heights far outside the range of the "
+                          "WRF z-face heights; the reconstruction is not usable as terrain.");
+                }
             }
 
             // Store the surface
@@ -2106,40 +2150,64 @@ init_terrain_from_wrfinput (int /*lev*/,
             }
         } // k
 
-        // Sanity check
-        Print() << "Verifying nodal heights average to WRF z-face heights" << std::endl;
-        for ( MFIter mfi(mf_PHB); mfi.isValid(); ++mfi ) {
-            Box vbx = mfi.validbox();
+        // Sanity check.
+        //
+        // The nodal heights are a regularized least-squares fit to the WRF
+        // z-face heights, not an exact de-averaging of them.  The four-node average
+        // therefore no longer reproduces WRF to round-off, and the size of the
+        // mismatch is a genuine diagnostic of how much grid-scale terrain the
+        // WRF field carries.  We report it, and we abort only on failures that
+        // make the mesh unusable: non-finite heights, or a layer that is not
+        // strictly increasing in z.
+        Print() << "Verifying reconstructed nodal heights" << std::endl;
+        {
+            ReduceOps<ReduceOpMax, ReduceOpMin> reduce_op;
+            ReduceData<Real, Real> reduce_data(reduce_op);
+            using ReduceTuple = typename decltype(reduce_data)::Type;
 
-            if (!use_wrf_height_grid) { vbx.setBig(2,klo+1); }
+            for ( MFIter mfi(mf_PHB); mfi.isValid(); ++mfi ) {
+                Box vbx = mfi.validbox();
+                if (vbx.smallEnd(2) > klo+1) { continue; }
+                vbx.setBig(2,klo+1);
 
-            const Array4<const Real>& nc_phb_arr = mf_PHB.const_array(mfi);
-            const Array4<const Real>& nc_ph_arr  = mf_PH.const_array(mfi);
-            const Array4<const Real>& z_arr      = z_phys->const_array(mfi);
+                const Array4<const Real>& nc_phb_arr = mf_PHB.const_array(mfi);
+                const Array4<const Real>& nc_ph_arr  = mf_PH.const_array(mfi);
+                const Array4<const Real>& z_arr      = z_phys->const_array(mfi);
 
-#ifdef AMREX_USE_FLOAT
-            const Real tol = Real(1.e-4);
-#else
-            const Real tol = Real(1.e-8);
-#endif
-            ParallelFor(vbx, [=] AMREX_GPU_DEVICE(int i, int j, int k) noexcept
-            {
-                Real z_face_wrf = ( nc_ph_arr(i,j,k) + nc_phb_arr(i,j,k) ) / CONST_GRAV;
-                Real z_face_erf = fourth * ( z_arr(i, j  , k) + z_arr(i+1, j  , k)
-                                           + z_arr(i, j+1, k) + z_arr(i+1, j+1, k) );
-                if ((std::fabs(z_face_erf-z_face_wrf) > tol) && (k < khi)) {
-#ifdef AMREX_USE_GPU
-                    AMREX_DEVICE_PRINTF("z-face does not match WRF at (%d,%d,%d). ERF and WRF values are: %f, %f\n",
-                                        i,j,k, z_face_erf, z_face_wrf);
-#else
-                    printf("z-face does not match WRF at (%d,%d,%d). ERF and WRF values are: %f, %f\n",
-                           i,j,k, z_face_erf, z_face_wrf);
+                reduce_op.eval(vbx, reduce_data,
+                [=] AMREX_GPU_DEVICE (int i, int j, int k) -> ReduceTuple
+                {
+                    Real z_face_wrf = ( nc_ph_arr(i,j,k) + nc_phb_arr(i,j,k) ) / CONST_GRAV;
+                    Real z_face_erf = fourth * ( z_arr(i, j  , k) + z_arr(i+1, j  , k)
+                                               + z_arr(i, j+1, k) + z_arr(i+1, j+1, k) );
+                    Real avg_err = (k < khi) ? std::fabs(z_face_erf-z_face_wrf) : zero;
 
-#endif
-                    Error("Grid integrity issue detected");
-                }
-            });
-        } // mfi
+                    // Nodal layer thickness; only defined once we are at klo
+                    Real dz = (k == klo) ? (z_arr(i,j,klo+1) - z_arr(i,j,klo))
+                                         : std::numeric_limits<Real>::max();
+                    return {avg_err, dz};
+                });
+            } // mfi
+
+            ReduceTuple hv = reduce_data.value(reduce_op);
+            Real max_avg_err = amrex::max(amrex::get<0>(hv), zero);
+            Real min_dz      = amrex::get<1>(hv);
+            ParallelAllReduce::Max(max_avg_err, ParallelContext::CommunicatorAll());
+            ParallelAllReduce::Min(min_dz     , ParallelContext::CommunicatorAll());
+
+            Print() << "Max |avg4(nodal z) - WRF z-face| over the reconstructed levels: "
+                    << max_avg_err << " m" << std::endl;
+            Print() << "Min nodal thickness of the first layer: " << min_dz << " m" << std::endl;
+
+            if (!std::isfinite(max_avg_err) || !std::isfinite(min_dz)) {
+                Error("Non-finite nodal heights produced by the terrain reconstruction");
+            }
+            if (min_dz <= zero) {
+                Error("Reconstructed nodal terrain gives a non-positive first layer thickness; "
+                      "the WRF terrain is too rough to represent on the ERF nodal mesh. "
+                      "Consider running with erf.use_wrf_height_grid = true.");
+            }
+        }
     } // use wrf grid
 }
 #endif // ERF_USE_NETCDF

--- a/Source/Utils/ERF_NodalReconstruction.H
+++ b/Source/Utils/ERF_NodalReconstruction.H
@@ -3,7 +3,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <cstddef>
 #include <limits>
 #include <stdexcept>
 #include <utility>
@@ -11,8 +10,8 @@
 #include "AMReX_Array4.H"
 #include "AMReX_Box.H"
 #include "AMReX_FArrayBox.H"
+#include "AMReX_Geometry.H"
 #include "AMReX_REAL.H"
-#include "AMReX_Vector.H"
 
 #include "ERF_Constants.H"
 
@@ -23,16 +22,104 @@ enum class VariationOperator
 };
 
 struct SolveInfo {
-    int iterations = 0;
-    amrex::Real final_residual = zero;
-    bool converged = false;
+    int  iterations           = 0;     //!< total CG iterations, summed over attempts
+    amrex::Real final_residual = zero; //!< CG residual of the accepted solve
+    bool converged            = false;
+    int  refinements          = 0;     //!< times the regularization had to be raised
+    amrex::Real regularization = zero; //!< accepted value of mu
+
+    // Diagnostics on the reconstructed field
+    amrex::Real deviation            = zero; //!< max |S - S_ref|
+    amrex::Real deviation_cap        = zero; //!< bound imposed on the above
+    amrex::Real max_average_error    = zero; //!< max |avg4(S) - T|
+    amrex::Real interp_average_error = zero; //!< max |avg4(S_ref) - T|, for comparison
+    amrex::Real min_value            = zero; //!< min over nodes of S
+    amrex::Real max_value            = zero; //!< max over nodes of S
 };
 
+/**
+ * Reconstruct a nodal field S from data T that lives at cell centers in (x,y),
+ * such that the four-node average of S matches T as closely as a *bounded*,
+ * smooth nodal field can.
+ *
+ * ---------------------------------------------------------------------------
+ * Why we do not simply invert the averaging operator
+ * ---------------------------------------------------------------------------
+ * The four-node averaging operator A,
+ *
+ *     (A S)(i,j) = 1/4 [ S(i,j) + S(i+1,j) + S(i,j+1) + S(i+1,j+1) ] ,
+ *
+ * has symbol cos(kx/2) cos(ky/2), which vanishes at the grid Nyquist mode.
+ * Inverting A exactly -- e.g. with the back substitution
+ *
+ *     S(i+1,j+1) = 4 T(i,j) - S(i,j) - S(i+1,j) - S(i,j+1)
+ *
+ * -- therefore amplifies grid-scale content of T without bound.  The Green's
+ * function of that recursion is 4 / [(1+x)(1+y)], a doubly alternating
+ * cumulative sum, so a checkerboard component of T of amplitude a produces a
+ * nodal response of amplitude a*i*j.  On a 128^2 grid an O(10 m) grid-scale
+ * roughness in the WRF terrain thus yields nodal heights that are kilometers
+ * away from the WRF terrain, including physically impossible negative
+ * elevations (ERF issue #3709).  Adding a free homogeneous solution cannot
+ * repair this: the null space of A is spanned by (-1)^i f(j) + (-1)^j g(i),
+ * which cannot represent the (-1)^(i+j) i j growth of the particular solution.
+ * The failure is silent, because checking that avg4(S) reproduces T is then
+ * satisfied by construction.
+ *
+ * ---------------------------------------------------------------------------
+ * What we do instead
+ * ---------------------------------------------------------------------------
+ * Let S_ref be the direct interpolation of T to the nodes (makeReference) and
+ * R = T - A S_ref the part of T that interpolation fails to reproduce.  We
+ * solve for a *correction* E to the interpolant,
+ *
+ *     min_E  || A E - R ||^2 + lambda || V E ||^2 + mu || E ||^2 ,   S = S_ref + E,
+ *
+ * where V is a roughness operator (first derivative or Laplacian).  The normal
+ * equations
+ *
+ *     ( A^T A + lambda V^T V + mu I ) E = A^T R
+ *
+ * are symmetric positive definite for any mu > 0, so E exists, is unique, and
+ * -- unlike the exact inverse -- is bounded.  Specifically, writing
+ * ( A^T A + lambda V^T V + mu I ) E = A^T R and pairing with E gives
+ *
+ *     || A E ||^2 + lambda || V E ||^2 + mu || E ||^2 <= || A E || || R || ,
+ *
+ * and since 2 sqrt(mu) ||A E|| ||E|| <= ||A E||^2 + mu ||E||^2, we get the
+ * a priori bound
+ *
+ *     || E || <= || R || / ( 2 sqrt(mu) ) .
+ *
+ * The correction is therefore controlled by how badly interpolation already
+ * fails, never by the conditioning of A.
+ *
+ * ---------------------------------------------------------------------------
+ * Choosing mu
+ * ---------------------------------------------------------------------------
+ * A single fixed mu cannot serve both smooth and rough terrain: small mu
+ * recovers well-resolved features almost exactly but lets rough fields drift
+ * far from the interpolant, and large mu does the reverse.  We therefore start
+ * from a small mu and raise it until the correction satisfies the pointwise cap
+ *
+ *     max |E| <= min( 2 max|R| , 1/4 (max T - min T) ) ,
+ *
+ * i.e. the nodes may not move away from the direct interpolation by more than
+ * twice the interpolation misfit, nor by more than a quarter of the relief of
+ * the data.  Because ||E|| -> 0 as mu -> infinity the loop always terminates,
+ * and on failure we fall back to the interpolant itself.  Smooth terrain keeps
+ * the smallest mu and is reproduced to well below the interpolation error;
+ * rough terrain is pulled back toward the interpolant instead of blowing up.
+ *
+ * The averaging error max |avg4(S) - T| returned in SolveInfo is now a genuine
+ * diagnostic -- it is no longer satisfied by construction -- and is reported
+ * alongside the same quantity for the plain interpolant and the range of S, so
+ * callers can sanity check the result.
+ */
 class NodalReconstruction
 {
 public:
-    using Real   = amrex::Real;
-    using Vector = amrex::Vector<Real>;
+    using Real = amrex::Real;
 
     explicit NodalReconstruction (amrex::Box const& face_box,
                                   amrex::Geometry const& geom)
@@ -40,99 +127,185 @@ public:
           m_ilo(face_box.smallEnd(0)),
           m_ihi(face_box.bigEnd(0)),
           m_jlo(face_box.smallEnd(1)),
-          m_jhi(face_box.bigEnd(1)),
-          m_nx(face_box.length(0)),
-          m_ny(face_box.length(1)),
-          m_boundary_count(m_nx + m_ny + 1)
+          m_jhi(face_box.bigEnd(1))
     {
         if (face_box.length(2) != 1) {
             throw std::invalid_argument(
                 "face_box must contain exactly one z cell.");
+        }
+        if (face_box.smallEnd(2) != 0) {
+            throw std::invalid_argument(
+                "face_box must be a slab at k = 0; all fabs are indexed at k = 0.");
         }
 
         m_nodal_box = amrex::surroundingNodes(face_box);
         m_nodal_box.setSmall(2, 0);
         m_nodal_box.setBig(2, 0);
 
-        m_dx = geom.CellSizeArray()[0];
-        m_dy = geom.CellSizeArray()[1];
-    }
+        Real const dx = geom.CellSizeArray()[0];
+        Real const dy = geom.CellSizeArray()[1];
+        if (!(dx > zero) || !(dy > zero)) {
+            throw std::invalid_argument("Cell sizes must be positive.");
+        }
 
-    [[nodiscard]] int boundaryCount () const noexcept {
-        return m_boundary_count;
+        // Non-dimensional, O(1) stencil weights that respect grid anisotropy.
+        // They are unity on an isotropic grid, so the smoothing weight has the
+        // same meaning regardless of the mesh spacing.
+        Real const h = std::min(dx,dy);
+        m_gx  = h / dx;
+        m_gy  = h / dy;
+        m_gxx = m_gx * m_gx;
+        m_gyy = m_gy * m_gy;
     }
 
     [[nodiscard]] amrex::Box const& nodalBox () const noexcept {
         return m_nodal_box;
     }
 
-    [[nodiscard]] Vector makeBoundaryFromT (amrex::FArrayBox const& T) const
+    /**
+     * Direct interpolation of the cell-centered data to the nodes: the average
+     * of the (up to four) cells that touch each node, with edge and corner
+     * nodes taking the average of the cells that exist.  This is the field the
+     * solve corrects, and the field it falls back to.
+     */
+    [[nodiscard]] amrex::FArrayBox makeReference (amrex::FArrayBox const& T) const
     {
+        amrex::FArrayBox R(m_nodal_box,1,amrex::The_Managed_Arena());
         auto const T_arr = T.const_array();
-        Vector b(static_cast<std::size_t>(m_boundary_count), zero);
+        auto const R_arr = R.array();
 
-        b[bottomIndex(0)] = T_arr(m_ilo, m_jlo, 0);
-        for (int ii = 1; ii < m_nx; ++ii) {
-            int const i = m_ilo + ii;
-            b[bottomIndex(ii)] = myhalf * ( T_arr(i-1, m_jlo, 0) + T_arr(i,  m_jlo, 0) );
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            int const jm = std::max(m_jlo, std::min(j-1, m_jhi));
+            int const jp = std::max(m_jlo, std::min(j  , m_jhi));
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                int const im = std::max(m_ilo, std::min(i-1, m_ihi));
+                int const ip = std::max(m_ilo, std::min(i  , m_ihi));
+                R_arr(i,j,0) = fourth * ( T_arr(im,jm,0) + T_arr(ip,jm,0)
+                                        + T_arr(im,jp,0) + T_arr(ip,jp,0) );
+            }
         }
-        b[bottomIndex(m_nx)] = T_arr(m_ihi, m_jlo, 0);
-
-        for (int jj = 1; jj < m_ny; ++jj) {
-            int const j = m_jlo + jj;
-            b[leftIndex(jj)] = myhalf * ( T_arr(m_ilo, j-1, 0) + T_arr(m_ilo, j, 0) );
-        }
-        b[leftIndex(m_ny)] = T_arr(m_ilo, m_jhi, 0);
-        return b;
+        return R;
     }
 
-    [[nodiscard]] std::pair<amrex::FArrayBox,SolveInfo> solve (amrex::FArrayBox const& T,
-                                                               Vector const& boundary_reference,
-                                                               VariationOperator var_op,
-                                                               Real relative_tolerance = Real(1.e-8),
-                                                               Real epsilon = Real(1.e-2),
-                                                               int max_iterations = 1000)
+    /**
+     * Solve the regularized least-squares problem described above.
+     *
+     * \param T                  cell-centered data to be matched
+     * \param reference          the interpolant to correct (see makeReference)
+     * \param var_op             roughness operator used as the smoothness prior
+     * \param relative_tolerance CG stopping tolerance
+     * \param smoothing          lambda; weight of the roughness penalty
+     * \param min_regularization smallest mu tried; raised by factors of four
+     *                           until the correction respects its cap
+     * \param max_iterations     CG iteration cap per attempt
+     */
+    [[nodiscard]] std::pair<amrex::FArrayBox,SolveInfo>
+    solve (amrex::FArrayBox const& T,
+           amrex::FArrayBox const& reference,
+           VariationOperator var_op,
+           Real relative_tolerance  = Real(1.e-10),
+           Real smoothing           = Real(1.e-2),
+           Real min_regularization  = Real(2.5e-4),
+           int  max_iterations      = 1000)
     {
-        m_var_op = var_op;
-
-        amrex::FArrayBox c(m_nodal_box,1,amrex::The_Managed_Arena());
-        computeParticularSolution(T,c);
-
-        amrex::FArrayBox vtv_c(m_nodal_box,1,amrex::The_Managed_Arena());
-        applyVariationOperator(c,vtv_c);
-
-        Vector rhs;
-        applyGT(vtv_c,rhs);
-        for (int m=0; m<m_boundary_count; ++m) {
-            auto const k = static_cast<std::size_t>(m);
-            rhs[k] = -rhs[k] + epsilon*boundary_reference[k];
+        if (!(smoothing > zero)) {
+            throw std::invalid_argument("Smoothing weight must be positive.");
+        }
+        if (!(min_regularization > zero)) {
+            // With mu == 0 the operator can be singular: the roughness penalty
+            // alone does not control every mode (the Laplacian penalty, for
+            // instance, is blind to bilinear and discrete-harmonic fields).
+            throw std::invalid_argument("Regularization must be positive.");
         }
 
-        Vector b = boundary_reference;
-        SolveInfo info = conjugateGradient(rhs, b, epsilon, relative_tolerance, max_iterations);
+        m_var_op = var_op;
+        m_lambda = smoothing;
 
+        m_cc_scratch.resize(m_face_box ,1,amrex::The_Managed_Arena());
+        m_nd_scratch.resize(m_nodal_box,1,amrex::The_Managed_Arena());
+
+        SolveInfo info;
+
+        // Misfit of the plain interpolation, and the cap it earns the solve.
+        amrex::FArrayBox misfit(m_face_box,1,amrex::The_Managed_Arena());
+        Real misfit_max = zero;
+        Real t_min      =  std::numeric_limits<Real>::max();
+        Real t_max      = -std::numeric_limits<Real>::max();
+        {
+            applyA(reference,misfit);
+            auto const T_arr = T.const_array();
+            auto const m_arr = misfit.array();
+            for (int j=m_jlo; j<=m_jhi; ++j) {
+                for (int i=m_ilo; i<=m_ihi; ++i) {
+                    m_arr(i,j,0) = T_arr(i,j,0) - m_arr(i,j,0);
+                    misfit_max = std::max(misfit_max, std::abs(m_arr(i,j,0)));
+                    t_min      = std::min(t_min, T_arr(i,j,0));
+                    t_max      = std::max(t_max, T_arr(i,j,0));
+                }
+            }
+        }
+        info.interp_average_error = misfit_max;
+        info.deviation_cap = std::min(deviation_factor * misfit_max,
+                                      relief_factor * (t_max - t_min));
+
+        // rhs = A^T (T - A S_ref); the correction solves M E = rhs from E = 0.
+        amrex::FArrayBox rhs(m_nodal_box,1,amrex::The_Managed_Arena());
+        applyAT(misfit,rhs);
+
+        amrex::FArrayBox E(m_nodal_box,1,amrex::The_Managed_Arena());
         amrex::FArrayBox S(m_nodal_box,1,amrex::The_Managed_Arena());
-        reconstruct(T,b,S);
+
+        m_mu = min_regularization;
+        bool accepted = false;
+        for (int attempt=0; attempt<max_attempts; ++attempt) {
+            SolveInfo attempt_info = conjugateGradient(rhs,E,relative_tolerance,max_iterations);
+            info.iterations += attempt_info.iterations;
+            info.final_residual = attempt_info.final_residual;
+            info.converged      = attempt_info.converged;
+
+            info.deviation = maxAbs(E);
+            if (info.deviation <= info.deviation_cap) { accepted = true; break; }
+
+            m_mu *= mu_growth;
+            ++info.refinements;
+        }
+
+        if (accepted) {
+            auto const S_arr = S.array();
+            auto const r_arr = reference.const_array();
+            auto const E_arr = E.const_array();
+            for (int j=m_jlo; j<=m_jhi+1; ++j) {
+                for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                    S_arr(i,j,0) = r_arr(i,j,0) + E_arr(i,j,0);
+                }
+            }
+        } else {
+            // Should not happen -- ||E|| -> 0 as mu -> infinity -- but if it
+            // does, the interpolant is a safe, bounded answer.
+            S.copy<amrex::RunOn::Host>(reference,0,0,1);
+            info.deviation = zero;
+        }
+        info.regularization = m_mu;
+
+        computeDiagnostics(T,S,info);
         return {std::move(S),info};
     }
 
-    void reconstruct (amrex::FArrayBox const& T,
-                      Vector const& boundary,
-                      amrex::FArrayBox& S) const
+    //! max_ij | avg4(S) - T |
+    [[nodiscard]] Real maxAverageError (amrex::FArrayBox const& T,
+                                        amrex::FArrayBox const& S) const
     {
-        S.setVal<amrex::RunOn::Host>(zero);
         auto const T_arr = T.const_array();
-        auto const S_arr = S.array();
-        injectBoundary(boundary,S_arr);
-
+        auto const S_arr = S.const_array();
+        Real err = zero;
         for (int j=m_jlo; j<=m_jhi; ++j) {
             for (int i=m_ilo; i<=m_ihi; ++i) {
-                S_arr(i+1,j+1,0) = four * T_arr(i,j,0)
-                                 - S_arr(i,  j  , 0)
-                                 - S_arr(i+1,j  , 0)
-                                 - S_arr(i,  j+1, 0);
+                Real const avg = fourth * ( S_arr(i  ,j  ,0) + S_arr(i+1,j  ,0)
+                                          + S_arr(i  ,j+1,0) + S_arr(i+1,j+1,0) );
+                err = std::max(err, std::abs(avg - T_arr(i,j,0)));
             }
         }
+        return err;
     }
 
     [[nodiscard]] Real totalSquaredVariation (amrex::FArrayBox const& S) const
@@ -156,79 +329,61 @@ public:
     }
 
 private:
+    //! The correction may not move a node further from the direct interpolation
+    //! than this multiple of the interpolation misfit ...
+    static constexpr amrex::Real deviation_factor = amrex::Real(2.0);
+    //! ... nor than this fraction of the relief of the data.
+    static constexpr amrex::Real relief_factor    = amrex::Real(0.25);
+    //! Factor by which mu is raised when the cap is violated, and the number of
+    //! times we are willing to do so.
+    static constexpr amrex::Real mu_growth        = amrex::Real(4.0);
+    static constexpr int         max_attempts     = 24;
+
     amrex::Box m_face_box;
     amrex::Box m_nodal_box;
     int m_ilo=0;
     int m_ihi=-1;
     int m_jlo=0;
     int m_jhi=-1;
-    int m_nx=0;
-    int m_ny=0;
-    int m_boundary_count=0;
-    amrex::Real m_dx;
-    amrex::Real m_dy;
-    VariationOperator m_var_op;
+    amrex::Real m_gx  = one;
+    amrex::Real m_gy  = one;
+    amrex::Real m_gxx = one;
+    amrex::Real m_gyy = one;
+    amrex::Real m_lambda = zero;
+    amrex::Real m_mu     = zero;
+    VariationOperator m_var_op = VariationOperator::FirstDeriv;
 
-    [[nodiscard]] std::size_t bottomIndex (int ii) const noexcept
-    {
-        return static_cast<std::size_t>(ii);
-    }
+    mutable amrex::FArrayBox m_cc_scratch;
+    mutable amrex::FArrayBox m_nd_scratch;
 
-    [[nodiscard]] std::size_t leftIndex (int jj) const noexcept
+    //! (A S)(i,j) = 1/4 [ S(i,j) + S(i+1,j) + S(i,j+1) + S(i+1,j+1) ]
+    void applyA (amrex::FArrayBox const& S,
+                 amrex::FArrayBox& T) const
     {
-        return static_cast<std::size_t>(m_nx+jj);
-    }
-
-    void injectBoundary (Vector const& b,
-                         amrex::Array4<Real> const& u) const
-    {
-        for (int ii=0; ii<=m_nx; ++ii) {
-            u(m_ilo+ii, m_jlo , 0) = b[bottomIndex(ii)];
-        }
-        for (int jj=1; jj<=m_ny; ++jj) {
-            u(m_ilo, m_jlo+jj, 0) = b[leftIndex(jj)];
-        }
-    }
-
-    void extractBoundary (amrex::Array4<Real const> const& u,
-                          Vector& b) const
-    {
-        b.assign(static_cast<std::size_t>(m_boundary_count), zero);
-        for (int ii=0; ii<=m_nx; ++ii) {
-            b[bottomIndex(ii)]=u(m_ilo+ii, m_jlo, 0);
-        }
-        for (int jj=1; jj<=m_ny; ++jj) {
-            b[leftIndex(jj)]=u(m_ilo, m_jlo+jj, 0);
-        }
-    }
-
-    void computeParticularSolution (amrex::FArrayBox const& T,
-                                    amrex::FArrayBox& c) const
-    {
-        c.setVal<amrex::RunOn::Host>(zero);
-        auto const T_arr=T.const_array();
-        auto const c_arr=c.array();
+        auto const S_arr = S.const_array();
+        auto const T_arr = T.array();
         for (int j=m_jlo; j<=m_jhi; ++j) {
             for (int i=m_ilo; i<=m_ihi; ++i) {
-                c_arr(i+1,j+1,0) = four * T_arr(i,j,0)
-                                 - c_arr(i,  j  , 0)
-                                 - c_arr(i+1,j  , 0)
-                                 - c_arr(i,  j+1, 0);
+                T_arr(i,j,0) = fourth * ( S_arr(i  ,j  ,0) + S_arr(i+1,j  ,0)
+                                        + S_arr(i  ,j+1,0) + S_arr(i+1,j+1,0) );
             }
         }
     }
 
-    void applyG (Vector const& b,
-                 amrex::FArrayBox& U) const
+    //! Adjoint of applyA: scatter each cell value to its four nodes.
+    void applyAT (amrex::FArrayBox const& T,
+                  amrex::FArrayBox& R) const
     {
-        U.setVal<amrex::RunOn::Host>(zero);
-        auto const U_arr = U.array();
-        injectBoundary(b,U_arr);
+        R.setVal<amrex::RunOn::Host>(zero);
+        auto const T_arr = T.const_array();
+        auto const R_arr = R.array();
         for (int j=m_jlo; j<=m_jhi; ++j) {
             for (int i=m_ilo; i<=m_ihi; ++i) {
-                U_arr(i+1,j+1,0) = -U_arr(i  ,j  , 0)
-                                   -U_arr(i+1,j  , 0)
-                                   -U_arr(i  ,j+1, 0);
+                Real const q = fourth * T_arr(i,j,0);
+                R_arr(i  ,j  ,0) += q;
+                R_arr(i+1,j  ,0) += q;
+                R_arr(i  ,j+1,0) += q;
+                R_arr(i+1,j+1,0) += q;
             }
         }
     }
@@ -244,18 +399,15 @@ private:
         auto const difx_arr = difx.array();
         auto const dify_arr = dify.array();
 
-        const amrex::Real idx = std::max(one, one / m_dx);
-        const amrex::Real idy = std::max(one, one / m_dy);
-
         for (int j = m_jlo; j <= m_jhi + 1; ++j) {
             for (int i = m_ilo; i <= m_ihi; ++i) {
-                difx_arr(i, j, 0) = idx * ( S_arr(i+1, j, 0) - S_arr(i, j, 0) );
+                difx_arr(i, j, 0) = m_gx * ( S_arr(i+1, j, 0) - S_arr(i, j, 0) );
             }
         }
 
         for (int j = m_jlo; j <= m_jhi; ++j) {
             for (int i = m_ilo; i <= m_ihi + 1; ++i) {
-                dify_arr(i, j, 0) = idy * ( S_arr(i, j+1, 0) - S_arr(i, j, 0) );
+                dify_arr(i, j, 0) = m_gy * ( S_arr(i, j+1, 0) - S_arr(i, j, 0) );
             }
         }
     }
@@ -270,23 +422,19 @@ private:
         auto const qy_arr = dify.const_array();
         auto const R_arr  = R.array();
 
-        const amrex::Real idx = std::max(one, one / m_dx);
-        const amrex::Real idy = std::max(one, one / m_dy);
-
         for (int j = m_jlo; j <= m_jhi + 1; ++j) {
             for (int i = m_ilo; i <= m_ihi; ++i) {
-                R_arr(i  , j, 0) -= idx * qx_arr(i, j, 0);
-                R_arr(i+1, j, 0) += idx * qx_arr(i, j, 0);
+                R_arr(i  , j, 0) -= m_gx * qx_arr(i, j, 0);
+                R_arr(i+1, j, 0) += m_gx * qx_arr(i, j, 0);
             }
         }
 
         for (int j = m_jlo; j <= m_jhi; ++j) {
             for (int i = m_ilo; i <= m_ihi + 1; ++i) {
-                R_arr(i, j  , 0) -= idy * qy_arr(i, j, 0);
-                R_arr(i, j+1, 0) += idy * qy_arr(i, j, 0);
+                R_arr(i, j  , 0) -= m_gy * qy_arr(i, j, 0);
+                R_arr(i, j+1, 0) += m_gy * qy_arr(i, j, 0);
             }
         }
-
     }
 
     void applyDTD (amrex::FArrayBox const& S,
@@ -310,18 +458,14 @@ private:
         auto const S_arr   = S.const_array();
         auto const lap_arr = lap.array();
 
-        const amrex::Real idx2 = std::max(one, one / (m_dx * m_dx));
-        const amrex::Real idy2 = std::max(one, one / (m_dy * m_dy));
-
-
         for (int j = m_jlo + 1; j <= m_jhi; ++j) {
             for (int i = m_ilo + 1; i <= m_ihi; ++i) {
-                lap_arr(i, j, 0) = idx2 * (       S_arr(i+1, j  , 0)
-                                          - two * S_arr(i  , j  , 0)
-                                                + S_arr(i-1, j  , 0) )
-                                 + idy2 * (       S_arr(i  , j+1, 0)
-                                          - two * S_arr(i  , j  , 0)
-                                                + S_arr(i  , j-1, 0) );
+                lap_arr(i, j, 0) = m_gxx * (         S_arr(i+1, j  , 0)
+                                            - two *  S_arr(i  , j  , 0)
+                                                   + S_arr(i-1, j  , 0) )
+                                 + m_gyy * (         S_arr(i  , j+1, 0)
+                                            - two *  S_arr(i  , j  , 0)
+                                                   + S_arr(i  , j-1, 0) );
             }
         }
     }
@@ -334,18 +478,14 @@ private:
         auto const q_arr = lap.const_array();
         auto const R_arr = R.array();
 
-        const amrex::Real idx2 = std::max(one, one / (m_dx * m_dx));
-        const amrex::Real idy2 = std::max(one, one / (m_dy * m_dy));
-
-
         for (int j = m_jlo + 1; j <= m_jhi; ++j) {
             for (int i = m_ilo + 1; i <= m_ihi; ++i) {
                 const amrex::Real val = q_arr(i, j, 0);
-                R_arr(i-1, j  , 0) += idx2 * val;
-                R_arr(i+1, j  , 0) += idx2 * val;
-                R_arr(i  , j-1, 0) += idy2 * val;
-                R_arr(i  , j+1, 0) += idy2 * val;
-                R_arr(i  , j  , 0) -= two * (idx2 + idy2) * val;
+                R_arr(i-1, j  , 0) += m_gxx * val;
+                R_arr(i+1, j  , 0) += m_gxx * val;
+                R_arr(i  , j-1, 0) += m_gyy * val;
+                R_arr(i  , j+1, 0) += m_gyy * val;
+                R_arr(i  , j  , 0) -= two * (m_gxx + m_gyy) * val;
             }
         }
     }
@@ -356,6 +496,12 @@ private:
         amrex::Box interior_nodal_box = m_nodal_box;
         interior_nodal_box.grow(0,-1);
         interior_nodal_box.grow(1,-1);
+        if (!interior_nodal_box.ok()) {
+            // Fewer than two cells in a direction: there is no interior node to
+            // evaluate the Laplacian at.  mu keeps the operator definite.
+            R.setVal<amrex::RunOn::Host>(zero);
+            return;
+        }
         amrex::FArrayBox lap(interior_nodal_box,1,amrex::The_Managed_Arena());
         applyL(S, lap);
         applyLT(lap, R);
@@ -378,108 +524,209 @@ private:
         }
     }
 
-    void applyGT (amrex::FArrayBox const& R,
-                  Vector& result) const
+    //! R = ( A^T A + lambda V^T V + mu I ) S
+    void applyM (amrex::FArrayBox const& S,
+                 amrex::FArrayBox& R) const
     {
-        amrex::FArrayBox adj(m_nodal_box,1,amrex::The_Managed_Arena());
-        adj.copy<amrex::RunOn::Host>(R,0,0,1);
-        auto const a_arr = adj.array();
+        applyA(S,m_cc_scratch);
+        applyAT(m_cc_scratch,R);
+        applyVariationOperator(S,m_nd_scratch);
 
-        for (int j=m_jhi; j>=m_jlo; --j) {
-            for (int i=m_ihi; i>=m_ilo; --i) {
-                Real const child= a_arr(i+1,j+1,0);
-                a_arr(i,  j  ,0) -= child;
-                a_arr(i+1,j  ,0) -= child;
-                a_arr(i,  j+1,0) -= child;
+        auto const R_arr = R.array();
+        auto const v_arr = m_nd_scratch.const_array();
+        auto const S_arr = S.const_array();
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                R_arr(i,j,0) += m_lambda * v_arr(i,j,0) + m_mu * S_arr(i,j,0);
             }
         }
-        extractBoundary(adj.const_array(),result);
     }
 
-    void applyH (Vector const& v,
-                 Vector& Hv,
-                 Real epsilon) const
+    /**
+     * Diagonal of M, assembled by accumulating the square of every stencil
+     * coefficient that touches a node.  Used as a Jacobi preconditioner.
+     */
+    void computeDiagonal (amrex::FArrayBox& diag) const
     {
-        amrex::FArrayBox Gv(m_nodal_box,1,amrex::The_Managed_Arena());
-        amrex::FArrayBox  q(m_nodal_box,1,amrex::The_Managed_Arena());
-        applyG(v,Gv);
-        applyVariationOperator(Gv,q);
-        applyGT(q,Hv);
-        for (int m=0; m<m_boundary_count; ++m) {
-            auto const k=static_cast<std::size_t>(m);
-            Hv[k]+=epsilon*v[k];
+        diag.setVal<amrex::RunOn::Host>(m_mu);
+        auto const d_arr = diag.array();
+
+        // A^T A: each incident cell contributes (1/4)^2
+        Real const qa = fourth * fourth;
+        for (int j=m_jlo; j<=m_jhi; ++j) {
+            for (int i=m_ilo; i<=m_ihi; ++i) {
+                d_arr(i  ,j  ,0) += qa;
+                d_arr(i+1,j  ,0) += qa;
+                d_arr(i  ,j+1,0) += qa;
+                d_arr(i+1,j+1,0) += qa;
+            }
+        }
+
+        // lambda V^T V
+        if (m_var_op == VariationOperator::FirstDeriv) {
+            Real const qx = m_lambda * m_gx * m_gx;
+            Real const qy = m_lambda * m_gy * m_gy;
+            for (int j=m_jlo; j<=m_jhi+1; ++j) {
+                for (int i=m_ilo; i<=m_ihi; ++i) {
+                    d_arr(i  ,j,0) += qx;
+                    d_arr(i+1,j,0) += qx;
+                }
+            }
+            for (int j=m_jlo; j<=m_jhi; ++j) {
+                for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                    d_arr(i,j  ,0) += qy;
+                    d_arr(i,j+1,0) += qy;
+                }
+            }
+        } else {
+            Real const qx = m_lambda * m_gxx * m_gxx;
+            Real const qy = m_lambda * m_gyy * m_gyy;
+            Real const qc = m_lambda * four * (m_gxx + m_gyy) * (m_gxx + m_gyy);
+            for (int j=m_jlo+1; j<=m_jhi; ++j) {
+                for (int i=m_ilo+1; i<=m_ihi; ++i) {
+                    d_arr(i-1,j  ,0) += qx;
+                    d_arr(i+1,j  ,0) += qx;
+                    d_arr(i  ,j-1,0) += qy;
+                    d_arr(i  ,j+1,0) += qy;
+                    d_arr(i  ,j  ,0) += qc;
+                }
+            }
         }
     }
 
-    [[nodiscard]] SolveInfo conjugateGradient (Vector const& rhs,
-                                               Vector& x,
-                                               Real epsilon,
+    void computeDiagnostics (amrex::FArrayBox const& T,
+                             amrex::FArrayBox const& S,
+                             SolveInfo& info) const
+    {
+        auto const S_arr = S.const_array();
+        Real smin =  std::numeric_limits<Real>::max();
+        Real smax = -std::numeric_limits<Real>::max();
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                smin = std::min(smin, S_arr(i,j,0));
+                smax = std::max(smax, S_arr(i,j,0));
+            }
+        }
+        info.min_value = smin;
+        info.max_value = smax;
+        info.max_average_error = maxAverageError(T,S);
+    }
+
+    [[nodiscard]] Real maxAbs (amrex::FArrayBox const& F) const
+    {
+        auto const F_arr = F.const_array();
+        Real v = zero;
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                v = std::max(v, std::abs(F_arr(i,j,0)));
+            }
+        }
+        return v;
+    }
+
+    //! Jacobi-preconditioned conjugate gradient on the SPD operator M.
+    //! x is both the initial guess and the result; it is reset to zero here
+    //! because every attempt restarts the correction from the interpolant.
+    [[nodiscard]] SolveInfo conjugateGradient (amrex::FArrayBox const& rhs,
+                                               amrex::FArrayBox& x,
                                                Real relative_tolerance,
                                                int max_iterations) const
     {
-        Vector Hx;
-        applyH(x,Hx,epsilon);
+        amrex::FArrayBox diag(m_nodal_box,1,amrex::The_Managed_Arena());
+        computeDiagonal(diag);
 
-        Vector r(rhs.size()),p(rhs.size()),Hp;
-        for (int k=0; k<rhs.size(); ++k) {
-            r[k]=rhs[k]-Hx[k];
-            p[k]=r[k];
-        }
+        amrex::FArrayBox r (m_nodal_box,1,amrex::The_Managed_Arena());
+        amrex::FArrayBox z (m_nodal_box,1,amrex::The_Managed_Arena());
+        amrex::FArrayBox p (m_nodal_box,1,amrex::The_Managed_Arena());
+        amrex::FArrayBox Mp(m_nodal_box,1,amrex::The_Managed_Arena());
 
-        Real rr=dot(r,r);
-        Real const initial=std::sqrt(rr);
-        Real const tol=relative_tolerance*std::max({norm(rhs),initial,one});
+        x.setVal<amrex::RunOn::Host>(zero);
+        r.copy<amrex::RunOn::Host>(rhs,0,0,1);   // r = rhs - M*0
+        applyJacobi(diag,r,z);
+        p.copy<amrex::RunOn::Host>(z,0,0,1);
+
+        Real rz = dot(r,z);
+        Real const initial = std::sqrt(dot(r,r));
+        Real const tol = relative_tolerance * std::max({initial,one});
 
         SolveInfo info;
-        info.final_residual=initial;
-        if (initial<=tol) {
-            info.converged=true;
+        info.final_residual = initial;
+        if (initial <= tol) {
+            info.converged = true;
             return info;
         }
 
         for (int it=0; it<max_iterations; ++it) {
-            applyH(p,Hp,epsilon);
-            Real const pHp=dot(p,Hp);
-            if (!(pHp>zero) || !std::isfinite(pHp)) {
+            applyM(p,Mp);
+            Real const pMp = dot(p,Mp);
+            if (!(pMp > zero) || !std::isfinite(pMp)) {
                 throw std::runtime_error("CG curvature failure.");
             }
 
-            Real const alpha=rr/pHp;
-            for (int k=0; k<x.size(); ++k) {
-                x[k]+=alpha*p[k];
-                r[k]-=alpha*Hp[k];
+            Real const alpha = rz/pMp;
+            {
+                auto const x_arr  = x.array();
+                auto const r_arr  = r.array();
+                auto const p_arr  = p.const_array();
+                auto const Mp_arr = Mp.const_array();
+                for (int j=m_jlo; j<=m_jhi+1; ++j) {
+                    for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                        x_arr(i,j,0) += alpha * p_arr(i,j,0);
+                        r_arr(i,j,0) -= alpha * Mp_arr(i,j,0);
+                    }
+                }
             }
 
-            Real const rr_new=dot(r,r);
-            info.iterations=it+1;
-            info.final_residual=std::sqrt(rr_new);
-            if (info.final_residual<=tol) {
-                info.converged=true;
+            info.iterations = it+1;
+            info.final_residual = std::sqrt(dot(r,r));
+            if (info.final_residual <= tol) {
+                info.converged = true;
                 return info;
             }
 
-            Real const beta=rr_new/rr;
-            for (int k=0; k<p.size(); ++k) {
-                p[k]=r[k]+beta*p[k];
+            applyJacobi(diag,r,z);
+            Real const rz_new = dot(r,z);
+            Real const beta = rz_new/rz;
+            {
+                auto const p_arr = p.array();
+                auto const z_arr = z.const_array();
+                for (int j=m_jlo; j<=m_jhi+1; ++j) {
+                    for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                        p_arr(i,j,0) = z_arr(i,j,0) + beta * p_arr(i,j,0);
+                    }
+                }
             }
-            rr=rr_new;
+            rz = rz_new;
         }
         return info;
     }
 
-    [[nodiscard]] static Real dot (Vector const& a,
-                                   Vector const& b)
+    void applyJacobi (amrex::FArrayBox const& diag,
+                      amrex::FArrayBox const& r,
+                      amrex::FArrayBox& z) const
     {
-        if (a.size()!=b.size()) {
-            throw std::invalid_argument("Vector size mismatch.");
+        auto const d_arr = diag.const_array();
+        auto const r_arr = r.const_array();
+        auto const z_arr = z.array();
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                z_arr(i,j,0) = r_arr(i,j,0) / d_arr(i,j,0);
+            }
         }
-        Real v = zero;
-        for (int k=0; k<a.size(); ++k) v+=a[k]*b[k];
-        return v;
     }
 
-    [[nodiscard]] static Real norm (Vector const& a) {
-        return std::sqrt(dot(a,a));
+    [[nodiscard]] Real dot (amrex::FArrayBox const& a,
+                            amrex::FArrayBox const& b) const
+    {
+        auto const a_arr = a.const_array();
+        auto const b_arr = b.const_array();
+        Real v = zero;
+        for (int j=m_jlo; j<=m_jhi+1; ++j) {
+            for (int i=m_ilo; i<=m_ihi+1; ++i) {
+                v += a_arr(i,j,0) * b_arr(i,j,0);
+            }
+        }
+        return v;
     }
 };
 


### PR DESCRIPTION
This resolves #3709 

# Summary
This PR modifies the nodal reconstruction to no longer utilize the direct de-averaging operator G^T. This operator ensured that the result nodes averaged to the wrf heights to machine precision. However, it also induces grid-scale fluctuations. We now solve a regularized optimization problem **WITHOUT** enforcing the nodal average constraint exactly. This is far better conditioned. Note the WPS case no longer has small sawtooth patterns in it's deformation vector `nu` near the xlo/ylo corner.

<img width="1470" height="573" alt="image" src="https://github.com/user-attachments/assets/dc89773e-c048-4eb4-8929-9a3d79c459c7" />


