### PR TITLE
Fix WPS Restart

### DIFF
--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -452,6 +452,32 @@ ERF::WriteCheckpointFile () const
 #endif
     } // for lev
 
+    // Write zlevels to its own directory and read it as well, similar to bdy data
+    if (ParallelDescriptor::IOProcessor()) {
+        std::string ZLevelsFileName(checkpointname + "/zlevels");
+        std::ofstream ZLevelsFile;
+        ZLevelsFile.open(ZLevelsFileName.c_str(), std::ofstream::out   |
+                                                  std::ofstream::trunc |
+                                                  std::ofstream::binary);
+        if(! ZLevelsFile.good()) {
+            FileOpenFailed(ZLevelsFileName);
+        } else {
+            ZLevelsFile.precision(17);
+
+            // Write every level we hold (max_level+1) rather than finest_level+1, so
+            // that levels which are not currently active are still restored.
+            ZLevelsFile << zlevels_stag.size() << "\n";
+
+            for (int lev = 0; lev < static_cast<int>(zlevels_stag.size()); ++lev) {
+                ZLevelsFile << zlevels_stag[lev].size();
+                for (int k = 0; k < static_cast<int>(zlevels_stag[lev].size()); ++k) {
+                    ZLevelsFile << " " << zlevels_stag[lev][k];
+                }
+                ZLevelsFile << "\n";
+            }
+        }
+    }
+
 #ifdef ERF_USE_PARTICLES
    particleData.Checkpoint(checkpointname);
 #endif
@@ -618,6 +644,46 @@ ERF::ReadCheckpointFile ()
         while (lis >> word) {
             t_new[i++] = std::stod(word);
         }
+    }
+
+    // Read zlevels from its own directory
+    // NOTE: This read should occur before MakeNewLevelFromScratch
+    {
+        std::string ZLevelsFile(restart_chkfile + "/zlevels");
+        if (amrex::FileExists(ZLevelsFile)) {
+            Vector<char> ZLevelsfileCharPtr;
+            ParallelDescriptor::ReadAndBcastFile(ZLevelsFile, ZLevelsfileCharPtr);
+            std::string ZLevelsfileCharPtrString(ZLevelsfileCharPtr.dataPtr());
+            std::istringstream isz(ZLevelsfileCharPtrString, std::istringstream::in);
+
+            int nlevs_in_chk = 0;
+            isz >> nlevs_in_chk;
+
+            for (int lev = 0; lev < nlevs_in_chk; ++lev) {
+                int nz_stag = 0;
+                isz >> nz_stag;
+
+                Vector<Real> zlevels_from_chk(nz_stag);
+                for (int k = 0; k < nz_stag; ++k) {
+                    isz >> zlevels_from_chk[k];
+                }
+
+                // A checkpoint from a run with more levels than we hold: read past it
+                if (lev >= static_cast<int>(zlevels_stag.size())) { continue; }
+
+                if (static_cast<int>(zlevels_stag[lev].size()) != nz_stag) {
+                    Print() << "Checkpoint holds " << nz_stag << " staggered z levels at level "
+                            << lev << " but this run expects "
+                            << zlevels_stag[lev].size() << std::endl;
+                    Abort("Cannot restart with a different number of cells in z");
+                }
+
+                zlevels_stag[lev] = zlevels_from_chk;
+
+                // Keep the cell heights consistent with the levels we just read in
+                update_stretched_dz(lev, zlevels_stag, stretched_dz_h, stretched_dz_d);
+            }
+        } // zlevels file exists
     }
 
     for (int lev = 0; lev <= finest_level; ++lev) {
@@ -1097,6 +1163,8 @@ ERF::ReadCheckpointFile ()
                            << std::endl;
         }
     }
+
+
 
 #ifdef ERF_USE_PARTICLES
     restartTracers((ParGDBBase*)GetParGDB(),restart_chkfile);

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -1140,23 +1140,31 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
 #else
             const Real tol = Real(1.e-8);
 #endif
-            int max_iter = 50;
+            Real SFact = Real(1.03);
+            Real Nz = static_cast<Real>(zlevels_stag[lev].size() - 1);
 
