### PR TITLE
Advection Fix (No Change)

### DIFF
--- a/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
+++ b/Source/Advection/ERF_AdvectionSrcForMom_TF.cpp
@@ -109,23 +109,23 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
             [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
             {
                 Real xflux_hi = fourth * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i+1,j,k) * mf_uy_inv(i+1,j,0)) *
-                                       (u(i+1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i+1,j,k));
+                                         (u(i+1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i+1,j,k));
 
                 Real xflux_lo = fourth * (rho_u(i,j,k) * mf_uy_inv(i,j,0) + rho_u(i-1,j,k) * mf_uy_inv(i-1,j,0)) *
-                                       (u(i-1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i-1,j,k));
+                                         (u(i-1,j,k) + u(i,j,k)) * myhalf * (ax(i,j,k) + ax(i-1,j,k));
 
                 Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterK(i,j+1,k,cellSizeInv,z_nd);
                 Real yflux_hi = fourth * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i-1,j+1,k)*mf_vx_inv(i-1,j+1,0)) *
-                                       (u(i,j+1,k) + u(i,j,k)) * met_h_zeta_yhi;
+                                         (u(i,j+1,k) + u(i,j,k)) * met_h_zeta_yhi;
 
                 Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterK(i,j  ,k,cellSizeInv,z_nd);
                 Real yflux_lo = fourth * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i-1,j  ,k)*mf_vx_inv(i-1,j  ,0)) *
-                                       (u(i,j-1,k) + u(i,j,k)) * met_h_zeta_ylo;
+                                         (u(i,j-1,k) + u(i,j,k)) * met_h_zeta_ylo;
 
                 Real zflux_hi = fourth * (Omega(i,j,k+1) + Omega(i-1,j,k+1)) * (u(i,j,k+1) + u(i,j,k)) *
-                                        myhalf * (az(i,j,k+1) + az(i-1,j,k+1));
+                                myhalf * (az(i,j,k+1) + az(i-1,j,k+1));
                 Real zflux_lo = fourth * (Omega(i,j,k  ) + Omega(i-1,j,k  )) * (u(i,j,k-1) + u(i,j,k)) *
-                                        myhalf * (az(i,j,k  ) + az(i-1,j,k  ));
+                                myhalf * (az(i,j,k  ) + az(i-1,j,k  ));
 
                 Real mfsq = mf_ux(i,j,0) * mf_uy(i,j,0);
 
@@ -139,22 +139,22 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
 
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterK(i+1,j,k,cellSizeInv,z_nd);
                 Real xflux_hi = fourth * (rho_u(i+1,j,k)*mf_uy_inv(i+1,j,0) + rho_u(i+1,j-1,k)*mf_uy_inv(i+1,j-1,0)) *
-                                       (v(i+1,j,k) + v(i,j,k)) * met_h_zeta_xhi;
+                                         (v(i+1,j,k) + v(i,j,k)) * met_h_zeta_xhi;
 
                 Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterK(i  ,j,k,cellSizeInv,z_nd);
                 Real xflux_lo = fourth * (rho_u(i, j, k)*mf_uy_inv(i  ,j,0) + rho_u(i  ,j-1,k)*mf_uy_inv(i  ,j-1,0)) *
-                                       (v(i-1,j,k) + v(i,j,k)) * met_h_zeta_xlo;
+                                         (v(i-1,j,k) + v(i,j,k)) * met_h_zeta_xlo;
 
                 Real yflux_hi = fourth * (rho_v(i,j+1,k)*mf_vx_inv(i,j+1,0) + rho_v(i,j  ,k) * mf_vx_inv(i,j  ,0)) *
-                                       (v(i,j+1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j+1,k));
+                                         (v(i,j+1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j+1,k));
 
                 Real yflux_lo = fourth * (rho_v(i,j  ,k)*mf_vx_inv(i,j  ,0) + rho_v(i,j-1,k) * mf_vx_inv(i,j-1,0)) *
-                                       (v(i,j-1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j-1,k));
+                                         (v(i,j-1,k) + v(i,j,k)) * myhalf * (ay(i,j,k) + ay(i,j-1,k));
 
                 Real zflux_hi = fourth * (Omega(i,j,k+1) + Omega(i, j-1, k+1)) * (v(i,j,k+1) + v(i,j,k)) *
