### PR TITLE
Fix BellForest terrain box index type

### DIFF
--- a/Source/ERF_ProbCommon.H
+++ b/Source/ERF_ProbCommon.H
@@ -718,7 +718,7 @@ public:
         const amrex::Real terrain_dy = m_yterrain[1] - m_yterrain[0];
 
         if (!mass_point_terrain && !zbx.isEmpty()) {
-            amrex::Box target_box = zbx & amrex::convert(geom.Domain(), amrex::IntVect(1, 1, 0));
+            amrex::Box target_box = zbx & amrex::convert(geom.Domain(), zbx.ixType());
             if (!target_box.isEmpty()) {
                 target_box.setSmall(2, zbx.smallEnd(2));
                 target_box.setBig(2, zbx.smallEnd(2));


### PR DESCRIPTION
# Fix `BellForest` CTest runtime failure

## Suggested PR title

Fix terrain-box index-type mismatch in `BellForest`

## Summary

The `BellForest` regression test aborted during terrain initialization before writing `plt00001`. The failure was an AMReX assertion, not a plotfile comparison mismatch:

```text
Assertion `sameType(rhs)' failed, file AMReX_Box.H, line 615
```

`ProblemBase::read_terrain_netcdf` intersected the terrain slab box with the domain converted using a hard-coded index type. The terrain slab is nodal in all three directions, while that conversion was nodal in `x` and `y` but cell-centered in `z`. AMReX requires both boxes in an intersection to have the same index type.

## Fix

Use the index type of the actual terrain box when converting the domain:

```cpp
amrex::Box target_box = zbx & amrex::convert(geom.Domain(), zbx.ixType());
```

This preserves the existing terrain interpolation and slab handling while making the box intersection satisfy AMReX's contract. No gold files or test tolerances were changed.

## Verification

Built with the CI material settings: Debug, 3-D, MPI, NetCDF, HDF5, Kokkos, EKAT, RRTMGP, tests, and fcompare enabled, using GNU 14.3.0 and MPICH 9.0.1.

- `BellForest`: passed with 2 MPI ranks.
- `fcompare`: passed against the unchanged gold file with the existing
  absolute and relative tolerances of `2e-9`.
- Related terrain and forest tests: passed 15/15, including terrain tests at
  1, 2, and 4 MPI ranks.
- `git diff --check`: passed.

The maximum absolute fcompare error after the fix was `7.28e-11`, well below the existing tolerance. AMReX was tested at the recorded current revision `f2cbba4`; the failure is in the ERF caller's box construction, so no AMReX change is required.
