### PR TITLE
Add large scale forcing docs

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -1677,6 +1677,53 @@ with an ``erf.abl_geo_wind_table``.
   or ``-DERF_ENABLE_WINDFARM`` (cmake) at build time.
   See :ref:`sec:WindFarmModels` for theory and examples.
 
+
+Large Scale Forcing
+--------------------
+
+Large-scale forcing can be used to prescribe time-varying vertical profiles for
+temperature, water vapor, horizontal wind, and vertical subsidence.
+A text file containing the large scale forcing data is provided using the ``erf.large_scale_forcing_file``
+option. The file contains one or more time blocks, where each time block is denoted with
+a header containing the day, number of levels in the block, and reference pressure for that time.
+Each row of data in the block contains ``z, p, tls, qls, uls, vls, wls`` corresponding to level
+height, pressure, large scale temperature and moisture tendency, large scale zonal and meridonal velocity,
+and large scale vertical subsidence velocity.
+
+- Either a height grid ``z[m]`` or pressure grid ``p[mb]`` can be provided, where one can be a negative number
+  to indicate the other grid type should be used (e.g. if the ``z`` values are negative, the file is
+  interpreted as pressure-level data instead of height-level data). If both grids are provided, then the ``z`` grid is used.
+
+- The large scale forcing grid is interpolated to the ERF grid, similar to the input sounding.
+
+- Large scale tendencies are applied based on a time period in seconds specified by the ``erf.forcing_timescale`` option.
+
+- Times are converted to elapsed seconds relative to the first timestamp in the file.
+
+- Temperature and moisture nudging can be restricted to a custom interval instead of entire domain with the
+  ``erf.nudging_t_z1`` and ``erf.nudging_t_z2``, and ``erf.nudging_q_z1`` and ``erf.nudging_q_z2`` options, respectively.
+
+- **NOTE:** When both large scale forcing and ``erf.nudging_from_input_sounding`` are used, the u and v velocities are nudged
+  according to the observed large scale velocity ``uls`` and ``vls`` instead of the input sounding (using the lsf forcing timescale).
+  Temperature and moisture are nudged from input sounding as normal (using the input sounding tau_nudging timescale).
+
+Example file format for large scale forcing:
+
+.. code-block:: text
+
+   z[m] p[mb]  tls[K/s] qls[kg/kg/s] uls  vls  wls[m/s]
+   0.0,   4, 1000.0  day, levels, pres0
+      0.0  1000.00  0.000e+00  0.000e+00  0.0  0.0  0.000e+00
+    100.0   990.00  0.000e+00  0.000e+00  0.5  0.2  0.000e+00
+   1000.0   900.00 -5.000e-06  0.000e+00  2.0  1.0  0.000e+00
+   5000.0   500.00 -1.000e-05  0.000e+00  6.0  3.0  0.000e+00
+   0.5,   4, 1000.0  day, levels, pres0
+      0.0  1000.00  0.000e+00  0.000e+00  0.2  0.1  0.000e+00
+    100.0   990.00  0.000e+00  0.000e+00  0.7  0.3  0.000e+00
+   1000.0   900.00 -2.500e-06  0.000e+00  2.5  1.2  0.000e+00
+   5000.0   500.00 -8.000e-06  0.000e+00  6.5  3.2  0.000e+00
+
+
 Boundary Plane I/O (Coupling Support)
 =====================================
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -918,9 +918,9 @@ The requested output files have the following columns:
 
   #. Height (m)
 
-  #. Large-scale temperature tendency, :math:`\partial \theta / \partial t` (K/s)
+  #. Total applied temperature tendency, :math:`\partial \theta / \partial t` (K/s)
 
-  #. Large-scale water vapor tendency, :math:`\partial q_v / \partial t` (kg/kg/s)
+  #. Total applied water vapor tendency, :math:`\partial q_v / \partial t` (kg/kg/s)
 
   #. Large-scale subsidence velocity, :math:`w_{sub}` (m/s)
 
@@ -941,6 +941,11 @@ The requested output files have the following columns:
   #. X-velocity nudging tendency, :math:`u_{nudge}` (m/s2)
 
   #. Y-velocity nudging tendency, :math:`v_{nudge}` (m/s2)
