### PR TITLE
Keep the SHOC energy-fixer active top off a measure-zero comparison (…

### DIFF
--- a/Source/PBL/Shoc/ERF_ShocConstants.H
+++ b/Source/PBL/Shoc/ERF_ShocConstants.H
@@ -9,6 +9,31 @@ namespace shoc::constants {
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real min_tke () noexcept { return amrex::Real(4.0e-4); }
 
+// Relative margin above min_tke() used to decide whether a level is still
+// turbulently active. Above the boundary layer both the explicit TKE update
+// and the implicit TKE solve clamp TKE to exactly min_tke(), so a bare
+// "tke > min_tke()" test is settled by the last bit of the tridiagonal
+// solution. Host and device builds differ there by one ulp, because the CUDA
+// build contracts to FMA and the host build does not, and that flips the
+// diagnosed active top from step to step. The margin keeps the comparison off
+// that measure-zero boundary.
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real active_tke_rel_margin () noexcept
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(1.0e-4);
+#else
+    return amrex::Real(1.0e-6);
+#endif
+}
+
+// Smallest TKE that counts as turbulently active. See active_tke_rel_margin().
+AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+amrex::Real active_tke_threshold () noexcept
+{
+    return min_tke() * (amrex::Real(1.0) + active_tke_rel_margin());
+}
+
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
 amrex::Real latent_ice () noexcept { return amrex::Real(3.34e5); }
 

--- a/Source/PBL/Shoc/ERF_ShocEnergyFixer.H
+++ b/Source/PBL/Shoc/ERF_ShocEnergyFixer.H
@@ -71,7 +71,7 @@ diagnose_active_top (const amrex::Array4<const amrex::Real>& tke,
 {
     int shoc_top = -1;
     for (int k = nlev - 1; k >= 0; --k) {
-        if (tke(ic,k,0) > constants::min_tke()) {
+        if (tke(ic,k,0) > constants::active_tke_threshold()) {
             shoc_top = k;
             break;
         }

--- a/Source/PBL/Shoc/ERF_ShocEnergyFixer.cpp
+++ b/Source/PBL/Shoc/ERF_ShocEnergyFixer.cpp
@@ -7,7 +7,7 @@ ShocEnergyFixer::diagnose_active_top (const Vector<Real>& tke)
 {
     int shoc_top = -1;
     for (int k = static_cast<int>(tke.size()) - 1; k >= 0; --k) {
-        if (tke[k] > shoc::constants::min_tke()) {
+        if (tke[k] > shoc::constants::active_tke_threshold()) {
             shoc_top = k;
             break;
         }

--- a/Tests/Unit/Shoc/ERF_ShocImplicitTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocImplicitTests.cpp
@@ -539,6 +539,33 @@ TEST(ShocEnergyFixer, ActiveTopFollowsHighestTurbulentLevel)
     EXPECT_EQ(ShocEnergyFixer::diagnose_active_top(tke), -1);
 }
 
+TEST(ShocEnergyFixer, ActiveTopIgnoresRoundoffAboveTheTkeFloor)
+{
+    // The implicit TKE solve leaves an exponentially decaying tail on top of
+    // the clamped floor, so quiescent levels sit at min_tke() plus a few ulps.
+    // A bare "tke > min_tke()" test resolves that tail differently on host and
+    // device builds (FMA contraction), which flips the diagnosed active top and
+    // changes the depth over which the energy fixer spreads its increment.
+    const amrex::Real floor_tke = shoc::constants::min_tke();
+    const amrex::Real one_ulp_above = std::nextafter(floor_tke,
+                                                     amrex::Real(1.0));
+    EXPECT_GT(one_ulp_above, floor_tke);
+
+    amrex::Vector<amrex::Real> tke = {6.0e-4, one_ulp_above, one_ulp_above};
+    EXPECT_EQ(ShocEnergyFixer::diagnose_active_top(tke), 0);
+
+    // Anything inside the documented relative margin is likewise not active.
+    const amrex::Real inside_margin =
+        floor_tke * (amrex::Real(1.0)
+                     + amrex::Real(0.5) * shoc::constants::active_tke_rel_margin());
+    tke = {6.0e-4, inside_margin, inside_margin};
+    EXPECT_EQ(ShocEnergyFixer::diagnose_active_top(tke), 0);
+
+    // A level that is genuinely turbulent must still be found.
+    tke = {6.0e-4, one_ulp_above, 5.0e-4};
+    EXPECT_EQ(ShocEnergyFixer::diagnose_active_top(tke), 2);
+}
+
 TEST(ShocEnergyFixer, LiquidPartitionChangeDoesNotCreateEnergyCorrection)
 {
     auto col = shoc_test::make_column(3);


### PR DESCRIPTION
…#3962)

Above the boundary layer, both the explicit TKE update and the implicit TKE solve clamp TKE to exactly shoc::constants::min_tke(), so the bare "tke > min_tke()" test in diagnose_active_top() was settled by the last bit of the tridiagonal solution's exponentially decaying tail. Host and device builds differ there by one ulp, since the CUDA build contracts to FMA (--use_fast_math is on by default in the GNUmake path) and the host build does not. That flipped the diagnosed active top from step to step, changing both the magnitude of delta_tabs and the depth over which the energy fixer spreads it.

For the GABLS1 ABL case with erf.pbl_type=NATIVE_SHOC this made a CUDA run and a pure-CPU run differ by ~1e-5 relative in velocity after 50 steps, against ~1e-10 for the same comparison with MYNN25.

Compare against a threshold carrying a small relative margin above the floor instead. The margin is precision-aware so it stays well clear of one ulp in single-precision builds, and both the Array4 and Vector overloads of diagnose_active_top() use it so the device path and the unit-tested host path cannot diverge.