### PR TITLE
Keep the MRF scheme from raising invalid floating-point flags it never uses

### DIFF
--- a/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
@@ -351,10 +351,14 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
             // HOL computed from predictor height (WRF uses predictor height for wstar/VPERT)
             const Real HOL = sf * pblh_pred_arr(i, j, 0) / obuk_val;
             const Real HOL_bounded = amrex::max(amrex::min(HOL, Real(100.0)), Real(-100.0));
+            // |HOL|, so the base 1 + 16*HOL_abs of the unstable arm below equals its
+            // 1 - 16*HOL there and is at least 1 for every HOL; a guard written inside the
+            // arm gets folded away by the optimiser and the pow hoisted (see sqrt_neg_Ri).
+            const Real HOL_abs = std::abs(HOL_bounded);
             const Real one_quarter = Real(0.25);
             const Real phiM = (obuk_val > 0)
                             ? (1 + 5 * HOL_bounded)
-                            : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -one_quarter);
+                            : std::pow(1 + 16 * HOL_abs, -one_quarter);
             const Real phiM_safe = amrex::max(phiM, Real(0.01));
 
             // wstar = u* / phi_m
@@ -515,10 +519,14 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
             // HOL now uses corrected PBLH for full internal consistency
             const Real HOL = sf * pblh_corr_arr(i, j, 0) / obuk_val;
             const Real HOL_bounded = amrex::max(amrex::min(HOL, Real(100.0)), Real(-100.0));
+            // |HOL|, so the base 1 + 16*HOL_abs of the unstable arm below equals its
+            // 1 - 16*HOL there and is at least 1 for every HOL; a guard written inside the
+            // arm gets folded away by the optimiser and the pow hoisted (see sqrt_neg_Ri).
+            const Real HOL_abs = std::abs(HOL_bounded);
             const Real one_quarter = Real(0.25);
             const Real phiM = (obuk_val > 0)
                             ? (1 + 5 * HOL_bounded)
-                            : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -one_quarter);
+                            : std::pow(1 + 16 * HOL_abs, -one_quarter);
             const Real phiM_safe = amrex::max(phiM, Real(0.01));
 
             // Absolute bounds [0.01, 5.0] m/s
@@ -702,14 +710,18 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
 
                 const Real HOL = sf * pblh_corr_arr(i, j, 0) / obuk_val;
                 const Real HOL_bounded = amrex::max(amrex::min(HOL, Real(100.0)), Real(-100.0));
+                // |HOL|, so the base 1 + 16*HOL_abs of the unstable arm below equals its
+                // 1 - 16*HOL there and is at least 1 for every HOL; a guard written inside the
+                // arm gets folded away by the optimiser and the pow hoisted (see sqrt_neg_Ri).
+                const Real HOL_abs = std::abs(HOL_bounded);
 
                 const Real one_quarter = Real(0.25);
                 const Real phiM = (obuk_val > 0)
                                 ? (1 + 5 * HOL_bounded)
-                                : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -one_quarter);
+                                : std::pow(1 + 16 * HOL_abs, -one_quarter);
                 const Real phit = (obuk_val > 0)
                                 ? (1 + 5 * HOL_bounded)
-                                : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -Real(0.5));
+                                : std::pow(1 + 16 * HOL_abs, -Real(0.5));
 
                 Real phit_cloud = phit;
                 Real phiM_cloud = phiM;
@@ -719,8 +731,8 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                     phit_cloud = Real(1) + Real(5.0) * reduction_factor * sf * pblh_corr_arr(i, j, 0) / obuk_val;
                 } else if (has_cloud && obuk_val <= Real(0)) {
                     Real cloud_boost = Real(1.0) + Real(0.05) * amrex::min(total_qcloud / qc_threshold, Real(1));
-                    phiM_cloud = std::pow(amrex::max(Real(1) - Real(16.0) * HOL_bounded / cloud_boost, Real(0.01)), -one_quarter);
-                    phit_cloud = std::pow(amrex::max(Real(1) - Real(16.0) * HOL_bounded / cloud_boost, Real(0.01)), -Real(0.5));
+                    phiM_cloud = std::pow(Real(1) + Real(16.0) * HOL_abs / cloud_boost, -one_quarter);
+                    phit_cloud = std::pow(Real(1) + Real(16.0) * HOL_abs / cloud_boost, -Real(0.5));
                 }
 
                 const Real phiM_eff = phiM_cloud;