+
+.. note::
+
+   The vertical tendency columns are only populated for interior cells between
+   the bottom and top boundaries; they are zero at the domain edges.
 
 
 Data Sampling Outputs
@@ -1683,12 +1688,19 @@ Large Scale Forcing
 
 Large-scale forcing can be used to prescribe time-varying vertical profiles for
 temperature, water vapor, horizontal wind, and vertical subsidence.
-A text file containing the large scale forcing data is provided using the ``erf.large_scale_forcing_file``
-option. The file contains one or more time blocks, where each time block is denoted with
-a header containing the day, number of levels in the block, and reference pressure for that time.
-Each row of data in the block contains ``z, p, tls, qls, uls, vls, wls`` corresponding to level
-height, pressure, large scale temperature and moisture tendency, large scale zonal and meridonal velocity,
-and large scale vertical subsidence velocity.
+To enable it, set::
+
+  erf.large_scale_forcing      = true
+  erf.large_scale_forcing_file = lsf.txt
+  erf.forcing_timescale        = 3600.0
+
+where ``erf.large_scale_forcing_file`` is the path to a text file containing the
+large scale forcing data and ``erf.forcing_timescale`` is the relaxation timescale
+(in seconds) for nudging velocities. The file contains one or more time blocks, where each time
+block is denoted with a header containing the day, number of levels in the block, and reference
+pressure for that time. Each row of data in the block contains ``z, p, tls, qls, uls, vls, wls``
+corresponding to level height, pressure, large scale temperature and moisture tendency, large scale
+zonal and meridional velocity, and large scale vertical subsidence velocity.
 
 - Either a height grid ``z[m]`` or pressure grid ``p[mb]`` can be provided, where one can be a negative number
   to indicate the other grid type should be used (e.g. if the ``z`` values are negative, the file is
@@ -1696,7 +1708,10 @@ and large scale vertical subsidence velocity.
 
 - The large scale forcing grid is interpolated to the ERF grid, similar to the input sounding.
 
-- Large scale tendencies are applied based on a time period in seconds specified by the ``erf.forcing_timescale`` option.
+- ``erf.forcing_timescale`` is the relaxation time scale used when nudging the
+  horizontal velocities toward the ``uls`` and ``vls`` profiles. The
+  temperature, moisture, and subsidence tendencies are applied directly and
+  are not scaled by this option.
 
 - Times are converted to elapsed seconds relative to the first timestamp in the file.
 
@@ -1704,8 +1719,9 @@ and large scale vertical subsidence velocity.
   ``erf.nudging_t_z1`` and ``erf.nudging_t_z2``, and ``erf.nudging_q_z1`` and ``erf.nudging_q_z2`` options, respectively.
 
 - **NOTE:** When both large scale forcing and ``erf.nudging_from_input_sounding`` are used, the u and v velocities are nudged
-  according to the observed large scale velocity ``uls`` and ``vls`` instead of the input sounding (using the lsf forcing timescale).
-  Temperature and moisture are nudged from input sounding as normal (using the input sounding tau_nudging timescale).
+  according to the observed large scale velocity ``uls`` and ``vls`` instead of the input sounding, using
+  ``erf.forcing_timescale``. Temperature and moisture are nudged from input sounding as normal, using the input
+  sounding ``tau_nudging`` timescale.
 
 Example file format for large scale forcing:
 

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -745,13 +745,14 @@ Diagnostic Outputs
 If ``erf.v`` is set then one or more additional output files may be requested.
 These are **useful for idealized, horizontally homogeneous simulation domains**
 and include (1) a surface time history file, (2) a history of mean profiles,
-(3) a history of vertical flux profiles (i.e., variances and covariances), and
-(4) a history of modeled subgrid stresses. The profiles are calculated from
-planar averages.
+(3) a history of vertical flux profiles (i.e., variances and covariances),
+(4) a history of modeled subgrid stresses, and (5) a history of large scale
+forcing and nudging data. The profiles are calculated from planar averages.
 
 The number of output filenames specified through ``erf.data_log`` dictates the
-level of output. E.g., specifying 3 filenames will give outputs (1), (2), and (3).
-Data files are only written if ``erf.profile_int > 0``.
+level of output. E.g., specifying 3 filenames will give outputs (1), (2), and (3);
+specifying 5 filenames will also include output (5). Data files are only written
+if ``erf.profile_int > 0``.
 
 This output functionality has not been implemented for terrain.
 For **real simulation domains**, users should use 2-D and 3-D :ref:`sec:Plotfiles`.
@@ -766,7 +767,7 @@ List of Parameters
 | Parameter                     | Definition       | Acceptable     | Default        |
 |                               |                  | Values         |                |
 +===============================+==================+================+================+
-| **erf.data_log**              | Output           | Up to four     | NONE           |
+| **erf.data_log**              | Output           | Up to five     | NONE           |
 |                               | filename(s)      | strings        |                |
 +-------------------------------+------------------+----------------+----------------+
 | **erf.der_data_log**          | Output           | Up to four     | NONE           |
@@ -910,6 +911,36 @@ The requested output files have the following columns:
   #. *SGS cloud water flux*, :math:`\tau_{q_c w}` (K m/s) -- *staggered*
 
   #. SGS turbulence dissipation, :math:`\epsilon` (m2/s3)
+
+* Large scale forcing and nudging profiles
+
+  #. Time (s)
+
+  #. Height (m)
+
+  #. Large-scale temperature tendency, :math:`\partial \theta / \partial t` (K/s)
+
+  #. Large-scale water vapor tendency, :math:`\partial q_v / \partial t` (kg/kg/s)
+
+  #. Large-scale subsidence velocity, :math:`w_{sub}` (m/s)
+
+  #. Horizontal temperature tendency, :math:`\partial \theta / \partial t` (K/s)
+
+  #. Horizontal water vapor tendency, :math:`\partial q_v / \partial t` (kg/kg/s)
+
+  #. Vertical temperature tendency, :math:`\partial \theta / \partial t` (K/s)
+
+  #. Vertical water vapor tendency, :math:`\partial q_v / \partial t` (kg/kg/s)
+
+  #. Vertical cloud water tendency, :math:`\partial q_c / \partial t` (kg/kg/s)
+
+  #. Temperature nudging tendency, :math:`\theta_{nudge}` (K/s)
+
+  #. Water vapor nudging tendency, :math:`q_{v,nudge}` (kg/kg/s)
+
+  #. X-velocity nudging tendency, :math:`u_{nudge}` (m/s2)
+
+  #. Y-velocity nudging tendency, :math:`v_{nudge}` (m/s2)
 
 
 Data Sampling Outputs

--- a/Docs/sphinx_doc/SurfaceLayer.rst
+++ b/Docs/sphinx_doc/SurfaceLayer.rst
@@ -264,44 +264,44 @@ Instead of computing fluxes directly through MOST, the surface land/ocean fluxes
 
 Additionally, the sea-surface temperature can be prescribed while allowing MOST to compute the surface fluxes.
 
-**For prescribing surface fluxes from ``H``, ``LE``, and ``TAU``:**
+**For prescribing surface fluxes from H, LE, and TAU:**
 
-..
+.. code-block:: text
 
    erf.most.use_sfc_fluxes = true     # flag for prescribing surface fluxes
    erf.most.sfc_file       = sfc.txt  # path to file containing surface data
 
-where the `erf.most.sfc_file` is the path to a text file with the following example format:
+where ``erf.most.sfc_file`` is the path to a text file with the following example format:
 
-```
-day sst(K) H(W/m2) LE(W/m2) TAU(m2/s2)
-205.500 293.65   4.43  22.73 0.00
-205.542 295.63  43.55  88.67 0.00
-205.583 298.40 104.08 154.39 0.00
-```
+.. code-block:: text
 
-This mode implies `erf.most.flux_type = custom` and is not compatible with an activate land surface model or EB.
+   day sst(K) H(W/m2) LE(W/m2) TAU(m2/s2)
+   205.500 293.65   4.43  22.73 0.00
+   205.542 295.63  43.55  88.67 0.00
+   205.583 298.40 104.08 154.39 0.00
+
+This mode implies ``erf.most.flux_type = custom`` and is not compatible with an active land surface model or EB.
 
 
 **For prescribing sea-surface temperature:**
 
-..
+.. code-block:: text
 
    erf.most.use_sfc_sst = true     # flag for prescribing sea-surface temperature
    erf.most.sfc_file    = sfc.txt  # path to file containing surface data
 
-where the `erf.most.sfc_file` is the path to a text file with the same format as above,
+where ``erf.most.sfc_file`` is the path to a text file with the same format as above,
 or purely time and SST information, such as:
 
-```
-day sst(K)
-203.000000  292.800
-204.000000  294.580
-```
+.. code-block:: text
+
+   day sst(K)
+   203.000000  292.800
+   204.000000  294.580
 
 Notes
------
+^^^^^
 
 - For both flux and sst modes, the time column is reset relative to the simulation elapsed time (t=0s). This might cause issues with simulations initialized with real data, such as WRFInput.
-- The sst mode only applies the surface temperature where there are ocean cells (landmask=0). This can be forced with `erf.is_land = 0`.
+- The sst mode only applies the surface temperature where there are ocean cells (landmask=0). This can be forced with ``erf.is_land = 0``.
 - The surface fluxes are currently applied regardless of land mask (both ocean and land).

--- a/Source/DataStructs/ERF_LargeScaleForcingData.H
+++ b/Source/DataStructs/ERF_LargeScaleForcingData.H
@@ -276,16 +276,19 @@ public:
                             amrex::Real& coeff_next)
     {
         // helper function to get the current time indices of forcing data to use and
-        // coefficients based on the current simulation time
+        // coefficients based on the current simulation time. Historical callers
+        // pass elapsed time, while datetime-aware paths may pass total/epoch
+        // time, so normalize to elapsed time relative to the simulation start.
         curr = 0;
         next = 0;
         coeff_curr = one;
         coeff_next = zero;
+        const amrex::Real rel_time = (time >= start_time) ? (time - start_time) : time;
 
         // find the time index of forcing data to use
         for (int nt = 1; nt < num_times; nt++)
         {
-            if (time - start_time > times_lsf[nt])
+            if (rel_time > times_lsf[nt])
             {
                 curr = nt;
             }
@@ -299,7 +302,7 @@ public:
             coeff_next = zero;
         } else {
             next = curr + 1;
-            coeff_next = ((time - start_time) - times_lsf[curr]) / (times_lsf[next] - times_lsf[curr]);
+            coeff_next = (rel_time - times_lsf[curr]) / (times_lsf[next] - times_lsf[curr]);
             coeff_curr = (one - coeff_next);
         }
     }

