### PR TITLE
Fix unfilled ghost-node thickness in particle deposition

### DIFF
--- a/Source/Particles/ERFPCParticleToMesh.H
+++ b/Source/Particles/ERFPCParticleToMesh.H
@@ -34,6 +34,7 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
     const int  k_max  = domain.bigEnd(AMREX_SPACEDIM-1);
     const int  i_lo   = domain.smallEnd(0), i_hi = domain.bigEnd(0);
     const int  j_lo   = domain.smallEnd(1), j_hi = domain.bigEnd(1);
+    const int  k_lo   = domain.smallEnd(AMREX_SPACEDIM-1);
     const bool per_x  = geom.isPeriodic(0);
     const bool per_y  = geom.isPeriodic(1);
 
@@ -164,9 +165,9 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
                 // folds into; only the non-periodic exterior nodes need clamping.
                 const int ic_dz = per_x ? ic : amrex::max(i_lo, amrex::min(i_hi, ic));
                 const int jc_dz = per_y ? jc : amrex::max(j_lo, amrex::min(j_hi, jc));
-                const int kc_dz = amrex::max(0,  amrex::min(k_max, kc));
+                const int kc_dz = amrex::max(k_lo, amrex::min(k_max, kc));
                 const Real dz = dz_cell(ic_dz, jc_dz, kc_dz);
-                AMREX_ASSERT(dz > Real(0.0));
+                AMREX_ALWAYS_ASSERT(dz > Real(0.0));
                 const Real contrib = pval * w_horiz * w_z * inv_dxdy / dz;
                 Gpu::Atomic::AddNoRet(&rho(ic, jc, kc, a_comp), contrib);
             };

--- a/Source/Particles/ERFPCParticleToMesh.H
+++ b/Source/Particles/ERFPCParticleToMesh.H
@@ -34,6 +34,8 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
     const int  k_max  = domain.bigEnd(AMREX_SPACEDIM-1);
     const int  i_lo   = domain.smallEnd(0), i_hi = domain.bigEnd(0);
     const int  j_lo   = domain.smallEnd(1), j_hi = domain.bigEnd(1);
+    const bool per_x  = geom.isPeriodic(0);
+    const bool per_y  = geom.isPeriodic(1);
 
     a_mf.setVal(0.0);
 
@@ -156,13 +158,13 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
                 // an invalid-operation FPE.
                 if (w_horiz == Real(0.0) || w_z == Real(0.0)) { return; }
 
-                // Clamp only for the dz lookup; still write to the ghost rho cell. The
-                // z_phys_nd nodes outside the domain are not reliably filled, so a ghost
-                // deposit borrows the thickness of the outermost valid cell, which is the
-                // one SumBoundary folds it into.
-                const int ic_dz = amrex::max(i_lo, amrex::min(i_hi, ic));
-                const int jc_dz = amrex::max(j_lo, amrex::min(j_hi, jc));
-                const int kc_dz = amrex::max(0,    amrex::min(k_max, kc));
+                // Clamp only for the dz lookup; still write to the ghost rho cell. In a
+                // periodic direction the exterior nodes hold the wrapped image, so the
+                // unclamped stencil already gives the thickness of the cell SumBoundary
+                // folds into; only the non-periodic exterior nodes need clamping.
+                const int ic_dz = per_x ? ic : amrex::max(i_lo, amrex::min(i_hi, ic));
+                const int jc_dz = per_y ? jc : amrex::max(j_lo, amrex::min(j_hi, jc));
+                const int kc_dz = amrex::max(0,  amrex::min(k_max, kc));
                 const Real dz = dz_cell(ic_dz, jc_dz, kc_dz);
                 AMREX_ASSERT(dz > Real(0.0));
                 const Real contrib = pval * w_horiz * w_z * inv_dxdy / dz;

--- a/Source/Particles/ERFPCParticleToMesh.H
+++ b/Source/Particles/ERFPCParticleToMesh.H
@@ -32,6 +32,8 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
     const Real dy  = geom.CellSize(1);
     const Box  domain = geom.Domain();
     const int  k_max  = domain.bigEnd(AMREX_SPACEDIM-1);
+    const int  i_lo   = domain.smallEnd(0), i_hi = domain.bigEnd(0);
+    const int  j_lo   = domain.smallEnd(1), j_hi = domain.bigEnd(1);
 
     a_mf.setVal(0.0);
 
@@ -154,9 +156,15 @@ void ERFPC::ERFPCParticleToMesh(amrex::MultiFab& a_mf,
                 // an invalid-operation FPE.
                 if (w_horiz == Real(0.0) || w_z == Real(0.0)) { return; }
 
-                // Clamp kc only for dz lookup; still write to ghost rho cell.
-                const int kc_dz = amrex::max(0, amrex::min(k_max, kc));
-                const Real dz = dz_cell(ic, jc, kc_dz);
+                // Clamp only for the dz lookup; still write to the ghost rho cell. The
+                // z_phys_nd nodes outside the domain are not reliably filled, so a ghost
+                // deposit borrows the thickness of the outermost valid cell, which is the
+                // one SumBoundary folds it into.
+                const int ic_dz = amrex::max(i_lo, amrex::min(i_hi, ic));
+                const int jc_dz = amrex::max(j_lo, amrex::min(j_hi, jc));
+                const int kc_dz = amrex::max(0,    amrex::min(k_max, kc));
+                const Real dz = dz_cell(ic_dz, jc_dz, kc_dz);
+                AMREX_ASSERT(dz > Real(0.0));
                 const Real contrib = pval * w_horiz * w_z * inv_dxdy / dz;
                 Gpu::Atomic::AddNoRet(&rho(ic, jc, kc, a_comp), contrib);
             };


### PR DESCRIPTION
Clamps the horizontal indices of the CIC deposit thickness stencil into the valid nodal range, the way `kc` already was, so a ghost-cell deposit no longer normalizes by unfilled `z_phys_nd` ghost nodes. Fixes #3903, the half of the problem left open by the zero-weight guard added in #3902.
