### PR TITLE
replace query by queryAdd

### DIFF
--- a/Source/BoundaryConditions/ERF_MOSTAverage.cpp
+++ b/Source/BoundaryConditions/ERF_MOSTAverage.cpp
@@ -31,19 +31,19 @@ MOSTAverage::MOSTAverage (Vector<Geometry>  geom,
     // Get basic info
     //--------------------------------------------------------
     ParmParse pp(m_pp_prefix);
-    pp.query("most.radius",m_radius);
-    pp.query("most.time_average",m_t_avg);
-    pp.query("most.terrain_rotate",m_rotate);
-    pp.query("most.use_interpolation",m_interp);
-    pp.query("most.use_normal_vector",m_norm_vec);
+    pp.queryAdd("most.radius",m_radius);
+    pp.queryAdd("most.time_average",m_t_avg);
+    pp.queryAdd("most.terrain_rotate",m_rotate);
+    pp.queryAdd("most.use_interpolation",m_interp);
+    pp.queryAdd("most.use_normal_vector",m_norm_vec);
 
     // m_time_window is normalized by the time-step "dt"
-    pp.query("most.time_window", m_time_window);
+    pp.queryAdd("most.time_window", m_time_window);
 
     // Corrections to the mean surface velocity
-    pp.query("most.include_subgrid_vel", include_subgrid_vel);
+    pp.queryAdd("most.include_subgrid_vel", include_subgrid_vel);
 
-    auto specified_policy = pp.query("most.average_policy",m_policy);
+    auto specified_policy = pp.queryAdd("most.average_policy",m_policy);
     if ((m_mesh_type == MeshType::VariableDz) && (m_policy == 0)) {
         if (specified_policy) {
             Warning("MOST Planar averaging requested with variable dz -- proceed with caution");
@@ -529,7 +529,7 @@ MOSTAverage::set_k_indices_N (const int& lev)
 {
     ParmParse pp(m_pp_prefix);
     Real zref_tmp = zref_default;
-    auto read_z = pp.query("most.zref",zref_tmp);
+    auto read_z = pp.queryAdd("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
 
     // Default behavior is to use the first cell center
@@ -586,7 +586,7 @@ MOSTAverage::set_z_positions_EB (const int& lev)
 {
     Real zref_tmp = zref_default;
     ParmParse pp(m_pp_prefix);
-    auto read_z = pp.query("most.zref",zref_tmp);
+    auto read_z = pp.queryAdd("most.zref",zref_tmp);
 
     if (read_z) {
         m_zref[lev]->setVal( zref_tmp );
@@ -615,7 +615,7 @@ MOSTAverage::set_k_indices_T (const int& lev)
 
     ParmParse pp(m_pp_prefix);
     Real zref_tmp = zref_default;
-    auto read_z = pp.query("most.zref",zref_tmp);
+    auto read_z = pp.queryAdd("most.zref",zref_tmp);
     auto read_k = pp.queryarr("most.k_arr_in",m_k_in);
     int klo     = m_geom[lev].Domain().smallEnd(2);
 
@@ -696,7 +696,7 @@ MOSTAverage::set_norm_indices_T (const int& lev)
 
     ParmParse pp(m_pp_prefix);
     Real zref_tmp = zref_default;
-    auto read_zref = pp.query("most.zref",zref_tmp);
+    auto read_zref = pp.queryAdd("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }
@@ -785,7 +785,7 @@ MOSTAverage::set_z_positions_T (const int& lev)
 
     ParmParse pp(m_pp_prefix);
     Real zref_tmp = zref_default;
-    auto read_zref = pp.query("most.zref",zref_tmp);
+    auto read_zref = pp.queryAdd("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     } else {
@@ -850,7 +850,7 @@ MOSTAverage::set_norm_positions_T (const int& lev)
 
     ParmParse pp(m_pp_prefix);
     Real zref_tmp = zref_default;
-    auto read_zref = pp.query("most.zref",zref_tmp);
+    auto read_zref = pp.queryAdd("most.zref",zref_tmp);
     if (!read_zref) {
         Print() << "most.zref not specified, query distance default is " << zref_tmp << std::endl;
     }

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.H
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.H
@@ -81,7 +81,7 @@ public:
 
       // Get roughness
       amrex::ParmParse pp("erf");
-      pp.query("most.z0", z0_const);
+      pp.queryAdd("most.z0", z0_const);
 
       // Specify how to compute the flux
       if (use_rot_surface_flux) {
@@ -89,7 +89,7 @@ public:
       } else {
           std::string flux_string_in;
           std::string flux_string{"moeng"};
-          auto read_flux = pp.query("surface_layer.flux_type", flux_string_in);
+          auto read_flux = pp.queryAdd("surface_layer.flux_type", flux_string_in);
           if (read_flux) {
               flux_string = amrex::toLower(flux_string_in);
           }
@@ -109,11 +109,11 @@ public:
       }
 
       // Include w* to handle free convection (Beljaars 1995, QJRMS)
-      pp.query("most.include_wstar", m_include_wstar);
+      pp.queryAdd("most.include_wstar", m_include_wstar);
 
       std::string pblh_string_in;
       std::string pblh_string{"none"};
-      auto read_pblh = pp.query("most.pblh_calc", pblh_string_in);
+      auto read_pblh = pp.queryAdd("most.pblh_calc", pblh_string_in);
       if (read_pblh) {
           pblh_string = amrex::toLower(pblh_string_in);
       }
@@ -141,12 +141,12 @@ public:
       }
 
       // Get surface temperature
-      auto erf_st = pp.query("most.surf_temp", surf_temp);
+      auto erf_st = pp.queryAdd("most.surf_temp", surf_temp);
       if (erf_st) { default_land_surf_temp  = surf_temp; }
 
       // Get surface moisture
       bool erf_sq = false;
-      if (use_moisture) { erf_sq = pp.query("most.surf_moist", surf_moist); }
+      if (use_moisture) { erf_sq = pp.queryAdd("most.surf_moist", surf_moist); }
       if (erf_sq) { default_land_surf_moist = surf_moist; }
 
       // Custom type user must specify the fluxes
@@ -157,7 +157,7 @@ public:
           pp.get("most.ustar", custom_ustar);
           pp.get("most.tstar", custom_tstar);
           pp.get("most.qstar", custom_qstar);
-          pp.query("most.rhosurf", custom_rhosurf);
+          pp.queryAdd("most.rhosurf", custom_rhosurf);
           if (custom_qstar != 0) {
               AMREX_ASSERT_WITH_MESSAGE(use_moisture,
               "Specified custom MOST qv flux without moisture model!");
@@ -181,18 +181,18 @@ public:
       } else {
           if (erf_st) {
               theta_type = ThetaCalcType::SURFACE_TEMPERATURE;
-              pp.query("most.surf_heating_rate", surf_heating_rate); // [K/h]
+              pp.queryAdd("most.surf_heating_rate", surf_heating_rate); // [K/h]
 
               // Modify rate to be in units of K / s rather than K / hr
               surf_heating_rate /= amrex::Real(3600.0);        // [K/s]
 
-              if (pp.query("most.surf_temp_flux", surf_temp_flux)) {
+              if (pp.queryAdd("most.surf_temp_flux", surf_temp_flux)) {
                   amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }
           } else {
-              pp.query("most.surf_temp_flux", surf_temp_flux);
+              pp.queryAdd("most.surf_temp_flux", surf_temp_flux);
 
-              if (pp.query("most.surf_heating_rate", surf_heating_rate)) {
+              if (pp.queryAdd("most.surf_heating_rate", surf_heating_rate)) {
                   amrex::Abort("Can only specify one of surf_temp_flux or surf_heating_rate");
               }
               if (std::abs(surf_temp_flux) >
@@ -206,7 +206,7 @@ public:
           if (erf_sq) {
               moist_type = MoistCalcType::SURFACE_MOISTURE;
           } else {
-              pp.query("most.surf_moist_flux", surf_moist_flux);
+              pp.queryAdd("most.surf_moist_flux", surf_moist_flux);
               if (std::abs(surf_moist_flux) >
                   std::numeric_limits<amrex::Real>::epsilon()) {
                   moist_type = MoistCalcType::MOISTURE_FLUX;
@@ -218,13 +218,13 @@ public:
 
       if (flux_type == FluxCalcType::RICO)
       {
-          pp.query("most.rico.theta_z0", rico_theta_z0);
-          pp.query("most.rico.qsat_z0", rico_qsat_z0);
+          pp.queryAdd("most.rico.theta_z0", rico_theta_z0);
+          pp.queryAdd("most.rico.qsat_z0", rico_qsat_z0);
       }
 
       // Make sure the inputs file doesn't try to use most.roughness_type
       std::string bogus_input;
-      if (pp.query("most.roughness_type", bogus_input) > 0) {
+      if (pp.queryAdd("most.roughness_type", bogus_input) > 0) {
           amrex::Abort("most.roughness_type is deprecated; use "
                        "most.roughness_type_land and/or most.roughness_type_sea");
       }
@@ -233,7 +233,7 @@ public:
       std::string rough_land_string_in;
       std::string rough_land_string{"constant"};
       auto read_rough_land =
-          pp.query("most.roughness_type_land", rough_land_string_in);
+          pp.queryAdd("most.roughness_type_land", rough_land_string_in);
       if (read_rough_land) {
           rough_land_string = amrex::toLower(rough_land_string_in);
       }
@@ -246,14 +246,14 @@ public:
       // Specify how to compute the surface flux over sea (if there is any)
       std::string rough_sea_string_in;
       std::string rough_sea_string{"charnock"};
-      auto read_rough_sea = pp.query("most.roughness_type_sea", rough_sea_string_in);
+      auto read_rough_sea = pp.queryAdd("most.roughness_type_sea", rough_sea_string_in);
       if (read_rough_sea) {
           rough_sea_string = amrex::toLower(rough_sea_string_in);
       }
       if (rough_sea_string == "charnock") {
           rough_type_sea = RoughCalcType::CHARNOCK;
-          pp.query("most.charnock_constant", cnk_a);
-          pp.query("most.charnock_viscosity", cnk_visc);
+          pp.queryAdd("most.charnock_constant", cnk_a);
+          pp.queryAdd("most.charnock_viscosity", cnk_visc);
           if (cnk_a > 0) {
               amrex::Print() << "If there is water, Charnock relation with C_a="
                              << cnk_a << (cnk_visc ? " and viscosity" : "")
@@ -275,7 +275,7 @@ public:
           rough_type_sea = RoughCalcType::DONELAN;
       } else if (rough_sea_string == "modified_charnock") {
           rough_type_sea = RoughCalcType::MODIFIED_CHARNOCK;
-          pp.query("most.modified_charnock_depth", depth);
+          pp.queryAdd("most.modified_charnock_depth", depth);
       } else if (rough_sea_string == "wave_coupled") {
           rough_type_sea = RoughCalcType::WAVE_COUPLED;
       } else if (rough_sea_string == "constant") {
@@ -286,7 +286,7 @@ public:
 
       // use skin temperature instead of sea-surface temperature
       // (wrfinput data may have lower resolution SST data)
-      pp.query("most.ignore_sst", m_ignore_sst);
+      pp.queryAdd("most.ignore_sst", m_ignore_sst);
 
       // If we're using the RANS k model, then we need to update the dirichlet
       // BC based on the instantaneous u* and θ*; the turbulence modeling
@@ -359,7 +359,7 @@ public:
           m_var_z0 = (lmask_min < 1) & (rough_type_sea != RoughCalcType::CONSTANT);
           if (m_var_z0) {
               std::string rough_sea_string{"charnock"};
-              pp.query("most.roughness_type_sea", rough_sea_string);
+              pp.queryAdd("most.roughness_type_sea", rough_sea_string);
               amrex::Print() << "Variable sea roughness (type " << rough_sea_string
                              << ")" << std::endl;
           }
@@ -417,8 +417,8 @@ public:
 
       // Text-file driven surface forcing modes. The file always contains at
       // least time(day) and sst(K); prescribed-flux mode also uses H, LE, USTAR.
-      pp.query("most.use_sfc_fluxes", m_use_sfc_fluxes);
-      pp.query("most.use_sfc_sst", m_use_sfc_sst);
+      pp.queryAdd("most.use_sfc_fluxes", m_use_sfc_fluxes);
+      pp.queryAdd("most.use_sfc_sst", m_use_sfc_sst);
       if (m_use_sfc_fluxes && m_use_sfc_sst) {
           amrex::Abort("Only one of most.use_sfc_fluxes and most.use_sfc_sst may be enabled");
       }
@@ -429,7 +429,7 @@ public:
 
           // load sensible and latent heat fluxes from sfc to prescribe
           std::string sfc_file = "";
-          pp.query("most.sfc_file", sfc_file);
+          pp.queryAdd("most.sfc_file", sfc_file);
           if (sfc_file.empty()) {
               amrex::Abort("most.sfc_file must be set when using text-file surface forcing");
           }
@@ -510,7 +510,7 @@ public:
               read_z0 = true;
           } else if (count == 1) {
               if (lev == 0) {
-                  pp.query("most.roughness_file_name", fname);
+                  pp.queryAdd("most.roughness_file_name", fname);
               } else {
                   // we will interpolate from the coarsest level
                   fname = "";

--- a/Source/BoundaryConditions/ERF_WallScalarBC.H
+++ b/Source/BoundaryConditions/ERF_WallScalarBC.H
@@ -168,17 +168,17 @@ parse_wall_face_scalars (amrex::ParmParse& pp,
                          bool anelastic)
 {
     amrex::Real density = amrex::Real(0.0);
-    const bool density_specified = pp.query("density", density);
+    const bool density_specified = pp.queryAdd("density", density);
     amrex::Real density_grad = amrex::Real(0.0);
-    const bool density_gradient_specified = pp.query("density_grad", density_grad);
+    const bool density_gradient_specified = pp.queryAdd("density_grad", density_grad);
     amrex::Real theta = amrex::Real(0.0);
-    const bool theta_specified = pp.query("theta", theta);
+    const bool theta_specified = pp.queryAdd("theta", theta);
     amrex::Real theta_grad = amrex::Real(0.0);
-    const bool theta_gradient_specified = pp.query("theta_grad", theta_grad);
+    const bool theta_gradient_specified = pp.queryAdd("theta_grad", theta_grad);
 
     amrex::Real qv = amrex::Real(0.0);
     const bool qv_specified = (wall_kind == SolidWallKind::NoSlip) &&
-                              pp.query("qv", qv);
+                              pp.queryAdd("qv", qv);
 
     WallFaceParseResult result;
     if (anelastic && (density_specified || density_gradient_specified)) {

--- a/Source/DataStructs/ERF_AdvStruct.H
+++ b/Source/DataStructs/ERF_AdvStruct.H
@@ -27,17 +27,17 @@ struct AdvChoice {
         amrex::ParmParse pp(pp_prefix);
 
         // Order and type of spatial discretizations used in advection
-        pp.query("use_efficient_advection", use_efficient_advection);
+        pp.queryAdd("use_efficient_advection", use_efficient_advection);
         std::string dycore_horiz_adv_string    = "" ; std::string dycore_vert_adv_string   = "";
         std::string dryscal_horiz_adv_string   = "" ; std::string dryscal_vert_adv_string  = "";
-        pp.query("dycore_horiz_adv_type"   , dycore_horiz_adv_string);
-        pp.query("dycore_vert_adv_type"    , dycore_vert_adv_string);
-        pp.query("dryscal_horiz_adv_type"  , dryscal_horiz_adv_string);
-        pp.query("dryscal_vert_adv_type"   , dryscal_vert_adv_string);
+        pp.queryAdd("dycore_horiz_adv_type"   , dycore_horiz_adv_string);
+        pp.queryAdd("dycore_vert_adv_type"    , dycore_vert_adv_string);
+        pp.queryAdd("dryscal_horiz_adv_type"  , dryscal_horiz_adv_string);
+        pp.queryAdd("dryscal_vert_adv_type"   , dryscal_vert_adv_string);
 
         std::string moistscal_horiz_adv_string = ""; std::string moistscal_vert_adv_string = "";
-        pp.query("moistscal_horiz_adv_type", moistscal_horiz_adv_string);
-        pp.query("moistscal_vert_adv_type" , moistscal_vert_adv_string);
+        pp.queryAdd("moistscal_horiz_adv_type", moistscal_horiz_adv_string);
+        pp.queryAdd("moistscal_vert_adv_type" , moistscal_vert_adv_string);
 
         if (use_efficient_advection){
            amrex::Print() << "Using efficient advection scheme" << std::endl;
@@ -46,7 +46,7 @@ struct AdvChoice {
         if ( (dycore_horiz_adv_string == "Blended_3rd4th") ||
              (dycore_horiz_adv_string == "Blended_5th6th") )
         {
-            pp.query("dycore_horiz_upw_frac" , dycore_horiz_upw_frac);
+            pp.queryAdd("dycore_horiz_upw_frac" , dycore_horiz_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((dycore_horiz_upw_frac >= zero) && (dycore_horiz_upw_frac <= one),
                                       "The dycore horizontal upwinding fraction must be between 0 and 1");
         }
@@ -54,7 +54,7 @@ struct AdvChoice {
         if ( (dycore_vert_adv_string == "Blended_3rd4th") ||
              (dycore_vert_adv_string == "Blended_5th6th") )
         {
-            pp.query("dycore_vert_upw_frac" , dycore_vert_upw_frac);
+            pp.queryAdd("dycore_vert_upw_frac" , dycore_vert_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((dycore_vert_upw_frac >= zero) && (dycore_vert_upw_frac <= one),
                                       "The dycore vertical upwinding fraction must be between 0 and 1");
         }
@@ -62,7 +62,7 @@ struct AdvChoice {
         if ( (dryscal_horiz_adv_string == "Blended_3rd4th") ||
              (dryscal_horiz_adv_string == "Blended_5th6th") )
         {
-            pp.query("dryscal_horiz_upw_frac" , dryscal_horiz_upw_frac);
+            pp.queryAdd("dryscal_horiz_upw_frac" , dryscal_horiz_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((dryscal_horiz_upw_frac >= zero) && (dryscal_horiz_upw_frac <= one),
                                       "The dry scalar horizontal upwinding fraction must be between 0 and 1");
         }
@@ -70,7 +70,7 @@ struct AdvChoice {
         if ( (dryscal_vert_adv_string == "Blended_3rd4th") ||
              (dryscal_vert_adv_string == "Blended_5th6th") )
         {
-            pp.query("dryscal_vert_upw_frac" , dryscal_vert_upw_frac);
+            pp.queryAdd("dryscal_vert_upw_frac" , dryscal_vert_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((dryscal_vert_upw_frac >= zero) && (dryscal_vert_upw_frac <= one),
                                       "The dry scalar vertical upwinding fraction must be between 0 and 1");
         }
@@ -78,7 +78,7 @@ struct AdvChoice {
         if ( (moistscal_horiz_adv_string == "Blended_3rd4th") ||
              (moistscal_horiz_adv_string == "Blended_5th6th") )
         {
-            pp.query("moistscal_horiz_upw_frac" , moistscal_horiz_upw_frac);
+            pp.queryAdd("moistscal_horiz_upw_frac" , moistscal_horiz_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((moistscal_horiz_upw_frac >= zero) && (moistscal_horiz_upw_frac <= one),
                                       "The moist scalar horizontal upwinding fraction must be between 0 and 1");
         }
@@ -86,7 +86,7 @@ struct AdvChoice {
         if ( (moistscal_vert_adv_string == "Blended_3rd4th") ||
              (moistscal_vert_adv_string == "Blended_5th6th") )
         {
-            pp.query("moistscal_vert_upw_frac" , moistscal_vert_upw_frac);
+            pp.queryAdd("moistscal_vert_upw_frac" , moistscal_vert_upw_frac);
             AMREX_ASSERT_WITH_MESSAGE((moistscal_vert_upw_frac >= zero) && (moistscal_vert_upw_frac <= one),
                                       "The moist scalar vertical upwinding fraction must be between 0 and 1");
         }
@@ -227,7 +227,7 @@ struct AdvChoice {
 
         // We can can't use weno with Embedded Boundaries (for now)
         std::string terrain_type;
-        pp.query("terrain_type", terrain_type);
+        pp.queryAdd("terrain_type", terrain_type);
         validate_weno_momentum_compatibility(terrain_type == "EB");
 
         pp.queryarr("zero_xflux_faces", zero_xflux);
@@ -248,13 +248,13 @@ struct AdvChoice {
         amrex::ParmParse pp(pp_prefix);
         std::string dycore_horiz_adv_string    = "" ; std::string dycore_vert_adv_string   = "";
         std::string dryscal_horiz_adv_string   = "" ; std::string dryscal_vert_adv_string  = "";
-        pp.query("dycore_horiz_adv_type"   , dycore_horiz_adv_string);
-        pp.query("dycore_vert_adv_type"    , dycore_vert_adv_string);
-        pp.query("dryscal_horiz_adv_type"  , dryscal_horiz_adv_string);
-        pp.query("dryscal_vert_adv_type"   , dryscal_vert_adv_string);
+        pp.queryAdd("dycore_horiz_adv_type"   , dycore_horiz_adv_string);
+        pp.queryAdd("dycore_vert_adv_type"    , dycore_vert_adv_string);
+        pp.queryAdd("dryscal_horiz_adv_type"  , dryscal_horiz_adv_string);
+        pp.queryAdd("dryscal_vert_adv_type"   , dryscal_vert_adv_string);
         std::string moistscal_horiz_adv_string = ""; std::string moistscal_vert_adv_string = "";
-        pp.query("moistscal_horiz_adv_type", moistscal_horiz_adv_string);
-        pp.query("moistscal_vert_adv_type" , moistscal_vert_adv_string);
+        pp.queryAdd("moistscal_horiz_adv_type", moistscal_horiz_adv_string);
+        pp.queryAdd("moistscal_vert_adv_type" , moistscal_vert_adv_string);
 
         if (dycore_horiz_adv_string != "") {
             amrex::Print() << "    dycore_horiz_adv_type   : " << dycore_horiz_adv_string;

--- a/Source/DataStructs/ERF_DampingStruct.H
+++ b/Source/DataStructs/ERF_DampingStruct.H
@@ -30,7 +30,7 @@ struct DampingChoice {
         amrex::ParmParse pp(pp_prefix);
 
         static std::string rayleigh_type_string = "SlowExplicit";
-        pp.query("rayleigh_damping_type",rayleigh_type_string);
+        pp.queryAdd("rayleigh_damping_type",rayleigh_type_string);
 
         if (!rayleigh_type_string.compare("SlowExplicit")) {
             rayleigh_damping_type = RayleighDampingType::SlowExplicit;
@@ -43,22 +43,22 @@ struct DampingChoice {
         }
 
         // Include Rayleigh damping (separate flags for each variable)
-        pp.query("rayleigh_damp_U", rayleigh_damp_U);
-        pp.query("rayleigh_damp_V", rayleigh_damp_V);
-        pp.query("rayleigh_damp_W", rayleigh_damp_W);
-        pp.query("rayleigh_damp_T", rayleigh_damp_T);
-        pp.query("rayleigh_dampcoef", rayleigh_dampcoef);
-        pp.query("rayleigh_zdamp", rayleigh_zdamp);
+        pp.queryAdd("rayleigh_damp_U", rayleigh_damp_U);
+        pp.queryAdd("rayleigh_damp_V", rayleigh_damp_V);
+        pp.queryAdd("rayleigh_damp_W", rayleigh_damp_W);
+        pp.queryAdd("rayleigh_damp_T", rayleigh_damp_T);
+        pp.queryAdd("rayleigh_dampcoef", rayleigh_dampcoef);
+        pp.queryAdd("rayleigh_zdamp", rayleigh_zdamp);
 
         if (pp.countval("rayleigh_damp_substep") > 0) {
             amrex::Abort("The input rayleigh_damp_substep is deprecated.  Set rayleigh_damping_type instead.");
         }
 
         // Include vertical-velocity damping to improve robustness
-        pp.query("w_damping", w_damping);
-        pp.query("w_damping_cfl", w_damping_cfl);
-        pp.query("w_damping_const", w_damping_const);
-        pp.query("w_damping_coeff", w_damping_coeff);
+        pp.queryAdd("w_damping", w_damping);
+        pp.queryAdd("w_damping_cfl", w_damping_cfl);
+        pp.queryAdd("w_damping_const", w_damping_const);
+        pp.queryAdd("w_damping_coeff", w_damping_coeff);
 
         if (w_damping && (w_damping_const < 0 && w_damping_coeff < 0)) {
             amrex::Abort("Need to specify vertical damping coefficient w_damping_const (like WRF) or w_damping_coeff (~ dz/dt**2)");

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -642,30 +642,30 @@ struct SolverChoice {
         amrex::ParmParse pp(pp_prefix);
 
         bool bogus_bool;
-        if (pp.query("use_terrain",bogus_bool) > 0)  {
+        if (pp.queryAdd("use_terrain",bogus_bool) > 0)  {
             amrex::Error("The input use_terrain is deprecated.  Set terrain_type instead.");
         }
 
-        if (pp.query("use_moist_background",bogus_bool) > 0)  {
+        if (pp.queryAdd("use_moist_background",bogus_bool) > 0)  {
             amrex::Error("The input use_moist_background is deprecated.  Set init_type = MoistBaseState instead.");
         }
 
         // Do we set map scale factors to myhalf instead of 1 for testing?
-        pp.query("test_mapfactor", test_mapfactor);
+        pp.queryAdd("test_mapfactor", test_mapfactor);
 
         // Which horizontal pressure gradient formulation to use with terrain fitted coords?
         // 0: dp/dx with dp/dz correction (default)
         // 1: gradient of vertically interpolated p, see Klemp 2011
-        pp.query("gradp_type", gradp_type);
+        pp.queryAdd("gradp_type", gradp_type);
         AMREX_ALWAYS_ASSERT(gradp_type == 0 || gradp_type == 1);
 
         // For the lateral pressure gradient to be used in the momentum equation, should we
         // take the x- and y-derivatives of the perturbational pressure or the full pressure?
-        pp.query("use_pert_pres_gradient", use_pert_pres_gradient);
+        pp.queryAdd("use_pert_pres_gradient", use_pert_pres_gradient);
 
         // What type of moisture model to use?
         moisture_type = MoistureType::None; // Default
-        if (pp.query("moisture_type",moisture_type) > 0) {
+        if (pp.queryAdd("moisture_type",moisture_type) > 0) {
             amrex::Error("The input moisture_type is deprecated.  Set moisture_model instead.");
         }
 
@@ -685,7 +685,7 @@ struct SolverChoice {
         }
 
         if (moisture_type != MoistureType::None) {
-            pp.query("moisture_tight_coupling",moisture_tight_coupling);
+            pp.queryAdd("moisture_tight_coupling",moisture_tight_coupling);
         }
 
         // Which expression (1,2/3 or 4) to use for buoyancy
@@ -697,7 +697,7 @@ struct SolverChoice {
         // rather than just listing the enum values.
         {
             std::string lsm_string;
-            if (pp.query("land_surface_model", lsm_string) &&
+            if (pp.queryAdd("land_surface_model", lsm_string) &&
                 amrex::toLower(lsm_string) == "oceansurf") {
                 amrex::Abort("erf.land_surface_model = OceanSurf has been removed. "
                              "Coupled ocean SST is now applied through the "
@@ -718,7 +718,7 @@ struct SolverChoice {
         // has run yet. The surface layer needs it at Define time to select
         // ThetaCalcType::SURFACE_TEMPERATURE, which is long before the first
         // ApplyOceanSurfaceState call.
-        pp.query("use_coupled_sst", use_coupled_sst);
+        pp.queryAdd("use_coupled_sst", use_coupled_sst);
 
         read_int_string(max_level, "is_land", is_land, 1);
         for (int lev = 0; lev <= max_level; ++lev) {
@@ -745,7 +745,7 @@ struct SolverChoice {
 
         // Is the terrain none, static or moving?
         std::string terrain_type_temp = "";
-        pp.query("terrain_type", terrain_type_temp);
+        pp.queryAdd("terrain_type", terrain_type_temp);
         if (terrain_type_temp == "Moving") {
             amrex::Warning("erf.terrain_type = Moving is deprecated; please replace Moving by MovingFittedMesh");
             terrain_type = TerrainType::MovingFittedMesh;
@@ -758,7 +758,7 @@ struct SolverChoice {
 
         // Get buildings type
         std::string buildings_type_temp = "";
-        pp.query("buildings_type", buildings_type_temp);
+        pp.queryAdd("buildings_type", buildings_type_temp);
         if (buildings_type_temp == "ImmersedForcing") {
             buildings_type = BuildingsType::ImmersedForcing;
         }
@@ -768,7 +768,7 @@ struct SolverChoice {
         //
         std::string init_type_temp_string;
 
-        int found = pp.query("init_type",init_type_temp_string);
+        int found = pp.queryAdd("init_type",init_type_temp_string);
 
         if ( (init_type_temp_string == "Real") || (init_type_temp_string == "real") ) {
             amrex::Error("erf.init_type = Real is deprecated; please replace Real by WRFInput");
@@ -798,11 +798,11 @@ struct SolverChoice {
 
             // NetCDF wrfbdy lateral boundary file
             std::string nc_bdy_file_temp_string;
-            bool has_bdy = pp.query("nc_bdy_file", nc_bdy_file_temp_string);
+            bool has_bdy = pp.queryAdd("nc_bdy_file", nc_bdy_file_temp_string);
             if (!has_bdy) use_real_bcs = false;
 
             bool use_real_bcs_temp = use_real_bcs;
-            pp.query("use_real_bcs", use_real_bcs_temp);
+            pp.queryAdd("use_real_bcs", use_real_bcs_temp);
             if (use_real_bcs && !use_real_bcs_temp) {
                 use_real_bcs = false;
             }
@@ -833,7 +833,7 @@ struct SolverChoice {
             amrex::Abort("SAM is not correct with variable dz -- choose another moisture model");
         }
 
-        pp.query("grid_stretching_ratio", grid_stretching_ratio);
+        pp.queryAdd("grid_stretching_ratio", grid_stretching_ratio);
         if (grid_stretching_ratio != 0) {
             AMREX_ASSERT_WITH_MESSAGE((grid_stretching_ratio >= one),
                                       "The grid stretching ratio must be greater than 1");
@@ -845,7 +845,7 @@ struct SolverChoice {
             if (mesh_type == MeshType::ConstantDz) {
                 mesh_type = MeshType::StretchedDz;
             }
-            pp.query("zsurface", zsurf);
+            pp.queryAdd("zsurface", zsurf);
             if (zsurf != zero) {
                 amrex::Print() << "Nominal zsurface height != 0, may result in unexpected behavior"
                     << std::endl;
@@ -865,13 +865,13 @@ struct SolverChoice {
         }
 
         // Use lagged_delta_rt in the fast integrator?
-        pp.query("use_lagged_delta_rt", use_lagged_delta_rt);
+        pp.queryAdd("use_lagged_delta_rt", use_lagged_delta_rt);
 
         // Keep the default wrf grid or remake our own
-        pp.query("use_wrf_height_grid",use_wrf_height_grid);
+        pp.queryAdd("use_wrf_height_grid",use_wrf_height_grid);
 
         // Rebalance wrf state?
-        pp.query("rebalance_wrf_input", rebalance_wrf_input);
+        pp.queryAdd("rebalance_wrf_input", rebalance_wrf_input);
 
         // Must rebalance if not using WRF grid
         if (!use_wrf_height_grid && !rebalance_wrf_input) {
@@ -880,7 +880,7 @@ struct SolverChoice {
         }
 
         // These default to true but are used for unit testing
-        pp.query("use_gravity", use_gravity);
+        pp.queryAdd("use_gravity", use_gravity);
 
         // Initializing from Metgrid or WRFInput without gravity makes no sense
         if ( !use_gravity && ( (init_type == InitType::WRFInput) || (init_type == InitType::Metgrid) ) ) {
@@ -890,7 +890,7 @@ struct SolverChoice {
 
         gravity = use_gravity? CONST_GRAV: zero;
 
-        pp.query("c_p", c_p);
+        pp.queryAdd("c_p", c_p);
         rdOcp = R_d / c_p;
 
         // *******************************************************************************
@@ -941,9 +941,9 @@ struct SolverChoice {
                 pp, "substepping_type", substepping_type[i], i, max_level);
         }
 
-        pp.query("substepping_diag", substepping_diag);
+        pp.queryAdd("substepping_diag", substepping_diag);
 
-        pp.query("beta_s", beta_s);
+        pp.queryAdd("beta_s", beta_s);
 
 
 
@@ -957,9 +957,9 @@ struct SolverChoice {
 
         // *******************************************************************************
 
-        pp.query("ncorr", ncorr);
-        pp.query("poisson_abstol", poisson_abstol);
-        pp.query("poisson_reltol", poisson_reltol);
+        pp.queryAdd("ncorr", ncorr);
+        pp.queryAdd("poisson_abstol", poisson_abstol);
+        pp.queryAdd("poisson_reltol", poisson_reltol);
 #ifdef AMREX_USE_FLOAT
         poisson_abstol = amrex::max(poisson_abstol,amrex::Real(1e-6));
         poisson_reltol = amrex::max(poisson_reltol,amrex::Real(1e-6));
@@ -971,37 +971,37 @@ struct SolverChoice {
             }
         }
 
-        pp.query("force_stage1_single_substep", force_stage1_single_substep);
+        pp.queryAdd("force_stage1_single_substep", force_stage1_single_substep);
 
         // Include Coriolis forcing?
-        pp.query("use_coriolis", use_coriolis);
-        pp.query("variable_coriolis", variable_coriolis);
+        pp.queryAdd("use_coriolis", use_coriolis);
+        pp.queryAdd("variable_coriolis", variable_coriolis);
 
         // Include four stream radiation approximation
-        pp.query("four_stream_radiation", four_stream_radiation);
+        pp.queryAdd("four_stream_radiation", four_stream_radiation);
 
         // flags for whether to apply other source terms in substep only
-        pp.query("immersed_forcing_substep", immersed_forcing_substep); // apply immersed forcing source terms in substep only
-        pp.query("forest_substep", forest_substep);                     // apply canopy-related source terms in substep only
+        pp.queryAdd("immersed_forcing_substep", immersed_forcing_substep); // apply immersed forcing source terms in substep only
+        pp.queryAdd("forest_substep", forest_substep);                     // apply canopy-related source terms in substep only
 
         // immersed forcing parameters
-        pp.query("if_Cd_momentum", if_Cd_momentum);
-        pp.query("if_Cd_scalar", if_Cd_scalar);
-        pp.query("if_implicit_drag", if_implicit_drag); // flag for implicit vs. explicit drag formulation
-        pp.query("if_z0", if_z0);
-        pp.query("if_surf_temp_flux", if_surf_temp_flux);
-        pp.query("if_init_surf_temp", if_init_surf_temp);
+        pp.queryAdd("if_Cd_momentum", if_Cd_momentum);
+        pp.queryAdd("if_Cd_scalar", if_Cd_scalar);
+        pp.queryAdd("if_implicit_drag", if_implicit_drag); // flag for implicit vs. explicit drag formulation
+        pp.queryAdd("if_z0", if_z0);
+        pp.queryAdd("if_surf_temp_flux", if_surf_temp_flux);
+        pp.queryAdd("if_init_surf_temp", if_init_surf_temp);
 
-        pp.query("if_surf_heating_rate", if_surf_heating_rate);
+        pp.queryAdd("if_surf_heating_rate", if_surf_heating_rate);
 
         // Modify rate to be in units of K / s rather than K / hr
         if_surf_heating_rate /= amrex::Real(3600.0);        // [K/s]
 
-        pp.query("if_Olen", if_Olen_in);
-        pp.query("if_use_most",if_use_most);
-        pp.query("if_stability_correction",if_stability_correction);
-        pp.query("if_ws_floor",if_ws_floor);
-        pp.query("if_damp_alpha",if_damp_alpha);
+        pp.queryAdd("if_Olen", if_Olen_in);
+        pp.queryAdd("if_use_most",if_use_most);
+        pp.queryAdd("if_stability_correction",if_stability_correction);
+        pp.queryAdd("if_ws_floor",if_ws_floor);
+        pp.queryAdd("if_damp_alpha",if_damp_alpha);
 
         if ((if_init_surf_temp > zero        && if_surf_temp_flux != amrex::Real(1e-8)) ||
             (if_init_surf_temp > zero        && if_Olen_in        != amrex::Real(1e-8)) ||
@@ -1011,7 +1011,7 @@ struct SolverChoice {
         }
 
         // Flag to do MOST rotations with terrain
-        pp.query("use_rotate_surface_flux",use_rotate_surface_flux);
+        pp.queryAdd("use_rotate_surface_flux",use_rotate_surface_flux);
         if (use_rotate_surface_flux) {
             AMREX_ASSERT_WITH_MESSAGE(terrain_type != TerrainType::None,"MOST stress rotations are only valid with terrain!");
         }
@@ -1019,11 +1019,11 @@ struct SolverChoice {
         // Which external forcings?
         abl_driver_type = ABLDriverType::None; // Default: no ABL driver for simulating classical fluid dynamics problems
         pp.query_enum_case_insensitive("abl_driver_type",abl_driver_type);
-        pp.query("const_massflux_u", const_massflux_u);
-        pp.query("const_massflux_v", const_massflux_v);
-        pp.query("const_massflux_tau", const_massflux_tau);
-        pp.query("const_massflux_layer_lo", const_massflux_layer_lo);
-        pp.query("const_massflux_layer_hi", const_massflux_layer_hi);
+        pp.queryAdd("const_massflux_u", const_massflux_u);
+        pp.queryAdd("const_massflux_v", const_massflux_v);
+        pp.queryAdd("const_massflux_tau", const_massflux_tau);
+        pp.queryAdd("const_massflux_layer_lo", const_massflux_layer_lo);
+        pp.queryAdd("const_massflux_layer_hi", const_massflux_layer_hi);
 
         // Which type of inflow turbulent generation
         pert_type.resize(max_level+1);
@@ -1052,33 +1052,33 @@ struct SolverChoice {
             build_coriolis_forcings_const_lat(pp_prefix);
         }
 
-        pp.query("add_custom_rhotheta_forcing", custom_rhotheta_forcing);
-        pp.query("add_custom_moisture_forcing", custom_moisture_forcing);
-        pp.query("add_custom_w_subsidence", custom_w_subsidence);
-        pp.query("add_do_theta_advection", do_theta_advection);  // If true, apply custom subsidence to (rho*theta) when add_custom_w_subsidence is used
-        pp.query("add_do_mom_advection", do_mom_advection);      // If true, apply custom subsidence to momentum when add_custom_w_subsidence is used
-        pp.query("add_custom_geostrophic_profile", custom_geostrophic_profile);
-        pp.query("custom_forcing_uses_primitive_vars", custom_forcing_prim_vars);
-        pp.query("spatial_rhotheta_forcing", spatial_rhotheta_forcing);
-        pp.query("spatial_moisture_forcing", spatial_moisture_forcing);
+        pp.queryAdd("add_custom_rhotheta_forcing", custom_rhotheta_forcing);
+        pp.queryAdd("add_custom_moisture_forcing", custom_moisture_forcing);
+        pp.queryAdd("add_custom_w_subsidence", custom_w_subsidence);
+        pp.queryAdd("add_do_theta_advection", do_theta_advection);  // If true, apply custom subsidence to (rho*theta) when add_custom_w_subsidence is used
+        pp.queryAdd("add_do_mom_advection", do_mom_advection);      // If true, apply custom subsidence to momentum when add_custom_w_subsidence is used
+        pp.queryAdd("add_custom_geostrophic_profile", custom_geostrophic_profile);
+        pp.queryAdd("custom_forcing_uses_primitive_vars", custom_forcing_prim_vars);
+        pp.queryAdd("spatial_rhotheta_forcing", spatial_rhotheta_forcing);
+        pp.queryAdd("spatial_moisture_forcing", spatial_moisture_forcing);
 
-        pp.query("nudging_from_input_sounding", nudging_from_input_sounding);
+        pp.queryAdd("nudging_from_input_sounding", nudging_from_input_sounding);
 
-        pp.query("nudging_q_z1", nudging_q_z1);
-        pp.query("nudging_q_z2", nudging_q_z2);
-        pp.query("nudging_t_z1", nudging_t_z1);
-        pp.query("nudging_t_z2", nudging_t_z2);
+        pp.queryAdd("nudging_q_z1", nudging_q_z1);
+        pp.queryAdd("nudging_q_z2", nudging_q_z2);
+        pp.queryAdd("nudging_t_z1", nudging_t_z1);
+        pp.queryAdd("nudging_t_z2", nudging_t_z2);
 
-        pp.query("large_scale_forcing", large_scale_forcing);
+        pp.queryAdd("large_scale_forcing", large_scale_forcing);
 
         have_geo_wind_profile = (!abl_geo_wind_table.empty() || custom_geostrophic_profile);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(!(!abl_geo_wind_table.empty() && custom_geostrophic_profile),
             "Should not have both abl_geo_wind_table and custom_geostrophic_profile set.");
 
-        pp.query("Ave_Plane", ave_plane);
+        pp.queryAdd("Ave_Plane", ave_plane);
 
         // Use numerical diffusion?
-        pp.query("num_diff_coeff",num_diff_coeff);
+        pp.queryAdd("num_diff_coeff",num_diff_coeff);
         AMREX_ASSERT_WITH_MESSAGE(( (num_diff_coeff >= zero) && (num_diff_coeff <= one) ),
                                   "Numerical diffusion coefficient must be between 0 & one");
         use_num_diff = (num_diff_coeff > 0);
@@ -1135,22 +1135,22 @@ struct SolverChoice {
         }
 
         // What's the strength of the bdy nudging?
-        pp.query("bdy_nudge_factor",bdy_nudge_factor);
+        pp.queryAdd("bdy_nudge_factor",bdy_nudge_factor);
 
         // Optionally use the dry-air density reconstructed from wrfbdy.
-        pp.query("use_wrf_bdy_density", use_wrf_bdy_density);
+        pp.queryAdd("use_wrf_bdy_density", use_wrf_bdy_density);
 
         // Optionally ingest cloud water and cloud ice from wrfinput/wrfbdy.
-        pp.query("use_wrf_bdy_qc_qi", use_wrf_bdy_qc_qi);
+        pp.queryAdd("use_wrf_bdy_qc_qi", use_wrf_bdy_qc_qi);
 
         if (!use_real_bcs || init_type != InitType::WRFInput) {
             use_wrf_bdy_density = false;
         }
 
-        pp.query("bdy_rho_nudge_factor", bdy_rho_nudge_factor);
+        pp.queryAdd("bdy_rho_nudge_factor", bdy_rho_nudge_factor);
 
         // Which approach to nudging the moist variables in the boundary region?
-        pp.query("bdy_moist_nudge_type",bdy_moist_nudge_type);
+        pp.queryAdd("bdy_moist_nudge_type",bdy_moist_nudge_type);
         if (bdy_moist_nudge_type < 0 || bdy_moist_nudge_type > 3) {
             amrex::Error("erf.bdy_moist_nudge_type must be one of 0, 1, 2, or 3");
         }
@@ -1180,7 +1180,7 @@ struct SolverChoice {
         }
 
         // Are me transporting the scalar component?
-        pp.query("transport_scalar",transport_scalar);
+        pp.queryAdd("transport_scalar",transport_scalar);
 
         for (int lev = 0; lev <= max_level; ++lev) {
             if (turbChoice[lev].uses_eamxx_shoc()) {
@@ -1202,7 +1202,7 @@ struct SolverChoice {
         } else {
             // This controls the time-centering of the vertical differences in the diffusive term
             bool do_vert_implicit = true;
-            pp.query("vert_implicit", do_vert_implicit);
+            pp.queryAdd("vert_implicit", do_vert_implicit);
 
             if (!do_vert_implicit) {
                 for (int lev = 0; lev <= max_level; lev++) {
@@ -1245,24 +1245,24 @@ struct SolverChoice {
 
                 // If true (default), include implicit contributions to vertical
                 // thermal diffusion
-                pp.query("implicit_thermal_diffusion", implicit_thermal_diffusion);
+                pp.queryAdd("implicit_thermal_diffusion", implicit_thermal_diffusion);
 
                 // If true (default), include implicit contributions to vertical
                 // moisture diffusion
-                pp.query("implicit_moisture_diffusion", implicit_moisture_diffusion);
+                pp.queryAdd("implicit_moisture_diffusion", implicit_moisture_diffusion);
 
                 // If true (default), include implicit contributions to vertical
                 // KE diffusion
-                pp.query("implicit_ke_diffusion", implicit_ke_diffusion);
+                pp.queryAdd("implicit_ke_diffusion", implicit_ke_diffusion);
 
                 // If true (default), include implicit contributions in tau13, tau23,
                 // (and if ERF_IMPLICIT_W is set, tau33) to correct u, v, (and w).
-                pp.query("implicit_momentum_diffusion", implicit_momentum_diffusion);
+                pp.queryAdd("implicit_momentum_diffusion", implicit_momentum_diffusion);
 
                 // This controls when the vertical implicit solve for the diffusive terms will happen relative to
                 //      the acoustic substepping (if it happens, i.e. if any of the implicit_fac > zero)
                 // The default is true (i.e. that it happens before the acoustic substepping).
-                pp.query("implicit_before_substep", implicit_before_substep);
+                pp.queryAdd("implicit_before_substep", implicit_before_substep);
                 for (int lev = 0; lev <= max_level; lev++) {
                     if ( (substepping_type[lev] == SubsteppingType::None) && !implicit_before_substep) {
                         amrex::Print() << "implicit_before_substep cannot be false without substepping; setting to true." << "\n";
@@ -1313,44 +1313,44 @@ struct SolverChoice {
         windfarm_loc_type = WindFarmLocType::None;
         pp.query_enum_case_insensitive("windfarm_loc_type",windfarm_loc_type);
 
-        pp.query("windfarm_loc_table",  windfarm_loc_table);
-        pp.query("windfarm_spec_table", windfarm_spec_table);
-        pp.query("windfarm_blade_table", windfarm_blade_table);
-        pp.query("windfarm_airfoil_tables", windfarm_airfoil_tables);
-        pp.query("windfarm_spec_table_extra", windfarm_spec_table_extra);
+        pp.queryAdd("windfarm_loc_table",  windfarm_loc_table);
+        pp.queryAdd("windfarm_spec_table", windfarm_spec_table);
+        pp.queryAdd("windfarm_blade_table", windfarm_blade_table);
+        pp.queryAdd("windfarm_airfoil_tables", windfarm_airfoil_tables);
+        pp.queryAdd("windfarm_spec_table_extra", windfarm_spec_table_extra);
 
         // Sampling distance upstream of the turbine to find the
         // incoming free stream velocity as a factor of the diameter of the
         // turbine. ie. the sampling distance will be this number multiplied
         // by the diameter of the turbine
-        pp.query("sampling_distance_by_D", sampling_distance_by_D);
-        pp.query("turb_disk_angle_from_x", turb_disk_angle);
+        pp.queryAdd("sampling_distance_by_D", sampling_distance_by_D);
+        pp.queryAdd("turb_disk_angle_from_x", turb_disk_angle);
 
-        pp.query("windfarm_x_shift",windfarm_x_shift);
-        pp.query("windfarm_y_shift",windfarm_y_shift);
+        pp.queryAdd("windfarm_x_shift",windfarm_x_shift);
+        pp.queryAdd("windfarm_y_shift",windfarm_y_shift);
         // Test if time averaged data is to be output
-        pp.query("time_avg_vel",time_avg_vel);
+        pp.queryAdd("time_avg_vel",time_avg_vel);
 
-        pp.query("hindcast_lateral_forcing", hindcast_lateral_forcing);
+        pp.queryAdd("hindcast_lateral_forcing", hindcast_lateral_forcing);
 
         if (hindcast_lateral_forcing) {
-            pp.query("hindcast_boundary_data_dir", hindcast_boundary_data_dir);
+            pp.queryAdd("hindcast_boundary_data_dir", hindcast_boundary_data_dir);
 
             if(hindcast_boundary_data_dir.empty()) {
                 amrex::Error("ERROR: Missing input parameter 'erf.hindcast_boundary_data_dir' for boundary data for lateral forcing");
             }
-            pp.query("hindcast_data_interval_in_hrs", hindcast_data_interval_in_hrs);
+            pp.queryAdd("hindcast_data_interval_in_hrs", hindcast_data_interval_in_hrs);
             if(hindcast_data_interval_in_hrs < zero) {
                 amrex::Error("ERROR: Input parameter 'erf.hindcast_data_interval_in_hrs' which is the time interval between the "
                              "data files is either missing or set to less than zero");
             }
-            pp.query("hindcast_lateral_sponge_strength", hindcast_lateral_sponge_strength);
-            pp.query("hindcast_lateral_sponge_length", hindcast_lateral_sponge_length);
+            pp.queryAdd("hindcast_lateral_sponge_strength", hindcast_lateral_sponge_strength);
+            pp.queryAdd("hindcast_lateral_sponge_length", hindcast_lateral_sponge_length);
 
-            pp.query("hindcast_zhi_sponge_length", hindcast_zhi_sponge_length);
-            pp.query("hindcast_zhi_sponge_strength", hindcast_zhi_sponge_strength);
+            pp.queryAdd("hindcast_zhi_sponge_length", hindcast_zhi_sponge_length);
+            pp.queryAdd("hindcast_zhi_sponge_strength", hindcast_zhi_sponge_strength);
 
-            pp.query("hindcast_zhi_sponge_damping", hindcast_zhi_sponge_damping);
+            pp.queryAdd("hindcast_zhi_sponge_damping", hindcast_zhi_sponge_damping);
 
             if (hindcast_lateral_forcing and hindcast_lateral_sponge_strength < zero) {
                 amrex::Error("ERROR: Missing input parameter 'erf.hindcast_lateral_sponge_strength' or it is specified to be less than zero");
@@ -1369,15 +1369,15 @@ struct SolverChoice {
             }
         }
 
-        pp.query("hindcast_surface_bcs", hindcast_surface_bcs);
+        pp.queryAdd("hindcast_surface_bcs", hindcast_surface_bcs);
         if(hindcast_surface_bcs) {
-            pp.query("hindcast_surface_data_dir", hindcast_surface_data_dir);
+            pp.queryAdd("hindcast_surface_data_dir", hindcast_surface_data_dir);
         }
 
-        pp.query("io_hurricane_eye_tracker", io_hurricane_eye_tracker);
+        pp.queryAdd("io_hurricane_eye_tracker", io_hurricane_eye_tracker);
         if (io_hurricane_eye_tracker) {
-            pp.query("hurricane_eye_latitude", hurricane_eye_latitude);
-            pp.query("hurricane_eye_longitude", hurricane_eye_longitude);
+            pp.queryAdd("hurricane_eye_latitude", hurricane_eye_latitude);
+            pp.queryAdd("hurricane_eye_longitude", hurricane_eye_longitude);
             if(hurricane_eye_latitude == amrex::Real(-1e10) or hurricane_eye_longitude == amrex::Real(-1e10)) {
                 amrex::Error("ERROR: You are using 'erf.io_hurricane_eye_tracker' to write out the files that track the eye of the hurricane"
                               " but have not provided the initial location of the eye of the hurricane to be tracked. There has to be two"
@@ -1386,28 +1386,28 @@ struct SolverChoice {
             }
         }
 
-        pp.query("is_init_for_ensemble", is_init_for_ensemble);
+        pp.queryAdd("is_init_for_ensemble", is_init_for_ensemble);
         if(is_init_for_ensemble) {
             amrex::ParmParse pp_ens("ensemble");
-            pp_ens.query("n_members", n_ensemble);
+            pp_ens.queryAdd("n_members", n_ensemble);
             if(n_ensemble < 2) {
                 amrex::Abort("You are using an ensemble run. There needs to be at least 2 ensemble members. "
                              "erf.n_ensemble must be >=2.");
             }
-            pp_ens.query("coarse_bckgnd_data_file", coarse_bckgnd_data_file);
+            pp_ens.queryAdd("coarse_bckgnd_data_file", coarse_bckgnd_data_file);
             if (coarse_bckgnd_data_file.empty()) {
                 amrex::Abort("coarse_bckgnd_data_file is empty! For ensmeble simulations, there needs to be a coarse background file which "
                              "contains the data which will be interpolated onto the fine mesh. There has to a entry ensemble.coarse_bckgnd_data_file "
                              "which contains the filename in the inputs.");
             }
-            pp_ens.query("ens_pert_amplitude", ens_pert_amplitude);
+            pp_ens.queryAdd("ens_pert_amplitude", ens_pert_amplitude);
             if(ens_pert_amplitude <= 0.0) {
                 amrex::Error("You are using initialization for ensemble simulations using the inputs option "
                              "ensemble.is_init_for_ensemble=true. In this case, there has to be an option "
                              "ensemble.ens_pert_amplitude which is the value of the amplitude of the perturbation  "
                              "to be added to the background state and has to be greater than 0.0");
             }
-            pp_ens.query("ens_pert_correlated_radius", ens_pert_correlated_radius);
+            pp_ens.queryAdd("ens_pert_correlated_radius", ens_pert_correlated_radius);
             if(ens_pert_correlated_radius <= 0.0) {
                 amrex::Error("You are using initialization with spatially correlated perturbations using the inputs option "
                              "ensemble.is_init_for_ensemble=true. In this case, there has to be an option "
@@ -1693,15 +1693,15 @@ struct SolverChoice {
 
         // Read the rotational time period (in seconds)
         double rot_time_period = 86400.0;
-        pp.query("rotational_time_period", rot_time_period);
+        pp.queryAdd("rotational_time_period", rot_time_period);
 
         coriolis_factor = static_cast<amrex::Real>(4.0 * PI / rot_time_period);
 
-        pp.query("coriolis_3d", coriolis_3d);
+        pp.queryAdd("coriolis_3d", coriolis_3d);
 
         // Convert to radians
         amrex::Real latitude_for_coriolis = amrex::Real(90.0);
-        pp.query("latitude", latitude_for_coriolis);
+        pp.queryAdd("latitude", latitude_for_coriolis);
         latitude_for_coriolis *= (PI/amrex::Real(180.));
         sinphi = std::sin(latitude_for_coriolis);
 
@@ -1718,7 +1718,7 @@ struct SolverChoice {
             amrex::Vector<amrex::Real> abl_geo_wind(3);
             pp.queryarr("abl_geo_wind",abl_geo_wind);
 
-            if(!pp.query("abl_geo_wind_table",abl_geo_wind_table)) {
+            if(!pp.queryAdd("abl_geo_wind_table",abl_geo_wind_table)) {
                 abl_geo_forcing = {
                     -coriolis_factor * (abl_geo_wind[1]*sinphi - abl_geo_wind[2]*cosphi),
                      coriolis_factor *  abl_geo_wind[0]*sinphi,

--- a/Source/DataStructs/ERF_DiffStruct.H
+++ b/Source/DataStructs/ERF_DiffStruct.H
@@ -30,7 +30,7 @@ struct DiffChoice {
         amrex::ParmParse pp(pp_prefix);
 
         static std::string molec_diff_type_string = "None";
-        pp.query("molec_diff_type",molec_diff_type_string);
+        pp.queryAdd("molec_diff_type",molec_diff_type_string);
 
         if (!molec_diff_type_string.compare("Constant")) {
             molec_diff_type = MolecDiffType::Constant;
@@ -43,13 +43,13 @@ struct DiffChoice {
         }
 
         if (molec_diff_type != MolecDiffType::None) {
-            pp.query("alpha_T", alpha_T);
-            pp.query("alpha_C", alpha_C);
-            pp.query("dynamic_viscosity", dynamic_viscosity);
-            pp.query("rho0_trans", rho0_trans);
-            pp.query("eb_diff_constraint_x", eb_diff_constraint_x);
-            pp.query("eb_diff_constraint_y", eb_diff_constraint_y);
-            pp.query("eb_diff_constraint_z", eb_diff_constraint_z);
+            pp.queryAdd("alpha_T", alpha_T);
+            pp.queryAdd("alpha_C", alpha_C);
+            pp.queryAdd("dynamic_viscosity", dynamic_viscosity);
+            pp.queryAdd("rho0_trans", rho0_trans);
+            pp.queryAdd("eb_diff_constraint_x", eb_diff_constraint_x);
+            pp.queryAdd("eb_diff_constraint_y", eb_diff_constraint_y);
+            pp.queryAdd("eb_diff_constraint_z", eb_diff_constraint_z);
         }
 
         // Compute relevant forms of diffusion parameters

--- a/Source/DataStructs/ERF_EBStruct.H
+++ b/Source/DataStructs/ERF_EBStruct.H
@@ -44,7 +44,7 @@ struct EBChoice {
         amrex::ParmParse pp(pp_prefix);
 
         static std::string eb_boundary_type_string = "NoSlipWall";
-        pp.query("eb_boundary_type",eb_boundary_type_string);
+        pp.queryAdd("eb_boundary_type",eb_boundary_type_string);
 
         if (!eb_boundary_type_string.compare("SlipWall")) {
             eb_boundary_type = EBBoundaryType::SlipWall;

--- a/Source/DataStructs/ERF_InputSoundingData.H
+++ b/Source/DataStructs/ERF_InputSoundingData.H
@@ -27,7 +27,7 @@ public:
     InputSoundingData ()
     {
         amrex::ParmParse pp("erf");
-        pp.query("tau_nudging", tau_nudging);
+        pp.queryAdd("tau_nudging", tau_nudging);
 
         // Read in input_sounding filename
         n_sounding_files = pp.countval("input_sounding_file");
@@ -141,7 +141,7 @@ public:
             amrex::ParmParse pp_erf("erf");
 
             amrex::Real surf_temp;
-            bool surf_temp_specified = pp_erf.query("most.surf_temp", surf_temp);
+            bool surf_temp_specified = pp_erf.queryAdd("most.surf_temp", surf_temp);
             if ( surf_temp_specified && (surf_temp != theta_inp_sound_tmp[0]) ) {
                 amrex::Print() << "Input sounding temp does not match most.surf_temp" << std::endl;
                 amrex::Print() << "Modify one or both to match." << std::endl;
@@ -153,7 +153,7 @@ public:
             //      those values must match
             // *************************************************************************************************
             amrex::Real surf_moist;
-            bool surf_moist_specified = pp_erf.query("most.surf_moist", surf_moist);
+            bool surf_moist_specified = pp_erf.queryAdd("most.surf_moist", surf_moist);
             if ( surf_moist_specified && (surf_moist != qv_inp_sound_tmp[0]) ) {
                 amrex::Print() << "Input sounding qv does not match most.surf_moist" << std::endl;
                 amrex::Print() << "Modify one or both to match." << std::endl;

--- a/Source/DataStructs/ERF_InputSpongeData.H
+++ b/Source/DataStructs/ERF_InputSpongeData.H
@@ -25,7 +25,7 @@ public:
     {
         // Text input_sounding file
         amrex::ParmParse pp("erf");
-        pp.query("input_sponge_file", input_sponge_file);
+        pp.queryAdd("input_sponge_file", input_sponge_file);
     }
 
     /**

--- a/Source/DataStructs/ERF_LargeScaleForcingData.H
+++ b/Source/DataStructs/ERF_LargeScaleForcingData.H
@@ -36,8 +36,8 @@ public:
     LargeScaleForcingData ()
     {
         amrex::ParmParse pp("erf");
-        pp.query("forcing_timescale", tau_lsf);
-        pp.query("large_scale_forcing_file", lsf_file);
+        pp.queryAdd("forcing_timescale", tau_lsf);
+        pp.queryAdd("large_scale_forcing_file", lsf_file);
     }
 
     /**

--- a/Source/DataStructs/ERF_SpongeStruct.H
+++ b/Source/DataStructs/ERF_SpongeStruct.H
@@ -35,7 +35,7 @@ struct SpongeChoice {
 
         if (sponge_type == SpongeType::None) return;
 
-        pp.query("sponge_strength" , sponge_strength);
+        pp.queryAdd("sponge_strength" , sponge_strength);
 
         // If sponge_strength == 0 then we set sponge_type to None
         if (std::abs(sponge_strength) == zero)
@@ -44,12 +44,12 @@ struct SpongeChoice {
         }
         else
         {
-            pp.query("use_xlo_sponge_damping", use_xlo_sponge_damping);
-            pp.query("use_xhi_sponge_damping", use_xhi_sponge_damping);
-            pp.query("use_ylo_sponge_damping", use_ylo_sponge_damping);
-            pp.query("use_yhi_sponge_damping", use_yhi_sponge_damping);
-            pp.query("use_zlo_sponge_damping", use_zlo_sponge_damping);
-            pp.query("use_zhi_sponge_damping", use_zhi_sponge_damping);
+            pp.queryAdd("use_xlo_sponge_damping", use_xlo_sponge_damping);
+            pp.queryAdd("use_xhi_sponge_damping", use_xhi_sponge_damping);
+            pp.queryAdd("use_ylo_sponge_damping", use_ylo_sponge_damping);
+            pp.queryAdd("use_yhi_sponge_damping", use_yhi_sponge_damping);
+            pp.queryAdd("use_zlo_sponge_damping", use_zlo_sponge_damping);
+            pp.queryAdd("use_zhi_sponge_damping", use_zhi_sponge_damping);
 
             if (use_xlo_sponge_damping) {
                 pp.get("xlo_sponge_end"  , xlo_sponge_end);
@@ -70,12 +70,12 @@ struct SpongeChoice {
                 pp.get("zhi_sponge_start"  , zhi_sponge_start);
             }
 
-            pp.query("sponge_density"    , sponge_density);
-            pp.query("sponge_rhotheta"   , sponge_rhotheta);
-            pp.query("sponge_rhomoist"   , sponge_rhomoist);
-            pp.query("sponge_x_velocity" , sponge_x_velocity);
-            pp.query("sponge_y_velocity" , sponge_y_velocity);
-            pp.query("sponge_z_velocity" , sponge_z_velocity);
+            pp.queryAdd("sponge_density"    , sponge_density);
+            pp.queryAdd("sponge_rhotheta"   , sponge_rhotheta);
+            pp.queryAdd("sponge_rhomoist"   , sponge_rhomoist);
+            pp.queryAdd("sponge_x_velocity" , sponge_x_velocity);
+            pp.queryAdd("sponge_y_velocity" , sponge_y_velocity);
+            pp.queryAdd("sponge_z_velocity" , sponge_z_velocity);
         }
     }
 

--- a/Source/DataStructs/ERF_TurbPertStruct.H
+++ b/Source/DataStructs/ERF_TurbPertStruct.H
@@ -92,25 +92,25 @@ struct TurbulentPerturbation {
         pp.get("perturbation_offset",tpi_offset);
 
         tpi_nonDim = zero;
-        pp.query("perturbation_nondimensional",tpi_nonDim);
+        pp.queryAdd("perturbation_nondimensional",tpi_nonDim);
 
         tpi_Tinf = amrex::Real(300.);
-        pp.query("perturbation_T_infinity",tpi_Tinf);
+        pp.queryAdd("perturbation_T_infinity",tpi_Tinf);
 
         tpi_Ti = zero;
-        pp.query("perturbation_T_intensity",tpi_Ti);
+        pp.queryAdd("perturbation_T_intensity",tpi_Ti);
 
         input_Ug = zero;
-        pp.query("perturbation_Ug",input_Ug);
+        pp.queryAdd("perturbation_Ug",input_Ug);
 
         input_w_amp = zero;
-        pp.query("perturbation_w_amp",input_w_amp);
+        pp.queryAdd("perturbation_w_amp",input_w_amp);
 
         perturbation_klo = 0;
-        bool have_klo = pp.query("perturbation_klo", perturbation_klo);
+        bool have_klo = pp.queryAdd("perturbation_klo", perturbation_klo);
 
         perturbation_khi = 0;
-        bool have_khi = pp.query("perturbation_khi", perturbation_khi);
+        bool have_khi = pp.queryAdd("perturbation_khi", perturbation_khi);
 
         // Check variables message
         if (tpi_offset < 0) { amrex::Abort("Please provide a valid inflow cell offset value for perturbation region (ie. 0-5)"); }
@@ -307,7 +307,7 @@ struct TurbulentPerturbation {
         // Seed the random generator at 1024UL for regression testing
         int fix_random_seed = 0;
         amrex::ParmParse pp("erf");
-        pp.query("fix_random_seed", fix_random_seed);
+        pp.queryAdd("fix_random_seed", fix_random_seed);
         if (fix_random_seed) {
             // We need this one for the ParalleForRNG used in calc_tpi
             amrex::InitRandom(1024UL, amrex::ParallelDescriptor::NProcs(), 1024UL);

--- a/Source/DataStructs/ERF_TurbStruct.H
+++ b/Source/DataStructs/ERF_TurbStruct.H
@@ -297,7 +297,7 @@ public:
 
     // There is a default value of 1e-6 but the user can override the value here,
     //   and in addition can add perturbational values.  and in addition can add perturbational values.
-    pp.query("tke_min",tke_min);
+    pp.queryAdd("tke_min",tke_min);
 
     // LES constants...
     query_one_or_per_level(pp, "Cs", Cs, lev, max_level);

--- a/Source/ERF.cpp
+++ b/Source/ERF.cpp
@@ -1548,7 +1548,7 @@ ERF::InitData_post ()
 
     // Create object to do line and plane sampling if needed
     bool do_line = false; bool do_plane = false;
-    pp.query("do_line_sampling",do_line); pp.query("do_plane_sampling",do_plane);
+    pp.queryAdd("do_line_sampling",do_line); pp.queryAdd("do_plane_sampling",do_plane);
     if (do_line) {
         if (line_sampling_interval < 0 && line_sampling_per < 0) {
             Abort("Need to specify line_sampling_interval or line_sampling_per");
@@ -1568,7 +1568,7 @@ ERF::InitData_post ()
          solverChoice.buildings_type == BuildingsType::ImmersedForcing )
     {
         bool write_eb_surface = false;
-        pp.query("write_eb_surface", write_eb_surface);
+        pp.queryAdd("write_eb_surface", write_eb_surface);
         if (write_eb_surface) {
             if (verbose > 0) {
                 amrex::Print() << "Writing the geometry to a vtp file.\n" << std::endl;
@@ -2040,26 +2040,26 @@ ERF::ReadParameters ()
     ParmParse pp(pp_prefix);
     ParmParse pp_amr("amr");
     {
-        pp.query("regrid_level_0_on_restart", regrid_level_0_on_restart);
-        pp.query("regrid_int", regrid_int);
-        pp.query("check_file", check_file);
+        pp.queryAdd("regrid_level_0_on_restart", regrid_level_0_on_restart);
+        pp.queryAdd("regrid_int", regrid_int);
+        pp.queryAdd("check_file", check_file);
 
         // The regression tests use "amr.restart" and "amr.m_check_int" so we allow
         //    for those or "erf.restart" / "erf.m_check_int". The amr.* values are
         //    queried after the erf.* values and therefore take precedence if both
         //    are specified.
-        pp.query("check_int", m_check_int);
-        pp.query("check_per", m_check_per);
-        pp_amr.query("check_int", m_check_int);
-        pp_amr.query("check_per", m_check_per);
+        pp.queryAdd("check_int", m_check_int);
+        pp.queryAdd("check_per", m_check_per);
+        pp_amr.queryAdd("check_int", m_check_int);
+        pp_amr.queryAdd("check_per", m_check_per);
 
-        pp.query("restart", restart_chkfile);
-        pp_amr.query("restart", restart_chkfile);
+        pp.queryAdd("restart", restart_chkfile);
+        pp_amr.queryAdd("restart", restart_chkfile);
 
         // Verbosity
-        pp.query("v", verbose);
-        pp.query("mg_v", mg_verbose);
-        pp.query("use_fft", use_fft);
+        pp.queryAdd("v", verbose);
+        pp.queryAdd("mg_v", mg_verbose);
+        pp.queryAdd("use_fft", use_fft);
 #ifndef ERF_USE_FFT
         if (use_fft) {
             Abort("You must build with USE_FFT in order to set use_fft = true in your inputs file");
@@ -2067,27 +2067,27 @@ ERF::ReadParameters ()
 #endif
 
         // Check for NaNs?
-        pp.query("check_for_nans", check_for_nans);
+        pp.queryAdd("check_for_nans", check_for_nans);
 
         // Frequency of diagnostic output
-        pp.query("sum_interval", sum_interval);
-        pp.query("sum_period"  , sum_per);
+        pp.queryAdd("sum_interval", sum_interval);
+        pp.queryAdd("sum_period"  , sum_per);
 
-        pp.query("pert_interval", pert_interval);
+        pp.queryAdd("pert_interval", pert_interval);
 
         // Time step controls
-        pp.query("cfl", cfl);
-        pp.query("substepping_cfl", sub_cfl);
-        pp.query("init_shrink", init_shrink);
-        pp.query("change_max", change_max);
-        pp.query("dt_max_initial", dt_max_initial);
-        pp.query("dt_max", dt_max);
+        pp.queryAdd("cfl", cfl);
+        pp.queryAdd("substepping_cfl", sub_cfl);
+        pp.queryAdd("init_shrink", init_shrink);
+        pp.queryAdd("change_max", change_max);
+        pp.queryAdd("dt_max_initial", dt_max_initial);
+        pp.queryAdd("dt_max", dt_max);
 
         fixed_dt.resize(max_level+1,-one);
         fixed_fast_dt.resize(max_level+1,-one);
 
-        pp.query("fixed_dt", fixed_dt[0]);
-        pp.query("fixed_fast_dt", fixed_fast_dt[0]);
+        pp.queryAdd("fixed_dt", fixed_dt[0]);
+        pp.queryAdd("fixed_fast_dt", fixed_fast_dt[0]);
 
         int nlevs_max = max_level + 1;
         istep.resize(nlevs_max, 0);
@@ -2124,7 +2124,7 @@ ERF::ReadParameters ()
             fixed_fast_dt[lev] = fixed_fast_dt[lev-1] / static_cast<Real>(nsubsteps[lev]);
         }
 
-        pp.query("fixed_mri_dt_ratio", fixed_mri_dt_ratio);
+        pp.queryAdd("fixed_mri_dt_ratio", fixed_mri_dt_ratio);
 
         // We use this to keep track of how many boxes we read in from WRF initialization
         num_files_at_level.resize(max_level+1,0);
@@ -2160,35 +2160,35 @@ ERF::ReadParameters ()
         } // lev
 
         // NetCDF wrfbdy lateral boundary file
-        if (pp.query("nc_bdy_file", nc_bdy_file)) {
+        if (pp.queryAdd("nc_bdy_file", nc_bdy_file)) {
             Print() << "Reading NC bdy file name " << nc_bdy_file << std::endl;
         }
 
         // NetCDF wrflow lateral boundary file
-        if (pp.query("nc_low_file", nc_low_file)) {
+        if (pp.queryAdd("nc_low_file", nc_low_file)) {
             Print() << "Reading NC low file name " << nc_low_file << std::endl;
         }
 
 #endif
 
         // Options for vertical interpolation of met_em*.nc data.
-        pp.query("metgrid_debug_quiescent",  metgrid_debug_quiescent);
-        pp.query("metgrid_debug_isothermal", metgrid_debug_isothermal);
-        pp.query("metgrid_debug_dry",        metgrid_debug_dry);
-        pp.query("metgrid_debug_psfc",       metgrid_debug_psfc);
-        pp.query("metgrid_debug_msf",        metgrid_debug_msf);
-        pp.query("metgrid_interp_theta",     metgrid_interp_theta);
-        pp.query("metgrid_basic_linear",     metgrid_basic_linear);
-        pp.query("metgrid_use_below_sfc",    metgrid_use_below_sfc);
-        pp.query("metgrid_use_sfc",          metgrid_use_sfc);
-        pp.query("metgrid_retain_sfc",       metgrid_retain_sfc);
-        pp.query("metgrid_proximity",        metgrid_proximity);
-        pp.query("metgrid_order",            metgrid_order);
-        pp.query("metgrid_force_sfc_k",      metgrid_force_sfc_k);
+        pp.queryAdd("metgrid_debug_quiescent",  metgrid_debug_quiescent);
+        pp.queryAdd("metgrid_debug_isothermal", metgrid_debug_isothermal);
+        pp.queryAdd("metgrid_debug_dry",        metgrid_debug_dry);
+        pp.queryAdd("metgrid_debug_psfc",       metgrid_debug_psfc);
+        pp.queryAdd("metgrid_debug_msf",        metgrid_debug_msf);
+        pp.queryAdd("metgrid_interp_theta",     metgrid_interp_theta);
+        pp.queryAdd("metgrid_basic_linear",     metgrid_basic_linear);
+        pp.queryAdd("metgrid_use_below_sfc",    metgrid_use_below_sfc);
+        pp.queryAdd("metgrid_use_sfc",          metgrid_use_sfc);
+        pp.queryAdd("metgrid_retain_sfc",       metgrid_retain_sfc);
+        pp.queryAdd("metgrid_proximity",        metgrid_proximity);
+        pp.queryAdd("metgrid_order",            metgrid_order);
+        pp.queryAdd("metgrid_force_sfc_k",      metgrid_force_sfc_k);
 
         // Options for boundary file.
-        pp.query("write_erfbdy",             write_erfbdy);
-        pp.query("erfbdy_file",              erfbdy_file);
+        pp.queryAdd("write_erfbdy",             write_erfbdy);
+        pp.queryAdd("erfbdy_file",              erfbdy_file);
 
         // Set default to FullState for now ... later we will try Perturbation
         interpolation_type = StateInterpType::FullState;
@@ -2256,28 +2256,28 @@ ERF::ReadParameters ()
         }
 #endif
 
-        pp.query("plot_file_1"  ,   plot3d_file_1);
-        pp.query("plot_file_2"  ,   plot3d_file_2);
-        pp.query("plot2d_file_1",   plot2d_file_1);
-        pp.query("plot2d_file_2",   plot2d_file_2);
+        pp.queryAdd("plot_file_1"  ,   plot3d_file_1);
+        pp.queryAdd("plot_file_2"  ,   plot3d_file_2);
+        pp.queryAdd("plot2d_file_1",   plot2d_file_1);
+        pp.queryAdd("plot2d_file_2",   plot2d_file_2);
 
-        pp.query("plot_int_1"   , m_plot3d_int_1);
-        pp.query("plot_int_2"   , m_plot3d_int_2);
-        pp.query("plot_per_1"   , m_plot3d_per_1);
-        pp.query("plot_per_2"   , m_plot3d_per_2);
+        pp.queryAdd("plot_int_1"   , m_plot3d_int_1);
+        pp.queryAdd("plot_int_2"   , m_plot3d_int_2);
+        pp.queryAdd("plot_per_1"   , m_plot3d_per_1);
+        pp.queryAdd("plot_per_2"   , m_plot3d_per_2);
 
-        pp.query("plot2d_int_1" , m_plot2d_int_1);
-        pp.query("plot2d_int_2" , m_plot2d_int_2);
-        pp.query("plot2d_per_1",  m_plot2d_per_1);
-        pp.query("plot2d_per_2",  m_plot2d_per_2);
+        pp.queryAdd("plot2d_int_1" , m_plot2d_int_1);
+        pp.queryAdd("plot2d_int_2" , m_plot2d_int_2);
+        pp.queryAdd("plot2d_per_1",  m_plot2d_per_1);
+        pp.queryAdd("plot2d_per_2",  m_plot2d_per_2);
 
-        pp.query("subvol_file",   subvol_file);
+        pp.queryAdd("subvol_file",   subvol_file);
 
         // Should we use format like plt1970-01-01_00:00:Real(00.000000) (if true) or plt00001 (if false)
-        pp.query("use_real_time_in_pltname", use_real_time_in_pltname);
+        pp.queryAdd("use_real_time_in_pltname", use_real_time_in_pltname);
 
         // If use_real_time_in_pltname is false, how many digits should we use for the timestep?
-        pp.query("file_name_digits", file_name_digits);
+        pp.queryAdd("file_name_digits", file_name_digits);
 
         // Default if subvol_int not specified
         m_subvol_int.resize(1); m_subvol_int[0] = -1;
@@ -2341,10 +2341,10 @@ ERF::ReadParameters ()
         //       is constructed after ReadParameters() returns, so setSubVolVariables
         //       is called alongside setPlotVariables in the ERF constructor.
 
-        pp.query("expand_plotvars_to_unif_rr",m_expand_plotvars_to_unif_rr);
+        pp.queryAdd("expand_plotvars_to_unif_rr",m_expand_plotvars_to_unif_rr);
 
-        pp.query("plot_face_vels",m_plot_face_vels);
-        pp.query("plot_face_terrain_blanking",m_plot_face_terrain_blanking);
+        pp.queryAdd("plot_face_vels",m_plot_face_vels);
+        pp.queryAdd("plot_face_terrain_blanking",m_plot_face_terrain_blanking);
 
         if ( (m_plot3d_int_1 > 0 && m_plot3d_per_1 > 0) ||
              (m_plot3d_int_2 > 0 && m_plot3d_per_2 > zero) ) {
@@ -2355,50 +2355,50 @@ ERF::ReadParameters ()
             Abort("Must choose only one of plot_int or plot_per");
         }
 
-        pp.query("profile_int", profile_int);
-        pp.query("destag_profiles", destag_profiles);
+        pp.queryAdd("profile_int", profile_int);
+        pp.queryAdd("destag_profiles", destag_profiles);
 
-        pp.query("plot_lsm", plot_lsm);
+        pp.queryAdd("plot_lsm", plot_lsm);
 #ifdef ERF_USE_RRTMGP
-        pp.query("plot_rad", plot_rad);
+        pp.queryAdd("plot_rad", plot_rad);
 #endif
-        pp.query("profile_rad_int", rad_datalog_int);
+        pp.queryAdd("profile_rad_int", rad_datalog_int);
 
-        pp.query("output_1d_column", output_1d_column);
-        pp.query("column_per", column_per);
-        pp.query("column_interval", column_interval);
-        pp.query("column_loc_x", column_loc_x);
-        pp.query("column_loc_y", column_loc_y);
-        pp.query("column_file_name", column_file_name);
+        pp.queryAdd("output_1d_column", output_1d_column);
+        pp.queryAdd("column_per", column_per);
+        pp.queryAdd("column_interval", column_interval);
+        pp.queryAdd("column_loc_x", column_loc_x);
+        pp.queryAdd("column_loc_y", column_loc_y);
+        pp.queryAdd("column_file_name", column_file_name);
 
         // Sampler output frequency
-        pp.query("line_sampling_per", line_sampling_per);
-        pp.query("line_sampling_interval", line_sampling_interval);
-        pp.query("plane_sampling_per", plane_sampling_per);
-        pp.query("plane_sampling_interval", plane_sampling_interval);
+        pp.queryAdd("line_sampling_per", line_sampling_per);
+        pp.queryAdd("line_sampling_interval", line_sampling_interval);
+        pp.queryAdd("plane_sampling_per", plane_sampling_per);
+        pp.queryAdd("plane_sampling_interval", plane_sampling_interval);
 
         // Specify information about outputting planes of data
-        pp.query("output_bndry_planes", output_bndry_planes);
-        pp.query("bndry_output_planes_interval", bndry_output_planes_interval);
-        pp.query("bndry_output_planes_per", bndry_output_planes_per);
-        pp.query("bndry_output_start_time", bndry_output_planes_start_time);
+        pp.queryAdd("output_bndry_planes", output_bndry_planes);
+        pp.queryAdd("bndry_output_planes_interval", bndry_output_planes_interval);
+        pp.queryAdd("bndry_output_planes_per", bndry_output_planes_per);
+        pp.queryAdd("bndry_output_start_time", bndry_output_planes_start_time);
 
         // Specify whether ingest boundary planes of data
-        pp.query("input_bndry_planes", input_bndry_planes);
+        pp.queryAdd("input_bndry_planes", input_bndry_planes);
 
         // Query the total width for wrfbdy interior ghost cells
-        pp.query("real_width", real_width);
+        pp.queryAdd("real_width", real_width);
 
         // If using real boundaries, do we extrapolate w (or set to 0)
-        pp.query("real_extrap_w", real_extrap_w);
+        pp.queryAdd("real_extrap_w", real_extrap_w);
 
         // Query the set and total widths for crse-fine interior ghost cells
-        pp.query("cf_width", cf_width);
-        pp.query("cf_set_width", cf_set_width);
+        pp.queryAdd("cf_width", cf_width);
+        pp.queryAdd("cf_set_width", cf_set_width);
 
         // AmrMesh iterate on grids?
         bool iterate(true);
-        pp_amr.query("iterate_grids",iterate);
+        pp_amr.queryAdd("iterate_grids",iterate);
         if (!iterate) SetIterateToFalse();
     }
 
@@ -2430,13 +2430,13 @@ ERF::ReadParameters ()
 
     {
         ParmParse pp_no_prefix;  // Traditionally, max_step and stop_time do not have prefix.
-        pp_no_prefix.query("max_step", max_step);
+        pp_no_prefix.queryAdd("max_step", max_step);
         if (max_step < 0) {
             max_step = std::numeric_limits<int>::max();
         }
 
         std::string start_datetime, stop_datetime;
-        if (pp_no_prefix.query("start_datetime", start_datetime)) {
+        if (pp_no_prefix.queryAdd("start_datetime", start_datetime)) {
             if (start_datetime.length() == 16) { // YYYY-MM-DD HH:MM
                 start_datetime += ":00"; // add seconds
             }
@@ -2482,7 +2482,7 @@ ERF::ReadParameters ()
 
                 use_datetime = true;
 
-                if (pp_no_prefix.query("start_time", start_time)) {
+                if (pp_no_prefix.queryAdd("start_time", start_time)) {
                     amrex::Print() << "start_time should not be set from inputs file; we are reading SIMULATION START DATE from wrfinput" << std::endl;
                     amrex::Abort();
                 }
@@ -2493,7 +2493,7 @@ ERF::ReadParameters ()
 
                 use_datetime = true;
 
-                if (pp_no_prefix.query("start_time", start_time)) {
+                if (pp_no_prefix.queryAdd("start_time", start_time)) {
                     amrex::Print() << "start_time should not be set from inputs file; we are reading SIMULATION START DATE from metgrid" << std::endl;
                     amrex::Abort();
                 }
@@ -2501,7 +2501,7 @@ ERF::ReadParameters ()
 #endif
         }
 
-        if (pp_no_prefix.query("stop_datetime", stop_datetime)) {
+        if (pp_no_prefix.queryAdd("stop_datetime", stop_datetime)) {
             if (stop_datetime.length() == 16) { // YYYY-MM-DD HH:MM
                 stop_datetime += ":00"; // add seconds
             }
@@ -2516,7 +2516,7 @@ ERF::ReadParameters ()
 
         } else {
 
-            if (pp_no_prefix.query("stop_time", stop_time)) {
+            if (pp_no_prefix.queryAdd("stop_time", stop_time)) {
                 Print() << "Maximum simulation length based on stop_time: " << stop_time << " s (elapsed) " << std::endl;
                 amrex::Print() <<" Adding stop time " << stop_time << " to start_time " << start_time << std::endl;
                 stop_time += start_time;
@@ -2533,7 +2533,7 @@ ERF::ReadParameters ()
 
     // Query the canopy model file name
     std::string forestfile;
-    solverChoice.do_forest_drag = pp.query("forest_file", forestfile);
+    solverChoice.do_forest_drag = pp.queryAdd("forest_file", forestfile);
     if (solverChoice.do_forest_drag) {
         for (int lev = 0; lev <= max_level; ++lev) {
             m_forest_drag[lev] = std::make_unique<ForestDrag>(forestfile);

--- a/Source/ERF_Constructors.cpp
+++ b/Source/ERF_Constructors.cpp
@@ -56,8 +56,8 @@ ERF::ERF_shared ()
     long random_seed = -1;
     {
         ParmParse pp("erf");
-        pp.query("fix_random_seed", fix_random_seed);
-        pp.query("random_seed", random_seed);
+        pp.queryAdd("fix_random_seed", fix_random_seed);
+        pp.queryAdd("random_seed", random_seed);
     }
     // Note that the value of 1024UL is not significant -- the point here is just to set the
     // same seed for all MPI processes for the purpose of regression testing
@@ -242,7 +242,7 @@ ERF::ERF_shared ()
 
     ParmParse pp_erf("erf");
     std::string prob_name;
-    pp_erf.query("prob_name", prob_name);
+    pp_erf.queryAdd("prob_name", prob_name);
     const std::string prob_name_ci = amrex::toLower(prob_name);
     if (prob_name_ci == "cloud chamber" || prob_name_ci == "cloudchamber") {
         cloud_chamber_config = erf_cloud_chamber::parse_config(
@@ -250,7 +250,7 @@ ERF::ERF_shared ()
     }
     {
         int budget_interval = 0;
-        pp_erf.query("cloud_chamber_budget_interval", budget_interval);
+        pp_erf.queryAdd("cloud_chamber_budget_interval", budget_interval);
         if (budget_interval > 0) {
             if (!cloud_chamber_config.active ||
                 !cloud_chamber_config.physical_initialization ||
@@ -508,8 +508,8 @@ ERF::ERF_shared ()
         } else if (geometry == "plane") {
             RealArray plane_point{zero, zero, zero};
             RealArray plane_normal{zero, zero, -one}; // pointing into the solid region
-            pp_eb2.query("plane_point", plane_point);
-            pp_eb2.query("plane_normal", plane_normal);
+            pp_eb2.queryAdd("plane_point", plane_point);
+            pp_eb2.queryAdd("plane_normal", plane_normal);
             EB2::PlaneIF implicit_fun(plane_point, plane_normal, true);
             auto gshop = EB2::makeShop(implicit_fun);
             if (build_eb_for_multigrid) {
@@ -524,8 +524,8 @@ ERF::ERF_shared ()
         } else if (geometry == "box") {
             RealArray box_lo{zero, zero, zero};
             RealArray box_hi{zero, zero, zero};
-            pp_eb2.query("box_lo", box_lo);
-            pp_eb2.query("box_hi", box_hi);
+            pp_eb2.queryAdd("box_lo", box_lo);
+            pp_eb2.queryAdd("box_hi", box_hi);
             EB2::BoxIF implicit_fun(box_lo, box_hi, false);
             auto gshop = EB2::makeShop(implicit_fun);
             if (build_eb_for_multigrid) {
@@ -575,8 +575,8 @@ ERF::ERF_shared ()
         } else if (geometry == "box") {
             RealArray box_lo{zero, zero, zero};
             RealArray box_hi{zero, zero, zero};
-            pp_eb2.query("box_lo", box_lo);
-            pp_eb2.query("box_hi", box_hi);
+            pp_eb2.queryAdd("box_lo", box_lo);
+            pp_eb2.queryAdd("box_hi", box_hi);
             EB2::BoxIF implicit_fun(box_lo, box_hi, false);
             auto gshop = EB2::makeShop(implicit_fun);
             EB2::Build(gshop, this->Geom(), ngrow_for_eb);

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -58,10 +58,10 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     if (solverChoice.terrain_type == TerrainType::EB) {
         ParmParse pp_eb2("eb2");
         std::string geometry;
-        pp_eb2.query("geometry", geometry);
+        pp_eb2.queryAdd("geometry", geometry);
         if (geometry == "plane") {
             RealArray plane_point{zero, zero, zero};
-            pp_eb2.query("plane_point", plane_point);
+            pp_eb2.queryAdd("plane_point", plane_point);
             z_offset = plane_point[2];
         }
     }
@@ -818,7 +818,7 @@ ERF::init_zphys (int lev, double elapsed_time)
         // Read the small_volfrac threshold from eb2 namespace
         Real small_volfrac = 0.005;
         ParmParse pp_eb2("eb2");
-        pp_eb2.query("small_volfrac", small_volfrac);
+        pp_eb2.queryAdd("small_volfrac", small_volfrac);
 
         // Cell-centered terrain blanking
         terrain_blanking[lev]->setVal(one);
@@ -965,7 +965,7 @@ ERF::remake_zphys (int lev, std::unique_ptr<MultiFab>& temp_zphys_nd)
         // Read the small_volfrac threshold from eb2 namespace
         Real small_volfrac = 0.005;
         ParmParse pp_eb2("eb2");
-        pp_eb2.query("small_volfrac", small_volfrac);
+        pp_eb2.queryAdd("small_volfrac", small_volfrac);
 
         terrain_blanking[lev]->setVal(one);
         MultiFab::Subtract(*terrain_blanking[lev], EBFactory(lev).getVolFrac(), 0, 0, 1, z_phys_nd[lev]->nGrowVect());

--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -326,7 +326,7 @@ public:
         // Check if a valid text file exists for the buildings
         std::string fname;
         amrex::ParmParse pp("erf");
-        auto valid_fname = pp.query("buildings_file_name",fname);
+        auto valid_fname = pp.queryAdd("buildings_file_name",fname);
 
         if (valid_fname) {
             read_custom_terrain(fname,false,geom,buildings_fab,time);
@@ -351,8 +351,8 @@ public:
         // Check if a valid text file exists for the terrain
         std::string fname, fname_usgs;
         amrex::ParmParse pp("erf");
-        auto valid_fname      = pp.query("terrain_file_name",fname);
-        auto valid_fname_USGS = pp.query("terrain_file_name_USGS",fname_usgs);
+        auto valid_fname      = pp.queryAdd("terrain_file_name",fname);
+        auto valid_fname_USGS = pp.queryAdd("terrain_file_name_USGS",fname_usgs);
 
         bool is_usgs;
 
@@ -681,7 +681,7 @@ public:
                          const double& time)
     {
         std::string custom_terrain_type = "None";
-        amrex::ParmParse pp_prob("prob"); pp_prob.query("custom_terrain_type",custom_terrain_type);
+        amrex::ParmParse pp_prob("prob"); pp_prob.queryAdd("custom_terrain_type",custom_terrain_type);
 
         if (custom_terrain_type != "None")
         {

--- a/Source/IO/ERF_Plotfile2DSampledLevel.cpp
+++ b/Source/IO/ERF_Plotfile2DSampledLevel.cpp
@@ -318,7 +318,7 @@ parse_sampled_level_definition (const std::string& level_set_name,
     const std::string base = "plot2d.level_set." + level_set_name + ".";
 
     std::string coordinate_value;
-    if (!pp.query((base + "coordinate").c_str(), coordinate_value)) {
+    if (!pp.queryAdd((base + "coordinate").c_str(), coordinate_value)) {
         amrex::Abort(build_missing_field_error(level_set_name, "coordinate"));
     }
     const std::string coordinate_error =
@@ -328,19 +328,19 @@ parse_sampled_level_definition (const std::string& level_set_name,
     }
     level_set.coordinate = sampled_coordinate_from_string(coordinate_value);
 
-    if (pp.query((base + "units").c_str(), level_set.units) == 0) {
+    if (pp.queryAdd((base + "units").c_str(), level_set.units) == 0) {
         level_set.units = sampled_coordinate_default_units(level_set.coordinate);
     }
 
     std::string interpolation_value;
-    if (pp.query((base + "interpolation").c_str(), interpolation_value) == 0) {
+    if (pp.queryAdd((base + "interpolation").c_str(), interpolation_value) == 0) {
         level_set.interpolation =
             sampled_interpolation_from_string(sampled_coordinate_default_interpolation(level_set.coordinate));
     } else {
         level_set.interpolation = sampled_interpolation_from_string(interpolation_value);
     }
 
-    if (pp.query((base + "missing_value").c_str(), level_set.missing_value) == 0) {
+    if (pp.queryAdd((base + "missing_value").c_str(), level_set.missing_value) == 0) {
         level_set.missing_value = amrex::Real(-999.0);
     }
 

--- a/Source/IO/ERF_Plotfile2DWaterPath.cpp
+++ b/Source/IO/ERF_Plotfile2DWaterPath.cpp
@@ -202,7 +202,7 @@ available_diagnostic_names (const SolverChoice& solver_choice,
         amrex::ParmParse pp("erf");
         int nsoil = 4;
         const auto soil_names = active_lsm_names.empty()
-            ? (pp.query("lsm_nsoil", nsoil), dynamic_soil_diagnostic_names(nsoil))
+            ? (pp.queryAdd("lsm_nsoil", nsoil), dynamic_soil_diagnostic_names(nsoil))
             : dynamic_soil_diagnostic_names(active_lsm_names);
         names.insert(names.end(), soil_names.begin(), soil_names.end());
     }

--- a/Source/IO/ERF_ReadBndryPlanes.cpp
+++ b/Source/IO/ERF_ReadBndryPlanes.cpp
@@ -221,10 +221,10 @@ ReadBndryPlanes::ReadBndryPlanes (const Geometry& geom, const Real& rdOcp_in)
     ParmParse pp("erf");
 
     // Get the radius inside the domain
-    pp.query("in_rad",m_in_rad);
+    pp.queryAdd("in_rad",m_in_rad);
 
     // Are we using real bcs?
-    pp.query("use_real_bcs", m_use_real_bcs);
+    pp.queryAdd("use_real_bcs", m_use_real_bcs);
 
     last_file_read = -1;
 

--- a/Source/IO/ERF_SampleData.H
+++ b/Source/IO/ERF_SampleData.H
@@ -186,7 +186,7 @@ struct LineSampler
 
             // Write outputs to text files, one file per variable, with all
             // times appended to the same file
-            pp.query("line_sampling_text_output",m_write_ascii);
+            pp.queryAdd("line_sampling_text_output",m_write_ascii);
             if (m_write_ascii && amrex::ParallelDescriptor::IOProcessor()) {
                 int nvar = static_cast<int>(m_varnames.size());
                 m_datastream.resize(nline * nvar);
@@ -631,7 +631,7 @@ struct PlaneSampler
             }
 
             // Optional cap on the finest level written (-1 => all intersecting levels)
-            pp.query("plane_sampling_max_level", m_max_level);
+            pp.queryAdd("plane_sampling_max_level", m_max_level);
 
             // Allocate per-plane vectors of per-level MF pointers
             m_ps_mf.resize(n_plane_lo);

--- a/Source/IO/ERF_WriteBndryPlanes.cpp
+++ b/Source/IO/ERF_WriteBndryPlanes.cpp
@@ -60,7 +60,7 @@ WriteBndryPlanes::WriteBndryPlanes (Vector<BoxArray>& grids,
     ParmParse pp("erf");
 
     // Get the radius inside the domain
-    pp.query("in_rad",m_in_rad);
+    pp.queryAdd("in_rad",m_in_rad);
 
     // User-specified region is given in physical coordinates, not index space
     std::vector<Real> box_lo(3), box_hi(3);

--- a/Source/Initialization/ERF_InitBCs.cpp
+++ b/Source/Initialization/ERF_InitBCs.cpp
@@ -69,11 +69,11 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
         ParmParse pp(pp_text);
 
         std::string bc_type_in;
-        if (pp.query("type", bc_type_in) <= 0)
+        if (pp.queryAdd("type", bc_type_in) <= 0)
         {
             pp_text = bcid;
             pp = ParmParse(pp_text);
-            pp.query("type", bc_type_in);
+            pp.queryAdd("type", bc_type_in);
         }
 
         std::string bc_type = amrex::toLower(bc_type_in);
@@ -136,9 +136,9 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
             } else {
                 // Test for input data file if at xlo face
                 std::string dirichlet_file;
-                auto file_exists = pp.query("dirichlet_file", dirichlet_file);
+                auto file_exists = pp.queryAdd("dirichlet_file", dirichlet_file);
                 if (file_exists) {
-                    pp.query("read_prim_theta", read_prim_theta);
+                    pp.queryAdd("read_prim_theta", read_prim_theta);
                     init_Dirichlet_bc_data(dirichlet_file);
                 } else {
                     pp.getarr("velocity", v, 0, AMREX_SPACEDIM);
@@ -152,7 +152,7 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
             if (input_bndry_planes && m_r2d->ingested_density()) {
                 m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = zero_d;
             } else {
-                if (!pp.query("density", rho_in)) {
+                if (!pp.queryAdd("density", rho_in)) {
                     amrex::Print() << "Using interior values to set conserved vars" << std::endl;
                 }
                 m_bc_extdir_vals[BCVars::Rho_bc_comp][ori] = rho_in;
@@ -174,14 +174,14 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
             // This lets upstream-propagating acoustic waves exit the domain
             // instead of reflecting off the rigid Dirichlet boundary.
             bool nonreflecting = false;
-            pp.query("nonreflecting", nonreflecting);
+            pp.queryAdd("nonreflecting", nonreflecting);
             m_bc_nonreflecting[ori] = nonreflecting;
 
             Real scalar_in = zero_d;
             if (input_bndry_planes && m_r2d->ingested_scalar()) {
                 m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = zero_d;
             } else {
-                if (pp.query("scalar", scalar_in))
+                if (pp.queryAdd("scalar", scalar_in))
                 m_bc_extdir_vals[BCVars::RhoScalar_bc_comp][ori] = rho_in*scalar_in;
             }
 
@@ -190,14 +190,14 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
                 if (input_bndry_planes && m_r2d->ingested_q1()) {
                     m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = zero_d;
                 } else {
-                    if (pp.query("qv", qv_in))
+                    if (pp.queryAdd("qv", qv_in))
                     m_bc_extdir_vals[BCVars::RhoQ1_bc_comp][ori] = rho_in*qv_in;
                 }
                 Real qc_in = zero_d;
                 if (input_bndry_planes && m_r2d->ingested_q2()) {
                     m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = zero_d;
                 } else {
-                    if (pp.query("qc", qc_in))
+                    if (pp.queryAdd("qc", qc_in))
                     m_bc_extdir_vals[BCVars::RhoQ2_bc_comp][ori] = rho_in*qc_in;
                 }
             }
@@ -206,7 +206,7 @@ void ERF::init_phys_bcs (bool& read_prim_theta)
             if (input_bndry_planes && m_r2d->ingested_KE()) {
                 m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori] = zero_d;
             } else {
-                if (pp.query("KE", KE_in))
+                if (pp.queryAdd("KE", KE_in))
                 m_bc_extdir_vals[BCVars::RhoKE_bc_comp][ori] = rho_in*KE_in;
             }
         }

--- a/Source/Initialization/ERF_InitCustomPertState.cpp
+++ b/Source/Initialization/ERF_InitCustomPertState.cpp
@@ -140,7 +140,7 @@ ERF::init_custom (int lev)
     // Should we initialize the velocities from a checkpoint file?
     static std::string init_vels_from_checkpoint;
     ParmParse pp("erf");
-    if (pp.query("init_vels_from_checkpoint",init_vels_from_checkpoint)) {
+    if (pp.queryAdd("init_vels_from_checkpoint",init_vels_from_checkpoint)) {
         ReadVelsOnlyFromCheckpointFile(lev,init_vels_from_checkpoint);
     } else {
         MultiFab::Add(lev_new[Vars::xvel], xvel_pert, 0,             0,             1, xvel_pert.nGrowVect());

--- a/Source/Initialization/ERF_InitCustomTerrain.cpp
+++ b/Source/Initialization/ERF_InitCustomTerrain.cpp
@@ -26,7 +26,7 @@ init_my_custom_terrain ( const Geometry& geom,
     //
     ParmParse pp("erf");
     bool test_mapfactor = false;
-    pp.query("test_mapfactor",test_mapfactor);
+    pp.queryAdd("test_mapfactor",test_mapfactor);
 
     Real mf_m;
     if (test_mapfactor) {
@@ -55,7 +55,7 @@ init_my_custom_terrain ( const Geometry& geom,
     int k0 = domlo_z;
 
     std::string custom_terrain_type = "None";
-    ParmParse pp_prob("prob"); pp_prob.query("custom_terrain_type", custom_terrain_type);
+    ParmParse pp_prob("prob"); pp_prob.queryAdd("custom_terrain_type", custom_terrain_type);
 
     amrex::Box zbx = terrain_fab.box();
     if (zbx.smallEnd(2) <= k0)
@@ -65,13 +65,13 @@ init_my_custom_terrain ( const Geometry& geom,
         if (custom_terrain_type == "WoA") {
 
             // Default to x-direction
-            int dir = 0;  pp_prob.query("dir", dir);
+            int dir = 0;  pp_prob.queryAdd("dir", dir);
 
-            Real  L        = Real(100.0); pp_prob.query("L"        , L);
-            Real  z_offset =   zero; pp_prob.query("z_offset" , z_offset);
+            Real  L        = Real(100.0); pp_prob.queryAdd("L"        , L);
+            Real  z_offset =   zero; pp_prob.queryAdd("z_offset" , z_offset);
 
             // If hm is nonzero, then use alternate hill definition
-            Real  hm       =   zero; pp_prob.query("hmax" , hm);
+            Real  hm       =   zero; pp_prob.queryAdd("hmax" , hm);
 
             // This is a 2D hill with variation in only the x-direction
             if (dir == 0) {
@@ -197,8 +197,8 @@ init_my_custom_terrain ( const Geometry& geom,
 
         } else if (custom_terrain_type == "MovingSineWave") {
 
-            Real Ampl        = zero;  pp_prob.query("Ampl", Ampl);
-            Real wavelength  = Real(100.); pp_prob.query("wavelength", wavelength);
+            Real Ampl        = zero;  pp_prob.queryAdd("Ampl", Ampl);
+            Real wavelength  = Real(100.); pp_prob.queryAdd("wavelength", wavelength);
 
             Real kp          = two * PI / wavelength;
             Real g           = CONST_GRAV;
@@ -240,7 +240,7 @@ init_my_custom_terrain ( const Geometry& geom,
             });
 
         } else if (custom_terrain_type == "RaisedFlat") {
-            Real  z_offset = zero; pp_prob.query("z_offset" , z_offset);
+            Real  z_offset = zero; pp_prob.queryAdd("z_offset" , z_offset);
             ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)
             {
                 z_arr(i,j,k0) = z_offset;
@@ -248,9 +248,9 @@ init_my_custom_terrain ( const Geometry& geom,
         } else if (custom_terrain_type == "Cos4Hill") {
 
             // Get prob parameters (must be outside GPU kernel)
-            Real hm = zero; pp_prob.query("hmax", hm);
-            Real L  = Real(100.0); pp_prob.query("L", L);
-            Real z_offset = zero; pp_prob.query("z_offset", z_offset);
+            Real hm = zero; pp_prob.queryAdd("hmax", hm);
+            Real L  = Real(100.0); pp_prob.queryAdd("L", L);
+            Real z_offset = zero; pp_prob.queryAdd("z_offset", z_offset);
             Real fourL = four * L;
 
             ParallelFor(zbx, [=] AMREX_GPU_DEVICE (int i, int j, int)

--- a/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
+++ b/Source/LandSurfaceModel/Noah-MP/ERF_NOAHMP.H
@@ -298,7 +298,7 @@ public:
     void m_ensure_nsoil_resolved () {
         if (m_nsoil_resolved) { return; }
         amrex::ParmParse pp_nsoil("erf");
-        pp_nsoil.query("lsm_nsoil", m_nsoil);
+        pp_nsoil.queryAdd("lsm_nsoil", m_nsoil);
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_nsoil >= 1, "erf.lsm_nsoil must be >= 1");
         m_lsm_data_size = LsmData_NOAHMP::NumVars + m_num_soil_groups*m_nsoil;
         m_nsoil_resolved = true;

--- a/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_AdvanceMorrison.cpp
@@ -186,7 +186,7 @@ Real ndcnst_to_number_mixing_ratio (const Real ndcnst, const Real rho_erf) noexc
         // Check if CPP or FORT answer is used
         ParmParse pp("erf");
         bool use_morr_cpp_answer = true;
-        pp.query("use_morr_cpp_answer", use_morr_cpp_answer);
+        pp.queryAdd("use_morr_cpp_answer", use_morr_cpp_answer);
 
         // Ensure that only one of these is true
         bool run_morr_cpp  =  use_morr_cpp_answer;
@@ -197,7 +197,7 @@ Real ndcnst_to_number_mixing_ratio (const Real ndcnst, const Real rho_erf) noexc
         // Allow user to override constant droplet concentration from inputs file
         // Constant droplet concentration (if INUM = 1)
         Real m_ndcnst = Real(250.0);  // Droplet number concentration (cm^-3)
-        pp.query("morrison_ndcnst", m_ndcnst);
+        pp.queryAdd("morrison_ndcnst", m_ndcnst);
 
         // Loop through the grids
         //

--- a/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
+++ b/Source/Microphysics/Morrison/ERF_InitMorrison.cpp
@@ -51,7 +51,7 @@ Morrison::Init (const MultiFab& cons_in,
 #ifdef ERF_USE_MORR_FORT
     bool use_cpp = true;
     amrex::ParmParse pp("erf");
-    pp.query("use_morr_cpp_answer", use_cpp);
+    pp.queryAdd("use_morr_cpp_answer", use_cpp);
 
     if (!use_cpp) {
         MoistureType moisture_type;

--- a/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
+++ b/Source/Microphysics/SuperDropletsMoist/ERF_SuperDropletsMoistInit.cpp
@@ -40,40 +40,40 @@ void SuperDropletsMoist::readInputs ()
 
     // include phase change in super-droplet dynamics?
     m_flag_phase_change = true; //default
-    pp.query("include_phase_change", m_flag_phase_change);
+    pp.queryAdd("include_phase_change", m_flag_phase_change);
     // include advection in super-droplet dynamics?
     m_flag_advection = true; //default
-    pp.query("include_advection", m_flag_advection);
+    pp.queryAdd("include_advection", m_flag_advection);
     // include coalescence in super-droplet dynamics?
     m_flag_coalescence = true; //default
-    pp.query("include_coalescence", m_flag_coalescence);
+    pp.queryAdd("include_coalescence", m_flag_coalescence);
 
     // include cold processes?
     m_with_ice = true;
-    pp.query("include_cold_processes", m_with_ice);
+    pp.queryAdd("include_cold_processes", m_with_ice);
 
     // initial distribution type
     m_init_type = SDMoistInit::uniform;
-    pp.query("distribution_type", m_init_type);
+    pp.queryAdd("distribution_type", m_init_type);
 
     // minimum radius for rain
     m_r_rain = Real(4.0e-5); // 40 micrometers
-    pp.query("radius_raindrop", m_r_rain);
+    pp.queryAdd("radius_raindrop", m_r_rain);
 
     m_rime_ratio = 0.3;
-    pp.query("rime_mass_ratio", m_rime_ratio);
+    pp.queryAdd("rime_mass_ratio", m_rime_ratio);
 
     // whether to run in kinematic mode
     m_kinematic_mode = false;
-    pp.query("kinematic_mode", m_kinematic_mode);
+    pp.queryAdd("kinematic_mode", m_kinematic_mode);
 
     // simulation dimensionality
     m_dimensionality = SDMSimulationDim::three_d;
-    pp.query("dimensionality", m_dimensionality);
+    pp.queryAdd("dimensionality", m_dimensionality);
 
     // recycle super-droplets
     m_recycle_particles = false;
-    pp.query("recycle_particles", m_recycle_particles);
+    pp.queryAdd("recycle_particles", m_recycle_particles);
 
 
     // get vapour/condensate species names
@@ -125,18 +125,18 @@ void SuperDropletsMoist::readInputs ()
 
     // number of time steps between writing distribution  diagnostics to file
     m_diagnostics_iter = 1; //default
-    pp.query("diagnostics_interval", m_diagnostics_iter);
+    pp.queryAdd("diagnostics_interval", m_diagnostics_iter);
 
     // number of substeps for phase change process
     m_num_substeps_phase_change = 1; //default
-    pp.query("num_substeps_phase_change", m_num_substeps_phase_change);
+    pp.queryAdd("num_substeps_phase_change", m_num_substeps_phase_change);
 
     // let superdroplets relax to a physically correct size at initialization?
     m_init_phase_change = false; //default
-    pp.query("initial_phase_change_relaxation", m_init_phase_change);
+    pp.queryAdd("initial_phase_change_relaxation", m_init_phase_change);
     // time (in seconds) of initial relaxation
     m_init_phase_change_time = Real(10.0); //default
-    pp.query("initial_phase_change_relaxation_time", m_init_phase_change_time);
+    pp.queryAdd("initial_phase_change_relaxation_time", m_init_phase_change_time);
 
     return;
 }

--- a/Source/Microphysics/WDM6/ERF_AdvanceWDM6.cpp
+++ b/Source/Microphysics/WDM6/ERF_AdvanceWDM6.cpp
@@ -688,7 +688,7 @@ void WDM6::Advance(const Real& dt_advance,
     std::vector<int> micro_diag_target_column;
     {
         amrex::ParmParse pp("erf");
-        pp.query("microphysics_debug", microphysics_debug);
+        pp.queryAdd("microphysics_debug", microphysics_debug);
         pp.queryarr("micro_diag_target_column", micro_diag_target_column);
     }
     microphysics_debug = std::max(0, std::min(2, microphysics_debug));
@@ -696,7 +696,7 @@ void WDM6::Advance(const Real& dt_advance,
     bool use_wdm6_cpp_answer = false;
     {
         amrex::ParmParse pp("erf");
-        pp.query("use_wdm6_cpp_answer", use_wdm6_cpp_answer);
+        pp.queryAdd("use_wdm6_cpp_answer", use_wdm6_cpp_answer);
     }
     const bool run_wdm6_fort = !use_wdm6_cpp_answer;
 #endif

--- a/Source/Microphysics/WDM6/ERF_InitWDM6.cpp
+++ b/Source/Microphysics/WDM6/ERF_InitWDM6.cpp
@@ -21,7 +21,7 @@ WDM6::Init(const MultiFab& cons_in,
 
     // Read CCN concentration from input
     amrex::ParmParse pp("wdm6");
-    pp.query("ccn0", m_ccn0);  // default 100.0e6 m^-3
+    pp.queryAdd("ccn0", m_ccn0);  // default 100.0e6 m^-3
 
     // Graupel/hail regime selector. The Fortran gates on `hail_opt .eq. 1`
     // (ERF_module_mp_wdm6.F90:3259), so every value other than 1 selects the
@@ -29,7 +29,7 @@ WDM6::Init(const MultiFab& cons_in,
     // inventing a stricter 0/1 validation the Fortran does not perform.
     // Must be resolved before initialize_coeffs(), which branches on it.
     int hail_opt_in = 0;
-    pp.query("hail_opt", hail_opt_in);  // default 0 = graupel
+    pp.queryAdd("hail_opt", hail_opt_in);  // default 0 = graupel
     m_hail_opt = (hail_opt_in == 1);
 
     amrex::Print() << "WDM6 Initialization: CCN0 = " << m_ccn0 << " #/m^3"

--- a/Source/Microphysics/WSM6/ERF_AdvanceWSM6.cpp
+++ b/Source/Microphysics/WSM6/ERF_AdvanceWSM6.cpp
@@ -852,8 +852,8 @@ WSM6::Advance(const Real& dt_advance,
     std::vector<int> micro_diag_target_column;
     {
       amrex::ParmParse pp("erf");
-      pp.query("microphysics_debug", microphysics_debug);
-      pp.query("micro_diag_mode", micro_diag_mode);
+      pp.queryAdd("microphysics_debug", microphysics_debug);
+      pp.queryAdd("micro_diag_mode", micro_diag_mode);
       pp.queryarr("micro_diag_tags", micro_diag_tags);
       pp.queryarr("micro_diag_expr", micro_diag_expr);
       pp.queryarr("micro_diag_store", micro_diag_store);
@@ -868,7 +868,7 @@ WSM6::Advance(const Real& dt_advance,
         : std::min(microphysics_debug, 1);
     bool use_wsm6_cpp_answer = false;
     { amrex::ParmParse pp("erf");
-      pp.query("use_wsm6_cpp_answer", use_wsm6_cpp_answer); }
+      pp.queryAdd("use_wsm6_cpp_answer", use_wsm6_cpp_answer); }
     bool run_wsm6_fort = !use_wsm6_cpp_answer;
 
     static bool wsm6_inited = false;

--- a/Source/PBL/Shoc/ERF_ShocTypes.H
+++ b/Source/PBL/Shoc/ERF_ShocTypes.H
@@ -284,43 +284,43 @@ read_shoc_runtime_options (ShocRuntimeOptions& opts)
 {
     amrex::ParmParse pp("erf.shoc");
 
-    pp.query("lambda_low", opts.lambda_low);
-    pp.query("lambda_high", opts.lambda_high);
-    pp.query("lambda_slope", opts.lambda_slope);
-    pp.query("lambda_thresh", opts.lambda_thresh);
-    pp.query("thl2tune", opts.thl2tune);
-    pp.query("qw2tune", opts.qw2tune);
-    pp.query("qwthl2tune", opts.qwthl2tune);
-    pp.query("w2tune", opts.w2tune);
-    pp.query("length_fac", opts.length_fac);
-    pp.query("c_diag_3rd_mom", opts.c_diag_3rd_mom);
-    pp.query("coeff_kh", opts.coeff_kh);
-    pp.query("coeff_km", opts.coeff_km);
-    pp.query("top_taper_depth", opts.top_taper_depth);
-    pp.query("top_taper_min_factor", opts.top_taper_min_factor);
-    pp.query("shoc_1p5tke", opts.shoc_1p5tke);
-    pp.query("extra_shoc_diags", opts.extra_shoc_diags);
-    pp.query("apply_tms", opts.apply_tms);
-    pp.query("check_flux_state", opts.check_flux_state);
-    pp.query("column_conservation_check", opts.column_conservation_check);
-    pp.query("debug_summary", opts.debug_summary);
-    pp.query("allow_tendency_microphysics_overlap", opts.allow_tendency_microphysics_overlap);
-    pp.query("signed_tke_production", opts.signed_tke_production);
-    pp.query("debug_bad_column", opts.debug_bad_column);
-    pp.query("debug_bad_column_abort", opts.debug_bad_column_abort);
-    pp.query("debug_bad_column_max_reports", opts.debug_bad_column_max_reports);
-    pp.query("debug_bad_column_theta_tend_threshold", opts.debug_bad_column_theta_tend_threshold);
-    pp.query("debug_bad_column_q_tend_threshold", opts.debug_bad_column_q_tend_threshold);
-    pp.query("debug_bad_column_brunt_threshold", opts.debug_bad_column_brunt_threshold);
-    pp.query("debug_bad_column_min_dz", opts.debug_bad_column_min_dz);
-    pp.query("debug_bad_column_scalar_moment_threshold", opts.debug_bad_column_scalar_moment_threshold);
-    pp.query("debug_disable_pdf_cloud_increment", opts.debug_disable_pdf_cloud_increment);
-    pp.query("debug_disable_theta_state_update", opts.debug_disable_theta_state_update);
-    pp.query("debug_disable_moisture_state_update", opts.debug_disable_moisture_state_update);
-    pp.query("debug_disable_tke_state_update", opts.debug_disable_tke_state_update);
+    pp.queryAdd("lambda_low", opts.lambda_low);
+    pp.queryAdd("lambda_high", opts.lambda_high);
+    pp.queryAdd("lambda_slope", opts.lambda_slope);
+    pp.queryAdd("lambda_thresh", opts.lambda_thresh);
+    pp.queryAdd("thl2tune", opts.thl2tune);
+    pp.queryAdd("qw2tune", opts.qw2tune);
+    pp.queryAdd("qwthl2tune", opts.qwthl2tune);
+    pp.queryAdd("w2tune", opts.w2tune);
+    pp.queryAdd("length_fac", opts.length_fac);
+    pp.queryAdd("c_diag_3rd_mom", opts.c_diag_3rd_mom);
+    pp.queryAdd("coeff_kh", opts.coeff_kh);
+    pp.queryAdd("coeff_km", opts.coeff_km);
+    pp.queryAdd("top_taper_depth", opts.top_taper_depth);
+    pp.queryAdd("top_taper_min_factor", opts.top_taper_min_factor);
+    pp.queryAdd("shoc_1p5tke", opts.shoc_1p5tke);
+    pp.queryAdd("extra_shoc_diags", opts.extra_shoc_diags);
+    pp.queryAdd("apply_tms", opts.apply_tms);
+    pp.queryAdd("check_flux_state", opts.check_flux_state);
+    pp.queryAdd("column_conservation_check", opts.column_conservation_check);
+    pp.queryAdd("debug_summary", opts.debug_summary);
+    pp.queryAdd("allow_tendency_microphysics_overlap", opts.allow_tendency_microphysics_overlap);
+    pp.queryAdd("signed_tke_production", opts.signed_tke_production);
+    pp.queryAdd("debug_bad_column", opts.debug_bad_column);
+    pp.queryAdd("debug_bad_column_abort", opts.debug_bad_column_abort);
+    pp.queryAdd("debug_bad_column_max_reports", opts.debug_bad_column_max_reports);
+    pp.queryAdd("debug_bad_column_theta_tend_threshold", opts.debug_bad_column_theta_tend_threshold);
+    pp.queryAdd("debug_bad_column_q_tend_threshold", opts.debug_bad_column_q_tend_threshold);
+    pp.queryAdd("debug_bad_column_brunt_threshold", opts.debug_bad_column_brunt_threshold);
+    pp.queryAdd("debug_bad_column_min_dz", opts.debug_bad_column_min_dz);
+    pp.queryAdd("debug_bad_column_scalar_moment_threshold", opts.debug_bad_column_scalar_moment_threshold);
+    pp.queryAdd("debug_disable_pdf_cloud_increment", opts.debug_disable_pdf_cloud_increment);
+    pp.queryAdd("debug_disable_theta_state_update", opts.debug_disable_theta_state_update);
+    pp.queryAdd("debug_disable_moisture_state_update", opts.debug_disable_moisture_state_update);
+    pp.queryAdd("debug_disable_tke_state_update", opts.debug_disable_tke_state_update);
 
     std::string transport_mode = shoc_transport_mode_name(opts.transport_mode);
-    if (pp.query("transport_mode", transport_mode)) {
+    if (pp.queryAdd("transport_mode", transport_mode)) {
         std::string error_message;
         if (!parse_shoc_transport_mode_string(transport_mode, opts.transport_mode, error_message)) {
             amrex::Abort(error_message.c_str());
@@ -328,7 +328,7 @@ read_shoc_runtime_options (ShocRuntimeOptions& opts)
     }
 
     std::string momentum_transport = shoc_momentum_transport_name(opts.momentum_transport);
-    if (pp.query("momentum_transport", momentum_transport)) {
+    if (pp.queryAdd("momentum_transport", momentum_transport)) {
         std::string error_message;
         if (!parse_shoc_momentum_transport_string(momentum_transport,
                                                   opts.momentum_transport,

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -100,17 +100,17 @@ Radiation::Radiation (const int& lev,
     pp.get("rad_t_sfc", m_rad_t_sfc);
 
     // Radiation timestep, as a number of atm steps
-    pp.query("rad_freq_in_steps", m_rad_freq_in_steps);
+    pp.queryAdd("rad_freq_in_steps", m_rad_freq_in_steps);
 
     // Get nvar if specified
-    pp.query("rad_nvar", m_rad_nvar);
+    pp.queryAdd("rad_nvar", m_rad_nvar);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_rad_nvar >= 0,
         "erf.rad_nvar must be greater than 0. "
         "It controls the amount of memory allocated for temporaries with RRTMGP; "
         "a value of 0 would allocate no memory.");
 
     // Number of columns per RRTMGP chunk (controls peak GPU memory)
-    pp.query("rad_ncol_chunk", m_ncol_chunk_requested);
+    pp.queryAdd("rad_ncol_chunk", m_ncol_chunk_requested);
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(m_ncol_chunk_requested > 0,
         "erf.rad_ncol_chunk must be a positive integer (default 5000). "
         "It controls the number of columns processed per RRTMGP kernel launch; "
@@ -118,50 +118,50 @@ Radiation::Radiation (const int& lev,
     m_ncol_chunk = m_ncol_chunk_requested;
 
     // Flag to write fluxes to plt file
-    pp.query("rad_write_fluxes", m_rad_write_fluxes);
+    pp.queryAdd("rad_write_fluxes", m_rad_write_fluxes);
 
     // Do MCICA subcolumn sampling
-    pp.query("rad_do_subcol_sampling", m_do_subcol_sampling);
+    pp.queryAdd("rad_do_subcol_sampling", m_do_subcol_sampling);
 
     // Determine orbital year. If orbital_year is negative, use current year
     // from timestamp for orbital year; if non-negative, use provided orbital year
     // for duration of simulation.  Note that this is keyed off the value itself,
     // not off whether the input was present, so that a negative value defers to
     // the timestamp as documented.
-    pp.query("rad_orbital_year", m_orbital_year);
+    pp.queryAdd("rad_orbital_year", m_orbital_year);
     m_fixed_orbital_year = (m_orbital_year >= 0);
 
     // Get orbital parameters from inputs file
-    pp.query("rad_orbital_eccentricity", m_orbital_eccen);
-    pp.query("rad_orbital_obliquity"   , m_orbital_obliq);
-    pp.query("rad_orbital_mvelp"       , m_orbital_mvelp);
+    pp.queryAdd("rad_orbital_eccentricity", m_orbital_eccen);
+    pp.queryAdd("rad_orbital_obliquity"   , m_orbital_obliq);
+    pp.queryAdd("rad_orbital_mvelp"       , m_orbital_mvelp);
 
     // Get a constant lat/lon for idealized simulations
-    pp.query("rad_cons_lat", m_lat_cons);
-    pp.query("rad_cons_lon", m_lon_cons);
+    pp.queryAdd("rad_cons_lat", m_lat_cons);
+    pp.queryAdd("rad_cons_lon", m_lon_cons);
 
     // Value for prescribing an invariant solar constant (i.e. total solar irradiance at
     // TOA).  Used for idealized experiments such as RCE. Disabled when value is less than zero
-    pp.query("fixed_total_solar_irradiance", m_fixed_total_solar_irradiance);
+    pp.queryAdd("fixed_total_solar_irradiance", m_fixed_total_solar_irradiance);
 
     // Determine whether or not we are using a fixed solar zenith angle (positive value)
-    pp.query("fixed_solar_zenith_angle", m_fixed_solar_zenith_angle);
+    pp.queryAdd("fixed_solar_zenith_angle", m_fixed_solar_zenith_angle);
 
     // Get prescribed surface values of greenhouse gases
-    pp.query("co2vmr", m_co2vmr);
+    pp.queryAdd("co2vmr", m_co2vmr);
     pp.queryarr("o3vmr" , m_o3vmr );
-    pp.query("n2ovmr", m_n2ovmr);
-    pp.query("covmr" , m_covmr );
-    pp.query("ch4vmr", m_ch4vmr);
-    pp.query("o2vmr" , m_o2vmr );
-    pp.query("n2vmr" , m_n2vmr );
+    pp.queryAdd("n2ovmr", m_n2ovmr);
+    pp.queryAdd("covmr" , m_covmr );
+    pp.queryAdd("ch4vmr", m_ch4vmr);
+    pp.queryAdd("o2vmr" , m_o2vmr );
+    pp.queryAdd("n2vmr" , m_n2vmr );
 
     // Aerosol forcing hook (not implemented). The aerosol arrays that used to be
     // passed through rrtmgp_main were never populated with real data, so enabling
     // this flag only ever multiplied radiation by zero aerosol optics. The hook is
     // kept so a future SPA/prescribed-aerosol scheme can wire in without touching
     // the ParmParse surface.
-    pp.query("rad_do_aerosol", m_do_aerosol_rad);
+    pp.queryAdd("rad_do_aerosol", m_do_aerosol_rad);
     if (m_do_aerosol_rad) {
         amrex::Abort("erf.rad_do_aerosol = true is not supported: aerosol forcing is "
                      "currently not implemented in the ERF RRTMGP interface. The hook "
@@ -170,15 +170,15 @@ Radiation::Radiation (const int& lev,
     }
 
     // Whether we do extra clean/clear sky calculations
-    pp.query("rad_extra_clnclrsky_diag", m_extra_clnclrsky_diag);
-    pp.query("rad_extra_clnsky_diag"   , m_extra_clnsky_diag);
+    pp.queryAdd("rad_extra_clnclrsky_diag", m_extra_clnclrsky_diag);
+    pp.queryAdd("rad_extra_clnsky_diag"   , m_extra_clnsky_diag);
 
     // Parse path and file names
-    pp.query("rrtmgp_file_path"      , rrtmgp_file_path);
-    pp.query("rrtmgp_coeffs_sw"      , rrtmgp_coeffs_sw  );
-    pp.query("rrtmgp_coeffs_lw"      , rrtmgp_coeffs_lw  );
-    pp.query("rrtmgp_cloud_optics_sw", rrtmgp_cloud_optics_sw);
-    pp.query("rrtmgp_cloud_optics_lw", rrtmgp_cloud_optics_lw);
+    pp.queryAdd("rrtmgp_file_path"      , rrtmgp_file_path);
+    pp.queryAdd("rrtmgp_coeffs_sw"      , rrtmgp_coeffs_sw  );
+    pp.queryAdd("rrtmgp_coeffs_lw"      , rrtmgp_coeffs_lw  );
+    pp.queryAdd("rrtmgp_cloud_optics_sw", rrtmgp_cloud_optics_sw);
+    pp.queryAdd("rrtmgp_cloud_optics_lw", rrtmgp_cloud_optics_lw);
 
     // Fail early, and with a message that names the missing files and the inputs that
     // control them, rather than letting netCDF report a bare "No such file or directory"

--- a/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
@@ -68,7 +68,7 @@ public:
     {
         amrex::ParmParse pp("erf.rad");
         if (pp.contains("datalog")) {
-            pp.query("datalog", datalogname);
+            pp.queryAdd("datalog", datalogname);
 
             setRecordDataInfo(datalogname);
         }

--- a/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
+++ b/Source/PhysicsInterfaces/Shoc/ERF_ShocInterface.cpp
@@ -57,26 +57,26 @@ SHOCInterface::SHOCInterface (const int& lev,
     ParmParse pp("erf.shoc");
 
     // Parse runtime inputs at start up
-    pp.query("lambda_low"      , runtime_options.lambda_low    );
-    pp.query("lambda_high"     , runtime_options.lambda_high   );
-    pp.query("lambda_slope"    , runtime_options.lambda_slope  );
-    pp.query("lambda_thresh"   , runtime_options.lambda_thresh );
-    pp.query("thl2tune"        , runtime_options.thl2tune      );
-    pp.query("qw2tune"         , runtime_options.qw2tune       );
-    pp.query("qwthl2tune"      , runtime_options.qwthl2tune    );
-    pp.query("w2tune"          , runtime_options.w2tune        );
-    pp.query("length_fac"      , runtime_options.length_fac    );
-    pp.query("c_diag_3rd_mom"  , runtime_options.c_diag_3rd_mom);
-    pp.query("coeff_kh"        , runtime_options.Ckh           );
-    pp.query("coeff_km"        , runtime_options.Ckm           );
-    pp.query("shoc_1p5tke"     , runtime_options.shoc_1p5tke   );
-    pp.query("extra_shoc_diags", runtime_options.extra_diags   );
+    pp.queryAdd("lambda_low"      , runtime_options.lambda_low    );
+    pp.queryAdd("lambda_high"     , runtime_options.lambda_high   );
+    pp.queryAdd("lambda_slope"    , runtime_options.lambda_slope  );
+    pp.queryAdd("lambda_thresh"   , runtime_options.lambda_thresh );
+    pp.queryAdd("thl2tune"        , runtime_options.thl2tune      );
+    pp.queryAdd("qw2tune"         , runtime_options.qw2tune       );
+    pp.queryAdd("qwthl2tune"      , runtime_options.qwthl2tune    );
+    pp.queryAdd("w2tune"          , runtime_options.w2tune        );
+    pp.queryAdd("length_fac"      , runtime_options.length_fac    );
+    pp.queryAdd("c_diag_3rd_mom"  , runtime_options.c_diag_3rd_mom);
+    pp.queryAdd("coeff_kh"        , runtime_options.Ckh           );
+    pp.queryAdd("coeff_km"        , runtime_options.Ckm           );
+    pp.queryAdd("shoc_1p5tke"     , runtime_options.shoc_1p5tke   );
+    pp.queryAdd("extra_shoc_diags", runtime_options.extra_diags   );
 
     // Set to default but allow us to change it through the inputs file
-    pp.query("apply_tms", apply_tms);
-    pp.query("check_flux_state", check_flux_state);
-    pp.query("extra_shoc_diags", extra_shoc_diags);
-    pp.query("column_conservation_check", column_conservation_check);
+    pp.queryAdd("apply_tms", apply_tms);
+    pp.queryAdd("check_flux_state", check_flux_state);
+    pp.queryAdd("extra_shoc_diags", extra_shoc_diags);
+    pp.queryAdd("column_conservation_check", column_conservation_check);
 }
 
 

--- a/Source/Refinement/ERF_RefineBox.cpp
+++ b/Source/Refinement/ERF_RefineBox.cpp
@@ -41,7 +41,7 @@ ERF::read_box_for_refinement (std::string& ref_prefix, int& lev_for_box, RealBox
 
     lev_for_box = max_level;
     if (num_real_lo > 0) {
-        ppr.query("max_level",lev_for_box);
+        ppr.queryAdd("max_level",lev_for_box);
     } else if (num_indx_lo > 0 || num_indx_lo_crse > 0) {
         ppr.get("max_level",lev_for_box);
     }

--- a/Source/Refinement/ERF_Tagging.cpp
+++ b/Source/Refinement/ERF_Tagging.cpp
@@ -450,7 +450,7 @@ ERF::ErrorEst (int levc, TagBoxArray& tags, Real time, int /*ngrow*/)
             ParmParse ppr(ref_prefix);
 
             double ref_start_time = -1.0;
-            ppr.query("start_time",ref_start_time);
+            ppr.queryAdd("start_time",ref_start_time);
 
             if (time >= ref_start_time) {
 

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -180,7 +180,7 @@ init_which_terrain_grid (int lev,
     // User-selected method from inputs file (BTF default)
     ParmParse pp("erf");
     int terrain_smoothing = 0;
-    pp.query("terrain_smoothing", terrain_smoothing);
+    pp.queryAdd("terrain_smoothing", terrain_smoothing);
 
     if (lev > 0 && terrain_smoothing != 0) {
         Abort("Must use terrain_smoothing = 0 when doing multilevel");
@@ -349,7 +349,7 @@ init_which_terrain_grid (int lev,
 
         // Minimum allowed fractional grid spacing
         Real gamma_m = myhalf;
-        pp.query("terrain_gamma_m", gamma_m);
+        pp.queryAdd("terrain_gamma_m", gamma_m);
         Real z_H     = Real(2.44)*h_m/(1-gamma_m); // Klemp2011 Eqn. 11
 
         // Populate h_mf at k>0 with h_s, solving in ordered 2D slices

--- a/Source/WindFarmParametrization/ERF_WindFarm.cpp
+++ b/Source/WindFarmParametrization/ERF_WindFarm.cpp
@@ -109,7 +109,7 @@ WindFarm::init_windfarm_lat_lon (const std::string windfarm_loc_table,
     // Rotate about that point
     ParmParse pp("erf");
     std::string fname_usgs;
-    auto valid_fname_USGS = pp.query("terrain_file_name_USGS",fname_usgs);
+    auto valid_fname_USGS = pp.queryAdd("terrain_file_name_USGS",fname_usgs);
     Real lon_ref, lat_ref;
 
     if (valid_fname_USGS) {


### PR DESCRIPTION
This has no change in code functionality but allows the ParmParse data base to include default values which then become evident when the data base is printed.