### PR TITLE
BTF fine level: make the terrain-fitted mesh independent of the z split

### DIFF
--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -3,7 +3,13 @@
 #include <AMReX_ParmParse.H>
 #include <ERF_Constants.H>
 #include <ERF_Interpolation_1D.H>
+#include <algorithm>
+#include <array>
 #include <cmath>
+#include <map>
+#include <numeric>
+#include <utility>
+#include <vector>
 
 using namespace amrex;
 
@@ -41,6 +47,119 @@ init_default_zphys (int /*lev*/,
         });
     }
 }
+
+namespace {
+
+/**
+ * The cells of a (cell-centered) BoxArray as boxes that are never stacked on each other.
+ *
+ * Wherever a box of ba sits on the top face of another box of ba, the run of cells in z
+ * that the two belong to becomes a single box.  Boxes stacked with different lateral
+ * extents are first cut at each other's lateral edges; the joined pieces are then merged
+ * in x and y and chopped to no more than the largest lateral size of the boxes they came
+ * from.  Returns ba itself when no two boxes of ba are stacked.
+ */
+BoxArray
+join_boxes_stacked_in_z (const BoxArray& ba)
+{
+    AMREX_ALWAYS_ASSERT(ba.ixType().cellCentered());
+
+    const int nboxes = static_cast<int>(ba.size());
+
+    // Gather the boxes into stacks: link every box to the boxes that sit on its top face
+    std::vector<int> stack_of(nboxes);
+    std::iota(stack_of.begin(), stack_of.end(), 0);
+    auto find_stack = [&stack_of] (int i) {
+        while (stack_of[i] != i) {
+            stack_of[i] = stack_of[stack_of[i]];
+            i = stack_of[i];
+        }
+        return i;
+    };
+
+    bool any_stacked = false;
+    for (int i = 0; i < nboxes; ++i) {
+        Box above(ba[i]);
+        above.setRange(2, ba[i].bigEnd(2)+1);
+        for (const auto& isect : ba.intersections(above)) {
+            stack_of[find_stack(isect.first)] = find_stack(i);
+            any_stacked = true;
+        }
+    }
+    if (!any_stacked) { return ba; }
+
+    // std::map keeps the order, and so the joined boxes, the same on every rank
+    std::map<int, std::vector<Box>> stacks;
+    for (int i = 0; i < nboxes; ++i) {
+        stacks[find_stack(i)].push_back(ba[i]);
+    }
+
+    BoxList bl_joined;
+    for (const auto& stack : stacks)
+    {
+        const std::vector<Box>& boxes = stack.second;
+        if (boxes.size() == 1) {
+            bl_joined.push_back(boxes[0]);
+            continue;
+        }
+
+        // Cut the stack at every lateral edge of its boxes
+        std::array<std::vector<int>,2> cuts;
+        IntVect max_size(1);
+        for (const auto& b : boxes) {
+            for (int idim = 0; idim < 2; ++idim) {
+                cuts[idim].push_back(b.smallEnd(idim));
+                cuts[idim].push_back(b.bigEnd(idim)+1);
+                max_size[idim] = std::max(max_size[idim], b.length(idim));
+            }
+        }
+        for (auto& c : cuts) {
+            std::sort(c.begin(), c.end());
+            c.erase(std::unique(c.begin(), c.end()), c.end());
+        }
+        auto cut_index = [&cuts] (int idim, int coord) {
+            return static_cast<int>(std::lower_bound(cuts[idim].begin(), cuts[idim].end(), coord)
+                                    - cuts[idim].begin());
+        };
+
+        // The z extents of the boxes over each piece, keyed by the piece's cut indices
+        std::map<std::pair<int,int>, std::vector<std::pair<int,int>>> zruns_of_piece;
+        for (const auto& b : boxes) {
+            for (int ix = cut_index(0, b.smallEnd(0)); ix < cut_index(0, b.bigEnd(0)+1); ++ix) {
+                for (int iy = cut_index(1, b.smallEnd(1)); iy < cut_index(1, b.bigEnd(1)+1); ++iy) {
+                    zruns_of_piece[std::make_pair(ix,iy)].emplace_back(b.smallEnd(2), b.bigEnd(2));
+                }
+            }
+        }
+
+        // Over each piece, join the extents that touch into one box per run of cells
+        BoxList bl_stack;
+        for (auto& piece : zruns_of_piece) {
+            const int ix = piece.first.first;
+            const int iy = piece.first.second;
+            auto& zruns = piece.second;
+            std::sort(zruns.begin(), zruns.end());
+            std::size_t n_first = 0;
+            for (std::size_t n = 1; n <= zruns.size(); ++n) {
+                if (n == zruns.size() || zruns[n].first != zruns[n-1].second+1) {
+                    bl_stack.push_back(Box(IntVect(cuts[0][ix],     cuts[1][iy],     zruns[n_first].first),
+                                           IntVect(cuts[0][ix+1]-1, cuts[1][iy+1]-1, zruns[n-1].second)));
+                    n_first = n;
+                }
+            }
+        }
+
+        // Merging in x and y joins pieces with the same z extent, so it cannot stack them again
+        bl_stack.simplify();
+        max_size[2] = bl_stack.minimalBox().length(2);
+        bl_stack.maxSize(max_size);
+        bl_joined.join(bl_stack);
+    }
+
+    return BoxArray(std::move(bl_joined));
+}
+
+} // namespace
 
 /**
  * Computation of the terrain grid from BTF, STF, or Sullivan TF model
@@ -93,7 +212,40 @@ make_terrain_fitted_coords (int lev,
             z_phys_nd.ParallelCopy(z_phys_nd_new,0,0,1,z_phys_nd.nGrowVect(),z_phys_nd.nGrowVect());
         }
     } else { // lev > 0
-        init_which_terrain_grid(lev, geom, z_phys_nd, z_levels_h, fine_terrain, z_phys_interp);
+        //
+        // BTF maps each column of a box between the box's lowest node and the domain top.
+        // A box that sits on another box of this level must continue the columns of the box
+        // below it: its own lowest node holds only the mesh interpolated from the coarse
+        // level, so starting from there would make the mesh above it follow the coarse
+        // terrain and depend on where the grids are split in z.  As on level 0 we therefore
+        // build the mesh on boxes that hold whole columns and copy it back.  The bottom box
+        // of a column, such as a refined patch aloft, still starts from its own lowest node.
+        //
+        ParmParse pp("erf");
+        int terrain_smoothing = 0;
+        pp.query("terrain_smoothing", terrain_smoothing);
+
+        const BoxArray ba_cc = amrex::convert(z_phys_nd.boxArray(), IntVect::TheCellVector());
+        BoxArray ba_col = (terrain_smoothing == 0) ? join_boxes_stacked_in_z(ba_cc) : ba_cc;
+
+        if (ba_col == ba_cc) {
+            init_which_terrain_grid(lev, geom, z_phys_nd, z_levels_h, fine_terrain, z_phys_interp);
+        } else {
+            DistributionMapping dm_col(ba_col);
+            ba_col.surroundingNodes();
+
+            const IntVect& ng = z_phys_nd.nGrowVect();
+            MultiFab z_phys_nd_col(ba_col, dm_col, 1, ng);
+
+            z_phys_nd_col.ParallelCopy(z_phys_nd,0,0,1,ng,ng);
+
+            init_which_terrain_grid(lev, geom, z_phys_nd_col, z_levels_h, fine_terrain, z_phys_interp);
+
+            // Copy the ghost nodes too, then give every node the value of a box that holds it
+            // as valid, rather than one a neighbouring box computed for its ghost node
+            z_phys_nd.ParallelCopy(z_phys_nd_col,0,0,1,ng,ng);
+            z_phys_nd.ParallelCopy(z_phys_nd_col,0,0,1,IntVect(0),ng);
+        }
     }
 
     //

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -169,6 +169,7 @@ struct ColumnGrids
     bool stacked = false;       // whether any two of those grids are stacked in z
     BoxArray ba_col_nd;         // the nodal column boxes (only if stacked)
     DistributionMapping dm_col;
+    MultiFab hold_bd;           // holds no data; see column_grids
 };
 
 /**
@@ -177,7 +178,12 @@ struct ColumnGrids
  * With a moving mesh make_terrain_fitted_coords runs several times per substep, but the
  * columns only change when the level is regridded.  Reusing the same BoxArray and
  * DistributionMapping also lets every ParallelCopy to and from the columns reuse its
- * communication metadata instead of rebuilding it.
+ * communication metadata instead of rebuilding it -- but only as long as some FabArray
+ * on those grids stays alive: AMReX erases the copy descriptors of a BoxArray and
+ * DistributionMapping pair as soon as the last FabArray built on it is destroyed.  The
+ * MultiFab that make_terrain_fitted_coords builds on the columns is a temporary, so
+ * without hold_bd, which is defined with no data of its own, every call would take the
+ * metadata of all three of its ParallelCopy calls with it.
  */
 ColumnGrids const&
 column_grids (int lev, const Geometry& geom, const BoxArray& ba_cc)
