### PR TITLE
Keep 1/theta_ref from tripping fpe_trap_zero when theta_ref is unset

### DIFF
--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -253,8 +253,10 @@ SurfaceLayer::update_fluxes (const int& lev,
     }
 
     if (m_update_k_rans) {
+        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
         const bool use_ref_theta = (theta_ref > 0);
-        const Real l_inv_theta0  = (use_ref_theta) ? one / theta_ref : one;
+        const Real inv_theta_ref = one / (std::abs(theta_ref) + Real(1e-30));
+        const Real l_inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
         const Real l_inv_Cmu2    = inv_Cmu2;
         const int klo = m_geom[lev].Domain().smallEnd(2);
         IntVect ng = u_star[lev]->nGrowVect(); ng[2] = 0;

--- a/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
+++ b/Source/BoundaryConditions/ERF_SurfaceLayer.cpp
@@ -253,9 +253,10 @@ SurfaceLayer::update_fluxes (const int& lev,
     }
 
     if (m_update_k_rans) {
-        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
+        // Clamped divisor: the select is if-converted, so 1/theta_ref runs even
+        //   when theta_ref = 0 and would trip fpe_trap_zero (see ERF_SetupDiff.H)
         const bool use_ref_theta = (theta_ref > 0);
-        const Real inv_theta_ref = one / (std::abs(theta_ref) + Real(1e-30));
+        const Real inv_theta_ref = one / amrex::max(theta_ref, std::numeric_limits<Real>::min());
         const Real l_inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
         const Real l_inv_Cmu2    = inv_Cmu2;
         const int klo = m_geom[lev].Domain().smallEnd(2);

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -170,8 +170,10 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
         const Real Ce_lcoeff    = amrex::max(zero, l_C_e - Real(1.9)*l_C_k);
         const Real l_abs_g      = const_grav;
 
+        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
         const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        const Real l_inv_theta0  = (use_ref_theta) ? one / turbChoice.theta_ref : one;
+        const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
+        const Real l_inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())
@@ -610,8 +612,10 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
         const Real l_g_max    = turbChoice.l_g_max;
         const Real abs_g      = const_grav;
 
+        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
         const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        const Real inv_theta0  = (use_ref_theta) ? one / turbChoice.theta_ref : one;
+        const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
+        const Real inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
+++ b/Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp
@@ -170,9 +170,10 @@ void ComputeTurbulentViscosityLES (Vector<std::unique_ptr<MultiFab>>& Tau_lev,
         const Real Ce_lcoeff    = amrex::max(zero, l_C_e - Real(1.9)*l_C_k);
         const Real l_abs_g      = const_grav;
 
-        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
+        // Clamped divisor: the select is if-converted, so 1/theta_ref runs even
+        //   when theta_ref = 0 and would trip fpe_trap_zero (see ERF_SetupDiff.H)
         const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
+        const Real inv_theta_ref = one / amrex::max(turbChoice.theta_ref, std::numeric_limits<Real>::min());
         const Real l_inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
 
 #ifdef _OPENMP
@@ -612,10 +613,11 @@ void ComputeTurbulentViscosityRANS (Vector<std::unique_ptr<MultiFab>>& /*Tau_lev
         const Real l_g_max    = turbChoice.l_g_max;
         const Real abs_g      = const_grav;
 
-        // Nonzero divisor: both arms of the select are evaluated (fpe_trap_zero)
+        // Clamped divisor: the select is if-converted, so 1/theta_ref runs even
+        //   when theta_ref = 0 and would trip fpe_trap_zero (see ERF_SetupDiff.H)
         const bool use_ref_theta = (turbChoice.theta_ref > 0);
-        const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
-        const Real inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
+        const Real inv_theta_ref = one / amrex::max(turbChoice.theta_ref, std::numeric_limits<Real>::min());
+        const Real inv_theta0    = (use_ref_theta) ? inv_theta_ref : one;
 
 #ifdef _OPENMP
 #pragma omp parallel if (Gpu::notInLaunchRegion())

--- a/Source/Diffusion/ERF_SetupDiff.H
+++ b/Source/Diffusion/ERF_SetupDiff.H
@@ -14,10 +14,13 @@
     [[maybe_unused]] bool l_use_mynn = turbChoice.use_pbl_tke;
 
     // used by ERF_AddTKESources.H
-    // The divisor is never zero: an optimised build evaluates both arms of the
-    //   select, and 1/theta_ref with the default theta_ref = 0 trips fpe_trap_zero
+    // Clamp the divisor to the smallest normal Real before the select: an optimised
+    //   build if-converts the select into an unconditional 1/theta_ref (also when
+    //   the select is on the divisor), which trips fpe_trap_zero with the default
+    //   theta_ref = 0. The clamp is exact for any normal theta_ref > 0 and its
+    //   reciprocal is finite in single and double precision.
     [[maybe_unused]] const bool use_ref_theta = (turbChoice.theta_ref > 0);
-    [[maybe_unused]] const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
+    [[maybe_unused]] const Real inv_theta_ref = one / amrex::max(turbChoice.theta_ref, std::numeric_limits<Real>::min());
     [[maybe_unused]] const Real l_inv_theta0 = (use_ref_theta) ? inv_theta_ref : one;
 
     // vertical diffusivities are defined in ERF_SetupVertDiff.H

--- a/Source/Diffusion/ERF_SetupDiff.H
+++ b/Source/Diffusion/ERF_SetupDiff.H
@@ -14,8 +14,11 @@
     [[maybe_unused]] bool l_use_mynn = turbChoice.use_pbl_tke;
 
     // used by ERF_AddTKESources.H
+    // The divisor is never zero: an optimised build evaluates both arms of the
+    //   select, and 1/theta_ref with the default theta_ref = 0 trips fpe_trap_zero
     [[maybe_unused]] const bool use_ref_theta = (turbChoice.theta_ref > 0);
-    [[maybe_unused]] const Real l_inv_theta0 = (use_ref_theta) ? one / turbChoice.theta_ref : one;
+    [[maybe_unused]] const Real inv_theta_ref = one / (std::abs(turbChoice.theta_ref) + Real(1e-30));
+    [[maybe_unused]] const Real l_inv_theta0 = (use_ref_theta) ? inv_theta_ref : one;
 
     // vertical diffusivities are defined in ERF_SetupVertDiff.H
     // The number of quantities following Scalar_h must be equal to the number


### PR DESCRIPTION
## Defect

With `amrex.fpe_trap_zero = 1`, a Release build aborts in two places when `erf.theta_ref` is left unset (its default is 0). On macOS the FP trap reports as SIGILL.

- Step 1 in `DiffusionSrcForState_S`, called from `erf_slow_rhs_pre`, e.g. `Exec/CanonicalTests/ABL/mrf_unstable`. This affects any deck with diffusion.
- During `InitData_post` in `SurfaceLayer::update_fluxes`, with `erf.rans_type = kEqn` and `erf.dirichlet_k = true`.

The same runs complete with `fpe_trap_invalid` or `fpe_trap_overflow` alone. A Debug build does not trap.

## Cause

Four places compute

```cpp
const Real l_inv_theta0 = (use_ref_theta) ? one / theta_ref : one;
```

At -O3, clang turns the select into an unconditional `fdiv` followed by `fcsel`:

```
fmov  d0, #1.0
fdiv  d1, d0, d11      <- trap, d11 = theta_ref = 0
fcmp  d11, #0.0
fcsel d12, d1, d0, gt
```

The 1/0 result is discarded, but it still raises FE_DIVBYZERO. lldb stopped at this instruction with `d11 = 0`. Compiling only `ERF_DiffusionSrcForState_S.cpp` with `-ffp-model=strict` and relinking removes the trap. In a standalone -O3 test, GCC 14 kept a real branch for this pattern, so GCC builds may not show the defect.

| Site | Reached by |
|---|---|
| `Source/Diffusion/ERF_SetupDiff.H` (included by the S, N, T and EB diffusion kernels) | every run with diffusion |
| `Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp`, Deardorff branch | `les_type = Deardorff` |
| `Source/Diffusion/ERF_ComputeTurbulentViscosity.cpp`, k-eqn RANS branch | `rans_type = kEqn` |
| `Source/BoundaryConditions/ERF_SurfaceLayer.cpp`, k-eqn Dirichlet update | `rans_type = kEqn`, `dirichlet_k = true` |

## Fix

Before the selection, clamp the divisor to the smallest normal `Real`:

```cpp
const bool use_ref_theta = (turbChoice.theta_ref > 0);
const Real inv_theta_ref = one / amrex::max(turbChoice.theta_ref, std::numeric_limits<Real>::min());
const Real l_inv_theta0  = (use_ref_theta) ? inv_theta_ref : one;
```

- **No zero division, in either precision.** The divisor is never zero, and `1/numeric_limits<Real>::min()` is finite in both `float` and `double`. There is no absolute constant to re-validate for a different precision.
- **Values unchanged.** The selected value is `one` when `theta_ref <= 0`. For every normal `theta_ref > 0` it is bit-identical to `1/theta_ref`, since the clamp is the identity there.
- **The guard stays in place.** `theta_ref > 0` does not imply `theta_ref >= min()` (denormals), so the optimiser cannot remove the `max` inside the selected arm.

Two forms that do not work:
- `one / (std::abs(theta_ref) + Real(1e-30))`, the first version of this PR, relied on an absolute epsilon.
- Selecting the divisor, `one / (use_ref_theta ? theta_ref : one)`, still traps. Clang folds `1/1` and moves the division back into the select arm, giving the same `fdiv`/`fcsel` as the original. An ERF build with that form trapped in three cases:
  - `mrf_unstable`, in `DiffusionSrcForState_S`
  - Deardorff with `theta_ref = 0`, in `ComputeTurbulentViscosity`
  - the k-eqn Dirichlet case, in `SurfaceLayer::update_fluxes`

## Verification

Release, AppleClang on arm64, MPI, `ERF_ENABLE_ALL_WARNINGS=ON`.

Reproduction with `amrex.fpe_trap_zero=1`. The unfixed binary was built from `development` 489a2aa64:

| Case | development | this branch |
|---|---|---|
| `ABL/mrf_unstable` | SIGILL at step 1 in `DiffusionSrcForState_S` | 300 steps clean |
| `mrf_unstable` + `pbl_type=None rans_type=kEqn dirichlet_k=true` | SIGILL at init in `SurfaceLayer::update_fluxes` | clean |

Results are unchanged in double and single precision. All runs use `amrex.fpe_trap_zero=1`, and fcompare uses `--abs_tol 0 --rel_tol 0` on all plotted fields. Each build is compared with the epsilon version of this branch at the same precision; that version was itself bit-identical to `development`.

| Case | Steps | `PRECISION=DOUBLE` | `PRECISION=SINGLE` |
|---|---|---|---|
| `ABL/mrf_unstable` (theta_ref unset) | 300 | clean, bit-identical | clean, bit-identical |
| `ABL/inputs_deardorff`, `n_cell = 32 32 32`, `theta_ref = 300` | 40 | clean, bit-identical | clean, bit-identical |
| `ABL/inputs_deardorff`, `n_cell = 32 32 32`, `theta_ref = 0` | 10 | clean, bit-identical | clean, bit-identical |
| k-eqn variant, `theta_ref = 300` | 2 | clean, bit-identical | clean, bit-identical |
| k-eqn variant, theta_ref unset | 2 | clean, bit-identical | clean, bit-identical |

`codespell` and `git diff --check` are clean, and the change adds no warnings in either precision.

## Notes

- The k-eqn variant is only a way to reach the RANS sites; it is not a supported deck. It went to NaN in step 5 with both the `development` binary and the first version of this branch, identically, so comparisons stop at step 2.
- The ERF-Hazard fork took the first version as hgopalan/ERF#396 and gets the clamp in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