--- a/Source/DataStructs/ERF_LargeScaleForcingData.H
+++ b/Source/DataStructs/ERF_LargeScaleForcingData.H
@@ -194,17 +194,14 @@ public:
         amrex::Print() << "  Read " << nz_lsf << " levels at " << num_times << " times" << std::endl;
 
         // debugging print
-        if (verbose_print) {
-            for (int i = 0; i < times_lsf.size(); i++)
+        if (verbose_print && !times_lsf.empty()) {
+            const int i = 0; // print only the first time block
+            amrex::Print() << " LSF at time = " << times_lsf[i] << std::endl;
+            for (int lev = 0; lev < nz_lsf + 1; lev++)
             {
-                amrex::Print() << " LSF at time = " << times_lsf[i] << std::endl;
-                for (int lev = 0; lev < nz_lsf + 1; lev++)
-                {
-                    amrex::Print() << "   level " << lev << ": z = " << z_lsf[i][lev] << " p = " << p_lsf[i][lev] << " tls = "
-                                   << t_lsf[i][lev] << " qls = " << q_lsf[i][lev] << " uls = " << u_lsf[i][lev] << " vls = "
-                                   << v_lsf[i][lev] << " wls = " << w_lsf[i][lev] << std::endl;
-                }
-                break; // print only the first time block
+                amrex::Print() << "   level " << lev << ": z = " << z_lsf[i][lev] << " p = " << p_lsf[i][lev] << " tls = "
+                               << t_lsf[i][lev] << " qls = " << q_lsf[i][lev] << " uls = " << u_lsf[i][lev] << " vls = "
+                               << v_lsf[i][lev] << " wls = " << w_lsf[i][lev] << std::endl;
             }
         }
     }
