### PR TITLE
Issue 3662 + Other Finds

### DIFF
--- a/Source/TimeIntegration/ERF_Substep_NS.cpp
+++ b/Source/TimeIntegration/ERF_Substep_NS.cpp
@@ -80,8 +80,8 @@ void erf_substep_NS (int step, int nrk,
     Real dtau = static_cast<Real>(dtau_d);
 
     const Box& domain = geom.Domain();
-    auto const domlo = lbound(domain);
-    auto const domhi = ubound(domain);
+    auto const domlo  = lbound(domain);
+    auto const domhi  = ubound(domain);
 
     int ilo = domlo.x;
     int ihi = domhi.x + 1;
@@ -94,8 +94,6 @@ void erf_substep_NS (int step, int nrk,
     // How much do we project forward the (rho theta) that is used in the horizontal momentum equations
     Real beta_d = Real(0.1);
 
-    Real RvOverRd = R_v / R_d;
-
     bool l_rayleigh_impl_for_w = (sinesq_stag_d != nullptr);
 
     const Real* dx = geom.CellSize();
@@ -103,6 +101,7 @@ void erf_substep_NS (int step, int nrk,
 
     Real dxi = dxInv[0];
     Real dyi = dxInv[1];
+    Real dzi = dxInv[2];
 
     auto dz_ptr = stretched_dz_d.data();
 
@@ -171,7 +170,7 @@ void erf_substep_NS (int step, int nrk,
 
             // NOTE: qv is not changing over the fast steps so we use the stage data
             Real qv = (l_use_moisture) ? prim(i,j,k,PrimQ1_comp) : zero;
-            theta_extrap(i,j,k) *= (one + RvOverRd*qv);
+            theta_extrap(i,j,k) *= (one + RvoRd*qv);
 
             // We define lagged_delta_rt for our next step as the current delta_rt
             // (after using it above to extrapolate theta for this step)
@@ -225,23 +224,42 @@ void erf_substep_NS (int step, int nrk,
 
         // Map factors
         const Array4<const Real>& mf_ux = mapfac[MapFacType::u_x]->const_array(mfi);
+        const Array4<const Real>& mf_uy = mapfac[MapFacType::u_y]->const_array(mfi);
+        const Array4<const Real>& mf_vx = mapfac[MapFacType::v_x]->const_array(mfi);
         const Array4<const Real>& mf_vy = mapfac[MapFacType::v_y]->const_array(mfi);
 
         // *********************************************************************
         // Define updates in the RHS of {x, y, z}-momentum equations
+        //
+        // NOTE: avg_{x,y}mom is a *flux* that is later handed to the scalar
+        //       advection in erf_slow_rhs_post, which applies (mfsq/detJ) to its
+        //       divergence.  So what we accumulate here must be in the same
+        //       convention as the base value set in AdvectionSrcForRho, namely
+        //       ax*rho_u/mf_uy (and ay*rho_v/mf_vx).  Two weightings are needed:
+        //
+        //       (1) the map factor, matching the density fluxes formed below;
+        //
+        //       (2) h_zeta = ax = detJ, which for this (laterally homogeneous)
+        //           mesh is just dz_ptr[k]/dz.  Note this factor cancels out of
+        //           the rho update we do here -- temp_rhs uses a bare dxi and no
+        //           1/detJ -- but it does NOT cancel for avg_{x,y}mom, because
+        //           the consumer downstream re-applies the 1/detJ that we never
+        //           applied.  It is identically 1 for MeshType::ConstantDz.
         // *********************************************************************
         if (nrk == 0 and step == 0) { // prev == stage
             ParallelFor(tbx, tby,
             [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                Real h_zeta = dz_ptr[k] * dzi;
                 Real new_drho_u = dtau * slow_rhs_rho_u(i,j,k) + dtau * xmom_src_arr(i,j,k);;
-                avg_xmom_arr(i,j,k) += facinv*new_drho_u;
+                avg_xmom_arr(i,j,k) += facinv * new_drho_u * h_zeta / mf_uy(i,j,0);
                 temp_cur_xmom_arr(i,j,k) = stage_xmom(i,j,k) + new_drho_u;
             },
             [=] AMREX_GPU_DEVICE (int i, int j, int k)
             {
+                Real h_zeta = dz_ptr[k] * dzi;
                 Real new_drho_v = dtau * slow_rhs_rho_v(i,j,k) + dtau * ymom_src_arr(i,j,k);
-                avg_ymom_arr(i,j,k) += facinv*new_drho_v;
+                avg_ymom_arr(i,j,k) += facinv * new_drho_v * h_zeta / mf_vx(i,j,0);
                 temp_cur_ymom_arr(i,j,k) = stage_ymom(i,j,k) + new_drho_v;
             });
         } else {
@@ -262,7 +280,8 @@ void erf_substep_NS (int step, int nrk,
                                 + dtau * fast_rhs_rho_u + dtau * slow_rhs_rho_u(i,j,k)
                                 + dtau * xmom_src_arr(i,j,k);
 
-                avg_xmom_arr(i,j,k) += facinv*new_drho_u;
+                Real h_zeta = dz_ptr[k] * dzi;
+                avg_xmom_arr(i,j,k) += facinv * new_drho_u * h_zeta / mf_uy(i,j,0);
 
                 temp_cur_xmom_arr(i,j,k) = stage_xmom(i,j,k) + new_drho_u;
             },
@@ -282,7 +301,8 @@ void erf_substep_NS (int step, int nrk,
                                 + dtau * fast_rhs_rho_v + dtau * slow_rhs_rho_v(i,j,k)
                                 + dtau * ymom_src_arr(i,j,k);
 
-                avg_ymom_arr(i,j,k) += facinv*new_drho_v;
+                Real h_zeta = dz_ptr[k] * dzi;
+                avg_ymom_arr(i,j,k) += facinv * new_drho_v * h_zeta / mf_vx(i,j,0);
 
                 temp_cur_ymom_arr(i,j,k) = stage_ymom(i,j,k) + new_drho_v;
             });

--- a/Source/TimeIntegration/ERF_Substep_T.cpp
+++ b/Source/TimeIntegration/ERF_Substep_T.cpp
@@ -270,6 +270,8 @@ void erf_substep_T (int step, int /*nrk*/,
 
         // Map factors
         const Array4<const Real>& mf_ux = mapfac[MapFacType::u_x]->const_array(mfi);
+        const Array4<const Real>& mf_uy = mapfac[MapFacType::u_y]->const_array(mfi);
+        const Array4<const Real>& mf_vx = mapfac[MapFacType::v_x]->const_array(mfi);
         const Array4<const Real>& mf_vy = mapfac[MapFacType::v_y]->const_array(mfi);
 
         // Create old_drho_u/v/w/theta  = U'', V'', W'', Theta'' in the docs
@@ -318,7 +320,11 @@ void erf_substep_T (int step, int /*nrk*/,
                     new_drho_u(i,j,k+1) = new_drho_u(i,j,k);
                 }
 
-                avg_xmom_arr(i,j,k) += facinv*new_drho_u(i,j,k);
+                // NOTE: met_h_zeta here is identically the x-face area ax computed by
+                //       make_areas, so this matches the base value of avg_xmom defined in
+                //       AdvectionSrcForRho (ax*rho_u/mf_uy) as well as the density flux
+                //       (new_drho_u*h_zeta_cc_xface/mf_uy) formed below.
+                avg_xmom_arr(i,j,k) += facinv * new_drho_u(i,j,k) * met_h_zeta / mf_uy(i,j,0);
 
                 cur_xmom(i,j,k) = stage_xmom(i,j,k) + new_drho_u(i,j,k);
             },
@@ -353,7 +359,11 @@ void erf_substep_T (int step, int /*nrk*/,
                     new_drho_v(i,j,k+1) = new_drho_v(i,j,k);
                 }
 
-                avg_ymom_arr(i,j,k) += facinv*new_drho_v(i,j,k);
+                // NOTE: met_h_zeta here is identically the y-face area ay computed by
+                //       make_areas, so this matches the base value of avg_ymom defined in
+                //       AdvectionSrcForRho (ay*rho_v/mf_vx) as well as the density flux
+                //       (new_drho_v*h_zeta_cc_yface/mf_vx) formed below.
+                avg_ymom_arr(i,j,k) += facinv * new_drho_v(i,j,k) * met_h_zeta / mf_vx(i,j,0);
 
                 cur_ymom(i,j,k) = stage_ymom(i,j,k) + new_drho_v(i,j,k);
             });


### PR DESCRIPTION
This resolves #3662 

# Summary
Other bugs were found while investigating `Issue 3662`. Specifically, the numerical flux in the divergence operator is:
<img width="567" height="104" alt="image" src="https://github.com/user-attachments/assets/a4b09ba8-23f8-4b8f-a37b-f8f1b8fb3b1e" />
The lateral momenta, averaged during substepping, was not `F = met_h_zeta * f / mf` as it should be. Therefore, scalar advection fluxes were not correct for T and NS pathways.