### PR TITLE
Fix SYCL issues in SDM code

### DIFF
--- a/Source/Particles/ERF_SuperDropletPCMassChange.H
+++ b/Source/Particles/ERF_SuperDropletPCMassChange.H
@@ -2,6 +2,7 @@
 #define SUPERDROPLET_PC_MASSCHANGE_H_
 
 #include <cmath>
+#include <AMReX_GpuPrint.H>
 #include "ERF_Constants.H"
 
 #ifdef ERF_USE_PARTICLES
@@ -1070,8 +1071,8 @@ namespace SDMassChangeUtils_SV
                 cur_time += m_dt;
 
                 if (m_verbose) {
-                    printf( "Time %1.2e, m_dt = %1.2e, mass = %1.4e, snorm = %1.1e\n",
-                            cur_time, m_dt, a_u, snorm);
+                    AMREX_DEVICE_PRINTF( "Time %1.2e, m_dt = %1.2e, mass = %1.4e, snorm = %1.1e\n",
+                                         cur_time, m_dt, a_u, snorm);
                 }
 
                 n_step++;

--- a/Tests/Unit/Microphysics/Freezing/ERF_GTestFreezingCommon.H
+++ b/Tests/Unit/Microphysics/Freezing/ERF_GTestFreezingCommon.H
@@ -40,7 +40,7 @@ amrex::Real nonneg (const amrex::Real x) noexcept { return amrex::max(amrex::Rea
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real freezing_metric (const int i) noexcept
 {
-    const INAS_Niemand2012 inas;
+    const INAS_Niemand2012 inas{};
     const amrex::Real A = amrex::Real(1.0e-9);   // typical INP surface area [m^2]
 
     switch (i) {


### PR DESCRIPTION
Replaces the variadic `printf` in the SDM ODE solver with `AMREX_DEVICE_PRINTF`, which SYCL device code accepts, and value-initializes the `INAS_Niemand2012` constant in the freezing unit test to silence nvcc warning `#811-D`.
