### PR TITLE
Fix development CI warnings and Windows SHOC startup tests

### DIFF
--- a/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
@@ -601,7 +601,7 @@ pblh_mf.setVal(0.0);
                             ? (enable_qnse_d > Real(0.5)
                                ? (1 + qnse_am_d * HOL_bounded) / (1 + qnse_bm_d * HOL_bounded)
                                : (1 + 5 * HOL_bounded))
-                            : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -one_quarter);
+                            : std::pow(1 + 16 * HOL_abs, -one_quarter);
             const Real phiM_safe = amrex::max(phiM, Real(0.01));
 
             // Absolute bounds [0.01, 5.0] m/s

--- a/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
+++ b/Source/PBL/ERF_ComputeDiffusivityMRF.cpp
@@ -821,12 +821,12 @@ pblh_mf.setVal(0.0);
                                 ? (enable_qnse_d > Real(0.5)
                                    ? (1 + qnse_am_d * HOL_bounded) / (1 + qnse_bm_d * HOL_bounded)
                                    : (1 + 5 * HOL_bounded))
-                                : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -one_quarter);
+                                : std::pow(1 + 16 * HOL_abs, -one_quarter);
                 const Real phit = (obuk_val > 0)
                                 ? (enable_qnse_d > Real(0.5)
                                    ? (1 + qnse_ah_d * HOL_bounded) / (1 + qnse_bh_d * HOL_bounded)
                                    : (1 + 5 * HOL_bounded))
-                                : std::pow(amrex::max(1 - 16 * HOL_bounded, Real(0.01)), -Real(0.5));
+                                : std::pow(1 + 16 * HOL_abs, -Real(0.5));
 
                 Real phit_cloud = phit;
                 Real phiM_cloud = phiM;

--- a/Tests/RunShocRemovedTransportConfig.cmake
+++ b/Tests/RunShocRemovedTransportConfig.cmake
@@ -9,9 +9,13 @@ if(NOT DEFINED MPIEXEC OR NOT DEFINED MPIEXEC_NUMPROC_FLAG OR
     message(FATAL_ERROR "RunShocRemovedTransportConfig.cmake missing required argument")
 endif()
 
-if(NOT EXISTS "${TEST_EXE}")
-    message(FATAL_ERROR "Native SHOC startup test executable is missing: ${TEST_EXE}")
+file(GLOB test_exe_candidates "${TEST_EXE}")
+list(LENGTH test_exe_candidates test_exe_count)
+if(NOT test_exe_count EQUAL 1)
+    message(FATAL_ERROR
+        "Native SHOC startup test executable pattern must resolve to exactly one file: ${TEST_EXE}")
 endif()
+list(GET test_exe_candidates 0 TEST_EXE)
 if(NOT EXISTS "${INPUT}")
     message(FATAL_ERROR "Native SHOC startup test input is missing: ${INPUT}")
 endif()


### PR DESCRIPTION
## Summary

Fix the CI failures present on `development`:

- Restore the safe unstable-branch MRF expression using `HOL_abs`, eliminating the GCC/SYCL/HIP unused-variable warning.
- Resolve multi-configuration Windows executable paths in the native SHOC removed-transport startup tests.

## Testing

Using the provided OpenMPI environment and a parallel build with `--parallel 8`:

- Unit tests: 552/552 passed
- Parallel tests: 48/48 passed
- Regression tests: 74/74 passed
- Removed transport-mode tests: 2/2 passed

No existing branches were modified.