@@ -308,24 +305,21 @@ public:
         }
 
         // debugging print
-        if (verbose_print) {
-            for (int i = 0; i < times_lsf.size(); i++)
+        if (verbose_print && !times_lsf.empty()) {
+            const int i = 0; // print only the first time block
+            amrex::Print() << " INTERPOLATED LSF at time = " << times_lsf[i] << std::endl;
+            for (int k = 0; k <= Nz; k++)
             {
-                amrex::Print() << " INTERPOLATED LSF at time = " << times_lsf[i] << std::endl;
-                for (int k = 0; k <= Nz; k++)
-                {
-                    amrex::Print() << "   level " << k << ": z = " << z_int_lsf[i][k] << " tls = " << t_int_lsf[i][k]
-                                   << " qls = " << q_int_lsf[i][k] << " uls = " << u_int_lsf[i][k] << " vls = "
-                                   << v_int_lsf[i][k] << " wls = " << w_int_lsf[i][k] << std::endl;
-                }
-                break; // print only the first time block
+                amrex::Print() << "   level " << k << ": z = " << z_int_lsf[i][k] << " tls = " << t_int_lsf[i][k]
+                               << " qls = " << q_int_lsf[i][k] << " uls = " << u_int_lsf[i][k] << " vls = "
+                               << v_int_lsf[i][k] << " wls = " << w_int_lsf[i][k] << std::endl;
             }
         }
     }
 
     /**
-     * @brief Determine the two forcing times that bracket a simulation time.
-     * @param time Simulation time, either elapsed or absolute.
+     * @brief Determine interpolation coefficients to apply tendencies for the given time
+     * @param time Elapsed simulation time in seconds.
      * @param curr Index of the lower bracketing forcing time.
      * @param next Index of the upper bracketing forcing time.
      * @param coeff_curr Interpolation weight for the lower time slice.
@@ -339,19 +333,16 @@ public:
                             amrex::Real& coeff_next)
     {
         // helper function to get the current time indices of forcing data to use and
-        // coefficients based on the current simulation time. Historical callers
-        // pass elapsed time, while datetime-aware paths may pass total/epoch
-        // time, so normalize to elapsed time relative to the simulation start.
+        // coefficients based on the current simulation time.
         curr = 0;
         next = 0;
         coeff_curr = one;
         coeff_next = zero;
-        const amrex::Real rel_time = (time >= start_time) ? (time - start_time) : time;
 
         // find the time index of forcing data to use
         for (int nt = 1; nt < num_times; nt++)
         {
-            if (rel_time > times_lsf[nt])
+            if (time > times_lsf[nt])
             {
                 curr = nt;
             }
@@ -365,7 +356,7 @@ public:
             coeff_next = zero;
         } else {
             next = curr + 1;
-            coeff_next = (rel_time - times_lsf[curr]) / (times_lsf[next] - times_lsf[curr]);
+            coeff_next = (time - times_lsf[curr]) / (times_lsf[next] - times_lsf[curr]);
             coeff_curr = (one - coeff_next);
         }
     }
@@ -404,10 +395,6 @@ public:
                          w_int_lsf_d[itime].begin());
     }
 
-    /**
-     * Simulation start time used when forcing timestamps are absolute.
-     */
-    amrex::Real start_time = zero;
     /**
      * Relaxation time scale used by the large-scale forcing and nudging terms.
      */

