### PR TITLE
Limit the SHOC third moment to the clipping bound instead of a fixed …

### DIFF
--- a/Source/PBL/Shoc/ERF_ShocMoments.cpp
+++ b/Source/PBL/Shoc/ERF_ShocMoments.cpp
@@ -12,7 +12,6 @@ namespace
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_min_tke () noexcept { return 4.0e-4_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_large_neg () noexcept { return -99999999.99_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_w3clip () noexcept { return 1.2_rt; }
-    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_w3clipdef () noexcept { return 0.02_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_base_temp () noexcept { return 300.0_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_ufmin () noexcept { return 0.01_rt; }
 #ifdef AMREX_USE_FLOAT
@@ -369,8 +368,15 @@ ShocMoments::clip_third_moments (const ShocColumnData& col,
         for (int k = 0; k <= layout.nlev; ++k) {
             const Real wsec3 = wsec(ic,k,0) * wsec(ic,k,0) * wsec(ic,k,0);
             const Real clip_cond = shoc_w3clip() * std::sqrt(amrex::max(0.0_rt, 2.0_rt * wsec3));
+            // E3SM/EAMxx replaces an out-of-range w3 with a fixed positive
+            // constant (0.02). That discards the sign of the third moment,
+            // so a strongly negatively skewed column is handed back a
+            // positively skewed w3, and it can also move |w3| further away
+            // from the bound it is supposed to enforce when clip_cond is
+            // small. Limit the magnitude to clip_cond instead and keep the
+            // sign, which is continuous in w3 and respects the bound.
             if (amrex::Math::abs(w3(ic,k,0)) > clip_cond) {
-                w3(ic,k,0) = shoc_w3clipdef();
+                w3(ic,k,0) = std::copysign(clip_cond, w3(ic,k,0));
             }
         }
     });

--- a/Tests/Unit/Shoc/ERF_ShocMomentsTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocMomentsTests.cpp
@@ -248,13 +248,17 @@ TEST(ShocMoments, OnePointFiveTkeModeZerosVarianceAndThirdMoment)
     }
 }
 
-TEST(ShocMoments, ThirdMomentClippingUsesPositiveFallback)
+TEST(ShocMoments, ThirdMomentClippingLimitsMagnitudeAndKeepsSign)
 {
     auto col = shoc_test::make_column(5);
     const amrex::Box iface_box(amrex::IntVect(0,0,0), amrex::IntVect(col.layout.ncell - 1, col.layout.nlev, 0));
     amrex::FArrayBox w_sec_zi(iface_box, 1, shoc_test::test_arena());
     amrex::FArrayBox w3(iface_box, 1, shoc_test::test_arena());
-    shoc::set_fab_val(w_sec_zi, 0.1, shoc::InitRunOn::Host);
+
+    const amrex::Real w_sec_val = 0.1;
+    const amrex::Real clip_cond = 1.2 * std::sqrt(2.0 * w_sec_val * w_sec_val * w_sec_val);
+
+    shoc::set_fab_val(w_sec_zi, w_sec_val, shoc::InitRunOn::Host);
     shoc::set_fab_val(w3, -10.0, shoc::InitRunOn::Host);
 
     shoc_test::run_and_sync([&] {
@@ -262,7 +266,59 @@ TEST(ShocMoments, ThirdMomentClippingUsesPositiveFallback)
     });
 
     for (int k = 0; k <= col.layout.nlev; ++k) {
-        EXPECT_DOUBLE_EQ(w3.const_array()(0,k,0), 0.02);
+        EXPECT_DOUBLE_EQ(w3.const_array()(0,k,0), -clip_cond);
+    }
+
+    shoc::set_fab_val(w3, 10.0, shoc::InitRunOn::Host);
+
+    shoc_test::run_and_sync([&] {
+        ShocMoments::clip_third_moments(col, w_sec_zi, w3);
+    });
+
+    for (int k = 0; k <= col.layout.nlev; ++k) {
+        EXPECT_DOUBLE_EQ(w3.const_array()(0,k,0), clip_cond);
+    }
+}
+
+TEST(ShocMoments, ThirdMomentClippingLeavesInRangeValuesAlone)
+{
+    auto col = shoc_test::make_column(5);
+    const amrex::Box iface_box(amrex::IntVect(0,0,0), amrex::IntVect(col.layout.ncell - 1, col.layout.nlev, 0));
+    amrex::FArrayBox w_sec_zi(iface_box, 1, shoc_test::test_arena());
+    amrex::FArrayBox w3(iface_box, 1, shoc_test::test_arena());
+
+    const amrex::Real w_sec_val = 0.1;
+    const amrex::Real clip_cond = 1.2 * std::sqrt(2.0 * w_sec_val * w_sec_val * w_sec_val);
+    const amrex::Real w3_val = -0.5 * clip_cond;
+
+    shoc::set_fab_val(w_sec_zi, w_sec_val, shoc::InitRunOn::Host);
+    shoc::set_fab_val(w3, w3_val, shoc::InitRunOn::Host);
+
+    shoc_test::run_and_sync([&] {
+        ShocMoments::clip_third_moments(col, w_sec_zi, w3);
+    });
+
+    for (int k = 0; k <= col.layout.nlev; ++k) {
+        EXPECT_DOUBLE_EQ(w3.const_array()(0,k,0), w3_val);
+    }
+}
+
+TEST(ShocMoments, ThirdMomentClippingZeroesQuiescentLevels)
+{
+    auto col = shoc_test::make_column(5);
+    const amrex::Box iface_box(amrex::IntVect(0,0,0), amrex::IntVect(col.layout.ncell - 1, col.layout.nlev, 0));
+    amrex::FArrayBox w_sec_zi(iface_box, 1, shoc_test::test_arena());
+    amrex::FArrayBox w3(iface_box, 1, shoc_test::test_arena());
+
+    shoc::set_fab_val(w_sec_zi, 0.0, shoc::InitRunOn::Host);
+    shoc::set_fab_val(w3, 1.0, shoc::InitRunOn::Host);
+
+    shoc_test::run_and_sync([&] {
+        ShocMoments::clip_third_moments(col, w_sec_zi, w3);
+    });
+
+    for (int k = 0; k <= col.layout.nlev; ++k) {
+        EXPECT_DOUBLE_EQ(w3.const_array()(0,k,0), 0.0);
     }
 }
 


### PR DESCRIPTION
…constant (#3962)

clip_third_moments() replaced an out-of-range w3 with shoc_w3clipdef(), a fixed positive 0.02, following E3SM/EAMxx. That has two problems. It discards the sign of the third moment, so a strongly negatively skewed column is handed back a positively skewed w3, which flips the direction of the skewness that the assumed PDF and the third-moment closure then see. It also ignores the bound the clip is meant to enforce: when clip_cond = 1.2*sqrt(2*w_sec^3) is smaller than 0.02, the "clip" moves |w3| further outside the bound rather than back inside it, and in either direction it is a large discontinuous jump in w3.

Clamp the magnitude to clip_cond and keep the sign instead. That is continuous in w3, always lands on the bound, and leaves in-range values untouched.

This is the second item in the "Related problems" section of #3962. It is latent for the cases in the test suite: instrumenting the branch shows it never fires in any of the twelve SHOC regression cases, and the plotfile comparisons are unchanged. It matters for moist or convective columns where the third-moment path carries a large skewness.

The ERF-native SHOC is deliberately not a bit-for-bit port of EAMxx SHOC (Source/PBL/Shoc/README.md), so this diverges from upstream on purpose.

Unit tests cover the sign-preserving limit in both directions, an in-range value that must be left alone, and a quiescent level where w_sec is zero and w3 must therefore go to zero rather than to 0.02.