### PR TITLE
Keep the moist HSE initialisation off the invalid-operation trap

### DIFF
--- a/Source/Prob/ERF_InitDensityHSE.H
+++ b/Source/Prob/ERF_InitDensityHSE.H
@@ -167,10 +167,8 @@ erf_init_dens_hse_moist (amrex::MultiFab& rho_hse,
     pp.query("height", z_tr_1);
     pp.query("z_tr", z_tr_2);
 
-    // Placeholders, read only with T_from_theta_in_moist_init. They must be
-    // physical temperatures rather than zero: the compute_theta arm they feed
-    // is evaluated speculatively in optimised builds, and g/(Cp_d*0) followed
-    // by 0*exp(inf) raised the invalid flag under amrex.fpe_trap_invalid.
+    // Used only with T_from_theta_in_moist_init, but kept at physical values:
+    // zeros raise an FPE in the speculatively evaluated compute_theta arm.
     amrex::Real T_tr = amrex::Real(300), theta_tr = amrex::Real(300), theta_0 = amrex::Real(300);
 
     bool T_from_theta = false;

--- a/Source/Prob/ERF_InitDensityHSE.H
+++ b/Source/Prob/ERF_InitDensityHSE.H
@@ -167,8 +167,11 @@ erf_init_dens_hse_moist (amrex::MultiFab& rho_hse,
     pp.query("height", z_tr_1);
     pp.query("z_tr", z_tr_2);
 
-    // We only set them to zero to make sure they are initialized
-    amrex::Real T_tr = zero, theta_tr = zero, theta_0 = zero;
+    // Placeholders, read only with T_from_theta_in_moist_init. They must be
+    // physical temperatures rather than zero: the compute_theta arm they feed
+    // is evaluated speculatively in optimised builds, and g/(Cp_d*0) followed
+    // by 0*exp(inf) raised the invalid flag under amrex.fpe_trap_invalid.
+    amrex::Real T_tr = amrex::Real(300), theta_tr = amrex::Real(300), theta_0 = amrex::Real(300);
 
     bool T_from_theta = false;
     pp.query("T_from_theta_in_moist_init", T_from_theta);

--- a/Source/Utils/ERF_HSEUtils.H
+++ b/Source/Utils/ERF_HSEUtils.H
@@ -677,8 +677,15 @@ init_isentropic_hse_no_terrain(Real *theta, Real* r, Real* p, Real *q_v,
                                const Real eq_pot_temp, const bool use_empirical,
                                const bool T_from_theta = false,
                                const Real z_tr_1 = -one, const Real z_tr_2 = -one,
-                               const Real theta_0 = amrex::Real(0), const Real theta_tr = amrex::Real(0), const Real T_tr = amrex::Real(0))
+                               const Real theta_0 = amrex::Real(300), const Real theta_tr = amrex::Real(300), const Real T_tr = amrex::Real(300))
 {
+    // theta_0, theta_tr and T_tr are read only when T_from_theta is set, but
+    // compute_theta is inlined into the Newton loops below and clang evaluates
+    // its arm speculatively at -O3: with the old placeholders of zero that arm
+    // formed g/(Cp_d*0) and then 0*exp(inf), which raised the invalid flag and
+    // killed a run under amrex.fpe_trap_invalid (the MoistBubble regression
+    // test). The placeholders are now physical temperatures so every
+    // speculated expression stays finite; a selected result never sees them.
     Real T_b, T_dp;
 
     int which_zone = -1;

--- a/Source/Utils/ERF_HSEUtils.H
+++ b/Source/Utils/ERF_HSEUtils.H
@@ -679,13 +679,10 @@ init_isentropic_hse_no_terrain(Real *theta, Real* r, Real* p, Real *q_v,
                                const Real z_tr_1 = -one, const Real z_tr_2 = -one,
                                const Real theta_0 = amrex::Real(300), const Real theta_tr = amrex::Real(300), const Real T_tr = amrex::Real(300))
 {
-    // theta_0, theta_tr and T_tr are read only when T_from_theta is set, but
-    // compute_theta is inlined into the Newton loops below and clang evaluates
-    // its arm speculatively at -O3: with the old placeholders of zero that arm
-    // formed g/(Cp_d*0) and then 0*exp(inf), which raised the invalid flag and
-    // killed a run under amrex.fpe_trap_invalid (the MoistBubble regression
-    // test). The placeholders are now physical temperatures so every
-    // speculated expression stays finite; a selected result never sees them.
+    // theta_0, theta_tr and T_tr are used only when T_from_theta is set. Their
+    // defaults are still physical temperatures: compute_theta is inlined into
+    // the Newton loops and optimised builds evaluate its arm speculatively, so
+    // zeros would raise an FPE (g/(Cp_d*0), then 0*exp(inf)) on a discarded value.
     Real T_b, T_dp;
 
     int which_zone = -1;


### PR DESCRIPTION
## Problem
`Tests/test_files/MoistBubble` arms `amrex.fpe_trap_invalid = 1` and dies in `Problem::erf_init_dens_hse_moist` in optimised builds (SIGILL on macOS arm64 with AppleClang at `-O3`; a Debug build is clean), so `ctest -L regression` fails locally on a Mac.

## Cause
`HSEutils::compute_theta` is only called when `T_from_theta` is set, but it is force-inlined into the Newton loops of `init_isentropic_hse_no_terrain` and clang evaluates its arm speculatively. The callers that do not use the theta profile (`erf_init_dens_hse_moist`, the Bubble and MultiSpeciesBubble perturbations) pass placeholders of zero for `theta_0`, `theta_tr` and `T_tr`, so the speculated arm forms `g/(Cp_d*0)` and then `0*exp(inf)`, which raises the invalid flag although the value is discarded. Same pattern as #3961.

## Fix
The placeholders are physical temperatures (300 K) in the helper's default arguments and in `erf_init_dens_hse_moist`. Every speculated expression is then finite, and a selected result never reads them.

## Verification (macOS arm64, AppleClang, Release, MPI, `ERF_ENABLE_ALL_WARNINGS`)
| Check | Result |
|---|---|
| `ctest -R MoistBubble` on stock `development` | fails, SIGILL in `erf_init_dens_hse_moist` |
| `ctest -R MoistBubble` with this change | passes (trap armed, gold comparison) |
| MoistBubble plotfile, pre-fix binary with the trap disabled vs fixed binary, `fcompare` at zero tolerance | PLOTFILE AGREE |
| `SquallLine_2D`, `SuperCell_3D` (real theta-profile values), `DensityCurrent` | pass |
| Build warnings outside Submodules | none |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