@@ -774,13 +786,29 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                     grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                     const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));
+
+                    // sqrt(|Ri|), which equals the sqrt(-Ri) of the unstable arm below and is valid
+
+                    // for every Ri. Written as max(-Ri, 0) inside the arm, the optimiser used the
+
+                    // arm\'s condition to drop the max and then hoisted the bare sqrt above the
+
+                    // selection, where Ri can be positive; written as min(Ri, 0) it folded the
+
+                    // sqrt into the arms of the min. Either way an invalid operation whose
+
+                    // result is discarded but whose flag kills the run under
+
+                    // amrex.fpe_trap_invalid. There is nothing to fold in the absolute value.
+
+                    const Real sqrt_neg_Ri = std::sqrt(std::abs(grad_Ri_safe));
                     Real Pr_rich = Real(1) + Real(2.1) * grad_Ri;
                     const Real fm = (grad_Ri_safe > 0)
                                   ? Real(1) / ((Real(1) + Real(5.0) * grad_Ri_safe) * (Real(1) + Real(5.0) * grad_Ri_safe))
-                                  : 1 - 8 * grad_Ri_safe / (1 + Real(1.746) * std::sqrt(amrex::max(-grad_Ri_safe, Real(0))));
+                                  : 1 - 8 * grad_Ri_safe / (1 + Real(1.746) * sqrt_neg_Ri);
                     const Real ft = (grad_Ri_safe > 0)
                                   ? Real(1) / ((Real(1) + Real(5.0) * grad_Ri_safe) * (Real(1) + Real(5.0) * grad_Ri_safe))
-                                  : 1 - 8 * grad_Ri_safe / (1 + Real(1.286) * std::sqrt(amrex::max(-grad_Ri_safe, Real(0))));
+                                  : 1 - 8 * grad_Ri_safe / (1 + Real(1.286) * sqrt_neg_Ri);
                     const Real rl2wsp = rho * lscale * lscale * std::sqrt(wind_shear);
 
                     Pr_rich = std::max(amrex::Real(0.25), std::min(Pr_rich, Real(4.0)));
@@ -824,13 +852,29 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                 const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));
+
+                // sqrt(|Ri|), which equals the sqrt(-Ri) of the unstable arm below and is valid
+
+                // for every Ri. Written as max(-Ri, 0) inside the arm, the optimiser used the
+
+                // arm\'s condition to drop the max and then hoisted the bare sqrt above the
+
+                // selection, where Ri can be positive; written as min(Ri, 0) it folded the
+
+                // sqrt into the arms of the min. Either way an invalid operation whose
+
+                // result is discarded but whose flag kills the run under
+
+                // amrex.fpe_trap_invalid. There is nothing to fold in the absolute value.
+
+                const Real sqrt_neg_Ri = std::sqrt(std::abs(grad_Ri_safe));
                 Real Pr = Real(1) + Real(2.1) * grad_Ri;
                 const Real fm = (grad_Ri_safe > 0)
                               ? Real(1) / ((Real(1) + Real(5.0) * grad_Ri_safe) * (Real(1) + Real(5.0) * grad_Ri_safe))
-                              : 1 - 8 * grad_Ri_safe / (1 + Real(1.746) * std::sqrt(amrex::max(-grad_Ri_safe, Real(0))));
+                              : 1 - 8 * grad_Ri_safe / (1 + Real(1.746) * sqrt_neg_Ri);
                 const Real ft = (grad_Ri_safe > 0)
                               ? Real(1) / ((Real(1) + Real(5.0) * grad_Ri_safe) * (Real(1) + Real(5.0) * grad_Ri_safe))
-                              : 1 - 8 * grad_Ri_safe / (1 + Real(1.286) * std::sqrt(amrex::max(-grad_Ri_safe, Real(0))));
+                              : 1 - 8 * grad_Ri_safe / (1 + Real(1.286) * sqrt_neg_Ri);
                 const Real rl2wsp = rho * lscale * lscale * std::sqrt(wind_shear);
 
                 Pr = std::max(amrex::Real(0.25), std::min(Pr, Real(4.0)));

