### PR TITLE
Fix the surface-layer restart with input_sounding initialisation (#3954)

### DIFF
--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -203,8 +203,12 @@ void ERF::MakeNewLevelFromScratch (int lev, Real time, const BoxArray& ba_in,
             init_only(lev, time);
         }
     } else {
-        // if restarting and nudging from input sounding, load the input sounding files
-        if (lev == 0 && solverChoice.init_type == InitType::Input_Sounding && solverChoice.nudging_from_input_sounding)
+        // If restarting from an input-sounding run, load the sounding again. It is
+        // needed for nudging, and InitData_post also takes the surface temperature
+        // and moisture of the surface layer from its reference values; without this
+        // read those are zero on a restart, the surface layer sees a 0 K surface,
+        // and the restarted run drifts from the uninterrupted one.
+        if (lev == 0 && solverChoice.init_type == InitType::Input_Sounding)
         {
             if (input_sounding_data.input_sounding_file.empty()) {
                 Error("input_sounding file name must be provided via input");

--- a/Source/IO/ERF_Checkpoint.cpp
+++ b/Source/IO/ERF_Checkpoint.cpp
@@ -460,6 +460,7 @@ ERF::WriteCheckpointFile () const
             write_sl_var(m_SurfaceLayer->get_q_surf(lev), "Qsurf");
             write_sl_var(m_SurfaceLayer->get_pblh(lev)  , "PBLH");
             write_sl_var(m_SurfaceLayer->get_z0(lev)    , "Z0");
+            write_sl_var(m_SurfaceLayer->get_t_surf(lev), "Tsurf");
 
             // The exponentially filtered averages behind erf.most.time_average.  The
             // region policy carries the filter state in these MultiFabs (the plane and
@@ -1683,6 +1684,10 @@ ERF::ReadCheckpointFileSurfaceLayer ()
 
         // Z0
         read_most_var("Z0", m_SurfaceLayer->get_z0(lev));
+        // Surface temperature. Not every path rewrites it each step (a fixed
+        // surface temperature with no heating rate keeps whatever was set at
+        // initialization), so it has to come back from the checkpoint too.
+        read_most_var("Tsurf", m_SurfaceLayer->get_t_surf(lev));
 
         // The exponentially filtered averages.  We only mark the filter as initialized
         // if every piece of its state came back, so that a partial restore degrades to


### PR DESCRIPTION
Fixes #3954.

## Problem

A run with `zlo.type = surface_layer` and `erf.init_type = input_sounding` does not reproduce itself after a checkpoint restart. `InitData_post` sets the surface layer's surface temperature and moisture from the sounding's reference values on every start, but on a restart the sounding was only re-read when `nudging_from_input_sounding` was on. So `theta_ref_inp_sound` was still 0, the surface layer was handed a 0 K surface, the MOST iteration produced a strongly stable solution on the first restarted step, and the restarted run drifted from the uninterrupted one. With `most.surf_temp` set and no heating rate nothing rewrites `t_surf` afterwards, and `t_surf` was not among the surface-layer fields in the checkpoint, so nothing corrected it.

## Changes

- `Source/ERF_MakeNewLevel.cpp`: read the input sounding on every restart of an `input_sounding` run, not only when nudging from it is enabled.
- `Source/IO/ERF_Checkpoint.cpp`: write `Tsurf` to the checkpoint alongside the other surface-layer fields and read it back in `ReadCheckpointFileSurfaceLayer`, so a run whose surface temperature has evolved also resumes correctly. The read goes through the existing `read_most_var` helper, which skips fields that are absent, so checkpoints written before this change still restart (falling back to the sounding value from the first change).

The checkpoint read happens after `InitData_post` sets the sounding value, so the checkpointed surface temperature wins when present.

## Verification

The reproduction from the issue (doubly periodic neutral ABL, MRF, 40x40x64, dt = 0.1): a straight 50-step run versus a 25-step run checkpointed at step 25 and restarted to step 50, compared with `amrex_fcompare` on the step-50 plotfiles.

| case | binary | max x-velocity diff | max theta diff | result |
|---|---|---|---|---|
| fixed surface temperature, no heating rate | `development` | 0.033 m/s | 0.025 K | differs in every field |
| fixed surface temperature, no heating rate | this PR | 0 | 0 | `PLOTFILE AGREE` |
| `surf_heating_rate = 0.5` (surface temperature evolves) | this PR | 0 | 0 | `PLOTFILE AGREE` |
| checkpoint written by `development` (no `Tsurf`), restarted with this PR | this PR | 0 | 0 | `PLOTFILE AGREE` |

The uninterrupted 50-step run is bit-identical between `development` and this PR, so the change only affects restarts. Built with `-DERF_ENABLE_ALL_WARNINGS=ON` (AppleClang, Release) with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