-                                        myhalf * (az(i,j,k+1) + az(i,j-1,k+1));
+                                myhalf * (az(i,j,k+1) + az(i,j-1,k+1));
                 Real zflux_lo = fourth * (Omega(i,j,k  ) + Omega(i, j-1, k  )) * (v(i,j,k-1) + v(i,j,k)) *
-                                        myhalf * (az(i,j,k  ) + az(i,j-1,k  ));
+                                myhalf * (az(i,j,k  ) + az(i,j-1,k  ));
 
                 Real mfsq = mf_vx(i,j,0) * mf_vy(i,j,0);
 
@@ -166,26 +166,27 @@ AdvectionSrcForMom_TF (const Box& bxx, const Box& bxy, const Box& bxz,
         [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
         {
                 Real met_h_zeta_xhi = Compute_h_zeta_AtEdgeCenterJ(i+1,j  ,k  ,cellSizeInv,z_nd);
-                Real xflux_hi = fourth*(rho_u(i+1,j  ,k) + rho_u(i+1,j,k-1)) * mf_uy_inv(i+1,j,0) *
-                                     (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi;
+                Real xflux_hi = fourth * (rho_u(i+1,j  ,k) + rho_u(i+1,j,k-1)) * mf_uy_inv(i+1,j,0) *
+                                         (w(i+1,j,k) + w(i,j,k)) * met_h_zeta_xhi;
 
                 Real met_h_zeta_xlo = Compute_h_zeta_AtEdgeCenterJ(i  ,j  ,k  ,cellSizeInv,z_nd);
-                Real xflux_lo = fourth*(rho_u(i  ,j  ,k) + rho_u(i  ,j,k-1)) * mf_uy_inv(i  ,j,0) *
-                                     (w(i-1,j,k) + w(i,j,k)) * met_h_zeta_xlo;
+                Real xflux_lo = fourth * (rho_u(i  ,j  ,k) + rho_u(i  ,j,k-1)) * mf_uy_inv(i  ,j,0) *
+                                         (w(i-1,j,k) + w(i,j,k)) * met_h_zeta_xlo;
 
                 Real met_h_zeta_yhi = Compute_h_zeta_AtEdgeCenterI(i  ,j+1,k  ,cellSizeInv,z_nd);
-                Real yflux_hi = fourth*(rho_v(i,j+1,k) + rho_v(i,j+1,k-1)) * mf_vx_inv(i,j+1,0) *
-                                     (w(i,j+1,k) + w(i,j,k)) * met_h_zeta_yhi;
+                Real yflux_hi = fourth * (rho_v(i,j+1,k) + rho_v(i,j+1,k-1)) * mf_vx_inv(i,j+1,0) *
+                                         (w(i,j+1,k) + w(i,j,k)) * met_h_zeta_yhi;
 
                 Real met_h_zeta_ylo = Compute_h_zeta_AtEdgeCenterI(i  ,j  ,k  ,cellSizeInv,z_nd);
-                Real yflux_lo = fourth*(rho_v(i,j  ,k) + rho_v(i,j  ,k-1)) * mf_vx_inv(i,j  ,0) *
-                                     (w(i,j-1,k) + w(i,j,k)) * met_h_zeta_ylo;
+                Real yflux_lo = fourth * (rho_v(i,j  ,k) + rho_v(i,j  ,k-1)) * mf_vx_inv(i,j  ,0) *
+                                         (w(i,j-1,k) + w(i,j,k)) * met_h_zeta_ylo;
 
-                Real zflux_lo = fourth * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1));
+                Real zflux_lo = fourth * (Omega(i,j,k) + Omega(i,j,k-1)) * (w(i,j,k) + w(i,j,k-1)) *
+                                myhalf * (az(i,j,k) + az(i,j,k+1));
 
                 Real zflux_hi = (k == hi_z_face) ? Omega(i,j,k) * w(i,j,k)  * az(i,j,k):
                     fourth * (Omega(i,j,k) + Omega(i,j,k+1)) * (w(i,j,k) + w(i,j,k+1)) *
-                    myhalf  * (az(i,j,k) + az(i,j,k+1));
+                    myhalf * (az(i,j,k) + az(i,j,k+1));
 
                 Real mfsq = mf_mx(i,j,0) * mf_my(i,j,0);
 


### PR DESCRIPTION
# Summary
The `az` area corrections are carried around for complex terrain even though they only hold `1` for **non**-EB simulations. For consistency, the low z flux of vertical momentum is corrected to utilize `az` just like the upper flux. This should not change anything.