@@ -205,9 +211,11 @@ column_grids (int lev, const Geometry& geom, const BoxArray& ba_cc)
             cg.dm_col = DistributionMapping(ba_col);
             ba_col.surroundingNodes();
             cg.ba_col_nd = ba_col;
+            cg.hold_bd.define(cg.ba_col_nd, cg.dm_col, 1, 0, MFInfo().SetAlloc(false));
         } else {
             cg.ba_col_nd = BoxArray();
             cg.dm_col    = DistributionMapping();
+            cg.hold_bd.clear();
         }
     }
     return cg;

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -159,6 +159,60 @@ join_boxes_stacked_in_z (const BoxArray& ba)
     return BoxArray(std::move(bl_joined));
 }
 
+/**
+ * The boxes on which a fine BTF level is built: whole columns, with their DistributionMapping.
+ */
+struct ColumnGrids
+{
+    Box domain;                 // the level's domain and ...
+    BoxArray ba_cc;             // ... its (cell-centered) grids, which the columns were made for
+    bool stacked = false;       // whether any two of those grids are stacked in z
+    BoxArray ba_col_nd;         // the nodal column boxes (only if stacked)
+    DistributionMapping dm_col;
+};
+
+/**
+ * The column boxes for a level's grids, made once per set of grids.
+ *
+ * With a moving mesh make_terrain_fitted_coords runs several times per substep, but the
+ * columns only change when the level is regridded.  Reusing the same BoxArray and
+ * DistributionMapping also lets every ParallelCopy to and from the columns reuse its
+ * communication metadata instead of rebuilding it.
+ */
+ColumnGrids const&
+column_grids (int lev, const Geometry& geom, const BoxArray& ba_cc)
+{
+    static std::map<int, ColumnGrids> cache;
+    static bool clear_on_finalize = false;
+    if (!clear_on_finalize) {
+        ExecOnFinalize([] () { cache.clear(); clear_on_finalize = false; });
+        clear_on_finalize = true;
+    }
+
+    ColumnGrids& cg = cache[lev];
+    if (cg.ba_cc.empty() || cg.domain != geom.Domain() || cg.ba_cc != ba_cc)
+    {
+        cg.domain = geom.Domain();
+        cg.ba_cc  = ba_cc;
+
+        BoxArray ba_col = join_boxes_stacked_in_z(ba_cc);
+        cg.stacked = (ba_col != ba_cc);
+
+        if (cg.stacked) {
+            // Joining divides the number of boxes by the number of splits in z, so chop the
+            // columns laterally, as level 0 does, until there are at least as many as ranks
+            ChopGrids2D(ba_col, cg.domain, ParallelDescriptor::NProcs());
+            cg.dm_col = DistributionMapping(ba_col);
+            ba_col.surroundingNodes();
+            cg.ba_col_nd = ba_col;
+        } else {
+            cg.ba_col_nd = BoxArray();
+            cg.dm_col    = DistributionMapping();
+        }
+    }
+    return cg;
+}
+
 } // namespace
 
 /**
@@ -225,17 +279,15 @@ make_terrain_fitted_coords (int lev,
         int terrain_smoothing = 0;
         pp.query("terrain_smoothing", terrain_smoothing);
 
-        const BoxArray ba_cc = amrex::convert(z_phys_nd.boxArray(), IntVect::TheCellVector());
-        BoxArray ba_col = (terrain_smoothing == 0) ? join_boxes_stacked_in_z(ba_cc) : ba_cc;
+        const ColumnGrids* cg = (terrain_smoothing == 0)
+            ? &column_grids(lev, geom, amrex::convert(z_phys_nd.boxArray(), IntVect::TheCellVector()))
+            : nullptr;
 
-        if (ba_col == ba_cc) {
+        if (cg == nullptr || !cg->stacked) {
             init_which_terrain_grid(lev, geom, z_phys_nd, z_levels_h, fine_terrain, z_phys_interp);
         } else {
-            DistributionMapping dm_col(ba_col);
-            ba_col.surroundingNodes();
-
             const IntVect& ng = z_phys_nd.nGrowVect();
-            MultiFab z_phys_nd_col(ba_col, dm_col, 1, ng);
+            MultiFab z_phys_nd_col(cg->ba_col_nd, cg->dm_col, 1, ng);
 
             z_phys_nd_col.ParallelCopy(z_phys_nd,0,0,1,ng,ng);
 

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -503,6 +503,10 @@ set_tests_properties(SHOC_Unstable_Cloud_SatAdj_vs_NoCond
     PROCESSORS 1
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/"
     LABELS "regression;shoc;microphysics")
+# execute_process needs mpiexec, and does not expand the executable globs used on Windows
+if(NOT WIN32)
+add_test_terrain_zsplit_parity(Terrain2Lev_BTF_ZSplit "plt00000")
+endif()
 endif()
 
 # Debug regression test with lower tolerance
@@ -711,7 +715,6 @@ add_test_r(MovingTerrain_nosub               ""  "erf_exec" "plt00020" RUNTIME_O
 add_test_r(MovingTerrain_sub                 ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(Terrain2Lev_STF_interp            ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(Terrain2Lev_STF_transform         ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
-add_test_terrain_zsplit_parity(Terrain2Lev_BTF_ZSplit "plt00000")
 add_test_r(RayleighDamping                   ""  "erf_exec" "plt00100" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(ScalarAdvectionUniformU           ""  "erf_exec" "plt00020" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(ScalarAdvectionShearedU           ""  "erf_exec" "plt00080" RUNTIME_OPTIONS "erf.vert_implicit=false ")

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -238,6 +238,31 @@ function(add_test_cloud_chamber_budget TEST_NAME MODE SOURCE_NAME)
         ATTACHED_FILES_ON_FAIL "${CURRENT_TEST_BINARY_DIR}/simulation.log;${CURRENT_TEST_BINARY_DIR}/checker.log;${CURRENT_TEST_BINARY_DIR}/cloud_chamber_budget.dat")
 endfunction(add_test_cloud_chamber_budget)
 
+# Parity test: the deck with whole-height fine grids and with the fine grids split in z
+# must give identical plotfiles
+function(add_test_terrain_zsplit_parity TEST_NAME PLTFILE)
+    setup_test()
+    resolve_test_exe("" "erf_exec" TEST_EXE)
+    add_test(${TEST_NAME} ${CMAKE_COMMAND}
+        -DMPIEXEC=${MPIEXEC_EXECUTABLE}
+        -DMPIEXEC_NUMPROC_FLAG=${MPIEXEC_NUMPROC_FLAG}
+        -DMPIEXEC_PREFLAGS=${MPIEXEC_PREFLAGS}
+        -DNRANKS=${NP}
+        -DTEST_EXE=${TEST_EXE}
+        -DINPUT=${CURRENT_TEST_BINARY_DIR}/${TEST_NAME}.i
+        -DWORKING_DIRECTORY=${CURRENT_TEST_BINARY_DIR}
+        -DFCOMPARE=${FCOMPARE_EXE}
+        -DPLTFILE=${PLTFILE}
+        -P ${PROJECT_SOURCE_DIR}/Tests/RunTerrainZSplitParity.cmake)
+    set_tests_properties(${TEST_NAME}
+        PROPERTIES
+        TIMEOUT 600
+        PROCESSORS ${NP}
+        WORKING_DIRECTORY "${CURRENT_TEST_BINARY_DIR}/"
+        LABELS "regression"
+        ATTACHED_FILES_ON_FAIL "${CURRENT_TEST_BINARY_DIR}/full_columns/simulation.log;${CURRENT_TEST_BINARY_DIR}/split_in_z/simulation.log;${CURRENT_TEST_BINARY_DIR}/parity.log")
+endfunction(add_test_terrain_zsplit_parity)
+
 # Positive startup regression for the retained legacy theta/qv parser path.
 # This intentionally has no physical-temperature or physical-wall keys.
 function(add_test_cloud_chamber_legacy_config TEST_NAME)
@@ -686,6 +711,7 @@ add_test_r(MovingTerrain_nosub               ""  "erf_exec" "plt00020" RUNTIME_O
 add_test_r(MovingTerrain_sub                 ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(Terrain2Lev_STF_interp            ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(Terrain2Lev_STF_transform         ""  "erf_exec" "plt00010" RUNTIME_OPTIONS "erf.vert_implicit=false ")
+add_test_terrain_zsplit_parity(Terrain2Lev_BTF_ZSplit "plt00000")
 add_test_r(RayleighDamping                   ""  "erf_exec" "plt00100" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(ScalarAdvectionUniformU           ""  "erf_exec" "plt00020" RUNTIME_OPTIONS "erf.vert_implicit=false ")
 add_test_r(ScalarAdvectionShearedU           ""  "erf_exec" "plt00080" RUNTIME_OPTIONS "erf.vert_implicit=false ")

--- a/Tests/RunTerrainZSplitParity.cmake
+++ b/Tests/RunTerrainZSplitParity.cmake
@@ -1,0 +1,41 @@
+# Run a two-level terrain deck with whole-height fine grids and with the fine grids split
+# in z, and require the two plotfiles to agree bit for bit.
+if(NOT DEFINED MPIEXEC OR NOT DEFINED MPIEXEC_NUMPROC_FLAG OR
+   NOT DEFINED NRANKS OR NOT DEFINED TEST_EXE OR NOT DEFINED INPUT OR
+   NOT DEFINED WORKING_DIRECTORY OR NOT DEFINED FCOMPARE OR NOT DEFINED PLTFILE)
+    message(FATAL_ERROR "RunTerrainZSplitParity.cmake missing required argument")
+endif()
+
+set(FULL_DIR "${WORKING_DIRECTORY}/full_columns")
+set(SPLIT_DIR "${WORKING_DIRECTORY}/split_in_z")
+file(REMOVE_RECURSE "${FULL_DIR}" "${SPLIT_DIR}")
+file(MAKE_DIRECTORY "${FULL_DIR}" "${SPLIT_DIR}")
+
+foreach(RUN IN ITEMS "full_columns|1024 1024" "split_in_z|1024 16")
+    string(REPLACE "|" ";" RUN "${RUN}")
+    list(GET RUN 0 RUN_NAME)
+    list(GET RUN 1 MAX_GRID_SIZE_Z)
+    execute_process(
+        COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} ${NRANKS} ${MPIEXEC_PREFLAGS}
+                ${TEST_EXE} ${INPUT} "amr.max_grid_size_z=${MAX_GRID_SIZE_Z}"
+        WORKING_DIRECTORY "${WORKING_DIRECTORY}/${RUN_NAME}"
+        OUTPUT_FILE "${WORKING_DIRECTORY}/${RUN_NAME}/simulation.log"
+        ERROR_FILE "${WORKING_DIRECTORY}/${RUN_NAME}/simulation.log"
+        RESULT_VARIABLE run_result)
+    if(NOT run_result EQUAL 0)
+        message(FATAL_ERROR "${RUN_NAME} simulation failed: ${run_result}")
+    endif()
+endforeach()
+
+# The BoxArrays differ, so allow different grids; any difference at all fails
+execute_process(
+    COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS}
+            ${FCOMPARE} --abort_if_not_all_found -a -r 0 --abs_tol 0
+            ${FULL_DIR}/${PLTFILE} ${SPLIT_DIR}/${PLTFILE}
+    WORKING_DIRECTORY "${WORKING_DIRECTORY}"
+    OUTPUT_FILE "${WORKING_DIRECTORY}/parity.log"
+    ERROR_FILE "${WORKING_DIRECTORY}/parity.log"
+    RESULT_VARIABLE parity_result)
+if(NOT parity_result EQUAL 0)
+    message(FATAL_ERROR "Fine-level plotfiles depend on the z split: ${parity_result}")
+endif()

--- a/Tests/RunTerrainZSplitParity.cmake
+++ b/Tests/RunTerrainZSplitParity.cmake
@@ -27,6 +27,25 @@ foreach(RUN IN ITEMS "full_columns|1024 1024" "split_in_z|1024 16")
     endif()
 endforeach()
 
+# The comparison only means something if the split run really has more level-1 boxes: an
+# override that stopped taking effect would give two identical plotfiles, which agree.
+foreach(RUN_NAME IN ITEMS full_columns split_in_z)
+    set(CELL_H "${WORKING_DIRECTORY}/${RUN_NAME}/${PLTFILE}/Level_1/Cell_H")
+    if(NOT EXISTS "${CELL_H}")
+        message(FATAL_ERROR "${RUN_NAME} wrote no level-1 data (${CELL_H})")
+    endif()
+    file(READ "${CELL_H}" CELL_H_TEXT)
+    # The BoxArray is written as "(<number of boxes> 0" followed by one line per box
+    if(NOT CELL_H_TEXT MATCHES "\n\\(([0-9]+) 0\n")
+        message(FATAL_ERROR "Cannot read the level-1 BoxArray from ${CELL_H}")
+    endif()
+    set(NBOXES_${RUN_NAME} "${CMAKE_MATCH_1}")
+endforeach()
+if(NOT NBOXES_split_in_z GREATER NBOXES_full_columns)
+    message(FATAL_ERROR "The split run has ${NBOXES_split_in_z} level-1 boxes and the "
+                        "whole-column run ${NBOXES_full_columns}: the fine grids were not split in z")
+endif()
+
 # The BoxArrays differ, so allow different grids; any difference at all fails
 execute_process(
     COMMAND ${MPIEXEC} ${MPIEXEC_NUMPROC_FLAG} 1 ${MPIEXEC_PREFLAGS}

--- a/Tests/Unit/CMakeLists.txt
+++ b/Tests/Unit/CMakeLists.txt
@@ -133,6 +133,8 @@ target_sources(${erf_exe_name}
     ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestProvenance.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/ERF_GTestEpochTime.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/ERF_GTestGridUtils.cpp
+    # Motivation: a BTF fine level's mesh must not depend on how its grids are split in z.
+    ${CMAKE_CURRENT_SOURCE_DIR}/Utils/ERF_GTestTerrainFineColumns.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/HashRng/ERF_GTestHashRngScalar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/HashRng/ERF_GTestHashRngKernel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Utils/EOS/ERF_GTestEOSScalar.cpp
@@ -295,6 +297,8 @@ if(ERF_ENABLE_MPI)
       ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SatAdj/ERF_GTestSatAdjParallel.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Microphysics/SAM/ERF_GTestSAMParallel.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/Utils/HashRng/ERF_GTestHashRngParallel.cpp
+      # The column boxes are distributed afresh, so check the copies across ranks too
+      ${CMAKE_CURRENT_SOURCE_DIR}/Utils/ERF_GTestTerrainFineColumns.cpp
       ${CMAKE_CURRENT_SOURCE_DIR}/IO/ERF_GTestProvenanceParallel.cpp
   )
   if(ERF_ENABLE_NETCDF)

--- a/Tests/Unit/Utils/ERF_GTestTerrainFineColumns.cpp
+++ b/Tests/Unit/Utils/ERF_GTestTerrainFineColumns.cpp
@@ -1,0 +1,248 @@
+#include <cmath>
+
+#include <AMReX_BoxArray.H>
+#include <AMReX_BoxList.H>
+#include <AMReX_DistributionMapping.H>
+#include <AMReX_Geometry.H>
+#include <AMReX_GpuContainers.H>
+#include <AMReX_MultiFab.H>
+#include <AMReX_ParallelDescriptor.H>
+#include <AMReX_Reduce.H>
+
+#include <gtest/gtest.h>
+
+#include "ERF_TerrainMetrics.H"
+
+// Motivation: with erf.terrain_smoothing = 0 (BTF) a fine level's mesh must not depend on
+// how its BoxArray is split in z.  Each box maps its columns from its own lowest node, so a
+// box stacked on another box of the level has to continue the column of the box below; it
+// used to start again from its lowest node, which holds the mesh interpolated from the
+// coarse level, and the fine mesh above a split followed the coarse terrain.
+
+using namespace amrex;
+
+namespace {
+
+constexpr int nx = 16;
+constexpr int ny = 16;
+constexpr int nz = 12;
+
+// Placeholder for nodes that the reference mesh does not cover
+constexpr Real not_covered = Real(-1.0e30);
+
+Geometry
+make_geom (bool periodic)
+{
+    const Box domain(IntVect(0,0,0), IntVect(nx-1,ny-1,nz-1));
+    const RealBox rb(Real(0.), Real(0.), Real(0.), Real(160.), Real(160.), Real(120.));
+    const int per = periodic ? 1 : 0;
+    return Geometry(domain, rb, CoordSys::cartesian, {per, per, 0});
+}
+
+// Stretched z levels, so that no level is a round number
+Vector<Real>
+make_z_levels ()
+{
+    Vector<Real> z_levels(nz+1);
+    for (int k = 0; k <= nz; ++k) {
+        z_levels[k] = Real(10.)*k + Real(0.5)*k*k;
+    }
+    return z_levels;
+}
+
+//
+// The state a fine level is in when the BTF branch runs: the mesh interpolated from the
+// coarse level everywhere, i.e. BTF over a smooth coarse terrain, and the fine terrain in
+// the k = 0 slab.  Every node gets a value that depends only on its index, as it does in
+// ERF, so any box that holds a node holds the same value there.
+//
+void
+fill_interpolated_mesh (MultiFab& z_phys_nd, Vector<Real> const& z_levels)
+{
+    Gpu::DeviceVector<Real> z_levels_d(z_levels.size());
+    Gpu::copy(Gpu::hostToDevice, z_levels.begin(), z_levels.end(), z_levels_d.begin());
+    const Real* z_lev = z_levels_d.data();
+    const Real z_top = z_levels[nz];
+
+    for (MFIter mfi(z_phys_nd); mfi.isValid(); ++mfi) {
+        auto const z = z_phys_nd.array(mfi);
+        ParallelFor(mfi.fabbox(), [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept
+        {
+            if (k == 0) {
+                z(i,j,k) = Real(25.) + Real(12.)*std::sin(Real(0.31)*i + Real(0.1))*std::cos(Real(0.23)*j);
+            } else {
+                const int kk = amrex::max(0, amrex::min(k, nz));
+                const Real h_coarse = Real(20.) + Real(10.)*std::sin(Real(0.3)*i)*std::cos(Real(0.2)*j);
+                z(i,j,k) = z_lev[kk] + h_coarse * (z_top - z_lev[kk]) / z_top;
+            }
+        });
+    }
+    Gpu::streamSynchronize();
+}
+
+// The fine-level mesh on the cells of ba_cc, built by make_terrain_fitted_coords or, for
+// per_box = true, by init_which_terrain_grid on each box on its own
+MultiFab
+build_fine_mesh (const BoxArray& ba_cc, const Geometry& geom, bool per_box = false)
+{
+    BoxArray ba_nd(ba_cc);
+    ba_nd.surroundingNodes();
+    DistributionMapping dm(ba_nd);
+    MultiFab z_phys_nd(ba_nd, dm, 1, IntVect(3));
+
+    const Vector<Real> z_levels = make_z_levels();
+    fill_interpolated_mesh(z_phys_nd, z_levels);
+
+    if (per_box) {
+        z_phys_nd.setDomainBndry(bogus_large_value, 0, 1, geom);
+        init_which_terrain_grid(1, geom, z_phys_nd, z_levels);
+    } else {
+        GpuArray<ERF_BC, AMREX_SPACEDIM*2> phys_bc_type;
+        for (auto& bc : phys_bc_type) { bc = ERF_BC::slip_wall; }
+        make_terrain_fitted_coords(1, geom, z_phys_nd, z_levels, phys_bc_type);
+    }
+    return z_phys_nd;
+}
+
+struct Mismatch
+{
+    Long valid = 0;   // valid nodes of the tested mesh that differ from the reference
+    Long ghost = 0;   // ghost nodes that differ, where the reference covers them
+    Real max_abs = Real(0.);
+};
+
+// Compare every node of test with the reference mesh, bit for bit
+Mismatch
+compare_meshes (MultiFab const& test, MultiFab const& ref)
+{
+    MultiFab ref_on_test(test.boxArray(), test.DistributionMap(), 1, test.nGrowVect());
+    ref_on_test.setVal(not_covered);
+    ref_on_test.ParallelCopy(ref, 0, 0, 1, ref.nGrowVect(), test.nGrowVect());
+    // Where the reference holds a node as valid, compare with that value
+    ref_on_test.ParallelCopy(ref, 0, 0, 1, IntVect(0), test.nGrowVect());
+
+    ReduceOps<ReduceOpSum, ReduceOpSum, ReduceOpMax> reduce_op;
+    ReduceData<Long, Long, Real> reduce_data(reduce_op);
+    using ReduceTuple = typename decltype(reduce_data)::Type;
+
+    for (MFIter mfi(test); mfi.isValid(); ++mfi) {
+        const Box vbx = mfi.validbox();
+        auto const a = test.const_array(mfi);
+        auto const b = ref_on_test.const_array(mfi);
+        reduce_op.eval(mfi.fabbox(), reduce_data,
+            [=] AMREX_GPU_DEVICE (int i, int j, int k) noexcept -> ReduceTuple
+        {
+            if (b(i,j,k) == not_covered) { return {Long(0), Long(0), Real(0.)}; }
+            const bool differs = (a(i,j,k) != b(i,j,k));
+            const bool valid = vbx.contains(IntVect(i,j,k));
+            return {Long(differs && valid), Long(differs && !valid), std::abs(a(i,j,k) - b(i,j,k))};
+        });
+    }
+
+    auto const result = reduce_data.value(reduce_op);
+    Mismatch m;
+    m.valid   = amrex::get<0>(result);
+    m.ghost   = amrex::get<1>(result);
+    m.max_abs = amrex::get<2>(result);
+    ParallelDescriptor::ReduceLongSum(m.valid);
+    ParallelDescriptor::ReduceLongSum(m.ghost);
+    ParallelDescriptor::ReduceRealMax(m.max_abs);
+    return m;
+}
+
+void
+expect_same_mesh (const BoxArray& ba_test, const BoxArray& ba_ref, bool periodic)
+{
+    const Geometry geom = make_geom(periodic);
+    const MultiFab ref  = build_fine_mesh(ba_ref,  geom);
+    const MultiFab test = build_fine_mesh(ba_test, geom);
+    const Mismatch m = compare_meshes(test, ref);
+    EXPECT_EQ(m.valid, 0) << "max |diff| " << m.max_abs << (periodic ? " (periodic)" : "");
+    EXPECT_EQ(m.ghost, 0) << "max |diff| " << m.max_abs << (periodic ? " (periodic)" : "");
+}
+
+// A fine region touching the lateral domain boundary in x, over the full height
+const Box full_region(IntVect(0,4,0), IntVect(7,11,nz-1));
+
+} // namespace
+
+TEST(TerrainFineColumns, SplitInZMatchesWholeColumns)
+{
+    BoxArray ba_ref(full_region);
+    ba_ref.maxSize(IntVect(4,4,nz));
+
+    BoxArray ba_split(full_region);
+    ba_split.maxSize(IntVect(4,4,4));
+
+    for (bool periodic : {false, true}) {
+        expect_same_mesh(ba_split, ba_ref, periodic);
+    }
+}
+
+TEST(TerrainFineColumns, UnevenSplitInZMatchesWholeColumns)
+{
+    BoxArray ba_ref(full_region);
+    ba_ref.maxSize(IntVect(4,4,nz));
+
+    BoxList bl;
+    Box lower(full_region); lower.setBig(2, 4);
+    Box upper(full_region); upper.setSmall(2, 5);
+    bl.push_back(lower);
+    bl.push_back(upper);
+    BoxArray ba_split(std::move(bl));
+    ba_split.maxSize(IntVect(4,4,nz));
+
+    for (bool periodic : {false, true}) {
+        expect_same_mesh(ba_split, ba_ref, periodic);
+    }
+}
+
+// Boxes stacked with different lateral extents: the lower boxes are cut in x, the upper in y
+TEST(TerrainFineColumns, MisalignedStackMatchesWholeColumns)
+{
+    BoxArray ba_ref(full_region);
+
+    Box lower(full_region); lower.setBig(2, 5);
+    Box upper(full_region); upper.setSmall(2, 6);
+    BoxList bl_lower(lower); bl_lower.maxSize(IntVect(4,8,nz));
+    BoxList bl_upper(upper); bl_upper.maxSize(IntVect(8,4,nz));
+    bl_lower.join(bl_upper);
+    const BoxArray ba_split(std::move(bl_lower));
+
+    for (bool periodic : {false, true}) {
+        expect_same_mesh(ba_split, ba_ref, periodic);
+    }
+}
+
+// A patch aloft still starts from its own lowest node; split in z, it must give the same mesh
+TEST(TerrainFineColumns, SplitPatchAloftMatchesWholePatch)
+{
+    Box aloft(full_region);
+    aloft.setSmall(2, 3);
+
+    const BoxArray ba_ref(aloft);
+
+    BoxArray ba_split(aloft);
+    ba_split.maxSize(IntVect(8,8,3));
+
+    for (bool periodic : {false, true}) {
+        expect_same_mesh(ba_split, ba_ref, periodic);
+    }
+}
+
+// The per-box build is what the fine level used to get; it does depend on the split, which
+// is what the tests above would catch
+TEST(TerrainFineColumns, PerBoxBuildDependsOnSplit)
+{
+    const Geometry geom = make_geom(true);
+
+    BoxArray ba_ref(full_region);
+    ba_ref.maxSize(IntVect(4,4,nz));
+
+    BoxArray ba_split(full_region);
+    ba_split.maxSize(IntVect(4,4,4));
+
+    const MultiFab ref  = build_fine_mesh(ba_ref,   geom);
+    const MultiFab test = build_fine_mesh(ba_split, geom, true);
+    EXPECT_GT(compare_meshes(test, ref).valid, 0);
+}

--- a/Tests/test_files/Terrain2Lev_BTF_ZSplit/Terrain2Lev_BTF_ZSplit.i
+++ b/Tests/test_files/Terrain2Lev_BTF_ZSplit/Terrain2Lev_BTF_ZSplit.i
@@ -1,0 +1,79 @@
+# ------------------  INPUTS TO MAIN PROGRAM  -------------------
+# Two-level BTF terrain-following mesh over a radial Witch of Agnesi hill, used by the
+# Terrain2Lev_BTF_ZSplit parity test (Tests/RunTerrainZSplitParity.cmake).
+#
+# The test runs this deck twice to step 0: once with whole-height fine grids
+# (amr.max_grid_size_z = 1024 1024) and once with the fine grids split at k = 16 and 32
+# (amr.max_grid_size_z = 1024 16), and requires the plotfiles to agree bit for bit.
+# The fine level covers the hill top, where the fine terrain differs most from the
+# terrain interpolated from the coarse level.
+#
+# Only the mesh is plotted: on a fine level the hydrostatic base state is still
+# integrated box by box (init_bcs_and_base_state), so dens_hse and pres_hse there still
+# depend on the z split.
+
+erf.prob_name = "Flow over Witch of Agnesi hill"
+
+erf.init_type = Isentropic
+
+max_step = 0
+
+amrex.fpe_trap_invalid = 1
+
+# PROBLEM SIZE & GEOMETRY
+geometry.prob_lo     =   0.   0.   0.
+geometry.prob_hi     = 640. 640. 400.
+amr.n_cell           =  32   32   40
+
+geometry.is_periodic = 1 1 0
+
+zlo.type = "SlipWall"
+zhi.type = "SlipWall"
+
+# TIME STEP CONTROL
+erf.fixed_dt = 0.1
+
+# DIAGNOSTICS & VERBOSITY
+erf.sum_interval = -1
+erf.v            = 0
+amr.v            = 0
+
+# CHECKPOINT FILES
+erf.check_int = -1
+
+# PLOTFILES
+erf.plot_file_1 = plt
+erf.plot_int_1  = 1
+erf.plot_vars_1 = z_phys detJ
+
+# SOLVER CHOICE
+erf.use_gravity     = true
+erf.molec_diff_type = "None"
+erf.les_type        = "None"
+
+# TERRAIN GRID TYPE
+erf.terrain_type      = StaticFittedMesh
+erf.terrain_smoothing = 0                       # BTF
+
+# MULTILEVEL
+amr.max_level      = 1
+amr.ref_ratio_vect = 2 2 1
+
+erf.refinement_indicators = box1
+erf.box1.max_level = 1
+erf.box1.in_box_lo = 160. 160.
+erf.box1.in_box_hi = 480. 480.
+
+amr.max_grid_size_x = 1024 16
+amr.max_grid_size_y = 1024 16
+amr.max_grid_size_z = 1024 1024
+
+# PROBLEM PARAMETERS
+prob.T_0   = 300.0
+prob.U_0   = 0.0
+prob.rho_0 = 1.16
+
+prob.custom_terrain_type = "WoA"
+prob.dir                 = 2                    # radial hill
+prob.hmax                = 100.0
+prob.L                   = 100.0


### PR DESCRIPTION
## Summary

With `erf.terrain_smoothing = 0` (BTF), the terrain-fitted mesh on a refined level depended on how that level's BoxArray is split in z.

- **The defect.** The BTF branch of `init_which_terrain_grid` maps every column of a box between the box's lowest node and the domain top, taking the height at that lowest node as the surface. On a fine level, a box that sits on another box of the level holds only the mesh interpolated from the coarse level at its lowest node. The mesh above a z split therefore followed the coarse terrain rather than the fine terrain. Level 0 never showed it, because `make_terrain_fitted_coords` already builds level 0 on full-height `ChopGrids2D` columns when a box does not reach the bottom.
- **The fix.** `make_terrain_fitted_coords` now builds a fine BTF level on boxes that hold whole columns, and copies the result back:
  - boxes stacked in z are joined (boxes stacked with different lateral extents are cut at each other's lateral edges first);
  - the mesh is copied in with its ghost nodes and built with the unchanged BTF branch;
  - it is copied back, with valid nodes taking precedence over ghost nodes.
- **Unchanged cases.** A layout with no boxes stacked in z takes the old call and is bitwise unchanged. The bottom box of a column, such as a refined patch aloft, still starts from its own lowest node. STF and Sullivan TF fine levels (`terrain_smoothing` 1 or 2) are not affected.

## Numbers

32 x 32 x 40 radial Witch of Agnesi hill (h = 100 m, L = 100 m, 640 x 640 x 400 m, periodic in x and y, Isentropic init), level 1 with `amr.ref_ratio_vect = 2 2 1` over the hill top (160..480 m), step 0. Split: `amr.max_grid_size_z = 1024 16` (fine grids split at k = 16 and 32). Whole columns: `amr.max_grid_size_z = 1024 1024`.

| comparison | `development` | this PR |
|---|---|---|
| split vs whole columns, level-1 `z_phys` | 0.54 m at k = 16, decaying to 0.01 m at k = 39 | bitwise |
| split vs whole columns, `detJ` (both levels) | 2.3e-3 | bitwise |
| whole columns, `development` vs this PR (all plotted fields) | | bitwise |
| unsplit patch aloft (fine grids k = 10..39), `development` vs this PR | | bitwise |
| split vs unsplit patch aloft, `z_phys` | 1.7e-13 | bitwise |

Together with #3970 (this PR's `ERF_TerrainMetrics.cpp` on top of its head 28f4f4813), the whole plotfile is bitwise identical between split and whole-column fine grids on both levels at step 0: `z_phys`, `detJ`, `dens_hse`, `pres_hse`, `density`, `theta` and `pressure`. The whole-column run is bitwise the same with and without #3970.

## Tests

- **`TerrainFineColumns` (gtest, serial and parallel executables).** Builds a fine-level mesh from a synthetic interpolated mesh and fine terrain, and compares every node, valid and ghost, bit for bit against whole columns. Cases: split in z, uneven split, a stack whose lower boxes are cut in x and upper boxes in y, a split patch aloft, each with and without periodic x and y. A fifth test shows that the per-box build does depend on the split.
- **`Terrain2Lev_BTF_ZSplit` (regression).** New `add_test_terrain_zsplit_parity` / `Tests/RunTerrainZSplitParity.cmake`. It runs the deck above with whole-column and split fine grids and compares `z_phys` and `detJ` with `fcompare -a` at zero tolerance. It takes about 1.5 s on 2 ranks and needs no gold file. `development` fails it.

All 455 serial and 21 parallel unit tests pass.

## Notes

- Independent of #3970: different files, either merge order. With this PR alone the fine-level `dens_hse` and `pres_hse` still depend on the split at step 0 (by 1.6e-4 and 19 Pa on the deck above), because the fine-level hydrostatic initialisation integrates box by box; item 5 of #3970 fixes that. The CTest therefore compares only the mesh.
- Seen in passing, not changed: the comment in the BTF branch saying the top node of a box is not overwritten is stale (the loop box is grown by `nGrow - 1` at the top), and the BTF loop reads the surface node in the same `ParallelFor` that rewrites it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