--- a/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
@@ -786,21 +786,13 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                     grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                     const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));
-
                     // sqrt(|Ri|), which equals the sqrt(-Ri) of the unstable arm below and is valid
-
                     // for every Ri. Written as max(-Ri, 0) inside the arm, the optimiser used the
-
-                    // arm\'s condition to drop the max and then hoisted the bare sqrt above the
-
+                    // arm's condition to drop the max and then hoisted the bare sqrt above the
                     // selection, where Ri can be positive; written as min(Ri, 0) it folded the
-
                     // sqrt into the arms of the min. Either way an invalid operation whose
-
                     // result is discarded but whose flag kills the run under
-
                     // amrex.fpe_trap_invalid. There is nothing to fold in the absolute value.
-
                     const Real sqrt_neg_Ri = std::sqrt(std::abs(grad_Ri_safe));
                     Real Pr_rich = Real(1) + Real(2.1) * grad_Ri;
                     const Real fm = (grad_Ri_safe > 0)
@@ -852,21 +844,13 @@ ComputeDiffusivityMRF (const MultiFab& xvel,
                 grad_Ri = std::max(std::min(grad_Ri, Real(100.0)), -Real(100.0));
 
                 const Real grad_Ri_safe = amrex::max(grad_Ri, -Real(100.0));
-
                 // sqrt(|Ri|), which equals the sqrt(-Ri) of the unstable arm below and is valid
-
                 // for every Ri. Written as max(-Ri, 0) inside the arm, the optimiser used the
-
-                // arm\'s condition to drop the max and then hoisted the bare sqrt above the
-
+                // arm's condition to drop the max and then hoisted the bare sqrt above the
                 // selection, where Ri can be positive; written as min(Ri, 0) it folded the
-
                 // sqrt into the arms of the min. Either way an invalid operation whose
-
                 // result is discarded but whose flag kills the run under
-
                 // amrex.fpe_trap_invalid. There is nothing to fold in the absolute value.
-
                 const Real sqrt_neg_Ri = std::sqrt(std::abs(grad_Ri_safe));
                 Real Pr = Real(1) + Real(2.1) * grad_Ri;
                 const Real fm = (grad_Ri_safe > 0)

--- a/Source/PBL/ERF_PBLScaleAwareBlending.H
+++ b/Source/PBL/ERF_PBLScaleAwareBlending.H
@@ -63,9 +63,19 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real pbl_blend_factor(amrex::Real dx,
                               amrex::Real L_blend) noexcept
 {
-    if (L_blend <= 0.0) return 1.0;
-    const amrex::Real r = dx / L_blend;
-    return (r * r) / (1.0 + r * r);
+    // Written as dx^2 / (L^2 + dx^2), which is the same function, instead of the
+    // early return followed by (dx/L)^2 / (1 + (dx/L)^2). The caller's L_blend > 0
+    // test does not stop the optimiser from hoisting this loop-invariant arithmetic
+    // ahead of it (a division is speculatable in the default floating-point model),
+    // and with L_blend = 0 the hoisted dx/L_blend was inf and the ratio an inf/inf,
+    // which raised the invalid-operation flag and killed every MRF run under
+    // amrex.fpe_trap_invalid even though the result was never used. Guarding the
+    // division with a select does not help either, since the division is folded
+    // into the select's arms. In this form the denominator is at least dx^2 > 0 for
+    // every L_blend, so nothing can be invalid, and L_blend <= 0 gives exactly 1.
+    const amrex::Real L  = amrex::max(L_blend, amrex::Real(0.0));
+    const amrex::Real d2 = dx * dx;
+    return d2 / (L * L + d2);
 }
 
 /**

--- a/Source/PBL/ERF_PBLScaleAwareBlending.H
+++ b/Source/PBL/ERF_PBLScaleAwareBlending.H
@@ -63,16 +63,7 @@ AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real pbl_blend_factor(amrex::Real dx,
                               amrex::Real L_blend) noexcept
 {
-    // Written as dx^2 / (L^2 + dx^2), which is the same function, instead of the
-    // early return followed by (dx/L)^2 / (1 + (dx/L)^2). The caller's L_blend > 0
-    // test does not stop the optimiser from hoisting this loop-invariant arithmetic
-    // ahead of it (a division is speculatable in the default floating-point model),
-    // and with L_blend = 0 the hoisted dx/L_blend was inf and the ratio an inf/inf,
-    // which raised the invalid-operation flag and killed every MRF run under
-    // amrex.fpe_trap_invalid even though the result was never used. Guarding the
-    // division with a select does not help either, since the division is folded
-    // into the select's arms. In this form the denominator is at least dx^2 > 0 for
-    // every L_blend, so nothing can be invalid, and L_blend <= 0 gives exactly 1.
+    // dx^2 / (L^2 + dx^2): the denominator is never 0, so no inf/inf under amrex.fpe_trap_invalid
     const amrex::Real L  = amrex::max(L_blend, amrex::Real(0.0));
     const amrex::Real d2 = dx * dx;
     return d2 / (L * L + d2);


### PR DESCRIPTION
## Problem

Every MRF run dies at its first step under `amrex.fpe_trap_invalid = 1` in an optimised build (Apple clang, Release), on a plain neutral ABL whose results are fine, while a debug build of the same case runs clean. The canonical MRF cases all carry `amrex.fpe_trap_invalid = 0` for this reason.

The cause is the optimiser rather than the physics. Three guarded expressions in `ComputeDiffusivityMRF` are evaluated speculatively, ahead of the guard that makes them valid, and the NaN they produce is discarded but raises the invalid-operation flag the trap watches. Compiling just this file with `-ffp-model=strict` makes the trap disappear, which pins it on speculation; the debugger then identified each site from the faulting instruction and its registers.

## Changes (`Source/PBL/ERF_PBLScaleAwareBlending.H`, `Source/PBL/ERF_ComputeDiffusivityMRF.cpp`)

1. **Blending factor.** `pbl_blend_factor` computed `(dx/L)²/(1+(dx/L)²)` behind an early return for `L <= 0`. Being loop-invariant it was hoisted out of the K loop above the caller's `L > 0` test; with blending off `L = 0`, `dx/L` is inf and `inf/inf` is NaN (the registers showed the 200 m `dx` of the case divided by a zero `L`). It is now `dx²/(L²+dx²)`: the same function, a denominator of at least `dx²` for every `L`, and exactly 1 when `L <= 0`. A select around the division does not help, the division gets folded into the select's arms.
2. **Unstable stability functions.** `sqrt(max(-Ri, 0))` sat inside the `Ri <= 0` arm. Knowing `Ri <= 0` there, the optimiser removed the max and hoisted the bare sqrt above the selection, where `Ri` is positive. `min(Ri, 0)` moved the problem into the arms of the min. The argument is now `sqrt(|Ri|)`, evaluated before the selection; it equals `sqrt(-Ri)` in the arm that uses it and has nothing to fold.
3. **Unstable phi functions.** `pow(max(1 - 16 HOL, 0.01), -1/4)` inside the `L < 0` arm is the same construct; the base is now `1 + 16 |HOL|`, equal to `1 - 16 HOL` in that arm and at least 1 everywhere.

## Verification

Neutral ABL, doubly periodic, 40 x 40 x 64 on 8 km x 8 km x 2 km, input sounding 300 K and 10 m/s, `erf.pbl_type = MRF`, `dt = 0.1`.

| case | before | after |
|---|---|---|
| trap on, blending off, 10 steps | aborts at step 1 (blend factor) | runs |
| trap on, `pbl_blend_length = 750`, 10 steps | aborts at step 1 (sqrt) | runs |
| trap on, 4 ranks, 200 steps | aborts | runs |
| trap on, surface heating +3 K/h and -3 K/h, 60 steps each | aborts | runs |
| trap off, blending off: this PR vs development at step 10 | | `PLOTFILE AGREE` (bitwise) |
| trap off, blending 750 m: this PR vs development at step 10 | | `PLOTFILE AGREE` |
| `Exec/CanonicalTests/ABL/MRF_Enhancements/blending_active`, this PR vs development at step 5 | | `PLOTFILE AGREE` |

YSUNew and MYNN2.5 run the same case with the trap on before and after. YSU could not be checked on this grid (its 10 m reference height is below the first cell centre); it has a similar `sqrt(-Ri)` inside an `Ri < 0` branch in `ERF_ComputeDiffusivityYSU.cpp` that may need the same treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
