### PR TITLE
Remove Native SHOC host_diffusion runtime modes

### DIFF
--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -3319,7 +3319,7 @@ bit-for-bit identical calculations.
      - Real > 0
      - 0.5
    * - **erf.shoc.c_diag_3rd_mom**
-     - Diagnostic third-moment closure coefficient
+     - Diagnostic third-moment vertical-velocity damping coefficient; the default 7.0 is the tested baseline
      - Real
      - 7.0
    * - **erf.shoc.coeff_kh**
@@ -3338,6 +3338,14 @@ bit-for-bit identical calculations.
      - Enable additional SHOC diagnostic calculations; plot variables must still be requested explicitly
      - true / false
      - false
+
+.. warning::
+
+   For Native SHOC, do not set ``erf.shoc.c_diag_3rd_mom`` to zero. The Native
+   third-moment closure contains factors proportional to the inverse of this
+   coefficient. The default value ``7.0`` is the tested baseline. Changes to
+   this closure coefficient should be treated as sensitivity experiments rather
+   than routine configuration.
 
 Native SHOC inputs
 ------------------
@@ -3394,11 +3402,14 @@ Use ``state_update`` instead.
 Native SHOC debugging controls
 ------------------------------
 
-These controls also apply to ``erf.pbl_type = NATIVE_SHOC``.  They exist for
-debugging and for regression testing rather than for production runs; the
-``debug_disable_*`` switches in particular deliberately break the scheme, and
-are what the ``SHOC_Mutation_*`` tests in ``Tests/CTestList.cmake`` use to
-confirm that each state update actually changes the answer.
+The following controls are intended for diagnosis and regression testing rather
+than routine production runs.  The ``debug_disable_*`` switches deliberately
+disable pieces of the coupled state update and are used by the SHOC mutation
+tests to verify that those updates affect the solution.
+
+Only controls listed here are part of the supported Native-SHOC debugging
+interface. Some historical or development ``erf.shoc`` keys may still be
+parsed internally but do not currently alter Native SHOC.
 
 .. list-table::
    :header-rows: 1
@@ -3408,14 +3419,6 @@ confirm that each state update actually changes the answer.
      - Definition
      - Acceptable Values
      - Default
-   * - **erf.shoc.column_conservation_check**
-     - Check column-integrated conservation after each native SHOC advance
-     - true / false
-     - false
-   * - **erf.shoc.allow_tendency_microphysics_overlap**
-     - Permit native SHOC tendencies to be applied in the same step as the microphysics update
-     - true / false
-     - false
    * - **erf.shoc.debug_bad_column**
      - Detect and report columns whose tendencies or stratification exceed the thresholds below
      - true / false
@@ -3437,7 +3440,7 @@ confirm that each state update actually changes the answer.
      - Real > 0
      - 1.0e-2
    * - **erf.shoc.debug_bad_column_brunt_threshold**
-     - Brunt-Vaisala frequency above which a column is flagged; must be positive
+     - Magnitude of the squared Brunt--Väisälä frequency, :math:`|N^2|` [s\ :sup:`-2`], above which a column is flagged; must be positive
      - Real > 0
      - 1.0
    * - **erf.shoc.debug_bad_column_min_dz**

--- a/Docs/sphinx_doc/Inputs.rst
+++ b/Docs/sphinx_doc/Inputs.rst
@@ -3354,12 +3354,12 @@ The following controls apply to ``erf.pbl_type = NATIVE_SHOC``.
      - Default
    * - **erf.shoc.transport_mode**
      - Selects how native SHOC transports thermodynamic variables, moisture/cloud state, and TKE
-     - ``state_update``, ``host_diffusion``
+     - ``state_update``
      - ``state_update``
    * - **erf.shoc.momentum_transport**
      - Selects how native SHOC applies horizontal-momentum transport
-     - ``none``, ``state_update``, ``host_diffusion``
-     - ``host_diffusion``
+     - ``none``, ``state_update``
+     - ``state_update``
    * - **erf.shoc.top_taper_depth**
      - Depth below the model top over which native SHOC smoothly tapers TKE/diffusivity and higher-order turbulence quantities [m]; zero disables the taper
      - Real >= 0
@@ -3377,11 +3377,11 @@ The following controls apply to ``erf.pbl_type = NATIVE_SHOC``.
      - true / false
      - false
 
-For moist native SHOC runs, use ``erf.shoc.transport_mode = state_update``.
-The full ``host_diffusion`` transport mode is currently supported only when
-``erf.moisture_model = None`` because native SHOC does not own cloud
-macrophysics in this mode while SHOC-family microphysics condensation is
-suppressed. It also requires ``erf.shoc.momentum_transport = host_diffusion``.
+Native SHOC uses ``state_update`` for scalar/cloud/TKE transport. Use
+``erf.shoc.momentum_transport = state_update`` for the normal/default momentum
+path, or ``none`` to disable Native SHOC horizontal-momentum transport.
+The former ``host_diffusion`` values for either selector are removed and fail
+at startup with migration guidance.
 Native ``state_update`` rejects moisture layouts containing cloud-water or
 cloud-ice number concentrations because a number closure has not yet been
 implemented.
@@ -3510,7 +3510,7 @@ The native transport defaults are:
 .. code-block:: text
 
    erf.shoc.transport_mode = state_update
-   erf.shoc.momentum_transport = host_diffusion
+   erf.shoc.momentum_transport = state_update
 
 These two transport lines may be omitted when the defaults are desired.
 

--- a/Docs/sphinx_doc/theory/PBLschemes.rst
+++ b/Docs/sphinx_doc/theory/PBLschemes.rst
@@ -209,12 +209,7 @@ the EAMxx path is retained for users who need the E3SM/EAMxx reference
 implementation path.
 
 Native SHOC is part of the ERF source tree and does not require EAMxx, EKAT, or
-Kokkos setup. A minimal native configuration is:
-
-.. code-block:: text
-
-   zlo.type = "surface_layer"
-   erf.pbl_type = NATIVE_SHOC
+Kokkos setup.
 
 ERF recognizes the following SHOC-family PBL selections:
 
@@ -231,6 +226,38 @@ ERF recognizes the following SHOC-family PBL selections:
        ``ERF_ENABLE_EAMXX_SHOC=ON``.
    * - ``SHOC``
      - Deprecated alias for ``EAMXX_SHOC``. It does **not** select native SHOC.
+
+Native SHOC quick start
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A minimal Native-SHOC configuration is
+
+.. code-block:: text
+
+   zlo.type = "surface_layer"
+   erf.pbl_type = NATIVE_SHOC
+
+The Native transport defaults are already
+
+.. code-block:: text
+
+   erf.shoc.transport_mode = state_update
+   erf.shoc.momentum_transport = state_update
+
+so those two lines do not need to be specified unless an input file benefits
+from making the choice explicit.
+
+Before running Native SHOC, note three important restrictions:
+
+* the lower boundary must use ``zlo.type = "surface_layer"``;
+* every AMReX box on a Native-SHOC-active level must span the full vertical
+  domain;
+* moisture layouts carrying cloud-liquid or cloud-ice number concentrations
+  are currently rejected because Native SHOC does not yet provide the required
+  number closure.
+
+The remaining sections describe these requirements and the available tuning and
+diagnostic controls in more detail.
 
 SHOC-family PBL schemes require ``zlo.type = "surface_layer"``. The surface
 layer supplies the lower-boundary heat, moisture, and momentum fluxes consumed
@@ -308,8 +335,11 @@ Horizontal momentum is controlled independently:
   ERF face velocities. This is the default production path.
 
 ``erf.shoc.momentum_transport = none``
-  Disable SHOC horizontal-momentum transport while preserving the existing
-  generic ERF momentum-diffusion ownership semantics.
+  Disable the Native-SHOC horizontal-momentum transport contribution. ERF
+  retains generic host ownership of vertical momentum diffusion in this mode.
+  This does not by itself create a nonzero host momentum diffusivity; it only
+  leaves the generic ERF momentum-diffusion path eligible to act when another
+  configured host closure supplies one.
 
 The former ``host_diffusion`` momentum value is removed. Use ``state_update``
 to retain SHOC momentum transport or ``none`` to disable it.
@@ -334,63 +364,117 @@ closure.
 TKE behavior and reduced 1.5-order mode
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Native SHOC uses the prognostic ERF TKE state. ERF initializes TKE for SHOC from
-``erf.tke_min`` before the run begins; see :ref:`sec:Initialization`.
+Native SHOC uses ERF's prognostic TKE state. At model initialization ERF sets
+TKE from ``erf.tke_min`` (default ``1.e-6 m^2/s^2``) before any
+problem-specific or surface-layer-based TKE initialization is applied.
+
+``erf.tke_min`` is an **initialization control**, not the internal Native-SHOC
+TKE floor. During each Native-SHOC update the closure currently bounds TKE to
+
+.. math::
+
+   4\times10^{-4}
+   \le e
+   \le 50
+   \qquad \mathrm{m^2\,s^{-2}},
+
+where :math:`e` denotes TKE. Consequently a run initialized below
+:math:`4\times10^{-4}\ \mathrm{m^2\,s^{-2}}` can move to the Native-SHOC
+internal floor on the first SHOC update.
 
 In the default higher-order form
-(``erf.shoc.shoc_1p5tke = false``), native SHOC diagnoses buoyancy production
-from the carried virtual-potential-temperature turbulent flux.
+(``erf.shoc.shoc_1p5tke = false``), the Native-SHOC buoyancy-production term is
 
-Setting:
+.. math::
+
+   P_b = \frac{g}{300\ \mathrm{K}}\,\overline{w'\theta_v'}.
+
+Setting
 
 .. code-block:: text
 
    erf.shoc.shoc_1p5tke = true
 
-selects the reduced 1.5-order form. In this mode the native TKE buoyancy term is
-computed as :math:`-K_h N^2` using the carried/lagged heat diffusivity, and the
-higher-order SHOC moment structure is suppressed. This option therefore changes
-the closure form; it is not merely an output switch.
+selects the reduced 1.5-order form. In that mode the buoyancy term is
 
-The production term used by the native TKE update is also controlled by:
+.. math::
 
-.. code-block:: text
+   P_b = -K_h N^2,
 
-   erf.shoc.signed_tke_production = false
+using the carried heat diffusivity and the diagnosed squared Brunt--Väisälä
+frequency :math:`N^2`. The higher-order thermodynamic variance/covariance
+structure and vertical-velocity third moment are suppressed in this mode, so
+``shoc_1p5tke`` changes the closure rather than merely changing diagnostics.
 
-which is the default. With the default, native SHOC clips the sum of shear and
-buoyancy production at zero before applying dissipation. With:
+The treatment of the total production term is controlled independently by
+``erf.shoc.signed_tke_production``. With the default value ``false``,
+
+.. math::
+
+   P = \max(0,\,P_s + P_b),
+
+where :math:`P_s` is shear production. With
 
 .. code-block:: text
 
    erf.shoc.signed_tke_production = true
 
-the signed sum of shear and buoyancy production is retained, allowing negative
-buoyancy production in stable conditions to directly reduce TKE.
+the clipping is removed:
+
+.. math::
+
+   P = P_s + P_b.
+
+The latter permits negative buoyancy production in stable conditions to reduce
+TKE directly. The default remains ``false``; use a non-default value only when
+the intended experiment calls for the signed-production formulation.
 
 Native stability and diffusivity tuning
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The full input table is given in :ref:`sec:Inputs`. The following points clarify
-the native meaning of the principal tuning controls:
+Native SHOC diagnoses the squared Brunt--Väisälä frequency from virtual
+potential temperature,
+
+.. math::
+
+   N^2 =
+   \frac{g}{\theta_v}
+   \frac{\partial\theta_v}{\partial z}.
+
+Positive :math:`N^2` denotes stable stratification in this diagnostic.
+
+On the general Native diffusivity path, the kinematic momentum and heat
+diffusivities are
+
+.. math::
+
+   K_m = C_{K_m}\,\tau\,e,
+   \qquad
+   K_h = C_{K_h}\,\tau\,e,
+
+where :math:`e` is TKE, :math:`\tau` is the diagnosed isotropy timescale,
+``erf.shoc.coeff_km`` supplies :math:`C_{K_m}`, and
+``erf.shoc.coeff_kh`` supplies :math:`C_{K_h}`. Native SHOC also contains a
+special stable-mixing branch with fixed coefficients, so these two runtime
+coefficients do not control every possible diffusivity calculation.
+
+The full input table is given in :ref:`sec:Inputs`. For normal use, begin with
+the documented defaults and change closure coefficients only for a deliberate
+sensitivity study.
 
 * ``erf.shoc.lambda_low``, ``lambda_high``, ``lambda_slope``, and