--- a/Source/DataStructs/ERF_LargeScaleForcingData.H
+++ b/Source/DataStructs/ERF_LargeScaleForcingData.H
@@ -173,6 +173,21 @@ public:
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(z_lsf.size() == num_times,
                                          "repeated timestamp in the large-scale forcing file");
         amrex::Print() << "  Read " << nz_lsf << " levels at " << num_times << " times" << std::endl;
+
+        // debugging print
+        if (verbose_print) {
+            for (int i = 0; i < times_lsf.size(); i++)
+            {
+                amrex::Print() << " LSF at time = " << times_lsf[i] << std::endl;
+                for (int lev = 0; lev < nz_lsf + 1; lev++)
+                {
+                    amrex::Print() << "   level " << lev << ": z = " << z_lsf[i][lev] << " p = " << p_lsf[i][lev] << " tls = "
+                                   << t_lsf[i][lev] << " qls = " << q_lsf[i][lev] << " uls = " << u_lsf[i][lev] << " vls = "
+                                   << v_lsf[i][lev] << " wls = " << w_lsf[i][lev] << std::endl;
+                }
+                break; // print only the first time block
+            }
+        }
     }
 
 
@@ -266,6 +281,21 @@ public:
 
             host_to_device(itime);
         }
+
+        // debugging print
+        if (verbose_print) {
+            for (int i = 0; i < times_lsf.size(); i++)
+            {
+                amrex::Print() << " INTERPOLATED LSF at time = " << times_lsf[i] << std::endl;
+                for (int k = 0; k <= Nz; k++)
+                {
+                    amrex::Print() << "   level " << k << ": z = " << z_int_lsf[i][k] << " tls = " << t_int_lsf[i][k]
+                                   << " qls = " << q_int_lsf[i][k] << " uls = " << u_int_lsf[i][k] << " vls = "
+                                   << v_int_lsf[i][k] << " wls = " << w_int_lsf[i][k] << std::endl;
+                }
+                break; // print only the first time block
+            }
+        }
     }
 
     void