-            int iter   = 0;
-            Real Nz    = static_cast<Real>(zlevels_stag[lev].size() - 1);
-            Real SFact = Real(1.1);
-            Real F     = dz0_max * ( (std::pow(SFact,Nz) - one) / (SFact - one) ) - z_top;
-            while (std::fabs(F)>tol && iter<max_iter) {
-                Real dFdSF = dz0_max * ( Nz * std::pow(SFact,Nz-one) * (SFact - one) - std::pow(SFact,Nz) + one )
-                           / std::pow(SFact-one,two);
-                SFact     -= F/dFdSF;
-                SFact      = std::max(one+tol,SFact);
-                F          = dz0_max * ( (std::pow(SFact,Nz) - one) / (SFact - one) ) - z_top;
-                ++iter;
+            // Default to uniform grid or solve for a stretched grid
+            if (dz0_max >= z_top/Nz) {
+                SFact   = one;
+                dz0_max = z_top/Nz;
+            } else {
+                int max_iter = 50;
+                int iter     = 0;
+                Real F       = dz0_max * ( (std::pow(SFact,Nz) - one) / (SFact - one) ) - z_top;
+                while (std::fabs(F)>tol && iter<max_iter) {
+                    Real dFdSF = dz0_max * ( Nz * std::pow(SFact,Nz-one) * (SFact - one)
+                                           - std::pow(SFact,Nz) + one ) /
+                                           std::pow(SFact-one,two);
+                    SFact     -= F/dFdSF;
+                    SFact      = std::max(one+tol,SFact);
+                    F          = dz0_max * ( (std::pow(SFact,Nz) - one) / (SFact - one) ) - z_top;
+                    ++iter;
+                }
+                AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::fabs(F) <= tol,
+                                                 "Newton iterations to determine the grid stretching factor failed!\n");
             }
-            AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::fabs(F) <= tol,
-                "Newton iterations to determine the grid stretching factor failed!\n");
 
+            // Build the zlevels
             Print() << "Building an ERF grid with dz0: " << dz0_max <<
                 " and stretching factor: " << SFact << "\n";
             Real dz = dz0_max;
@@ -1167,6 +1175,9 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
             }
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE(std::fabs(zlevels_stag[lev].back() - z_top) <= tol,
                 "Top of zlevels_stag does not match z_top!\n");
+
+            // Update stretched dz and build terrain fitted coords
+            update_stretched_dz(lev, zlevels_stag, stretched_dz_h, stretched_dz_d);
             make_terrain_fitted_coords(lev, geom[lev], *z_phys_nd[lev], zlevels_stag[lev], phys_bc_type);
         }
 

--- a/Source/Utils/ERF_InitZLevels.cpp
+++ b/Source/Utils/ERF_InitZLevels.cpp
@@ -118,3 +118,34 @@ init_zlevels (Vector<Vector<Real>>& zlevels_stag,
         Gpu::copy(Gpu::hostToDevice, stretched_dz_h[lev].begin(), stretched_dz_h[lev].end(), stretched_dz_d[lev].begin());
     }
 }