-  ``lambda_thresh`` control the stability-dependent coefficient used by the
-  native isotropy-timescale calculation. The stability correction acts for
-  stable stratification.
-* ``erf.shoc.length_fac`` is part of the diagnosed native turbulent mixing
-  length. In the native formula it appears in the denominator before the
-  mixing-length bounds are applied, so larger values reduce the otherwise
-  diagnosed length.
-* ``erf.shoc.coeff_kh`` and ``erf.shoc.coeff_km`` are the scalar/heat and
-  momentum diffusivity coefficients used in the general native diffusivity
-  branch. The special native stable-mixing branch uses its own fixed
-  coefficients.
+  ``lambda_thresh`` control the stability-dependent coefficient in the
+  isotropy-timescale calculation.
+* ``erf.shoc.length_fac`` scales the diagnosed mixing length inversely: larger
+  values reduce the otherwise diagnosed length.
+* The Native mixing-length expression is limited to the range 20 m--20 km
+  before an additional horizontal-grid cap of
+  :math:`\sqrt{\Delta x\,\Delta y}` is applied. On sufficiently fine
+  horizontal grids that final grid cap can therefore be smaller than 20 m.
 * ``erf.shoc.thl2tune``, ``qw2tune``, ``qwthl2tune``, and ``w2tune`` tune the
   diagnosed second moments.
-* ``erf.shoc.c_diag_3rd_mom`` controls the diagnostic third-moment closure.
-* The defaults are the recommended starting point unless a study is
-  intentionally investigating closure sensitivity.
+* ``erf.shoc.c_diag_3rd_mom`` is the damping coefficient used in the
+  diagnostic vertical-velocity third-moment closure.
 
 Upper-boundary taper
 ~~~~~~~~~~~~~~~~~~~~
@@ -401,10 +485,29 @@ The native upper taper is disabled by default:
 
    erf.shoc.top_taper_depth = 0.0
 
-For ``top_taper_depth > 0``, native SHOC applies a smooth taper over that many
-metres below the model top. The multiplier is
-``erf.shoc.top_taper_min_factor`` at the model top and increases smoothly to 1
-at the bottom of the taper layer.
+For a positive taper depth :math:`d_{\mathrm{taper}}`, define
+
+.. math::
+
+   x =
+   \operatorname{clip}
+   \left(
+       \frac{z_{\mathrm{top}}-z}{d_{\mathrm{taper}}},
+       0, 1
+   \right).
+
+Native SHOC uses the smooth multiplier
+
+.. math::
+
+   f =
+   f_{\min}
+   + (1-f_{\min})x^2(3-2x),
+
+where :math:`f_{\min}` is
+``erf.shoc.top_taper_min_factor``. Thus the multiplier is
+``top_taper_min_factor`` at the model top and smoothly reaches one at the
+bottom of the taper layer.
 
 The taper acts on native TKE evolution and TKE-budget quantities, isotropy and
 eddy diffusivities, and diagnosed higher-order moments. It is therefore a

--- a/Docs/sphinx_doc/theory/PBLschemes.rst
+++ b/Docs/sphinx_doc/theory/PBLschemes.rst
@@ -285,46 +285,34 @@ The default native configuration is:
 .. code-block:: text
 
    erf.shoc.transport_mode = state_update
-   erf.shoc.momentum_transport = host_diffusion
+   erf.shoc.momentum_transport = state_update
 
-This mixed configuration is the normal starting point for native SHOC.
+This is the normal starting point for native SHOC.
 
 ``erf.shoc.transport_mode = state_update``
   Native SHOC applies its coupled thermodynamic, moisture/cloud, and TKE column
   update to the ERF state before the dycore advances that state. This is the
   required native transport mode for moist SHOC configurations.
 
-``erf.shoc.transport_mode = host_diffusion``
-  Native SHOC diagnoses and exports the full vertical eddy-diffusivity block
-  for ERF's host diffusion path instead of applying the native pre-dycore
-  thermodynamic/moisture/TKE state update. This mode is currently supported
-  only for dry runs with ``erf.moisture_model = None`` because native SHOC does
-  not own cloud macrophysics in this mode while SHOC-family microphysics
-  condensation is suppressed. It requires
-  ``erf.shoc.momentum_transport = host_diffusion``.
+``erf.shoc.transport_mode`` accepts only ``state_update``. The former
+``host_diffusion`` value is removed and is rejected at startup with migration
+guidance.
 
 The former value ``erf.shoc.transport_mode = tendencies`` has been removed and
 is rejected at startup.
 
 Horizontal momentum is controlled independently:
 
-``erf.shoc.momentum_transport = host_diffusion``
-  Export the native SHOC vertical momentum diffusivity to ERF's host diffusion
-  path. This is the default. Because ERF's dycore then owns vertical momentum
-  diffusion, this mode leaves ERF's vertical implicit diffusion solve active for
-  momentum (``erf.implicit_momentum_diffusion``); see
-  :ref:`sec:Inputs` for the ``erf.vert_implicit*`` controls.
-
 ``erf.shoc.momentum_transport = state_update``
   Apply the native SHOC horizontal-velocity column increment directly to the
-  ERF face velocities. This is an alternate transport choice and is not the
-  default.
+  ERF face velocities. This is the default production path.
 
 ``erf.shoc.momentum_transport = none``
-  Disable SHOC horizontal-momentum transport.
+  Disable SHOC horizontal-momentum transport while preserving the existing
+  generic ERF momentum-diffusion ownership semantics.
 
-When the scalar/cloud/TKE transport mode is ``host_diffusion``, the momentum
-mode must also be ``host_diffusion``.
+The former ``host_diffusion`` momentum value is removed. Use ``state_update``
+to retain SHOC momentum transport or ``none`` to disable it.
 
 PBL height and turbulent structure
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -425,9 +413,10 @@ numerical/physical upper-boundary control, not only a plot-diagnostic filter.
 Diagnostics
 ~~~~~~~~~~~
 
