### PR TITLE
Fix SHOC first-level PBL height interpolation (#3583)

### DIFF
--- a/Source/PBL/Shoc/ERF_ShocStructure.cpp
+++ b/Source/PBL/Shoc/ERF_ShocStructure.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 
 using namespace amrex;
 
@@ -22,6 +23,15 @@ namespace
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_pbl_betam () noexcept { return 15.0_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_pbl_sffrac () noexcept { return 0.1_rt; }
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE Real shoc_kbfs_eps () noexcept { return 1.0e-10_rt; }
+
+    AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
+    bool shoc_richardson_values_are_equal (Real lhs, Real rhs) noexcept
+    {
+        const Real scale = amrex::max(Real(1.0),
+                                      amrex::max(amrex::Math::abs(lhs), amrex::Math::abs(rhs)));
+        const Real tolerance = Real(64.0) * std::numeric_limits<Real>::epsilon() * scale;
+        return amrex::Math::abs(lhs - rhs) <= tolerance;
+    }
 
     AMREX_GPU_HOST_DEVICE AMREX_FORCE_INLINE
     Real weighted_linear_interp (Real x0, Real x1, Real y0, Real y1, Real x)
@@ -153,7 +163,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
             const Real rino = CONST_GRAV * (thvk - thv0) * (ztk_agl - zt0_agl) /
                               (amrex::max(thv0, 1.0e-12_rt) * vvk);
             if (rino >= shoc_pbl_ricr()) {
-                if (amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
+                if (shoc_richardson_values_are_equal(rino, prev_rino)) {
                     pblh_loc = ztk_agl;
                 } else {
                     const Real ztkm1_agl = shoc::height_agl(zt(ic,k-1,0), z_sfc);
@@ -191,7 +201,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
                 const Real rino = CONST_GRAV * (thvk - tlv) * (ztk_agl - zt0_agl) /
                                   (amrex::max(thv0, 1.0e-12_rt) * vvk);
                 if (rino >= shoc_pbl_ricr()) {
-                    if (amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
+                    if (shoc_richardson_values_are_equal(rino, prev_rino)) {
                         pblh_loc = ztk_agl;
                     } else {
                         const Real ztkm1_agl = shoc::height_agl(zt(ic,k-1,0), z_sfc);

--- a/Source/PBL/Shoc/ERF_ShocStructure.cpp
+++ b/Source/PBL/Shoc/ERF_ShocStructure.cpp
@@ -153,7 +153,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
             const Real rino = CONST_GRAV * (thvk - thv0) * (ztk_agl - zt0_agl) /
                               (amrex::max(thv0, 1.0e-12_rt) * vvk);
             if (rino >= shoc_pbl_ricr()) {
-                if (k == 1 || amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
+                if (amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
                     pblh_loc = ztk_agl;
                 } else {
                     const Real ztkm1_agl = shoc::height_agl(zt(ic,k-1,0), z_sfc);
@@ -191,7 +191,7 @@ ShocStructure::diagnose_pblh (ShocColumnData& col)
                 const Real rino = CONST_GRAV * (thvk - tlv) * (ztk_agl - zt0_agl) /
                                   (amrex::max(thv0, 1.0e-12_rt) * vvk);
                 if (rino >= shoc_pbl_ricr()) {
-                    if (k == 1 || amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
+                    if (amrex::Math::abs(rino - prev_rino) <= 1.0e-12_rt) {
                         pblh_loc = ztk_agl;
                     } else {
                         const Real ztkm1_agl = shoc::height_agl(zt(ic,k-1,0), z_sfc);

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <limits>
 #include <string>
 
 TEST(ShocRuntimeOptions, DefaultsValidate)
@@ -99,6 +100,40 @@ shift_column_heights (ShocColumnData& col, amrex::Real offset)
         zi(0,k,0) += offset;
     }
     shoc_test::sync();
+}
+
+ShocColumnData
+make_first_level_ri_crossing_column (amrex::Real surface_sensible_flux)
+{
+    auto col = shoc_test::make_column(2);
+    auto thetal = col.thetal.array();
+    auto qv = col.qv.array();
+    auto qc = col.qc.array();
+    auto qi = col.qi.array();
+    auto qw = col.qw.array();
+    auto u = col.u.array();
+    auto v = col.v.array();
+
+    // With ustar = 0.01 m/s, this increment gives Ri(zt(1)) = 0.9
+    // for the 50/150 m test-column levels.
+    constexpr amrex::Real theta_increment = 0.002752293577981651;
+    for (int k = 0; k < col.layout.nlev; ++k) {
+        thetal(0,k,0) = 300.0 + theta_increment * k;
+        qv(0,k,0) = 0.0;
+        qc(0,k,0) = 0.0;
+        qi(0,k,0) = 0.0;
+        qw(0,k,0) = 0.0;
+        u(0,k,0) = 2.0;
+        v(0,k,0) = 1.0;
+    }
+
+    shoc::set_fab_val(col.surf_sens_flux, surface_sensible_flux, shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_lat_flux, 0.0, shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_tau_u, 0.0, shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_tau_v, 0.0, shoc::InitRunOn::Host);
+    shoc_test::sync();
+
+    return col;
 }
 }
 
@@ -429,6 +464,48 @@ TEST(ShocStructure, PblHeightUsesVaporNotTotalWaterInVirtualTheta)
     const auto pblh_inconsistent_qw = col.pblh.const_array()(0,0,0);
 
     EXPECT_NEAR(pblh_consistent_qw, pblh_inconsistent_qw, 1.0e-10);
+}
+
+TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
+{
+    auto col = make_first_level_ri_crossing_column(0.0);
+
+    shoc_test::run_and_sync([&] {
+        ShocStructure::diagnose_surface_layer(col);
+        ShocStructure::diagnose_pblh(col);
+    });
+
+    const auto pblh = col.pblh.const_array()(0,0,0);
+    const auto zt = col.zt.const_array();
+    const auto zi = col.zi.const_array();
+    const amrex::Real z0_agl = shoc::height_agl(zt(0,0,0), zi(0,0,0));
+    const amrex::Real z1_agl = shoc::height_agl(zt(0,1,0), zi(0,0,0));
+    const amrex::Real expected = z0_agl + (amrex::Real(0.3) / amrex::Real(0.9)) *
+                                           (z1_agl - z0_agl);
+    const amrex::Real tolerance = amrex::max(
+        amrex::Real(1.0e-8),
+        amrex::Real(1000.0) * std::numeric_limits<amrex::Real>::epsilon() * expected);
+
+    EXPECT_NEAR(pblh, expected, tolerance);
+}
+
+TEST(ShocStructure, PblHeightInterpolatesFirstConvectiveRichardsonCrossing)
+{
+    auto col = make_first_level_ri_crossing_column(1.0e-8);
+
+    shoc_test::run_and_sync([&] {
+        ShocStructure::diagnose_surface_layer(col);
+        ShocStructure::diagnose_pblh(col);
+    });
+
+    const auto pblh = col.pblh.const_array()(0,0,0);
+    const auto zt = col.zt.const_array();
+    const auto zi = col.zi.const_array();
+    const amrex::Real z0_agl = shoc::height_agl(zt(0,0,0), zi(0,0,0));
+    const amrex::Real z1_agl = shoc::height_agl(zt(0,1,0), zi(0,0,0));
+
+    EXPECT_GT(pblh, z0_agl);
+    EXPECT_LT(pblh, z1_agl);
 }
 
 TEST(ShocStructure, PblHeightStaysInsideColumn)

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -114,8 +114,8 @@ make_first_level_ri_crossing_column (amrex::Real surface_sensible_flux)
     auto u = col.u.array();
     auto v = col.v.array();
 
-    // With ustar = 0.01 m/s, this increment gives Ri(zt(1)) = 0.9
-    // for the 50/150 m test-column levels.
+    // Nominally target a Richardson number well above the critical value;
+    // the expected crossing below is derived from the represented state.
     constexpr amrex::Real theta_increment = 0.002752293577981651;
     for (int k = 0; k < col.layout.nlev; ++k) {
         thetal(0,k,0) = 300.0 + theta_increment * k;
@@ -475,20 +475,36 @@ TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
 
     shoc_test::run_and_sync([&] {
         ShocStructure::diagnose_surface_layer(col);
-        ShocStructure::diagnose_pblh(col);
     });
 
-    const auto pblh = col.pblh.const_array()(0,0,0);
     const auto zt = col.zt.const_array();
     const auto zi = col.zi.const_array();
+    const auto thetal = col.thetal.const_array();
+    const amrex::Real ustar = col.ustar.const_array()(0,0,0);
     const amrex::Real z0_agl = shoc::height_agl(zt(0,0,0), zi(0,0,0));
     const amrex::Real z1_agl = shoc::height_agl(zt(0,1,0), zi(0,0,0));
-    const amrex::Real expected = z0_agl + (amrex::Real(0.3) / amrex::Real(0.9)) *
+    const amrex::Real theta0 = thetal(0,0,0);
+    const amrex::Real theta1 = thetal(0,1,0);
+    const amrex::Real ri1 = CONST_GRAV * (theta1 - theta0) * (z1_agl - z0_agl) /
+                            (theta0 * (amrex::Real(100.0) * ustar * ustar));
+    ASSERT_TRUE(std::isfinite(ri1));
+    ASSERT_GT(ri1, amrex::Real(0.3));
+
+    // The first-level reference Richardson number is zero, so interpolate the
+    // critical crossing from the represented Ri(1), not from its nominal input.
+    const amrex::Real expected = z0_agl + (amrex::Real(0.3) / ri1) *
                                            (z1_agl - z0_agl);
     const amrex::Real tolerance = amrex::max(
         amrex::Real(1.0e-8),
         amrex::Real(1000.0) * std::numeric_limits<amrex::Real>::epsilon() * expected);
 
+    shoc_test::run_and_sync([&] {
+        ShocStructure::diagnose_pblh(col);
+    });
+    const auto pblh = col.pblh.const_array()(0,0,0);
+
+    EXPECT_GT(pblh, z0_agl);
+    EXPECT_LT(pblh, z1_agl);
     EXPECT_NEAR(pblh, expected, tolerance);
 }
 

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -116,21 +116,21 @@ make_first_level_ri_crossing_column (amrex::Real surface_sensible_flux)
 
     // Nominally target a Richardson number well above the critical value;
     // the expected crossing below is derived from the represented state.
-    constexpr amrex::Real theta_increment = 0.002752293577981651;
+    constexpr amrex::Real theta_increment = amrex::Real(0.002752293577981651);
     for (int k = 0; k < col.layout.nlev; ++k) {
-        thetal(0,k,0) = 300.0 + theta_increment * k;
-        qv(0,k,0) = 0.0;
-        qc(0,k,0) = 0.0;
-        qi(0,k,0) = 0.0;
-        qw(0,k,0) = 0.0;
-        u(0,k,0) = 2.0;
-        v(0,k,0) = 1.0;
+        thetal(0,k,0) = amrex::Real(300.0) + theta_increment * k;
+        qv(0,k,0) = amrex::Real(0.0);
+        qc(0,k,0) = amrex::Real(0.0);
+        qi(0,k,0) = amrex::Real(0.0);
+        qw(0,k,0) = amrex::Real(0.0);
+        u(0,k,0) = amrex::Real(2.0);
+        v(0,k,0) = amrex::Real(1.0);
     }
 
     shoc::set_fab_val(col.surf_sens_flux, surface_sensible_flux, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_lat_flux, 0.0, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_tau_u, 0.0, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_tau_v, 0.0, shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_lat_flux, amrex::Real(0.0), shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_tau_u, amrex::Real(0.0), shoc::InitRunOn::Host);
+    shoc::set_fab_val(col.surf_tau_v, amrex::Real(0.0), shoc::InitRunOn::Host);
     shoc_test::sync();
 
     return col;
@@ -471,7 +471,7 @@ TEST(ShocStructure, PblHeightUsesVaporNotTotalWaterInVirtualTheta)
 // this prevents the first crossing from being rounded up to the upper height.
 TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
 {
-    auto col = make_first_level_ri_crossing_column(0.0);
+    auto col = make_first_level_ri_crossing_column(amrex::Real(0.0));
 
     shoc_test::run_and_sync([&] {
         ShocStructure::diagnose_surface_layer(col);
@@ -513,7 +513,7 @@ TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
 // from retaining the old upper-level shortcut after the stable search is fixed.
 TEST(ShocStructure, PblHeightInterpolatesFirstConvectiveRichardsonCrossing)
 {
-    auto col = make_first_level_ri_crossing_column(1.0e-8);
+    auto col = make_first_level_ri_crossing_column(amrex::Real(1.0e-8));
 
     shoc_test::run_and_sync([&] {
         ShocStructure::diagnose_surface_layer(col);

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -466,6 +466,9 @@ TEST(ShocStructure, PblHeightUsesVaporNotTotalWaterInVirtualTheta)
     EXPECT_NEAR(pblh_consistent_qw, pblh_inconsistent_qw, 1.0e-10);
 }
 
+// Motivation: A bulk Richardson number that first exceeds the critical value
+// above the reference level must locate the crossing between the two levels;
+// this prevents the first crossing from being rounded up to the upper height.
 TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
 {
     auto col = make_first_level_ri_crossing_column(0.0);
@@ -489,6 +492,9 @@ TEST(ShocStructure, PblHeightInterpolatesFirstStableRichardsonCrossing)
     EXPECT_NEAR(pblh, expected, tolerance);
 }
 
+// Motivation: Positive surface buoyancy runs a second Richardson search for
+// the convective correction; this protects that duplicated first-level branch
+// from retaining the old upper-level shortcut after the stable search is fixed.
 TEST(ShocStructure, PblHeightInterpolatesFirstConvectiveRichardsonCrossing)
 {
     auto col = make_first_level_ri_crossing_column(1.0e-8);


### PR DESCRIPTION
### Summary

This PR fixes the SHOC bulk-Richardson PBL height diagnosis when the critical Richardson number is first exceeded at the first level above the reference level.

Previously, both Richardson-number searches in `ShocStructure::diagnose_pblh` special-cased the first crossing and set the PBL height directly to the upper model level. Since the reference-level Richardson number is zero, the first crossing can be interpolated in the same way as later crossings. The old behavior could therefore overestimate the diagnosed PBL height by nearly one vertical grid spacing.

This change:

* removes the first-level shortcut from both the primary and convective-correction Richardson searches;
* retains the existing degenerate-slope safeguard;
* leaves the existing PBL-height floors and other SHOC physics unchanged;
* adds focused regression tests for first-level crossings in both Richardson searches;
* derives the regression expectation from the represented `amrex::Real` state so the test is portable across SINGLE and DOUBLE precision.

### Testing

* SINGLE precision focused first-crossing tests: **2/2 passed**
* DOUBLE precision focused first-crossing tests: **2/2 passed**
* DOUBLE precision full SHOC unit suite: **118/118 passed**
* SINGLE precision full SHOC unit suite: **93/118 passed**; the two new first-crossing regression tests pass, while the remaining failures are outside the tests changed by this PR.

Closes #3583.
