### PR TITLE
NetCDF on Perlmutter w/ FPE Trap Invalid

### DIFF
--- a/.github/workflows/windows-mpi.yml
+++ b/.github/workflows/windows-mpi.yml
@@ -57,6 +57,8 @@ jobs:
             -DMPI_CXX_LIB_NAMES=msmpi `
             -DMPI_C_LIB_NAMES=msmpi `
             -DMPI_msmpi_LIBRARY="$env:MSMPI_LIB\msmpi.lib" `
+            -DMPI_C_INCLUDE_DIRS="$env:MSMPI_INC" `
+            -DMPI_CXX_INCLUDE_DIRS="$env:MSMPI_INC" `
               ${{ github.workspace }}
 
       - name: Build

--- a/Source/IO/ERF_NCWpsFile.H
+++ b/Source/IO/ERF_NCWpsFile.H
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <atomic>
+#include <cfenv>
 
 #include "AMReX_FArrayBox.H"
 #include "AMReX_IArrayBox.H"
@@ -159,6 +160,8 @@ void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
 
     if (amrex::ParallelDescriptor::IOProcessor())
     {
+        auto prev_fpe_except = amrex::disableFPExcept(amrex::FPExcept::all);
+
         auto ncf = ncutils::NCFile::open(fname, NC_CLOBBER | NC_NETCDF4);
 
         /*
@@ -223,6 +226,9 @@ void ReadNetCDFFile (const std::string& fname, amrex::Vector<std::string> names,
             } // has_var
         }
         ncf.close();
+
+        std::feclearexcept(FE_ALL_EXCEPT);
+        amrex::setFPExcept(prev_fpe_except);
     }
 }
 


### PR DESCRIPTION
# Summary
Allow codes to use fpe trap invalid enabled and netcdf on perlmutter. Also correct the include for windows workflow.