-Native SHOC diagnostics are produced after the native driver runs in both
-``state_update`` and ``host_diffusion`` transport modes. The values reflect the
-selected transport path.
+Native SHOC diagnostics are produced after the native driver runs in the
+supported ``state_update`` transport path. The diagnosed diffusivities remain
+available as diagnostics even though they are no longer exported for generic
+host reapplication.
 
 Request 3-D fields through the ordinary plotfile variable list. For example:
 

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -1996,7 +1996,7 @@ struct SolverChoice {
 
     // Native shoc transport mode
     ShocTransportMode     shoc_transport_mode     = ShocTransportMode::StateUpdate;
-    ShocMomentumTransport shoc_momentum_transport = ShocMomentumTransport::HostDiffusion;
+    ShocMomentumTransport shoc_momentum_transport = ShocMomentumTransport::StateUpdate;
 
     // Transport the passive scalar?
     bool transport_scalar = true;
@@ -2073,8 +2073,7 @@ struct SolverChoice {
     {
         if (use_eamxx_shoc)   { return false; }
         if (!use_native_shoc) { return true;  }
-        return (shoc_uses_momentum_host_diffusion(shoc_momentum_transport) ||
-                shoc_disables_momentum_transport (shoc_momentum_transport));
+        return shoc_disables_momentum_transport(shoc_momentum_transport);
     }
 
     /**
@@ -2085,7 +2084,7 @@ struct SolverChoice {
     {
         if (use_eamxx_shoc)   { return false; }
         if (!use_native_shoc) { return true;  }
-        return shoc_uses_host_diffusion(shoc_transport_mode);
+        return false;
     }
 
     /**

--- a/Source/DataStructs/ERF_ShocTransportStruct.H
+++ b/Source/DataStructs/ERF_ShocTransportStruct.H
@@ -9,23 +9,20 @@
 
 enum class ShocTransportMode
 {
-    StateUpdate,
-    HostDiffusion
+    StateUpdate
 };
 
 enum class ShocMomentumTransport
 {
     None,
-    StateUpdate,
-    HostDiffusion
+    StateUpdate
 };
 
 inline const char*
 shoc_transport_mode_name (ShocTransportMode mode)
 {
     switch (mode) {
-    case ShocTransportMode::StateUpdate:   return "state_update";
-    case ShocTransportMode::HostDiffusion: return "host_diffusion";
+    case ShocTransportMode::StateUpdate: return "state_update";
     }
     return "unknown";
 }
@@ -34,35 +31,16 @@ inline const char*
 shoc_momentum_transport_name (ShocMomentumTransport mode)
 {
     switch (mode) {
-    case ShocMomentumTransport::None:          return "none";
-    case ShocMomentumTransport::StateUpdate:   return "state_update";
-    case ShocMomentumTransport::HostDiffusion: return "host_diffusion";
+    case ShocMomentumTransport::None:        return "none";
+    case ShocMomentumTransport::StateUpdate: return "state_update";
     }
     return "unknown";
-}
-
-inline bool
-shoc_uses_state_update (ShocTransportMode mode)
-{
-    return (mode == ShocTransportMode::StateUpdate);
-}
-
-inline bool
-shoc_uses_host_diffusion (ShocTransportMode mode)
-{
-    return (mode == ShocTransportMode::HostDiffusion);
 }
 
 inline bool
 shoc_uses_momentum_state_update (ShocMomentumTransport mode)
 {
     return (mode == ShocMomentumTransport::StateUpdate);
-}
-
-inline bool
-shoc_uses_momentum_host_diffusion (ShocMomentumTransport mode)
-{
-    return (mode == ShocMomentumTransport::HostDiffusion);
 }
 
 inline bool
@@ -90,8 +68,9 @@ parse_shoc_transport_mode_string (std::string value,
         return true;
     }
     if (value == "host_diffusion") {
-        mode = ShocTransportMode::HostDiffusion;
-        return true;
+        error_message =
+            "erf.shoc.transport_mode = host_diffusion has been removed for native SHOC. Use erf.shoc.transport_mode = state_update.";
+        return false;
     }
     if (value == "tendencies") {
         error_message =
@@ -99,7 +78,7 @@ parse_shoc_transport_mode_string (std::string value,
         return false;
     }
 
-    error_message = "erf.shoc.transport_mode must be 'state_update' or 'host_diffusion'";
+    error_message = "erf.shoc.transport_mode must be 'state_update'";
     return false;
 }
 
@@ -118,11 +97,12 @@ parse_shoc_momentum_transport_string (std::string value,
         return true;
     }
     if (value == "host_diffusion") {
-        mode = ShocMomentumTransport::HostDiffusion;
-        return true;
+        error_message =
+            "erf.shoc.momentum_transport = host_diffusion has been removed for native SHOC. Use 'state_update' to retain SHOC momentum transport, or 'none' to disable SHOC momentum transport.";
+        return false;
     }
 
-    error_message = "erf.shoc.momentum_transport must be 'none', 'state_update', or 'host_diffusion'";
+    error_message = "erf.shoc.momentum_transport must be 'none' or 'state_update'";
     return false;
 }
 

--- a/Source/PBL/Shoc/ERF_ShocDriver.H
+++ b/Source/PBL/Shoc/ERF_ShocDriver.H
@@ -15,11 +15,6 @@
 bool shoc_boxarray_spans_full_height (const amrex::BoxArray& ba,
                                       const amrex::Box& domain);
 
-void shoc_fill_physical_boundary_ghosts (amrex::MultiFab& mf,
-                                         const amrex::Geometry& geom,
-                                         int comp,
-                                         int ncomp);
-
 inline bool
 shoc_layout_requires_number_closure (const MoistureComponentIndices& indices,
                                      int ncomp) noexcept
@@ -28,27 +23,11 @@ shoc_layout_requires_number_closure (const MoistureComponentIndices& indices,
 }
 
 inline bool
-shoc_driver_host_diffusion_moisture_supported (const ShocRuntimeOptions& opts,
-                                               MoistureType moisture_type,
-                                               std::string& error_message)
-{
-    if (!shoc_uses_host_diffusion(opts.transport_mode) || moisture_type == MoistureType::None) {
-        return true;
-    }
-
-    error_message =
-        "Native SHOC host_diffusion with moisture is not yet supported because SHOC does not own cloud macrophysics in this mode while SHOC-family microphysics condensation is suppressed. Use state_update for moist SHOC runs, or run host_diffusion only for dry cases until a transport-aware microphysics ownership predicate is implemented.";
-    return false;
-}
-
-inline bool
-shoc_driver_state_update_layout_supported (const ShocRuntimeOptions& opts,
-                                           const MoistureComponentIndices& indices,
+shoc_driver_state_update_layout_supported (const MoistureComponentIndices& indices,
                                            int ncomp,
                                            std::string& error_message)
 {
-    if (!shoc_uses_state_update(opts.transport_mode) ||
-        !shoc_layout_requires_number_closure(indices, ncomp)) {
+    if (!shoc_layout_requires_number_closure(indices, ncomp)) {
         return true;
     }
 
@@ -81,15 +60,9 @@ public:
     void add_slow_tend (const amrex::MFIter& mfi,
                         const amrex::Box& tbx,
                         const amrex::Array4<amrex::Real>& cell_rhs) const;
-    bool uses_state_update () const;
-    bool uses_host_diffusion () const;
     bool uses_momentum_state_update () const;
-    bool uses_momentum_host_diffusion () const;
     bool disables_momentum_transport () const;
     bool owns_scalar_surface_fluxes () const;
-    bool owns_momentum_surface_stresses () const;
-    bool needs_host_surface_momentum_stresses () const;
-    bool owns_surface_fluxes () const;
     bool debug_summary_enabled () const { return m_opts.debug_summary; }
     bool has_native_diagnostics () const { return m_eddy_coeffs_cc.isDefined(); }
     bool has_consumed_surface_flux_diagnostics () const
@@ -132,7 +105,6 @@ public:
 private:
     int m_lev;
     ShocRuntimeOptions m_opts;
-    MoistureType m_moisture_type;
     MoistureComponentIndices m_moisture_indices;
 
     amrex::MultiFab m_theta_tend_cc;
@@ -177,7 +149,6 @@ private:
     amrex::MultiFab* m_tau23_ptr = nullptr;
     amrex::MultiFab* m_eddy_diffs_ptr = nullptr;
     amrex::Vector<std::unique_ptr<ShocColumnWorkspace>> m_column_workspaces;
-    const amrex::Geometry* m_geom_ptr = nullptr;
     int m_advance_calls = 0;
     bool m_prev_turb_valid = false;
 

--- a/Source/PBL/Shoc/ERF_ShocDriver.cpp
+++ b/Source/PBL/Shoc/ERF_ShocDriver.cpp
@@ -30,44 +30,6 @@ shoc_boxarray_spans_full_height (const BoxArray& ba, const Box& domain)
     return true;
 }
 
-void
-shoc_fill_physical_boundary_ghosts (MultiFab& mf,
-                                    const Geometry& geom,
-                                    int comp,
-                                    int ncomp)
-{
-    mf.FillBoundary(comp, ncomp, geom.periodicity());
-
-    const Box domain = geom.Domain();
-    const bool nonperiodic_x = !geom.isPeriodic(0);
-    const bool nonperiodic_y = !geom.isPeriodic(1);
-    const bool nonperiodic_z = !geom.isPeriodic(2);
-
-    for (MFIter mfi(mf, false); mfi.isValid(); ++mfi) {
-        const Box gbx = mfi.growntilebox();
-        auto data = mf.array(mfi);
-        ParallelFor(gbx, ncomp,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
-            const int ii = nonperiodic_x
-                ? ((i < domain.smallEnd(0)) ? domain.smallEnd(0)
-                   : ((i > domain.bigEnd(0)) ? domain.bigEnd(0) : i))
-                : i;
-            const int jj = nonperiodic_y
-                ? ((j < domain.smallEnd(1)) ? domain.smallEnd(1)
-                   : ((j > domain.bigEnd(1)) ? domain.bigEnd(1) : j))
-                : j;
-            const int kk = nonperiodic_z
-                ? ((k < domain.smallEnd(2)) ? domain.smallEnd(2)
-                   : ((k > domain.bigEnd(2)) ? domain.bigEnd(2) : k))
-                : k;
-
-            if (ii != i || jj != j || kk != k) {
-                data(i,j,k,comp+n) = data(ii,jj,kk,comp+n);
-            }
-        });
-    }
-}
-
 namespace
 {
     constexpr int k_shoc_vertical_diff_comp = EddyDiff::Mom_v;
@@ -345,7 +307,6 @@ namespace
 
 ShocDriver::ShocDriver (int lev, const SolverChoice& solver_choice)
     : m_lev(lev),
-      m_moisture_type(solver_choice.moisture_type),
       m_moisture_indices(solver_choice.moisture_indices)
 {
     m_opts.transport_mode     = solver_choice.shoc_transport_mode;
@@ -354,11 +315,6 @@ ShocDriver::ShocDriver (int lev, const SolverChoice& solver_choice)
     read_shoc_runtime_options(m_opts);
     validate_shoc_runtime_options(m_opts);
     warn_if_shoc_debug_overrides_active_once(m_opts);
-
-    std::string error_message;
-    if (!shoc_driver_host_diffusion_moisture_supported(m_opts, m_moisture_type, error_message)) {
-        amrex::Abort(error_message.c_str());
-    }
 }
 
 void
@@ -542,7 +498,6 @@ ShocDriver::advance (MultiFab& cons,
     m_tau13_ptr = tau13;
     m_tau23_ptr = tau23;
     m_eddy_diffs_ptr = eddy_diffs;
-    m_geom_ptr = &geom;
 
     sync_face_multifab_impl(xvel, geom);
     sync_face_multifab_impl(yvel, geom);
@@ -559,7 +514,7 @@ ShocDriver::advance (MultiFab& cons,
     }
 
     std::string error_message;
-    if (!shoc_driver_state_update_layout_supported(m_opts, m_moisture_indices, cons.nComp(),
+    if (!shoc_driver_state_update_layout_supported(m_moisture_indices, cons.nComp(),
                                                     error_message)) {
         amrex::Abort(error_message.c_str());
     }
@@ -607,22 +562,16 @@ ShocDriver::advance (MultiFab& cons,
             seed_carried_turbulence(col, mfi, cons, *eddy_diffs);
         }
         const auto dx = geom.CellSizeArray();
-        if (uses_state_update()) {
-            BL_PROFILE("SHOC::advance::cache_baseline_state");
-            ShocImplicit::cache_baseline_state(col);
-        }
+        BL_PROFILE("SHOC::advance::cache_baseline_state");
+        ShocImplicit::cache_baseline_state(col);
         ShocDiagnostics::diagnose_pre_implicit(col, m_opts, dx[0], dx[1], dt);
-        if (uses_state_update()) {
-            BL_PROFILE("SHOC::advance::implicit");
-            ShocImplicit::advance_implicit_state(col, m_opts, dt);
-        }
+        BL_PROFILE("SHOC::advance::implicit");
+        ShocImplicit::advance_implicit_state(col, m_opts, dt);
         ShocDiagnostics::diagnose_post_implicit(col, m_opts, dt);
-        if (uses_state_update()) {
-            BL_PROFILE("SHOC::advance::finalize");
-            ShocImplicit::finalize_from_pdf(col, m_opts, dt);
-            BL_PROFILE("SHOC::advance::debug_bad_column");
-            debug_check_bad_column(col, mfi, z_phys_nd, hfx3, qfx3, tau13, tau23, geom, dt);
-        }
+        BL_PROFILE("SHOC::advance::finalize");
+        ShocImplicit::finalize_from_pdf(col, m_opts, dt);
+        BL_PROFILE("SHOC::advance::debug_bad_column");
+        debug_check_bad_column(col, mfi, z_phys_nd, hfx3, qfx3, tau13, tau23, geom, dt);
         {
             BL_PROFILE("SHOC::advance::store_carried_buoyancy_flux");
             store_carried_buoyancy_flux(col, mfi);
@@ -825,15 +774,11 @@ ShocDriver::advance (MultiFab& cons,
         }
     }
 
-    if (uses_state_update()) {
-        sync_face_multifab_impl(m_u_tend_fc, geom);
-        sync_face_multifab_impl(m_v_tend_fc, geom);
-    }
+    sync_face_multifab_impl(m_u_tend_fc, geom);
+    sync_face_multifab_impl(m_v_tend_fc, geom);
 
-    if (uses_state_update()) {
-        BL_PROFILE("SHOC::advance::state_update");
-        apply_state_update(cons, xvel, yvel, dt);
-    }
+    BL_PROFILE("SHOC::advance::state_update");
+    apply_state_update(cons, xvel, yvel, dt);
 
     if (uses_momentum_state_update()) {
         sync_face_multifab_impl(xvel, geom);
@@ -858,39 +803,12 @@ ShocDriver::set_eddy_diffs () const
                              m_eddy_diffs_ptr->nGrow());
     MultiFab::Copy(*m_eddy_diffs_ptr, m_eddy_coeffs_cc,
                    EddyDiff::Turb_lengthscale, EddyDiff::Turb_lengthscale, 1, 0);
-
-    if (uses_host_diffusion()) {
-        MultiFab::Copy(*m_eddy_diffs_ptr, m_eddy_coeffs_cc,
-                       k_shoc_vertical_diff_comp, k_shoc_vertical_diff_comp,
-                       k_shoc_vertical_diff_count, 0);
-    } else if (uses_momentum_host_diffusion()) {
-        MultiFab::Copy(*m_eddy_diffs_ptr, m_eddy_coeffs_cc,
-                       EddyDiff::Mom_v, EddyDiff::Mom_v, 1, 0);
-    }
-    const bool export_host_diff =
-        uses_host_diffusion() || uses_momentum_host_diffusion();
-    if (!export_host_diff) {
-        return;
-    }
-
-    AMREX_ALWAYS_ASSERT(m_geom_ptr != nullptr);
-    const Geometry& geom = *m_geom_ptr;
-    const int comp = uses_host_diffusion() ? k_shoc_vertical_diff_comp : EddyDiff::Mom_v;
-    const int ncomp = uses_host_diffusion() ? k_shoc_vertical_diff_count : 1;
-
-    shoc_fill_physical_boundary_ghosts(*m_eddy_diffs_ptr, geom, comp, ncomp);
 }
 
 void
 ShocDriver::set_diff_stresses () const
 {
     BL_PROFILE("SHOC::set_diff_stresses");
-
-    if (uses_host_diffusion()) {
-        // Full host-diffusion mode preserves the existing host-owned lower
-        // boundary fluxes and stresses.
-        return;
-    }
 
     if (!m_hfx3_ptr || !m_qfx3_ptr) {
         return;
@@ -908,8 +826,7 @@ ShocDriver::set_diff_stresses () const
             qfx(i,j,k) = 0.0;
         });
 
-        if ((owns_momentum_surface_stresses() || disables_momentum_transport()) &&
-            m_tau13_ptr && m_tau23_ptr) {
+        if (m_tau13_ptr && m_tau23_ptr) {
             auto tau13 = m_tau13_ptr->array(mfi);
             auto tau23 = m_tau23_ptr->array(mfi);
             ParallelFor(vbx_xz, [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept {
@@ -940,27 +857,9 @@ ShocDriver::add_slow_tend (const MFIter& mfi,
 }
 
 bool
-ShocDriver::uses_host_diffusion () const
-{
-    return shoc_uses_host_diffusion(m_opts.transport_mode);
-}
-
-bool
-ShocDriver::uses_state_update () const
-{
-    return shoc_uses_state_update(m_opts.transport_mode);
-}
-
-bool
 ShocDriver::uses_momentum_state_update () const
 {
     return shoc_uses_momentum_state_update(m_opts.momentum_transport);
-}
-
-bool
-ShocDriver::uses_momentum_host_diffusion () const
-{
-    return shoc_uses_momentum_host_diffusion(m_opts.momentum_transport);
 }
 
 bool
@@ -972,25 +871,7 @@ ShocDriver::disables_momentum_transport () const
 bool
 ShocDriver::owns_scalar_surface_fluxes () const
 {
-    return uses_state_update();
-}
-
-bool
-ShocDriver::owns_momentum_surface_stresses () const
-{
-    return uses_momentum_state_update();
-}
-
-bool
-ShocDriver::needs_host_surface_momentum_stresses () const
-{
-    return uses_momentum_host_diffusion();
-}
-
-bool
-ShocDriver::owns_surface_fluxes () const
-{
-    return owns_scalar_surface_fluxes();
+    return true;
 }
 
 void
@@ -1570,7 +1451,7 @@ ShocDriver::print_debug_summary (double dt) const
                    << " dt=" << dt
                    << " transport_mode=" << shoc_transport_mode_name(m_opts.transport_mode)
                    << " momentum_transport=" << shoc_momentum_transport_name(m_opts.momentum_transport)
-                   << " state_update=" << (uses_state_update() ? "on" : "off")
+                   << " state_update=on"
                    << "\n";
     print_shoc_debug_settings_once(m_opts);
 

--- a/Source/PBL/Shoc/ERF_ShocTypes.H
+++ b/Source/PBL/Shoc/ERF_ShocTypes.H
@@ -41,7 +41,7 @@ struct ShocRuntimeOptions
     bool allow_tendency_microphysics_overlap = false;
     bool signed_tke_production = false;
     ShocTransportMode transport_mode = ShocTransportMode::StateUpdate;
-    ShocMomentumTransport momentum_transport = ShocMomentumTransport::HostDiffusion;
+    ShocMomentumTransport momentum_transport = ShocMomentumTransport::StateUpdate;
     bool debug_bad_column = false;
     bool debug_bad_column_abort = true;
     int debug_bad_column_max_reports = 8;
@@ -55,19 +55,6 @@ struct ShocRuntimeOptions
     bool debug_disable_moisture_state_update = false;
     bool debug_disable_tke_state_update = false;
 };
-
-inline bool
-validate_shoc_runtime_options_message (const ShocRuntimeOptions& opts,
-                                      std::string& error_message)
-{
-    if (shoc_uses_host_diffusion(opts.transport_mode) &&
-        !shoc_uses_momentum_host_diffusion(opts.momentum_transport)) {
-        error_message =
-            "erf.shoc.transport_mode = host_diffusion requires erf.shoc.momentum_transport = host_diffusion";
-        return false;
-    }
-    return true;
-}
 
 struct ShocColumnLayout
 {
@@ -232,9 +219,6 @@ validate_shoc_runtime_options (const ShocRuntimeOptions& opts)
                                      "erf.shoc.debug_bad_column_min_dz must be positive");
     AMREX_ALWAYS_ASSERT_WITH_MESSAGE(opts.debug_bad_column_scalar_moment_threshold > 0.0,
                                      "erf.shoc.debug_bad_column_scalar_moment_threshold must be positive");
-    std::string error_message;
-    AMREX_ALWAYS_ASSERT_WITH_MESSAGE(validate_shoc_runtime_options_message(opts, error_message),
-                                     error_message.c_str());
 }
 
 AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE

--- a/Source/PBL/Shoc/README.md
+++ b/Source/PBL/Shoc/README.md
@@ -142,45 +142,45 @@ erf.shoc.momentum_transport = none
 erf.shoc.momentum_transport = state_update
 ```
 
-`none` disables SHOC momentum transport entirely while preserving the existing
-generic ERF momentum-diffusion ownership semantics.
+`none` disables the Native-SHOC horizontal-momentum transport contribution.
+ERF retains generic host ownership of vertical momentum diffusion in this mode.
+This does not by itself create a nonzero host momentum diffusivity; it only
+leaves the generic ERF momentum-diffusion path eligible to act when another
+configured host closure supplies one.
 
 `host_diffusion` is no longer a valid native SHOC momentum transport value.
 Use `state_update` to retain SHOC momentum transport or `none` to disable it.
 
-## Preferred baseline input settings
+## Baseline input settings
 
-Use `state_update` for both selectors as the baseline native SHOC coupling
-mode. Native SHOC runs its column physics before the ERF dycore, performs its
-implicit vertical turbulence solve, reconstructs one coupled heat, moisture,
-cloud, TKE, and horizontal-momentum update, and synchronizes the old-time ERF
-state before acoustic and Runge-Kutta dycore integration.
+The Sphinx SHOC documentation is the user-facing source of truth for runtime
+options and their defaults.
 
-A minimal preferred native SHOC block is:
+A minimal Native SHOC setup is:
 
 ```text
-# Native SHOC selection.
 zlo.type = "surface_layer"
 erf.pbl_type = NATIVE_SHOC
-
-# Native SHOC coupling.
-erf.shoc.transport_mode = state_update
-erf.shoc.momentum_transport = state_update
-
-# Preferred TKE-production behavior.
-erf.shoc.signed_tke_production = true
-
-# Useful during development and case bring-up.
-erf.shoc.extra_shoc_diags = true
 ```
 
-`state_update` is the supported coupled mode for moist native SHOC runs and the
-normal/default momentum path. Use `momentum_transport = none` when a case must
-disable Native SHOC horizontal-momentum transport.
+The Native transport defaults are:
 
-`erf.shoc.signed_tke_production = true` keeps the buoyancy contribution signed in
-the TKE production term. Use it for the baseline unless a case has a specific
-reason to use the clipped behavior.
+```text
+erf.shoc.transport_mode = state_update
+erf.shoc.momentum_transport = state_update
+```
+
+Those transport lines may be written explicitly for clarity, but they are not
+required when the defaults are desired.
+
+Leave closure-tuning and TKE-production options at their documented defaults
+unless the case is intentionally performing a sensitivity experiment.
+In particular, `erf.shoc.signed_tke_production` defaults to `false`;
+setting it to `true` changes the TKE production formulation.
+
+`erf.shoc.extra_shoc_diags = true` may be useful during case development when
+the additional diagnostics are needed. Plot variables must still be requested
+explicitly through the normal ERF plot-variable lists.
 
 Do not use `erf.shoc.transport_mode = tendencies` for native SHOC. That legacy
 mode has been removed and should be rejected by the runtime parser.

--- a/Source/PBL/Shoc/README.md
+++ b/Source/PBL/Shoc/README.md
@@ -122,26 +122,18 @@ non-precipitating cloud liquid, carried cloud ice, and TKE update before the
 dycore sees the state. That keeps the thermodynamic and moisture increments
 together.
 
-The host-diffusion scalar mode is:
-
-```text
-erf.shoc.transport_mode = host_diffusion
-```
-
-In this mode, SHOC exports the full vertical eddy-diffusivity block to ERF's
-host diffusion path. SHOC does not apply the pre-dycore state update. At
-present this mode is only supported for dry/no-moisture configurations, and it
-requires `erf.shoc.momentum_transport = host_diffusion`.
+`host_diffusion` is no longer a valid native SHOC scalar transport value. Old
+input decks using it fail at startup with a targeted migration diagnostic.
 
 The horizontal-momentum transport mode is:
 
 ```text
-erf.shoc.momentum_transport = host_diffusion
+erf.shoc.momentum_transport = state_update
 ```
 
-This is the default. In the mixed native SHOC mode, SHOC exports only the
-momentum diffusivity to ERF's host diffusion path while keeping the scalar
-transport on the `state_update` path.
+This is the default and normal production path. SHOC applies its existing
+horizontal-velocity increment directly to the ERF face velocities and consumes
+the corresponding surface stress.
 
 Other momentum choices are:
 
@@ -150,18 +142,19 @@ erf.shoc.momentum_transport = none
 erf.shoc.momentum_transport = state_update
 ```
 
-`none` disables SHOC momentum transport entirely. `state_update` keeps the
-legacy direct-velocity update available for debugging or targeted experiments,
-but it is not the default.
+`none` disables SHOC momentum transport entirely while preserving the existing
+generic ERF momentum-diffusion ownership semantics.
+
+`host_diffusion` is no longer a valid native SHOC momentum transport value.
+Use `state_update` to retain SHOC momentum transport or `none` to disable it.
 
 ## Preferred baseline input settings
 
-Use `state_update` plus `momentum_transport = host_diffusion` as the baseline
-native SHOC coupling mode. In this mode, native SHOC runs its column physics
-before the ERF dycore. SHOC performs its implicit vertical turbulence solve,
-reconstructs one coupled heat, moisture, cloud, and TKE update, and applies
-that update to the old-time ERF state before acoustic and Runge-Kutta dycore
-integration starts. Horizontal momentum stays on the host diffusion path.
+Use `state_update` for both selectors as the baseline native SHOC coupling
+mode. Native SHOC runs its column physics before the ERF dycore, performs its
+implicit vertical turbulence solve, reconstructs one coupled heat, moisture,
+cloud, TKE, and horizontal-momentum update, and synchronizes the old-time ERF
+state before acoustic and Runge-Kutta dycore integration.
 
 A minimal preferred native SHOC block is:
 
@@ -172,7 +165,7 @@ erf.pbl_type = NATIVE_SHOC
 
 # Native SHOC coupling.
 erf.shoc.transport_mode = state_update
-erf.shoc.momentum_transport = host_diffusion
+erf.shoc.momentum_transport = state_update
 
 # Preferred TKE-production behavior.
 erf.shoc.signed_tke_production = true
@@ -181,11 +174,9 @@ erf.shoc.signed_tke_production = true
 erf.shoc.extra_shoc_diags = true
 ```
 
-`state_update` is the preferred coupled mode for moist native SHOC runs.
-Pair it with `momentum_transport = host_diffusion` unless you are explicitly
-debugging the direct momentum update. This keeps SHOC's thermodynamic,
-moisture, cloud, and TKE increments together before the dycore sees the state
-without forcing a pre-dycore momentum update.
+`state_update` is the supported coupled mode for moist native SHOC runs and the
+normal/default momentum path. Use `momentum_transport = none` when a case must
+disable Native SHOC horizontal-momentum transport.
 
 `erf.shoc.signed_tke_production = true` keeps the buoyancy contribution signed in
 the TKE production term. Use it for the baseline unless a case has a specific
@@ -193,12 +184,6 @@ reason to use the clipped behavior.
 
 Do not use `erf.shoc.transport_mode = tendencies` for native SHOC. That legacy
 mode has been removed and should be rejected by the runtime parser.
-
-`host_diffusion` remains available for dry/no-moisture configurations. In that
-mode, SHOC exports vertical eddy diffusivities to ERF's host diffusion path, but
-it does not apply the coupled pre-dycore state update. Do not use
-`host_diffusion` for moist SHOC runs until microphysics and cloud-macrophysics
-ownership is made transport-mode-aware.
 
 The snippet above does not choose a microphysics package, radiation scheme, land
 surface model, terrain option, grid, or timestep. Those remain case choices.
@@ -248,27 +233,26 @@ Preserve these invariants unless the design changes deliberately:
    as a substitute for runtime checks.
 2. Native SHOC requires full-height AMReX boxes on SHOC-active levels. Do not
    use a vertical box split on those levels.
-3. `state_update` is the default native SHOC transport mode.
-4. `erf.shoc.momentum_transport = host_diffusion` is the default momentum mode.
+3. `erf.shoc.transport_mode = state_update` is the only scalar transport mode
+   and the default.
+4. `erf.shoc.momentum_transport = state_update` is the default momentum mode;
+   `none` is the supported way to disable SHOC momentum transport.
 5. In `state_update`, SHOC applies one coupled pre-dycore update to heat,
    moisture, non-precipitating cloud liquid, carried cloud ice, and TKE.
 6. The `state_update` scalar update does not change density, vertical velocity,
    passive scalars, or precipitating species.
-7. In mixed mode, SHOC consumes lower-boundary heat and moisture flux arrays,
-   while host diffusion still owns the momentum stresses.
-8. `erf.shoc.momentum_transport = state_update` is only for explicit debugging
-   or development. When selected, SHOC also consumes the lower-boundary
-   momentum stresses and performs the direct velocity update.
+7. SHOC consumes the lower-boundary heat and moisture flux arrays and does not
+   hand those consumed fluxes back to generic host diffusion.
+8. When `erf.shoc.momentum_transport = state_update`, SHOC also consumes the
+   lower-boundary momentum stresses and performs the direct velocity update.
 9. In `state_update`, SHOC must not also add fast or slow RHS tendencies.
 10. After native SHOC updates the old-time state, ERF must synchronize boundary
    and halo data before pre-dycore checks, strain, turbulent viscosity, momentum
    conversion, primitive variables, pressure, or fast coefficients read the
    fields.
-11. `host_diffusion` is dry/no-moisture only until microphysics and cloud
-   macrophysics ownership is transport-mode-aware.
-12. Number-aware microphysics layouts with cloud or ice number concentrations
+11. Number-aware microphysics layouts with cloud or ice number concentrations
     must abort until a number closure exists.
-13. Microphysics remains active after SHOC. SHOC owns only non-precipitating
+12. Microphysics remains active after SHOC. SHOC owns only non-precipitating
     liquid-cloud macrophysics under the interim cloud contract. Microphysics owns
     precipitation formation, precipitation sinks and sources, sedimentation,
     deposition, sublimation, freezing, melting, and other phase-change processes
@@ -343,24 +327,17 @@ pre-dycore NaN and temperature checks and before `advance_dycore()` computes
 strain, eddy viscosity, primitive variables, Exner pressure, fast coefficients,
 and the multirate time integrator.
 
-During the dycore step, native SHOC in `state_update` mode does not add fast or
-slow RHS source terms. `ShocDriver::set_eddy_diffs()` clears the SHOC-owned
-vertical diffusivity components from the host eddy-diffusivity arrays, except for
-non-transport diagnostics such as the SHOC length scale. In mixed mode it
-exports only the momentum diffusivity to the host diffusion path. This prevents
-the host from reapplying SHOC scalar vertical transport.
+During the dycore step, native SHOC does not add fast or slow RHS source terms.
+`ShocDriver::set_eddy_diffs()` clears all SHOC-owned vertical diffusivity
+components from the host eddy-diffusivity arrays, except for non-transport
+diagnostics such as the SHOC length scale. This prevents generic host diffusion
+from reapplying SHOC vertical transport.
 
 `ShocDriver::set_diff_stresses()` clears the lower-boundary scalar fluxes that
-SHOC already consumed in `state_update` mode. It clears the momentum stresses as
-well only when native SHOC is explicitly configured to own momentum
-state-update transport.
-
-In `host_diffusion`, SHOC does not apply the pre-dycore state update and does not
-own the surface fluxes. Instead, SHOC exports vertical eddy-diffusivity
-coefficients to ERF's host diffusion path. This mode is currently limited to
-dry/no-moisture configurations because SHOC-family microphysics suppresses
-saturation adjustment or condensation while host-diffusion SHOC does not own the
-cloud-macrophysics mass update.
+SHOC already consumed and clears the momentum stresses when SHOC owns momentum
+state update or momentum transport is disabled. No Native SHOC transport mode
+exports vertical SHOC diffusivities or momentum stresses to generic host
+diffusion.
 
 Microphysics runs after the dycore with the default loose coupling. In that mode,
 `ERF::Advance()` calls `advance_microphysics()` after `advance_dycore()` produces

--- a/Source/TimeIntegration/ERF_Advance.cpp
+++ b/Source/TimeIntegration/ERF_Advance.cpp
@@ -179,7 +179,7 @@ ERF::Advance (int lev, double time, double dt_lev, int iteration, int /*ncycle*/
                                            eddyDiffs_lev[lev].get()      , z_phys_nd[lev].get()          ,
                                            dt_lev);
 
-            if (native_shoc_driver[lev] && native_shoc_driver[lev]->uses_state_update()) {
+            if (native_shoc_driver[lev]) {
                 // Native SHOC updates the old-time state before the dycore reads it.
                 // Re-fill the updated state, velocities, and momenta now so the
                 // pre-dycore checks and strain calculation see coherent fields.

--- a/Source/TimeIntegration/ERF_SlowRhsPost.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPost.cpp
@@ -152,9 +152,7 @@ void erf_slow_rhs_post (int level, int finest_level,
 #endif
     if (tc.uses_native_shoc()) {
         AMREX_ALWAYS_ASSERT(native_shoc_lev != nullptr);
-        l_apply_surface_layer_fluxes_in_diffusion =
-            l_apply_surface_layer_fluxes_in_diffusion &&
-            native_shoc_lev->uses_host_diffusion();
+        l_apply_surface_layer_fluxes_in_diffusion = false;
     }
 
     const GpuArray<Real, AMREX_SPACEDIM> dxInv = geom.InvCellSizeArray();

--- a/Source/TimeIntegration/ERF_SlowRhsPre.cpp
+++ b/Source/TimeIntegration/ERF_SlowRhsPre.cpp
@@ -216,9 +216,9 @@ void erf_slow_rhs_pre (int level, int finest_level,
 #endif
         if (tc.uses_native_shoc()) {
             AMREX_ALWAYS_ASSERT(native_shoc_lev != nullptr);
-            // Native SHOC always owns the scalar fluxes in state_update mode.
-            // When it also owns momentum stresses, we skip the generic
-            // SurfaceLayer call entirely so the host does not re-apply them.
+            // Native SHOC owns the scalar fluxes and does not hand momentum
+            // stresses back to the generic host diffusion path.
+            l_apply_surface_layer_fluxes_in_diffusion = false;
             native_shoc_lev->set_eddy_diffs();
         }
 
@@ -253,12 +253,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
 #endif
         if (tc.uses_native_shoc()) {
             AMREX_ALWAYS_ASSERT(native_shoc_lev != nullptr);
-            if (native_shoc_lev->owns_scalar_surface_fluxes()) {
-                l_apply_surface_layer_fluxes_in_diffusion = false;
-            }
-            if (!native_shoc_lev->needs_host_surface_momentum_stresses()) {
-                surface_layer_handled = true;
-            }
+            surface_layer_handled = true;
         }
         if (!surface_layer_handled && l_use_SurfLayer) {
             Vector<const MultiFab*> mfs = {&S_data[IntVars::cons], &xvel, &yvel, &zvel};
@@ -277,7 +272,7 @@ void erf_slow_rhs_pre (int level, int finest_level,
                                                       Q1fx1, Q1fx2, Q1fx3);
             }
         }
-        if (tc.uses_native_shoc() && native_shoc_lev && native_shoc_lev->owns_scalar_surface_fluxes()) {
+        if (tc.uses_native_shoc() && native_shoc_lev) {
             // SHOC-owned scalar fluxes must not be reused by the host
             // diffusion source, even if the host SurfaceLayer path was also
             // evaluated for momentum stress ownership.

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -268,6 +268,50 @@ function(add_test_cloud_chamber_legacy_config TEST_NAME)
         ATTACHED_FILES_ON_FAIL "${test_log};${output_artifact}")
 endfunction(add_test_cloud_chamber_legacy_config)
 
+# Negative startup tests for the Native SHOC transport modes removed from the
+# production input contract.  The shared fixture supplies a complete Native
+# SHOC run, while the runtime option exercises the real ParmParse reader path.
+function(add_test_shoc_removed_transport TEST_NAME RUNTIME_OPTION EXPECTED_MESSAGE
+        EXPECTED_GUIDANCE_1 EXPECTED_GUIDANCE_2)
+    set(TEST_FILES_DIR "SHOC_Stable_Clear")
+    setup_test()
+    resolve_test_exe("" "erf_exec" TEST_EXE)
+
+    set(test_input "${CURRENT_TEST_BINARY_DIR}/SHOC_Stable_Clear.i")
+    set(test_log "${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.log")
+    add_test(${TEST_NAME} ${CMAKE_COMMAND}
+        -DMPIEXEC=${MPIEXEC_EXECUTABLE}
+        -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
+        -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
+        -DTEST_EXE=${TEST_EXE}
+        -DINPUT=${test_input}
+        -DRUNTIME_OPTIONS=${RUNTIME_OPTION}
+        -DWORKING_DIRECTORY=${CURRENT_TEST_BINARY_DIR}
+        -DLOG=${test_log}
+        -DEXPECTED_MESSAGE=${EXPECTED_MESSAGE}
+        -DEXPECTED_GUIDANCE_1=${EXPECTED_GUIDANCE_1}
+        -DEXPECTED_GUIDANCE_2=${EXPECTED_GUIDANCE_2}
+        -P ${PROJECT_SOURCE_DIR}/Tests/RunShocRemovedTransportConfig.cmake)
+    set_tests_properties(${TEST_NAME}
+        PROPERTIES
+        TIMEOUT 180
+        PROCESSORS 1
+        WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}/"
+        LABELS "regression;shoc;configuration"
+        ATTACHED_FILES_ON_FAIL "${test_log}")
+endfunction(add_test_shoc_removed_transport)
+
+add_test_shoc_removed_transport(SHOC_Removed_Scalar_Host_Diffusion
+    "erf.shoc.transport_mode=host_diffusion"
+    "erf.shoc.transport_mode = host_diffusion has been removed for native SHOC"
+    "Use erf.shoc.transport_mode = state_update"
+    "")
+add_test_shoc_removed_transport(SHOC_Removed_Momentum_Host_Diffusion
+    "erf.shoc.momentum_transport=host_diffusion"
+    "erf.shoc.momentum_transport = host_diffusion has been removed for native SHOC"
+    "state_update"
+    "none")
+
 function(add_test_cloud_chamber_openmp TEST_NAME)
     set(TEST_FILES_DIR "CloudChamber_SatAdj")
     setup_test()

--- a/Tests/RunShocRemovedTransportConfig.cmake
+++ b/Tests/RunShocRemovedTransportConfig.cmake
@@ -1,0 +1,79 @@
+cmake_minimum_required(VERSION 3.24)
+
+if(NOT DEFINED MPIEXEC OR NOT DEFINED MPIEXEC_NUMPROC_FLAG OR
+   NOT DEFINED MPIEXEC_PREFLAGS OR NOT DEFINED TEST_EXE OR
+   NOT DEFINED INPUT OR NOT DEFINED RUNTIME_OPTIONS OR
+   NOT DEFINED WORKING_DIRECTORY OR NOT DEFINED LOG OR
+   NOT DEFINED EXPECTED_MESSAGE OR NOT DEFINED EXPECTED_GUIDANCE_1 OR
+   NOT DEFINED EXPECTED_GUIDANCE_2)
+    message(FATAL_ERROR "RunShocRemovedTransportConfig.cmake missing required argument")
+endif()
+
+if(NOT EXISTS "${TEST_EXE}")
+    message(FATAL_ERROR "Native SHOC startup test executable is missing: ${TEST_EXE}")
+endif()
+if(NOT EXISTS "${INPUT}")
+    message(FATAL_ERROR "Native SHOC startup test input is missing: ${INPUT}")
+endif()
+
+set(run_command)
+if(NOT "${MPIEXEC}" STREQUAL "")
+    if(NOT EXISTS "${MPIEXEC}")
+        message(FATAL_ERROR "Native SHOC startup test MPI launcher is missing: ${MPIEXEC}")
+    endif()
+
+    list(APPEND run_command "${MPIEXEC}")
+    if(NOT "${MPIEXEC_NUMPROC_FLAG}" STREQUAL "")
+        list(APPEND run_command "${MPIEXEC_NUMPROC_FLAG}" 1)
+    endif()
+    if(NOT "${MPIEXEC_PREFLAGS}" STREQUAL "")
+        separate_arguments(mpi_preflags UNIX_COMMAND "${MPIEXEC_PREFLAGS}")
+        list(APPEND run_command ${mpi_preflags})
+    endif()
+endif()
+
+list(APPEND run_command "${TEST_EXE}" "${INPUT}")
+if(NOT "${RUNTIME_OPTIONS}" STREQUAL "")
+    separate_arguments(runtime_options UNIX_COMMAND "${RUNTIME_OPTIONS}")
+    list(APPEND run_command ${runtime_options})
+endif()
+
+execute_process(
+    COMMAND ${run_command}
+    WORKING_DIRECTORY "${WORKING_DIRECTORY}"
+    OUTPUT_VARIABLE simulation_stdout
+    ERROR_VARIABLE simulation_stderr
+    RESULT_VARIABLE simulation_result)
+
+set(combined_output "${simulation_stdout}\n${simulation_stderr}")
+file(WRITE "${LOG}"
+    "RESULT=${simulation_result}\nINPUT=${INPUT}\n\n${combined_output}")
+
+if("${simulation_result}" STREQUAL "0")
+    message(FATAL_ERROR
+        "Native SHOC removed transport option unexpectedly succeeded; see ${LOG}")
+endif()
+
+foreach(expected_text IN ITEMS "${EXPECTED_MESSAGE}" "${EXPECTED_GUIDANCE_1}" "${EXPECTED_GUIDANCE_2}")
+    if(NOT "${expected_text}" STREQUAL "")
+        string(FIND "${combined_output}" "${expected_text}" expected_index)
+        if(expected_index EQUAL -1)
+            message(FATAL_ERROR
+                "Native SHOC startup failure did not contain expected text '${expected_text}'; see ${LOG}")
+        endif()
+    endif()
+endforeach()
+
+string(FIND "${combined_output}" "Coarse STEP" advancement_index)
+if(NOT advancement_index EQUAL -1)
+    message(FATAL_ERROR
+        "Native SHOC removed transport option was rejected after time advancement; see ${LOG}")
+endif()
+
+string(FIND "${combined_output}" "Writing native 3D plotfile" output_index)
+if(NOT output_index EQUAL -1)
+    message(FATAL_ERROR
+        "Native SHOC removed transport option was rejected after output; see ${LOG}")
+endif()
+
+message(STATUS "Native SHOC removed transport option rejected during startup")

--- a/Tests/Unit/Shoc/ERF_ShocDriverTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocDriverTests.cpp
@@ -893,8 +893,6 @@ TEST(ShocDriver, FaceSyncKeepsSeamCopiesAlignedAfterStateUpdate)
     solver_choice.moisture_indices = MoistureComponentIndices(RhoQ1_comp, RhoQ2_comp);
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
-    EXPECT_FALSE(driver.uses_host_diffusion());
 
     shoc_test::run_and_sync([&] {
         driver.advance(cons, xvel, yvel, zvel,
@@ -962,10 +960,8 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     solver_choice.moisture_type = MoistureType::None;
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
-    EXPECT_FALSE(driver.uses_host_diffusion());
     EXPECT_TRUE(driver.owns_scalar_surface_fluxes());
-    EXPECT_TRUE(driver.uses_momentum_host_diffusion());
+    EXPECT_TRUE(driver.uses_momentum_state_update());
     const Real dt = 10.0_rt;
     const Real max_mix_len = std::sqrt(geom.CellSizeArray()[0] * geom.CellSizeArray()[1]);
 
@@ -976,8 +972,6 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     MultiFab scalar_before(ba, dm, 1, 0);
     MultiFab hfx3_before(ba, dm, 1, 0);
     MultiFab qfx3_before(ba, dm, 1, 0);
-    MultiFab tau13_before(xzba, dm, 1, 0);
-    MultiFab tau23_before(yzba, dm, 1, 0);
     MultiFab::Copy(cons_before, cons, 0, 0, NVAR_max, 0);
     MultiFab::Copy(xvel_before, xvel, 0, 0, 1, 0);
     MultiFab::Copy(yvel_before, yvel, 0, 0, 1, 0);
@@ -985,8 +979,6 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     MultiFab::Copy(scalar_before, cons, RhoScalar_comp, 0, 1, 0);
     MultiFab::Copy(hfx3_before, hfx3, 0, 0, 1, 0);
     MultiFab::Copy(qfx3_before, qfx3, 0, 0, 1, 0);
-    MultiFab::Copy(tau13_before, tau13, 0, 0, 1, 0);
-    MultiFab::Copy(tau23_before, tau23, 0, 0, 1, 0);
 
     shoc_test::run_and_sync([&] {
         driver.advance(cons, xvel, yvel, zvel,
@@ -994,7 +986,6 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
                        z_phys_nd, geom, dt);
     });
     EXPECT_TRUE(driver.has_native_diagnostics());
-    EXPECT_TRUE(driver.uses_state_update());
     EXPECT_TRUE(driver.has_consumed_surface_flux_diagnostics());
 
     expect_multifab_finite(driver.native_diagnostics(), 0, EddyDiff::NumDiffs, "native_diagnostics");
@@ -1030,8 +1021,8 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     EXPECT_GT(component_max_abs_difference(cons, RhoTheta_comp, cons_before, RhoTheta_comp), 0.0_rt);
     expect_component_nonnegative(cons, RhoQ1_comp, "state-update qv");
     expect_component_nonnegative(cons, RhoKE_comp, "state-update tke");
-    EXPECT_EQ(component_max_abs_difference(xvel, 0, xvel_before, 0), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(yvel, 0, yvel_before, 0), 0.0_rt);
+    EXPECT_GT(component_max_abs_difference(xvel, 0, xvel_before, 0), 0.0_rt);
+    EXPECT_GT(component_max_abs_difference(yvel, 0, yvel_before, 0), 0.0_rt);
     EXPECT_EQ(component_max_abs_difference(zvel, 0, zvel_before, 0), 0.0_rt);
     EXPECT_EQ(component_max_abs_difference(cons, RhoScalar_comp, scalar_before, 0), 0.0_rt);
 
@@ -1040,8 +1031,7 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
     });
 
     expect_multifab_finite(eddy_diffs, 0, EddyDiff::NumDiffs, "eddy_diffs");
-    expect_component_minmax_match(eddy_diffs, driver.native_diagnostics(),
-                                  EddyDiff::Mom_v, "eddy_diffs Mom_v writeback");
+    expect_component_between(eddy_diffs, EddyDiff::Mom_v, 0.0_rt, 0.0_rt, "eddy_diffs Mom_v cleared");
     expect_component_between(eddy_diffs, EddyDiff::Theta_v, 0.0_rt, 0.0_rt, "eddy_diffs Theta_v cleared");
     expect_component_between(eddy_diffs, EddyDiff::KE_v, 0.0_rt, 0.0_rt, "eddy_diffs KE_v cleared");
     expect_component_between(eddy_diffs, EddyDiff::Scalar_v, 0.0_rt, 0.0_rt, "eddy_diffs Scalar_v cleared");
@@ -1056,8 +1046,8 @@ TEST(ShocDriver, AdvanceAppliesStateUpdateAndProducesFiniteDiagnostics)
 
     expect_component_between(hfx3, 0, 0.0_rt, 0.0_rt, "hfx3 cleared");
     expect_component_between(qfx3, 0, 0.0_rt, 0.0_rt, "qfx3 cleared");
-    expect_component_minmax_match(tau13, tau13_before, 0, "tau13 preserved for host momentum diffusion");
-    expect_component_minmax_match(tau23, tau23_before, 0, "tau23 preserved for host momentum diffusion");
+    expect_component_between(tau13, 0, 0.0_rt, 0.0_rt, "tau13 cleared after SHOC momentum update");
+    expect_component_between(tau23, 0, 0.0_rt, 0.0_rt, "tau23 cleared after SHOC momentum update");
     expect_component_minmax_match(driver.consumed_sens_flux_diagnostics(), hfx3_before, 0,
                                   "consumed sensible flux preserved");
     expect_component_minmax_match(driver.consumed_laten_flux_diagnostics(), qfx3_before, 0,
@@ -1138,10 +1128,8 @@ TEST(ShocDriver, MomentumTransportNoneLeavesVelocitiesUntouchedAndSkipsMomentumE
     solver_choice.moisture_type = MoistureType::None;
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
     EXPECT_TRUE(driver.owns_scalar_surface_fluxes());
     EXPECT_TRUE(driver.disables_momentum_transport());
-    EXPECT_FALSE(driver.uses_momentum_host_diffusion());
     EXPECT_FALSE(driver.uses_momentum_state_update());
 
     shoc_test::run_and_sync([&] {
@@ -1204,21 +1192,15 @@ TEST(ShocDriver, MomentumTransportStateUpdateUpdatesFaceVelocitiesWhenRequested)
 
     MultiFab xvel_before(xba, dm, 1, 0);
     MultiFab yvel_before(yba, dm, 1, 0);
-    MultiFab tau13_before(xzba, dm, 1, 0);
-    MultiFab tau23_before(yzba, dm, 1, 0);
     MultiFab::Copy(xvel_before, xvel, 0, 0, 1, 0);
     MultiFab::Copy(yvel_before, yvel, 0, 0, 1, 0);
-    MultiFab::Copy(tau13_before, tau13, 0, 0, 1, 0);
-    MultiFab::Copy(tau23_before, tau23, 0, 0, 1, 0);
 
     SolverChoice solver_choice;
     solver_choice.moisture_type = MoistureType::None;
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
     EXPECT_TRUE(driver.owns_scalar_surface_fluxes());
     EXPECT_TRUE(driver.uses_momentum_state_update());
-    EXPECT_FALSE(driver.uses_momentum_host_diffusion());
 
     shoc_test::run_and_sync([&] {
         driver.advance(cons, xvel, yvel, zvel,
@@ -1496,278 +1478,6 @@ TEST(ShocDriver, SecondAdvanceIgnoresHostDiffSeedsAfterCarryStateIsEstablished)
     expect_component_minmax_match(driver_a.pblh_diagnostics(), driver_b.pblh_diagnostics(),
                                   0, "second-advance pblh diagnostics");
 }
-void
-initialize_exported_eddy_diffs (MultiFab& mf, int comp, int ncomp)
-{
-    mf.setVal(-7.0_rt);
-    for (MFIter mfi(mf, false); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
-        auto arr = mf.array(mfi);
-        ParallelFor(bx, ncomp,
-                    [=] AMREX_GPU_DEVICE (int i, int j, int k, int n) noexcept {
-            arr(i,j,k,comp+n) = 1000.0_rt * static_cast<Real>(n) +
-                                100.0_rt * static_cast<Real>(i) +
-                                10.0_rt * static_cast<Real>(j) +
-                                static_cast<Real>(k);
-        });
-    }
-}
-
-
-TEST(ShocDriver, PhysicalBoundaryGhostsPreserveGlobalTangentialIndices)
-{
-    const Box domain(IntVect(0,0,0), IntVect(3,3,1));
-    amrex::RealBox real_box(0.0_rt, 0.0_rt, 0.0_rt,
-                            400.0_rt, 400.0_rt, 200.0_rt);
-    int nonperiodic[AMREX_SPACEDIM] = {0, 0, 0};
-    Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, nonperiodic);
-
-    BoxArray split_ba(domain);
-    split_ba.maxSize(IntVect(domain.length(0), 2, domain.length(2)));
-    DistributionMapping split_dm(split_ba);
-    BoxArray single_ba(domain);
-    DistributionMapping single_dm(single_ba);
-
-    constexpr int comp = EddyDiff::Mom_v;
-    constexpr int ncomp = EddyDiff::Q_v - EddyDiff::Mom_v + 1;
-    MultiFab split(split_ba, split_dm, EddyDiff::NumDiffs, 1);
-    MultiFab single(single_ba, single_dm, EddyDiff::NumDiffs, 1);
-
-    shoc_test::run_and_sync([&] {
-        initialize_exported_eddy_diffs(split, comp, ncomp);
-        initialize_exported_eddy_diffs(single, comp, ncomp);
-    });
-
-    shoc_test::run_and_sync([&] {
-        shoc_fill_physical_boundary_ghosts(split, geom, comp, ncomp);
-        shoc_fill_physical_boundary_ghosts(single, geom, comp, ncomp);
-    });
-
-    int seam_j = -1;
-    amrex::Vector<Real> split_ghost(ncomp);
-    amrex::Vector<Real> split_expected(ncomp);
-    amrex::Vector<Real> split_local(ncomp);
-    amrex::Vector<Real> single_ghost(ncomp);
-    bool found_split = false;
-    bool found_expected = false;
-    bool found_single = false;
-
-    for (MFIter mfi(split, false); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
-        const auto host = shoc_test::copy_fab_to_host(split[mfi]);
-        const auto arr = host.const_array();
-        if (bx.smallEnd(1) > domain.smallEnd(1)) {
-            seam_j = bx.smallEnd(1);
-            for (int n = 0; n < ncomp; ++n) {
-                split_ghost[n] = arr(domain.smallEnd(0) - 1, seam_j - 1,
-                                     domain.smallEnd(2), comp+n);
-                split_local[n] = arr(domain.smallEnd(0), seam_j,
-                                     domain.smallEnd(2), comp+n);
-            }
-            found_split = true;
-        }
-    }
-
-    ASSERT_GT(seam_j, domain.smallEnd(1));
-    for (MFIter mfi(split, false); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
-        if (bx.contains(IntVect(domain.smallEnd(0), seam_j - 1,
-                                domain.smallEnd(2)))) {
-            const auto host = shoc_test::copy_fab_to_host(split[mfi]);
-            const auto arr = host.const_array();
-            for (int n = 0; n < ncomp; ++n) {
-                split_expected[n] = arr(domain.smallEnd(0), seam_j - 1,
-                                         domain.smallEnd(2), comp+n);
-            }
-            found_expected = true;
-        }
-    }
-
-    for (MFIter mfi(single, false); mfi.isValid(); ++mfi) {
-        const auto host = shoc_test::copy_fab_to_host(single[mfi]);
-        const auto arr = host.const_array();
-        for (int n = 0; n < ncomp; ++n) {
-            single_ghost[n] = arr(domain.smallEnd(0) - 1, seam_j - 1,
-                                  domain.smallEnd(2), comp+n);
-        }
-        found_single = true;
-    }
-
-    ASSERT_TRUE(found_split);
-    ASSERT_TRUE(found_expected);
-    ASSERT_TRUE(found_single);
-    for (int n = 0; n < ncomp; ++n) {
-        EXPECT_NEAR(split_ghost[n], split_expected[n], tol)
-            << "split physical/inter-box ghost component " << n;
-        EXPECT_NE(split_ghost[n], split_local[n])
-            << "split ghost incorrectly used the local tangential cell, component " << n;
-        EXPECT_NEAR(single_ghost[n], split_expected[n], tol)
-            << "single-box decomposition mismatch, component " << n;
-    }
-
-    int periodic_y[AMREX_SPACEDIM] = {0, 1, 0};
-    Geometry periodic_geom(domain, &real_box, amrex::CoordSys::cartesian, periodic_y);
-    MultiFab periodic(split_ba, split_dm, EddyDiff::NumDiffs, 1);
-    shoc_test::run_and_sync([&] {
-        initialize_exported_eddy_diffs(periodic, comp, ncomp);
-        shoc_fill_physical_boundary_ghosts(periodic, periodic_geom, comp, ncomp);
-    });
-
-    amrex::Vector<Real> periodic_ghost(ncomp);
-    amrex::Vector<Real> periodic_expected(ncomp);
-    amrex::Vector<Real> periodic_local(ncomp);
-    bool found_periodic = false;
-    bool found_periodic_expected = false;
-    for (MFIter mfi(periodic, false); mfi.isValid(); ++mfi) {
-        const Box& bx = mfi.validbox();
-        const auto host = shoc_test::copy_fab_to_host(periodic[mfi]);
-        const auto arr = host.const_array();
-        if (bx.smallEnd(1) == domain.smallEnd(1)) {
-            for (int n = 0; n < ncomp; ++n) {
-                periodic_ghost[n] = arr(domain.smallEnd(0) - 1,
-                                        domain.smallEnd(1) - 1,
-                                        domain.smallEnd(2), comp+n);
-                periodic_local[n] = arr(domain.smallEnd(0),
-                                        domain.smallEnd(1),
-                                        domain.smallEnd(2), comp+n);
-            }
-            found_periodic = true;
-        }
-        if (bx.bigEnd(1) == domain.bigEnd(1)) {
-            for (int n = 0; n < ncomp; ++n) {
-                periodic_expected[n] = arr(domain.smallEnd(0),
-                                           domain.bigEnd(1),
-                                           domain.smallEnd(2), comp+n);
-            }
-            found_periodic_expected = true;
-        }
-    }
-
-    ASSERT_TRUE(found_periodic);
-    ASSERT_TRUE(found_periodic_expected);
-    for (int n = 0; n < ncomp; ++n) {
-        EXPECT_NEAR(periodic_ghost[n], periodic_expected[n], tol)
-            << "periodic tangential ghost component " << n;
-        EXPECT_NE(periodic_ghost[n], periodic_local[n])
-            << "periodic tangential ghost was clamped locally, component " << n;
-    }
-}
-
-TEST(ShocDriver, HostDiffusionModeExportsDiffusivitiesWithoutInternalTransport)
-{
-    ScopedParmParseString transport_mode("erf.shoc", "transport_mode", "host_diffusion");
-
-    Box domain(IntVect(0,0,0), IntVect(nx-1, ny-1, nz-1));
-    amrex::RealBox real_box(0.0_rt, 0.0_rt, 0.0_rt,
-                            500.0_rt, 100.0_rt, 900.0_rt);
-    int is_periodic[AMREX_SPACEDIM] = {1, 1, 0};
-    Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic);
-    const FixtureMap fixture = load_driver_fixture();
-
-    amrex::BoxArray ba(domain);
-    // The current SHOC driver path maps each MFIter tile to a full-height
-    // column workspace, so keep tiling in x only here.
-    ba.maxSize(IntVect(3, ny, nz));
-    DistributionMapping dm(ba);
-
-    MultiFab cons(ba, dm, NVAR_max, 0);
-    amrex::BoxArray xba = amrex::convert(ba, IntVect(1,0,0));
-    amrex::BoxArray yba = amrex::convert(ba, IntVect(0,1,0));
-    amrex::BoxArray zba = amrex::convert(ba, IntVect(0,0,1));
-    amrex::BoxArray xzba = amrex::convert(ba, IntVect(1,0,1));
-    amrex::BoxArray yzba = amrex::convert(ba, IntVect(0,1,1));
-
-    MultiFab xvel(xba, dm, 1, 0);
-    MultiFab yvel(yba, dm, 1, 0);
-    MultiFab zvel(zba, dm, 1, 0);
-    MultiFab z_phys_nd(make_nodal_zphys_boxarray(ba), dm, 1, 0);
-    MultiFab hfx3(ba, dm, 1, 0);
-    MultiFab qfx3(ba, dm, 1, 0);
-    MultiFab tau13(xzba, dm, 1, 0);
-    MultiFab tau23(yzba, dm, 1, 0);
-    MultiFab eddy_diffs(ba, dm, EddyDiff::NumDiffs, 0);
-
-    initialize_state(cons, fixture);
-    initialize_velocity(xvel, yvel, zvel, fixture);
-    initialize_geometry(z_phys_nd, fixture);
-    initialize_surface_fluxes(hfx3, qfx3, tau13, tau23, fixture);
-    initialize_eddy_diffs(eddy_diffs, fixture);
-    shoc_test::sync();
-
-    MultiFab hfx3_before(ba, dm, 1, 0);
-    MultiFab qfx3_before(ba, dm, 1, 0);
-    MultiFab tau13_before(xzba, dm, 1, 0);
-    MultiFab tau23_before(yzba, dm, 1, 0);
-    MultiFab cons_before(ba, dm, NVAR_max, 0);
-    MultiFab xvel_before(xba, dm, 1, 0);
-    MultiFab yvel_before(yba, dm, 1, 0);
-    MultiFab zvel_before(zba, dm, 1, 0);
-    MultiFab::Copy(hfx3_before, hfx3, 0, 0, 1, 0);
-    MultiFab::Copy(qfx3_before, qfx3, 0, 0, 1, 0);
-    MultiFab::Copy(tau13_before, tau13, 0, 0, 1, 0);
-    MultiFab::Copy(tau23_before, tau23, 0, 0, 1, 0);
-    MultiFab::Copy(cons_before, cons, 0, 0, NVAR_max, 0);
-    MultiFab::Copy(xvel_before, xvel, 0, 0, 1, 0);
-    MultiFab::Copy(yvel_before, yvel, 0, 0, 1, 0);
-    MultiFab::Copy(zvel_before, zvel, 0, 0, 1, 0);
-
-    SolverChoice solver_choice;
-    solver_choice.moisture_type = MoistureType::None;
-
-    ShocDriver driver(0, solver_choice);
-    EXPECT_FALSE(driver.uses_state_update());
-    EXPECT_TRUE(driver.uses_host_diffusion());
-    EXPECT_TRUE(driver.uses_momentum_host_diffusion());
-
-    shoc_test::run_and_sync([&] {
-        driver.advance(cons, xvel, yvel, zvel,
-                       &tau13, &tau23, &hfx3, &qfx3, &eddy_diffs,
-                       z_phys_nd, geom, 10.0_rt);
-    });
-
-    shoc_test::run_and_sync([&] {
-        driver.set_eddy_diffs();
-        driver.set_diff_stresses();
-    });
-
-    for (int comp = 0; comp < EddyDiff::NumDiffs; ++comp) {
-        expect_component_minmax_match(eddy_diffs, driver.native_diagnostics(), comp,
-                                      "host-diffusion eddy_diffs writeback");
-    }
-    expect_component_minmax_match(hfx3, hfx3_before, 0, "host-diffusion hfx3 preservation");
-    expect_component_minmax_match(qfx3, qfx3_before, 0, "host-diffusion qfx3 preservation");
-    expect_component_minmax_match(tau13, tau13_before, 0, "host-diffusion tau13 preservation");
-    expect_component_minmax_match(tau23, tau23_before, 0, "host-diffusion tau23 preservation");
-
-    amrex::Vector<MultiFab> rhs(IntVars::NumTypes);
-    rhs[IntVars::cons].define(ba, dm, NVAR_max, 0);
-    rhs[IntVars::xmom].define(xba, dm, 1, 0);
-    rhs[IntVars::ymom].define(yba, dm, 1, 0);
-    rhs[IntVars::zmom].define(zba, dm, 1, 0);
-    for (auto& mf : rhs) {
-        fill_multifab(mf, 0.0_rt);
-    }
-
-    shoc_test::run_and_sync([&] {
-        driver.add_fast_tend(rhs);
-        for (MFIter mfi(rhs[IntVars::cons], false); mfi.isValid(); ++mfi) {
-            driver.add_slow_tend(mfi, mfi.validbox(), rhs[IntVars::cons].array(mfi));
-        }
-    });
-
-    EXPECT_EQ(component_max_abs_difference(cons, Rho_comp, cons_before, Rho_comp), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(cons, RhoTheta_comp, cons_before, RhoTheta_comp), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(cons, RhoQ1_comp, cons_before, RhoQ1_comp), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(xvel, 0, xvel_before, 0), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(yvel, 0, yvel_before, 0), 0.0_rt);
-    EXPECT_EQ(component_max_abs_difference(zvel, 0, zvel_before, 0), 0.0_rt);
-
-    expect_component_between(rhs[IntVars::cons], RhoTheta_comp, 0.0_rt, 0.0_rt, "host-diffusion theta rhs");
-    expect_component_between(rhs[IntVars::cons], RhoQ1_comp, 0.0_rt, 0.0_rt, "host-diffusion qv rhs");
-    expect_component_between(rhs[IntVars::cons], RhoKE_comp, 0.0_rt, 0.0_rt, "host-diffusion tke rhs");
-    expect_component_between(rhs[IntVars::xmom], 0, 0.0_rt, 0.0_rt, "host-diffusion xmom rhs");
-    expect_component_between(rhs[IntVars::ymom], 0, 0.0_rt, 0.0_rt, "host-diffusion ymom rhs");
-}
 
 TEST(ShocDriver, NumberAwareMoistureLayoutHelperRecognizesNcAndNi)
 {
@@ -1841,23 +1551,10 @@ TEST(ShocDriver, StateUpdateModeRejectsNumberAwareMoistureLayoutsWithoutNumberCl
         RhoQ1_comp, RhoQ2_comp, RhoQ3_comp, RhoQ4_comp, RhoQ5_comp, RhoQ6_comp,
         RhoQ7_comp, RhoQ8_comp, RhoQ9_comp, RhoQ10_comp, RhoQ11_comp);
 
-    ShocRuntimeOptions opts;
-    opts.transport_mode = ShocTransportMode::StateUpdate;
     std::string error_message;
     EXPECT_FALSE(shoc_driver_state_update_layout_supported(
-        opts, solver_choice.moisture_indices, cons.nComp(), error_message));
+        solver_choice.moisture_indices, cons.nComp(), error_message));
     EXPECT_NE(error_message.find("number closure"), std::string::npos);
-}
-
-TEST(ShocDriver, HostDiffusionWithMoistureIsRejected)
-{
-    ShocRuntimeOptions opts;
-    opts.transport_mode = ShocTransportMode::HostDiffusion;
-
-    std::string error_message;
-    EXPECT_FALSE(shoc_driver_host_diffusion_moisture_supported(
-        opts, MoistureType::Morrison, error_message));
-    EXPECT_NE(error_message.find("host_diffusion with moisture"), std::string::npos);
 }
 
 TEST(ShocDriver, StateUpdateModeSupportsIceCapableMoistureLayouts)
@@ -1905,8 +1602,6 @@ TEST(ShocDriver, StateUpdateModeSupportsIceCapableMoistureLayouts)
         RhoQ1_comp, RhoQ2_comp, RhoQ3_comp, RhoQ4_comp, RhoQ5_comp, RhoQ6_comp);
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
-    EXPECT_FALSE(driver.uses_host_diffusion());
 
     shoc_test::run_and_sync([&] {
         driver.advance(cons, xvel, yvel, zvel,
@@ -1988,7 +1683,6 @@ TEST(ShocDriver, MultiStepStateUpdateModeKeepsColumnDiagnosticsStable)
     solver_choice.moisture_type = MoistureType::None;
 
     ShocDriver driver(0, solver_choice);
-    EXPECT_TRUE(driver.uses_state_update());
 
     amrex::Vector<MultiFab> rhs(IntVars::NumTypes);
     rhs[IntVars::cons].define(ba, dm, NVAR_max, 0);
@@ -2021,119 +1715,6 @@ TEST(ShocDriver, MultiStepStateUpdateModeKeepsColumnDiagnosticsStable)
         expect_multifab_finite(cons, RhoKE_comp, 1, "multistep cons rho-ke");
         expect_multifab_finite(xvel, 0, 1, "multistep xvel");
         expect_multifab_finite(yvel, 0, 1, "multistep yvel");
-    }
-}
-
-TEST(ShocDriver, MultiStepHostDiffusionModeKeepsExportsStable)
-{
-    ScopedParmParseString transport_mode("erf.shoc", "transport_mode", "host_diffusion");
-
-    Box domain(IntVect(0,0,0), IntVect(nx-1, ny-1, nz-1));
-    amrex::RealBox real_box(0.0_rt, 0.0_rt, 0.0_rt,
-                            500.0_rt, 100.0_rt, 900.0_rt);
-    int is_periodic[AMREX_SPACEDIM] = {1, 1, 0};
-    Geometry geom(domain, &real_box, amrex::CoordSys::cartesian, is_periodic);
-    const FixtureMap fixture = load_driver_fixture();
-    const Real dt = 10.0_rt;
-    const int nsteps = 5;
-    const Real max_mix_len = std::sqrt(geom.CellSizeArray()[0] * geom.CellSizeArray()[1]);
-
-    amrex::BoxArray ba(domain);
-    // The current SHOC driver path maps each MFIter tile to a full-height
-    // column workspace, so keep tiling in x only here.
-    ba.maxSize(IntVect(3, ny, nz));
-    DistributionMapping dm(ba);
-
-    MultiFab cons(ba, dm, NVAR_max, 0);
-    amrex::BoxArray xba = amrex::convert(ba, IntVect(1,0,0));
-    amrex::BoxArray yba = amrex::convert(ba, IntVect(0,1,0));
-    amrex::BoxArray zba = amrex::convert(ba, IntVect(0,0,1));
-    amrex::BoxArray xzba = amrex::convert(ba, IntVect(1,0,1));
-    amrex::BoxArray yzba = amrex::convert(ba, IntVect(0,1,1));
-
-    MultiFab xvel(xba, dm, 1, 0);
-    MultiFab yvel(yba, dm, 1, 0);
-    MultiFab zvel(zba, dm, 1, 0);
-    MultiFab z_phys_nd(make_nodal_zphys_boxarray(ba), dm, 1, 0);
-    MultiFab hfx3(ba, dm, 1, 0);
-    MultiFab qfx3(ba, dm, 1, 0);
-    MultiFab tau13(xzba, dm, 1, 0);
-    MultiFab tau23(yzba, dm, 1, 0);
-    MultiFab eddy_diffs(ba, dm, EddyDiff::NumDiffs, 0);
-
-    initialize_state(cons, fixture);
-    initialize_velocity(xvel, yvel, zvel, fixture);
-    initialize_geometry(z_phys_nd, fixture);
-    initialize_surface_fluxes(hfx3, qfx3, tau13, tau23, fixture);
-    initialize_eddy_diffs(eddy_diffs, fixture);
-    shoc_test::sync();
-
-    SolverChoice solver_choice;
-    solver_choice.moisture_type = MoistureType::None;
-
-    ShocDriver driver(0, solver_choice);
-    EXPECT_FALSE(driver.uses_state_update());
-    EXPECT_TRUE(driver.uses_host_diffusion());
-    EXPECT_TRUE(driver.uses_momentum_host_diffusion());
-
-    amrex::Vector<MultiFab> rhs(IntVars::NumTypes);
-    rhs[IntVars::cons].define(ba, dm, NVAR_max, 0);
-    rhs[IntVars::xmom].define(xba, dm, 1, 0);
-    rhs[IntVars::ymom].define(yba, dm, 1, 0);
-    rhs[IntVars::zmom].define(zba, dm, 1, 0);
-
-    MultiFab hfx3_before(ba, dm, 1, 0);
-    MultiFab qfx3_before(ba, dm, 1, 0);
-    MultiFab tau13_before(xzba, dm, 1, 0);
-    MultiFab tau23_before(yzba, dm, 1, 0);
-    MultiFab cons_before(ba, dm, NVAR_max, 0);
-    MultiFab xvel_before(xba, dm, 1, 0);
-    MultiFab yvel_before(yba, dm, 1, 0);
-    MultiFab zvel_before(zba, dm, 1, 0);
-    MultiFab::Copy(hfx3_before, hfx3, 0, 0, 1, 0);
-    MultiFab::Copy(qfx3_before, qfx3, 0, 0, 1, 0);
-    MultiFab::Copy(tau13_before, tau13, 0, 0, 1, 0);
-    MultiFab::Copy(tau23_before, tau23, 0, 0, 1, 0);
-    MultiFab::Copy(cons_before, cons, 0, 0, NVAR_max, 0);
-    MultiFab::Copy(xvel_before, xvel, 0, 0, 1, 0);
-    MultiFab::Copy(yvel_before, yvel, 0, 0, 1, 0);
-    MultiFab::Copy(zvel_before, zvel, 0, 0, 1, 0);
-
-    for (int step = 0; step < nsteps; ++step) {
-        shoc_test::run_and_sync([&] {
-            driver.advance(cons, xvel, yvel, zvel,
-                           &tau13, &tau23, &hfx3, &qfx3, &eddy_diffs,
-                           z_phys_nd, geom, dt);
-            driver.set_eddy_diffs();
-            driver.set_diff_stresses();
-            reset_rhs(rhs);
-            driver.add_fast_tend(rhs);
-            for (MFIter mfi(rhs[IntVars::cons], false); mfi.isValid(); ++mfi) {
-                driver.add_slow_tend(mfi, mfi.validbox(), rhs[IntVars::cons].array(mfi));
-            }
-        });
-
-        EXPECT_EQ(component_max_abs_difference(cons, Rho_comp, cons_before, Rho_comp), 0.0_rt);
-        EXPECT_EQ(component_max_abs_difference(cons, RhoTheta_comp, cons_before, RhoTheta_comp), 0.0_rt);
-        EXPECT_EQ(component_max_abs_difference(cons, RhoQ1_comp, cons_before, RhoQ1_comp), 0.0_rt);
-        EXPECT_EQ(component_max_abs_difference(xvel, 0, xvel_before, 0), 0.0_rt);
-        EXPECT_EQ(component_max_abs_difference(yvel, 0, yvel_before, 0), 0.0_rt);
-        EXPECT_EQ(component_max_abs_difference(zvel, 0, zvel_before, 0), 0.0_rt);
-        expect_driver_diagnostics_stable(driver, max_mix_len);
-        for (int comp = 0; comp < EddyDiff::NumDiffs; ++comp) {
-            expect_component_minmax_match(eddy_diffs, driver.native_diagnostics(), comp,
-                                          "multistep host-diffusion eddy_diffs writeback");
-        }
-        expect_component_minmax_match(hfx3, hfx3_before, 0, "multistep host-diffusion hfx3 preservation");
-        expect_component_minmax_match(qfx3, qfx3_before, 0, "multistep host-diffusion qfx3 preservation");
-        expect_component_minmax_match(tau13, tau13_before, 0, "multistep host-diffusion tau13 preservation");
-        expect_component_minmax_match(tau23, tau23_before, 0, "multistep host-diffusion tau23 preservation");
-
-        expect_component_between(rhs[IntVars::cons], RhoTheta_comp, 0.0_rt, 0.0_rt, "multistep host-diffusion theta rhs");
-        expect_component_between(rhs[IntVars::cons], RhoQ1_comp, 0.0_rt, 0.0_rt, "multistep host-diffusion qv rhs");
-        expect_component_between(rhs[IntVars::cons], RhoKE_comp, 0.0_rt, 0.0_rt, "multistep host-diffusion tke rhs");
-        expect_component_between(rhs[IntVars::xmom], 0, 0.0_rt, 0.0_rt, "multistep host-diffusion xmom rhs");
-        expect_component_between(rhs[IntVars::ymom], 0, 0.0_rt, 0.0_rt, "multistep host-diffusion ymom rhs");
     }
 }
 

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -3,6 +3,8 @@
 #include "ERF_ShocTestUtils.H"
 #include "ERF_ShocTypes.H"
 
+#include <AMReX_ParmParse.H>
+
 #include <gtest/gtest.h>
 
 #include <cmath>
@@ -17,27 +19,74 @@ TEST(ShocRuntimeOptions, DefaultsValidate)
     EXPECT_GE(opts.coeff_kh, 0.0);
     EXPECT_FALSE(opts.debug_summary);
     EXPECT_EQ(opts.transport_mode, ShocTransportMode::StateUpdate);
-    EXPECT_EQ(opts.momentum_transport, ShocMomentumTransport::HostDiffusion);
+    EXPECT_EQ(opts.momentum_transport, ShocMomentumTransport::StateUpdate);
 }
 
 TEST(ShocRuntimeOptions, TransportModeHelpersMatchIntent)
 {
-    EXPECT_TRUE(shoc_uses_state_update(ShocTransportMode::StateUpdate));
-    EXPECT_FALSE(shoc_uses_host_diffusion(ShocTransportMode::StateUpdate));
-
-    EXPECT_FALSE(shoc_uses_state_update(ShocTransportMode::HostDiffusion));
-    EXPECT_TRUE(shoc_uses_host_diffusion(ShocTransportMode::HostDiffusion));
-
     EXPECT_TRUE(shoc_uses_momentum_state_update(ShocMomentumTransport::StateUpdate));
     EXPECT_FALSE(shoc_uses_momentum_state_update(ShocMomentumTransport::None));
-    EXPECT_TRUE(shoc_uses_momentum_host_diffusion(ShocMomentumTransport::HostDiffusion));
-    EXPECT_FALSE(shoc_uses_momentum_host_diffusion(ShocMomentumTransport::None));
     EXPECT_TRUE(shoc_disables_momentum_transport(ShocMomentumTransport::None));
+    EXPECT_FALSE(shoc_disables_momentum_transport(ShocMomentumTransport::StateUpdate));
+    EXPECT_EQ(std::string(shoc_transport_mode_name(ShocTransportMode::StateUpdate)), "state_update");
+    EXPECT_EQ(std::string(shoc_momentum_transport_name(ShocMomentumTransport::StateUpdate)), "state_update");
     EXPECT_EQ(std::string(shoc_momentum_transport_name(ShocMomentumTransport::None)), "none");
 }
 
 namespace
 {
+class ScopedParmParseString
+{
+public:
+    ScopedParmParseString (const char* name, const std::string& value)
+        : m_pp("erf.shoc"),
+          m_name(name)
+    {
+        m_had_previous = m_pp.query(m_name, m_previous);
+        m_pp.remove(m_name);
+        m_pp.add(m_name, value);
+    }
+
+    ~ScopedParmParseString ()
+    {
+        m_pp.remove(m_name);
+        if (m_had_previous) {
+            m_pp.add(m_name, m_previous);
+        }
+    }
+
+private:
+    amrex::ParmParse m_pp;
+    std::string m_name;
+    std::string m_previous;
+    bool m_had_previous = false;
+};
+
+class ScopedParmParseRemoval
+{
+public:
+    explicit ScopedParmParseRemoval (const char* name)
+        : m_pp("erf.shoc"),
+          m_name(name)
+    {
+        m_had_previous = m_pp.query(m_name, m_previous);
+        m_pp.remove(m_name);
+    }
+
+    ~ScopedParmParseRemoval ()
+    {
+        if (m_had_previous) {
+            m_pp.add(m_name, m_previous);
+        }
+    }
+
+private:
+    amrex::ParmParse m_pp;
+    std::string m_name;
+    std::string m_previous;
+    bool m_had_previous = false;
+};
+
 void
 shift_column_heights (ShocColumnData& col, amrex::Real offset)
 {
@@ -61,25 +110,65 @@ TEST(ShocRuntimeOptions, LegacyTendenciesTransportModeIsRejected)
     EXPECT_NE(error_message.find("removed for native SHOC"), std::string::npos);
 }
 
+TEST(ShocRuntimeOptions, RemovedScalarHostDiffusionModeIsRejected)
+{
+    ShocRuntimeOptions opts;
+    std::string error_message;
+    EXPECT_FALSE(parse_shoc_transport_mode_string("HOST_DIFFUSION", opts.transport_mode,
+                                                  error_message));
+    EXPECT_NE(error_message.find("has been removed for native SHOC"), std::string::npos);
+    EXPECT_NE(error_message.find("Use erf.shoc.transport_mode = state_update"),
+              std::string::npos);
+}
+
+TEST(ShocRuntimeOptions, RemovedMomentumHostDiffusionModeIsRejected)
+{
+    ShocMomentumTransport transport = ShocMomentumTransport::StateUpdate;
+    std::string error_message;
+    EXPECT_FALSE(parse_shoc_momentum_transport_string("HoSt_DiFfUsIoN", transport,
+                                                      error_message));
+    EXPECT_NE(error_message.find("has been removed for native SHOC"), std::string::npos);
+    EXPECT_NE(error_message.find("'state_update'"), std::string::npos);
+    EXPECT_NE(error_message.find("'none'"), std::string::npos);
+}
+
 TEST(ShocRuntimeOptions, InvalidMomentumTransportIsRejected)
 {
     ShocMomentumTransport transport = ShocMomentumTransport::None;
     std::string error_message;
     EXPECT_FALSE(parse_shoc_momentum_transport_string("tendons", transport, error_message));
     EXPECT_NE(error_message.find("erf.shoc.momentum_transport"), std::string::npos);
+    EXPECT_NE(error_message.find("'none'"), std::string::npos);
+    EXPECT_NE(error_message.find("'state_update'"), std::string::npos);
+    EXPECT_EQ(error_message.find("host_diffusion"), std::string::npos);
 }
 
-TEST(ShocRuntimeOptions, HostDiffusionTransportRequiresHostMomentumTransport)
+TEST(ShocRuntimeOptions, InvalidScalarTransportAdvertisesOnlyStateUpdate)
 {
     ShocRuntimeOptions opts;
-    opts.transport_mode = ShocTransportMode::HostDiffusion;
-    opts.momentum_transport = ShocMomentumTransport::StateUpdate;
-
     std::string error_message;
-    EXPECT_FALSE(validate_shoc_runtime_options_message(opts, error_message));
-    EXPECT_NE(error_message.find(
-                  "host_diffusion requires erf.shoc.momentum_transport = host_diffusion"),
-              std::string::npos);
+    EXPECT_FALSE(parse_shoc_transport_mode_string("unknown", opts.transport_mode, error_message));
+    EXPECT_NE(error_message.find("'state_update'"), std::string::npos);
+    EXPECT_EQ(error_message.find("host_diffusion"), std::string::npos);
+}
+
+TEST(ShocRuntimeOptions, SharedReaderUsesDefaultsAndAcceptsSupportedModes)
+{
+    ScopedParmParseRemoval remove_transport("transport_mode");
+    ScopedParmParseRemoval remove_momentum("momentum_transport");
+
+    ShocRuntimeOptions defaults;
+    read_shoc_transport_modes(defaults.transport_mode, defaults.momentum_transport);
+    EXPECT_EQ(defaults.transport_mode, ShocTransportMode::StateUpdate);
+    EXPECT_EQ(defaults.momentum_transport, ShocMomentumTransport::StateUpdate);
+
+    ScopedParmParseString transport("transport_mode", "state_update");
+    ScopedParmParseString momentum("momentum_transport", "none");
+    ShocTransportMode transport_mode = ShocTransportMode::StateUpdate;
+    ShocMomentumTransport momentum_mode = ShocMomentumTransport::StateUpdate;
+    read_shoc_transport_modes(transport_mode, momentum_mode);
+    EXPECT_EQ(transport_mode, ShocTransportMode::StateUpdate);
+    EXPECT_EQ(momentum_mode, ShocMomentumTransport::None);
 }
 
 TEST(ShocStructure, SurfaceLayerUsesUstarFloorAndFiniteObukhov)

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -171,6 +171,50 @@ TEST(ShocRuntimeOptions, SharedReaderUsesDefaultsAndAcceptsSupportedModes)
     EXPECT_EQ(momentum_mode, ShocMomentumTransport::None);
 }
 
+TEST(SolverChoice, NativeStateUpdateOwnsNoVerticalDiffusion)
+{
+    SolverChoice choice;
+    choice.use_native_shoc = true;
+    choice.use_eamxx_shoc = false;
+    choice.shoc_transport_mode = ShocTransportMode::StateUpdate;
+    choice.shoc_momentum_transport = ShocMomentumTransport::StateUpdate;
+
+    EXPECT_FALSE(choice.host_owns_vertical_scalar_diffusion());
+    EXPECT_FALSE(choice.host_owns_vertical_momentum_diffusion());
+}
+
+TEST(SolverChoice, NativeMomentumNoneLeavesHostMomentumOwnership)
+{
+    SolverChoice choice;
+    choice.use_native_shoc = true;
+    choice.use_eamxx_shoc = false;
+    choice.shoc_transport_mode = ShocTransportMode::StateUpdate;
+    choice.shoc_momentum_transport = ShocMomentumTransport::None;
+
+    EXPECT_FALSE(choice.host_owns_vertical_scalar_diffusion());
+    EXPECT_TRUE(choice.host_owns_vertical_momentum_diffusion());
+}
+
+TEST(SolverChoice, NonNativeShocRetainsGenericHostOwnership)
+{
+    SolverChoice choice;
+    choice.use_native_shoc = false;
+    choice.use_eamxx_shoc = false;
+
+    EXPECT_TRUE(choice.host_owns_vertical_scalar_diffusion());
+    EXPECT_TRUE(choice.host_owns_vertical_momentum_diffusion());
+}
+
+TEST(SolverChoice, EamxxShocRetainsExistingOwnership)
+{
+    SolverChoice choice;
+    choice.use_native_shoc = false;
+    choice.use_eamxx_shoc = true;
+
+    EXPECT_FALSE(choice.host_owns_vertical_scalar_diffusion());
+    EXPECT_FALSE(choice.host_owns_vertical_momentum_diffusion());
+}
+
 TEST(ShocStructure, SurfaceLayerUsesUstarFloorAndFiniteObukhov)
 {
     auto col = shoc_test::make_column(4);


### PR DESCRIPTION
## Summary

Remove the obsolete Native SHOC `host_diffusion` runtime modes and align tests and documentation with the current transport model.

## Changes

- Remove Native SHOC support for:
  - `erf.shoc.transport_mode = host_diffusion`
  - `erf.shoc.momentum_transport = host_diffusion`
  - legacy scalar `tendencies`
- Keep scalar transport on `state_update`.
- Keep momentum transport options as `state_update` or `none`.
- Simplify Native SHOC driver and host-diffusion ownership paths.
- Add startup rejection tests covering the real `ParmParse` configuration path.
- Add `SolverChoice` ownership predicate tests.
- Update Native SHOC theory documentation, input tables, equations, defaults, restrictions, and README guidance.
- Remove inactive debugging keys from the supported Native SHOC documentation table.
- Clarify that `signed_tke_production = false` is the default baseline.

No regression gold files or numerical tolerances were changed.

## Validation

- SHOC unit tests: 102/102 passed.
- Native SHOC removed-transport startup tests: 2/2 passed.
- Plotfile catalog checks: 15/15 passed.
- `git diff --check`: passed.