@@ -342,6 +372,8 @@ public:
     std::string lsf_file = "";
 
     bool use_z_grid = true;
+
+    bool verbose_print = false; // whether to display the lsf at initialization (before and after interpolation)
 
     // inputs from large scale forcing file
     int nz_lsf = -1;    // number of z levels in the LSF file

--- a/Source/DataStructs/ERF_LargeScaleForcingData.H
+++ b/Source/DataStructs/ERF_LargeScaleForcingData.H
@@ -18,10 +18,21 @@
 #include <ERF_InputSoundingData.H>
 
 /**
- * Data structure storing large scale forcing data.
+ * Data structure storing large-scale forcing data.
+ *
+ * This provides time-varying vertical profiles for large scale temperature,
+ * and water vapor tendencies, as well as observed large scale zonal and meridonal wind,
+ * and vertical subsidence.
+ * Profiles are read from a text file, interpolated to the model vertical grid, and then copied
+ * to device memory for use during time integration.
+ *
+ * This mirrors the lsf functionality as implemented in SAM.
  */
 struct LargeScaleForcingData {
 public:
+    /**
+     * @brief Construct large-scale forcing metadata from the ERF input namespace.
+     */
     LargeScaleForcingData ()
     {
         amrex::ParmParse pp("erf");
@@ -29,6 +40,11 @@ public:
         pp.query("large_scale_forcing_file", lsf_file);
     }
 
+    /**
+     * @brief Count the number of whitespace-separated columns in a line.
+     * @param str Input line to inspect.
+     * @return Number of columns in the line.
+     */
     int get_columns_in_str(std::string &str)
     {
         std::istringstream iss(str);
@@ -42,6 +58,9 @@ public:
     }
 
 
+    /**
+     * @brief Read the forcing file and cache the raw time slices on host.
+     */
     void read_forcing_file()
     {
         amrex::Print() << "  Opening LSF file '" << lsf_file << "'" << std::endl;
@@ -191,6 +210,12 @@ public:
     }
 
 
+    /**
+     * @brief Interpolate the forcing profiles onto the model grid.
+     * @param geom Geometry defining the vertical grid.
+     * @param zlevels_stag Staggered vertical coordinates used for interpolation.
+     * @param sounding Input sounding data used when the forcing file is on pressure levels.
+     */
     void
     interp_forcing(const amrex::GeometryData &geom,
                    const amrex::Vector<amrex::Real>& zlevels_stag,
@@ -298,6 +323,14 @@ public:
         }
     }
 
+    /**
+     * @brief Determine the two forcing times that bracket a simulation time.
+     * @param time Simulation time, either elapsed or absolute.
+     * @param curr Index of the lower bracketing forcing time.
+     * @param next Index of the upper bracketing forcing time.
+     * @param coeff_curr Interpolation weight for the lower time slice.
+     * @param coeff_next Interpolation weight for the upper time slice.
+     */
     void
     get_forcing_time_coeffs(const amrex::Real& time,
                             int& curr,
@@ -337,6 +370,10 @@ public:
         }
     }
 
+    /**
+     * @brief Copy one interpolated forcing slice from host memory to device memory.
+     * @param itime Time-slice index to copy.
+     */
     void host_to_device (int itime)
     {
         const int nz = z_int_lsf[itime].size();
@@ -367,19 +404,42 @@ public:
                          w_int_lsf_d[itime].begin());
     }
 