+
+/**
+ * Re-derive the cell heights at one level from the nominal staggered z-levels.
+ *
+ * @param[in] lev Level index.
+ * @param[in] zlevels_stag Staggered z-level coordinates.
+ * @param[out] stretched_dz_h Host-side cell heights in z.
+ * @param[out] stretched_dz_d Device-side cell heights in z.
+ */
+void
+update_stretched_dz (int lev,
+                     Vector<Vector<Real>> const& zlevels_stag,
+                     Vector<Vector<Real>>& stretched_dz_h,
+                     Vector<Gpu::DeviceVector<Real>>& stretched_dz_d)
+{
+    AMREX_ALWAYS_ASSERT(lev < static_cast<int>(zlevels_stag.size()));
+    AMREX_ALWAYS_ASSERT(lev < static_cast<int>(stretched_dz_h.size()));
+    AMREX_ALWAYS_ASSERT(lev < static_cast<int>(stretched_dz_d.size()));
+
+    const int nz = static_cast<int>(zlevels_stag[lev].size()) - 1;
+    AMREX_ALWAYS_ASSERT(nz > 0);
+
+    stretched_dz_h[lev].resize(nz);
+    for (int k = 0; k < nz; k++) {
+        stretched_dz_h[lev][k] = zlevels_stag[lev][k+1] - zlevels_stag[lev][k];
+    }
+
+    stretched_dz_d[lev].resize(nz);
+    Gpu::copy(Gpu::hostToDevice, stretched_dz_h[lev].begin(), stretched_dz_h[lev].end(),
+              stretched_dz_d[lev].begin());
+}

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -284,23 +284,26 @@ realbdy_compute_interior_ghost_rhs (const double& time,
     } // ivar
 
     if (use_wrf_bdy_density) {
+        const IntVect ng_vect(1,1,0);
         Box domain = geom.Domain();
-        const IntVect ng_vect(0);
+        Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
-        realbdy_interior_bxs_xy(domain, domain, width,
-                                bx_xlo, bx_xhi, bx_ylo, bx_yhi, ng_vect, true);
+        realbdy_interior_bxs_xy(domain, gdom, width,
+                                bx_xlo, bx_xhi, bx_ylo, bx_yhi,
+                                ng_vect, true);
+
         R_xlo.resize(bx_xlo, 1, The_Async_Arena());
         R_xhi.resize(bx_xhi, 1, The_Async_Arena());
         R_ylo.resize(bx_ylo, 1, The_Async_Arena());
         R_yhi.resize(bx_yhi, 1, The_Async_Arena());
 
-        const auto& r_xlo_n = bdy_data_xlo[n_time][WRFBdyVars::R].const_array();
+        const auto& r_xlo_n   = bdy_data_xlo[n_time   ][WRFBdyVars::R].const_array();
         const auto& r_xlo_np1 = bdy_data_xlo[n_time_p1][WRFBdyVars::R].const_array();
-        const auto& r_xhi_n = bdy_data_xhi[n_time][WRFBdyVars::R].const_array();
+        const auto& r_xhi_n   = bdy_data_xhi[n_time   ][WRFBdyVars::R].const_array();
         const auto& r_xhi_np1 = bdy_data_xhi[n_time_p1][WRFBdyVars::R].const_array();
-        const auto& r_ylo_n = bdy_data_ylo[n_time][WRFBdyVars::R].const_array();
+        const auto& r_ylo_n   = bdy_data_ylo[n_time   ][WRFBdyVars::R].const_array();
         const auto& r_ylo_np1 = bdy_data_ylo[n_time_p1][WRFBdyVars::R].const_array();
-        const auto& r_yhi_n = bdy_data_yhi[n_time][WRFBdyVars::R].const_array();
+        const auto& r_yhi_n   = bdy_data_yhi[n_time   ][WRFBdyVars::R].const_array();
         const auto& r_yhi_np1 = bdy_data_yhi[n_time_p1][WRFBdyVars::R].const_array();
         const auto& rbx = lbound(domain);
         const auto& rhi = ubound(domain);

--- a/Source/Utils/ERF_InteriorGhostCells.cpp
+++ b/Source/Utils/ERF_InteriorGhostCells.cpp
@@ -288,7 +288,7 @@ realbdy_compute_interior_ghost_rhs (const double& time,
         Box domain = geom.Domain();
         Box gdom(domain); gdom.grow(ng_vect);
         Box bx_xlo, bx_xhi, bx_ylo, bx_yhi;
-        realbdy_interior_bxs_xy(domain, gdom, width,
+        realbdy_interior_bxs_xy(gdom, domain, width,
                                 bx_xlo, bx_xhi, bx_ylo, bx_yhi,
                                 ng_vect, true);
 

--- a/Source/Utils/ERF_TerrainMetrics.H
+++ b/Source/Utils/ERF_TerrainMetrics.H
@@ -80,6 +80,26 @@ init_which_terrain_grid (int lev, const amrex::Geometry& geom,
 amrex::Real
 get_dzmin_terrain (amrex::MultiFab& z_phys_nd);
 
+/**
+ * Re-derive the stretched vertical spacing at one level from the nominal z-levels.
+ *
+ * init_zlevels() fills both zlevels_stag and stretched_dz_* together, but
+ * zlevels_stag can be replaced after construction (init_from_wrfinput() does this
+ * when erf.use_wrf_height_grid = false, and restart reads it back from the
+ * checkpoint).  Call this whenever zlevels_stag[lev] changes so that the cell
+ * heights never drift out of sync with the levels they are supposed to describe.
+ *
+ * @param[in] lev Level index.
+ * @param[in] zlevels_stag Staggered z-levels (the source of truth).
+ * @param[out] stretched_dz_h Host stretched vertical spacing.
+ * @param[out] stretched_dz_d Device stretched vertical spacing.
+ */
+void
+update_stretched_dz (int lev,
+                     amrex::Vector<amrex::Vector<amrex::Real>> const& zlevels_stag,
+                     amrex::Vector<amrex::Vector<amrex::Real>>& stretched_dz_h,
+                     amrex::Vector<amrex::Gpu::DeviceVector<amrex::Real>>& stretched_dz_d);
+
 //*****************************************************************************************
 // Compute terrain metric terms at cell-center
 //*****************************************************************************************


### PR DESCRIPTION
# Summary
1. This PR fixes the WPS restart, which failed from not reading and writing `zlevels_stag` to the checkpoint file. This is an issue for real simulations with `use_WRF_height_grid=false` since that capability modifies zlevels_stag.
2.  This PR alleviated #3866 by building a uniform spacing if `dz0_max >= dz`.
3.  This PR fixes a density nudging out of bounds error by adding ghost cells to the interpolated boxes