-    amrex::Real start_time = zero; // simulation start time
-    amrex::Real tau_lsf = zero; // timescale to apply lsf
+    /**
+     * Simulation start time used when forcing timestamps are absolute.
+     */
+    amrex::Real start_time = zero;
+    /**
+     * Relaxation time scale used by the large-scale forcing and nudging terms.
+     */
+    amrex::Real tau_lsf = zero;
+    /**
+     * Path to the large-scale forcing input file.
+     */
     std::string lsf_file = "";
 
+    /**
+     * True when the forcing file is tabulated on height levels, false when it is
+     * tabulated on pressure levels.
+     */
     bool use_z_grid = true;
 
-    bool verbose_print = false; // whether to display the lsf at initialization (before and after interpolation)
+    /**
+     * Whether to display the lsf at initialization (before and after interpolation)
+     */
+    bool verbose_print = false;
 
-    // inputs from large scale forcing file
-    int nz_lsf = -1;    // number of z levels in the LSF file
-    int num_times = -1; // number of times found in the LSF file
+    /**
+     * Number of vertical levels and times found in the forcing file.
+     */
+    int nz_lsf = -1;
+    int num_times = -1;
+    /**
+     * Forcing times read from the file, converted to elapsed seconds.
+     */
     amrex::Vector<amrex::Real> times_lsf;
-    // original data from the file
+    /**
+     * Raw forcing profiles read from the input file, indexed by time then level.
+     */
     amrex::Vector<amrex::Vector<amrex::Real>> z_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> p_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> t_lsf;
@@ -388,7 +448,9 @@ public:
     amrex::Vector<amrex::Vector<amrex::Real>> v_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> w_lsf;
 
-    // interpolated data from file
+    /**
+     * Forcing profiles interpolated onto the model grid, indexed by time then level.
+     */
     amrex::Vector<amrex::Vector<amrex::Real>> z_int_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> t_int_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> q_int_lsf;
@@ -396,6 +458,9 @@ public:
     amrex::Vector<amrex::Vector<amrex::Real>> v_int_lsf;
     amrex::Vector<amrex::Vector<amrex::Real>> w_int_lsf;
 
+    /**
+     * Device copies of the interpolated forcing profiles.
+     */
     amrex::Vector<amrex::Gpu::DeviceVector<amrex::Real>> z_int_lsf_d, t_int_lsf_d, q_int_lsf_d, u_int_lsf_d, v_int_lsf_d, w_int_lsf_d;
 
 };

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -907,7 +907,7 @@ ERF::InitData_post ()
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!solverChoice.nudging_from_input_sounding || lsf.tau_lsf > 0.0,
                                          "erf.forcing_timescale must be positive when nudging with large-scale forcing");
-        if (erf.Verbose()) {
+        if (verbose) {
             lsf.verbose_print = true;
         }
         lsf.read_forcing_file();

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -912,7 +912,6 @@ ERF::InitData_post ()
         }
         lsf.read_forcing_file();
         lsf.interp_forcing(geom[0].data(), zlevels_stag[0], input_sounding_data);
-        lsf.start_time = start_time;
     }
 
     if (solverChoice.dampingChoice.rayleigh_damp_U ||solverChoice.dampingChoice.rayleigh_damp_V ||

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -907,6 +907,9 @@ ERF::InitData_post ()
     {
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!solverChoice.nudging_from_input_sounding || lsf.tau_lsf > 0.0,
                                          "erf.forcing_timescale must be positive when nudging with large-scale forcing");
+        if (erf.Verbose()) {
+            lsf.verbose_print = true;
+        }
         lsf.read_forcing_file();
         lsf.interp_forcing(geom[0].data(), zlevels_stag[0], input_sounding_data);
         lsf.start_time = start_time;


### PR DESCRIPTION
This updates the docs to add more details about the large scale forcing option and fixes the time used for interpolating when a date time is used.

- Add a section describing the added data log for lsf and nudging terms
- Add a section describing the large scale forcing and nudging options with an example text file.
- Fix the time used in the large scale forcing interpolation when start time is used (e.g., start_datetime or real data case)
- Fix doc formatting issues added from sfc/sst MOST forcing option.
- Clean up large scale forcing file with more doxygen comments.
- Add print out of the lsf grid when ERF is ran in verbose mode.