### PR TITLE
Make SHOC tests precision-aware in SINGLE builds (#3981)

### DIFF
--- a/.github/workflows/gcc.yml
+++ b/.github/workflows/gcc.yml
@@ -102,6 +102,16 @@ jobs:
         ctest -L unit --output-on-failure --no-tests=error
       working-directory: ${{runner.workspace}}/ERF/build
 
+    # Keep the existing DOUBLE unit/regression coverage and add one focused
+    # SINGLE SHOC runtime job.  This avoids repeating the full SHOC suite for
+    # both particle-precision variants while exercising the precision-aware
+    # SHOC gold and unit oracles in CI.
+    - name: Run SINGLE SHOC Tests
+      if: matrix.mesh_precision == 'SINGLE' && matrix.particles == 'ON' && matrix.particles_precision == 'DOUBLE'
+      run: |
+        ctest -L shoc --output-on-failure --no-tests=error
+      working-directory: ${{runner.workspace}}/ERF/build
+
     - name: Run Parallel Tests
       if: matrix.particles_precision == 'DOUBLE' && matrix.mesh_precision == 'DOUBLE'
       run: |

--- a/Tests/CTestList.cmake
+++ b/Tests/CTestList.cmake
@@ -619,10 +619,20 @@ if(ERF_ENABLE_TESTS AND ERF_ENABLE_MPI)
     # The checker is a small AMReX PlotFileData consumer and is built only
     # when regression tests are enabled.  All SHOC cases use explicit
     # state-update ownership settings in their input fixture.
+    # DOUBLE keeps the historical strict fcompare oracle.  SINGLE uses the
+    # field-aware comparator so the shared gold remains the scientific
+    # reference while represented-float roundoff is bounded per field.
+    if(ERF_PRECISION STREQUAL "SINGLE")
+        set(_shoc_clear_gold_comparison "field_aware")
+    else()
+        set(_shoc_clear_gold_comparison "fcompare")
+    endif()
+
     add_test_shoc_r(SHOC_Stable_Clear "" "erf_exec" "plt00020"
         TEST_FILES_DIR "SHOC_Stable_Clear"
         CHECK_MODE "stable_clear"
-        GOLD_COMPARISON "fcompare"
+        GOLD_COMPARISON "${_shoc_clear_gold_comparison}"
+        GOLD_MODE "stable_clear"
         LABELS regression shoc
         TIMEOUT 900)
     add_test_shoc_r(SHOC_Stable_Cloud "" "erf_exec" "plt00020"
@@ -635,7 +645,8 @@ if(ERF_ENABLE_TESTS AND ERF_ENABLE_MPI)
     add_test_shoc_r(SHOC_Unstable_Clear_BOMEX "" "erf_exec" "plt00020"
         TEST_FILES_DIR "SHOC_Unstable_Clear_BOMEX"
         CHECK_MODE "unstable_clear"
-        GOLD_COMPARISON "fcompare"
+        GOLD_COMPARISON "${_shoc_clear_gold_comparison}"
+        GOLD_MODE "unstable_clear"
         LABELS regression shoc
         TIMEOUT 900)
     add_test_shoc_r(SHOC_Unstable_Cloud_SatAdj "" "erf_exec" "plt00020"

--- a/Tests/ShocGoldDifferential.cpp
+++ b/Tests/ShocGoldDifferential.cpp
@@ -29,13 +29,10 @@ struct FieldTolerance {
     Real relative;
 };
 
-// These are source-reviewed tolerances for the shared cloudy SHOC golds.  The
-// additive absolute-plus-relative rule below keeps small moisture and
-// diagnostic fields tighter than a single global fcompare absolute floor.
-// The expanded entries below cover the measured deterministic
-// CPU/compiler envelope from the stable-cloud CI failures; all other fields
-// retain their pre-repair limits.
-const std::map<std::string, FieldTolerance>& tolerance_profile ()
+// These are the existing DOUBLE tolerances for the shared cloudy SHOC golds.
+// They remain available for source review, but DOUBLE runs continue to use
+// the strict amrex_fcompare path in CTest.
+[[maybe_unused]] const std::map<std::string, FieldTolerance>& double_tolerance_profile ()
 {
     static const std::map<std::string, FieldTolerance> profile {
         {"density",     {1.0e-10, 3.0e-8}},
@@ -66,6 +63,96 @@ const std::map<std::string, FieldTolerance>& tolerance_profile ()
     return profile;
 }
 
+// SINGLE-vs-shared-gold tolerances are field-specific and were rounded up from
+// the measured deterministic baseline envelope across the seven SHOC cases.
+// The additive absolute-plus-relative rule keeps near-zero diagnostics from
+// receiving a global absolute floor.  The two clear profiles retain separate
+// z-velocity absolute bounds because that field is close to zero in BOMEX.
+[[maybe_unused]] const std::map<std::string, FieldTolerance>& single_cloudy_tolerance_profile ()
+{
+    static const std::map<std::string, FieldTolerance> profile {
+        {"density",     {1.0e-8,  3.0e-6}},
+        {"rhoKE",       {1.0e-8,  8.0e-5}},
+        {"x_velocity",  {1.0e-8,  7.0e-5}},
+        {"y_velocity",  {1.0e-8,  3.0e-5}},
+        {"z_velocity",  {6.0e-5,  2.0e-3}},
+        {"temp",        {1.0e-6,  5.0e-6}},
+        {"theta",       {1.0e-6,  5.0e-6}},
+        {"pressure",    {1.0e-3,  3.0e-6}},
+        {"Kmv",         {1.0e-6,  2.0e-4}},
+        {"Khv",         {1.0e-6,  2.0e-4}},
+        {"Lturb",       {1.0e-5,  1.5e-3}},
+        {"shoc_cldfrac",{1.0e-12, 1.0e-10}},
+        {"shoc_ql",     {1.0e-9,  7.0e-4}},
+        {"shoc_cond",   {1.0e-10, 4.0e-3}},
+        {"brunt",       {1.0e-9,  5.0e-3}},
+        {"shear_prod",  {1.0e-11, 1.0e-3}},
+        {"buoy_prod",   {1.0e-10, 3.0e-3}},
+        {"diss_tke",    {1.0e-10, 2.0e-4}},
+        {"qv",          {1.0e-9,  2.0e-5}},
+        {"qc",          {1.0e-9,  7.0e-4}},
+        {"qi",          {1.0e-12, 1.0e-8}},
+        {"qrain",       {1.0e-10, 2.0e-3}},
+        {"qsnow",       {1.0e-12, 1.0e-8}},
+        {"qgraup",      {1.0e-12, 1.0e-8}}
+    };
+    return profile;
+}
+
+[[maybe_unused]] const std::map<std::string, FieldTolerance>& single_stable_clear_tolerance_profile ()
+{
+    static const std::map<std::string, FieldTolerance> profile {
+        {"density",     {1.0e-8,  3.0e-6}},
+        {"rhoKE",       {1.0e-8,  3.0e-4}},
+        {"x_velocity",  {1.0e-8,  4.0e-5}},
+        {"y_velocity",  {1.0e-8,  4.0e-5}},
+        {"z_velocity",  {5.0e-5,  3.0e-3}},
+        {"temp",        {1.0e-6,  1.0e-6}},
+        {"theta",       {1.0e-6,  2.0e-6}},
+        {"pressure",    {1.0e-2,  2.0e-6}},
+        {"Kmv",         {1.0e-6,  3.0e-4}},
+        {"Khv",         {1.0e-6,  3.0e-4}},
+        {"Lturb",       {1.0e-4,  1.0e-4}},
+        {"shoc_cldfrac",{1.0e-12, 1.0e-12}},
+        {"shoc_ql",     {1.0e-12, 1.0e-12}},
+        {"shoc_cond",   {1.0e-12, 1.0e-12}},
+        {"brunt",       {1.0e-9,  3.0e-3}},
+        {"shear_prod",  {1.0e-11, 1.0e-3}},
+        {"buoy_prod",   {1.0e-9,  4.0e-3}},
+        {"diss_tke",    {1.0e-10, 3.0e-4}},
+        {"qv",          {1.0e-9,  1.0e-6}},
+        {"qc",          {1.0e-12, 1.0e-12}}
+    };
+    return profile;
+}
+
+[[maybe_unused]] const std::map<std::string, FieldTolerance>& single_unstable_clear_tolerance_profile ()
+{
+    static const std::map<std::string, FieldTolerance> profile {
+        {"density",     {1.0e-8,  3.0e-6}},
+        {"rhoKE",       {1.0e-8,  1.0e-4}},
+        {"x_velocity",  {1.0e-8,  2.0e-5}},
+        {"y_velocity",  {1.0e-8,  1.0e-5}},
+        {"z_velocity",  {1.2e-4, 1.0e-3}},
+        {"temp",        {1.0e-6,  3.0e-6}},
+        {"theta",       {1.0e-6,  3.0e-6}},
+        {"pressure",    {1.0e-2,  3.0e-6}},
+        {"Kmv",         {1.0e-6,  8.0e-5}},
+        {"Khv",         {1.0e-6,  8.0e-5}},
+        {"Lturb",       {1.0e-4,  1.0e-4}},
+        {"shoc_cldfrac",{1.0e-12, 1.0e-12}},
+        {"shoc_ql",     {1.0e-12, 1.0e-12}},
+        {"shoc_cond",   {1.0e-12, 1.0e-12}},
+        {"brunt",       {1.0e-9,  1.2e-2}},
+        {"shear_prod",  {1.0e-11, 5.0e-4}},
+        {"buoy_prod",   {1.0e-9,  1.2e-2}},
+        {"diss_tke",    {1.0e-10, 2.0e-4}},
+        {"qv",          {1.0e-9,  2.0e-6}},
+        {"qc",          {1.0e-12, 1.0e-12}}
+    };
+    return profile;
+}
+
 const std::vector<std::string>& base_fields ()
 {
     static const std::vector<std::string> fields {
@@ -82,6 +169,8 @@ const std::vector<std::string>& fields_for_mode (const std::string& mode)
     static const std::vector<std::string> stable_cloud = base_fields();
     static const std::vector<std::string> unstable_cloud = base_fields();
     static const std::vector<std::string> unstable_cloud_nocond = base_fields();
+    static const std::vector<std::string> stable_clear = base_fields();
+    static const std::vector<std::string> unstable_clear = base_fields();
     static const std::vector<std::string> unstable_cloud_kessler = [] {
         auto fields = base_fields();
         fields.emplace_back("qrain");
@@ -96,6 +185,12 @@ const std::vector<std::string>& fields_for_mode (const std::string& mode)
         return fields;
     }();
 
+    if (mode == "stable_clear") {
+        return stable_clear;
+    }
+    if (mode == "unstable_clear") {
+        return unstable_clear;
+    }
     if (mode == "stable_cloud") {
         return stable_cloud;
     }
@@ -116,7 +211,8 @@ const std::vector<std::string>& fields_for_mode (const std::string& mode)
 
 bool is_supported_mode (const std::string& mode)
 {
-    return mode == "stable_cloud" || mode == "unstable_cloud" ||
+    return mode == "stable_clear" || mode == "unstable_clear" ||
+           mode == "stable_cloud" || mode == "unstable_cloud" ||
            mode == "unstable_cloud_nocond" || mode == "unstable_cloud_kessler" ||
            mode == "unstable_cloud_wsm6";
 }
@@ -237,7 +333,24 @@ Real maximum_difference (const MultiFab& candidate, const MultiFab& gold)
     return difference.norm0();
 }
 
-bool compare_fields (PlotFileData& gold,
+const std::map<std::string, FieldTolerance>& tolerance_profile (const std::string& mode)
+{
+#ifdef AMREX_USE_FLOAT
+    if (mode == "stable_clear") {
+        return single_stable_clear_tolerance_profile();
+    }
+    if (mode == "unstable_clear") {
+        return single_unstable_clear_tolerance_profile();
+    }
+    return single_cloudy_tolerance_profile();
+#else
+    amrex::ignore_unused(mode);
+    return double_tolerance_profile();
+#endif
+}
+
+bool compare_fields (const std::string& mode,
+                     PlotFileData& gold,
                      PlotFileData& candidate,
                      const std::vector<std::string>& fields)
 {
@@ -255,7 +368,7 @@ bool compare_fields (PlotFileData& gold,
             scale = std::max(scale, std::max(candidate_field.norm0(), gold_field.norm0()));
         }
 
-        const FieldTolerance tolerance = tolerance_profile().at(field);
+        const FieldTolerance tolerance = tolerance_profile(mode).at(field);
         const Real allowed_error = tolerance.absolute + tolerance.relative * scale;
         const bool passed = absolute_error <= allowed_error;
         all_passed = all_passed && passed;
@@ -296,7 +409,7 @@ main (int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    const bool passed = compare_fields(gold, candidate, fields);
+    const bool passed = compare_fields(args.mode, gold, candidate, fields);
     amrex::Finalize();
     return passed ? EXIT_SUCCESS : EXIT_FAILURE;
 }

--- a/Tests/ShocGoldDifferential.cpp
+++ b/Tests/ShocGoldDifferential.cpp
@@ -29,9 +29,9 @@ struct FieldTolerance {
     Real relative;
 };
 
-// These are the existing DOUBLE tolerances for the shared cloudy SHOC golds.
-// They remain available for source review, but DOUBLE runs continue to use
-// the strict amrex_fcompare path in CTest.
+// These are the existing DOUBLE tolerances for field-aware cloudy SHOC
+// comparisons. Clear-sky DOUBLE regressions retain their historical strict
+// amrex_fcompare path in CTest.
 [[maybe_unused]] const std::map<std::string, FieldTolerance>& double_tolerance_profile ()
 {
     static const std::map<std::string, FieldTolerance> profile {

--- a/Tests/Unit/Shoc/ERF_ShocImplicitTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocImplicitTests.cpp
@@ -137,7 +137,8 @@ TEST(ShocImplicit, ThermodynamicHelpersMatchTranslatedE3smFixtures)
         shoc_test::read_fixture_vector("implicit_energy/e3sm_compute_shoc_temperature_decreasing_profile.txt");
     ASSERT_EQ(tabs_profile.size(), 3);
     EXPECT_NEAR(ShocImplicit::compute_temperature(300.0, 1.0e-5, 1.0 / 1.1), tabs_profile[0], 1.0e-12);
-    EXPECT_NEAR(ShocImplicit::compute_temperature(350.0, 1.0e-5, 1.0 / 1.5), tabs_profile[1], 1.0e-12);
+    EXPECT_NEAR(ShocImplicit::compute_temperature(350.0, 1.0e-5, 1.0 / 1.5), tabs_profile[1],
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12), tabs_profile[1], 2));
     EXPECT_NEAR(ShocImplicit::compute_temperature(400.0, 1.0e-5, 0.5), tabs_profile[2], 1.0e-12);
 
     const amrex::Real exner = 0.75;
@@ -154,7 +155,8 @@ TEST(ShocImplicit, ThermodynamicHelpersMatchTranslatedE3smFixtures)
     EXPECT_NEAR(ShocImplicit::compute_vapor(1.0e-2, 0.0), vapor_fixture[0], 1.0e-15);
     EXPECT_NEAR(ShocImplicit::compute_vapor(1.2e-2, 0.0), vapor_fixture[1], 1.0e-15);
     EXPECT_NEAR(ShocImplicit::compute_vapor(1.5e-2, 1.5e-4), vapor_fixture[2], 1.0e-15);
-    EXPECT_NEAR(ShocImplicit::compute_vapor(1.7e-2, 2.0e-3), vapor_fixture[3], 1.0e-15);
+    EXPECT_NEAR(ShocImplicit::compute_vapor(1.7e-2, 2.0e-3), vapor_fixture[3],
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-15), vapor_fixture[3], 4));
     EXPECT_NEAR(ShocImplicit::compute_vapor(2.0e-2, 0.0), vapor_fixture[4], 1.0e-15);
 }
 
@@ -208,8 +210,12 @@ TEST(ShocImplicit, GeometryHelpersMatchTranslatedE3smFixtures)
     ASSERT_EQ(rdp_zt.size(), rdp_fixture.size());
 
     for (int k = 0; k < static_cast<int>(rdp_fixture.size()); ++k) {
-        EXPECT_NEAR(rdp_zt[k], rdp_fixture[k], 1.0e-15);
-        EXPECT_NEAR(tmpi[k], tmpi_fixture[k], 1.0e-12);
+        EXPECT_NEAR(rdp_zt[k], rdp_fixture[k],
+                    shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-15),
+                                                           rdp_fixture[k], 4));
+        EXPECT_NEAR(tmpi[k], tmpi_fixture[k],
+                    shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                           tmpi_fixture[k], 4));
     }
 }
 
@@ -263,11 +269,19 @@ TEST(ShocImplicit, UniformProfileWithNoFluxRemainsUnchanged)
 
     for (int k = 0; k < col.layout.nlev; ++k) {
         EXPECT_NEAR(theta_tend(0,k,0), 0.0, 1.0e-12);
-        EXPECT_NEAR(qv_tend(0,k,0), 0.0, 1.0e-12);
+        // The largest observed SINGLE cancellation residual is 9.31e-11 for
+        // qv and 1.19e-8 for momentum/TKE tendencies in this zero-flux case.
+        EXPECT_NEAR(qv_tend(0,k,0), amrex::Real(0.0),
+                    shoc_test::precision_aware_tolerance(amrex::Real(1.0e-12),
+                                                          amrex::Real(2.0e-10)));
         EXPECT_NEAR(qc_tend(0,k,0), 0.0, 1.0e-12);
         EXPECT_NEAR(u_tend(0,k,0), 0.0, 1.0e-12);
-        EXPECT_NEAR(v_tend(0,k,0), 0.0, 1.0e-12);
-        EXPECT_NEAR(tke_tend(0,k,0), 0.0, 1.0e-12);
+        EXPECT_NEAR(v_tend(0,k,0), amrex::Real(0.0),
+                    shoc_test::precision_aware_tolerance(amrex::Real(1.0e-12),
+                                                          amrex::Real(2.0e-8)));
+        EXPECT_NEAR(tke_tend(0,k,0), amrex::Real(0.0),
+                    shoc_test::precision_aware_tolerance(amrex::Real(1.0e-12),
+                                                          amrex::Real(5.0e-9)));
     }
 }
 
@@ -323,8 +337,12 @@ TEST(ShocImplicit, PdfDiagnosedLiquidFeedsHostWriteback)
     const auto qv_out = col.qv.const_array();
     const auto qc_out = col.qc.const_array();
 
-    EXPECT_NEAR(qc_out(0,1,0), 1.0e-3, 1.0e-12);
-    EXPECT_NEAR(qv_out(0,1,0), 0.011, 1.0e-12);
+    EXPECT_NEAR(qc_out(0,1,0), amrex::Real(1.0e-3),
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       amrex::Real(1.0e-3), 2));
+    EXPECT_NEAR(qv_out(0,1,0), amrex::Real(0.011),
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       amrex::Real(0.011), 2));
     EXPECT_GT(theta_out(0,1,0), 300.0);
     EXPECT_GT(qc_tend(0,1,0), 0.0);
     EXPECT_LT(qv_tend(0,1,0), 0.0);
@@ -606,7 +624,11 @@ TEST(ShocEnergyFixer, LiquidPartitionChangeDoesNotCreateEnergyCorrection)
                                   u_new, v_new, tke_new);
 
     for (int k = 0; k < col.layout.nlev; ++k) {
-        EXPECT_NEAR(thl_new[k], thl_old[k], 1.0e-12)
+        // The SINGLE result is one represented-temperature ulp below 300 K;
+        // two ulps bound the measured liquid-repartition cancellation.
+        EXPECT_NEAR(thl_new[k], thl_old[k],
+                    shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                           thl_old[k], 2))
             << "E3SM's moist-energy convention cancels the latent heating "
             << "already present in host_dse for liquid repartitioning.";
     }
@@ -727,13 +749,13 @@ TEST(ShocImplicit, SurfaceFluxScalingMatchesE3smFormula)
     }
     zi(0,col.layout.nlev,0) = 40.0 * col.layout.nlev;
 
-    const amrex::Real wthl_sfc = 0.008;
+    const amrex::Real wthl_sfc = amrex::Real(0.008);
     shoc::set_fab_val(col.surf_sens_flux, wthl_sfc, shoc::InitRunOn::Host);
     shoc::set_fab_val(col.surf_lat_flux, 0.0, shoc::InitRunOn::Host);
     shoc::set_fab_val(col.surf_tau_u, 0.0, shoc::InitRunOn::Host);
     shoc::set_fab_val(col.surf_tau_v, 0.0, shoc::InitRunOn::Host);
 
-    const amrex::Real dt = 5.0;
+    const amrex::Real dt = amrex::Real(5.0);
     ShocRuntimeOptions opts;
     shoc_test::run_and_sync([&] {
         ShocImplicit::update_prognostics(col, opts, dt);
@@ -746,15 +768,20 @@ TEST(ShocImplicit, SurfaceFluxScalingMatchesE3smFormula)
     //   delta_thetal = cmnfac * wthl_sfc = dt / dz * wthl_sfc
     //               = 5.0 / 40.0 * 0.008 = 0.001 K
     const amrex::Real rho_zi_sfc = rho(0,0,0); // linear interp at z=0 ≈ rho
-    const amrex::Real expected_cmnfac = dt * rho_zi_sfc / (rho(0,0,0) * 40.0);
+    const amrex::Real expected_cmnfac = dt * rho_zi_sfc /
+                                        (rho(0,0,0) * amrex::Real(40.0));
     const amrex::Real expected_delta = expected_cmnfac * wthl_sfc;
+    const amrex::Real expected_delta_represented =
+        (amrex::Real(300.0) + expected_delta) - amrex::Real(300.0);
 
     const auto thetal_new = col.thetal.const_array();
     const amrex::Real actual_delta = thetal_new(0,0,0) - 300.0;
 
     // The key check: the bottom-cell increment must match the E3SM formula,
     // not be ~20x weaker (which the old tmpi[0]*rdp_zt[0] factor produced).
-    EXPECT_NEAR(actual_delta, expected_delta, 1.0e-6)
+    EXPECT_NEAR(actual_delta, expected_delta_represented,
+                shoc_test::precision_scaled_tolerance(
+                    amrex::Real(1.0e-6), amrex::Real(300.0), 1))
         << "Surface flux scaling diverges from E3SM cmnfac = dt*g*rho_zi*rdp_zt";
 
     // Cells above the bottom must be essentially unchanged (zero diffusion)

--- a/Tests/Unit/Shoc/ERF_ShocMomentsTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocMomentsTests.cpp
@@ -70,12 +70,20 @@ TEST(ShocMoments, SurfaceMomentBoundaryConditionsMatchTranslatedE3smSemantics)
         ShocMoments::diagnose_second_moments(col, opts);
     });
 
-    const amrex::Real ustar2 = std::sqrt(0.04 * 0.04 + 0.03 * 0.03);
-    const amrex::Real wstar = std::cbrt((CONST_GRAV / 300.0) * 0.02 * 400.0);
-    const amrex::Real uf = amrex::max(amrex::Real(0.01), std::sqrt(ustar2 + amrex::Real(0.3) * wstar * wstar));
-    const amrex::Real expected_thl_sec = 0.72 * std::pow(0.02 / uf, 2);
-    const amrex::Real expected_qw_sec = 0.72 * std::pow(1.0e-4 / uf, 2);
-    const amrex::Real expected_qwthl = 0.36 * (0.02 / uf) * (1.0e-4 / uf);
+    const amrex::Real ustar2 = std::sqrt(amrex::Real(0.04) * amrex::Real(0.04) +
+                                         amrex::Real(0.03) * amrex::Real(0.03));
+    const amrex::Real wstar = std::cbrt((CONST_GRAV / amrex::Real(300.0)) *
+                                        amrex::Real(0.02) * amrex::Real(400.0));
+    const amrex::Real uf = amrex::max(
+        amrex::Real(0.01),
+        std::sqrt(ustar2 + amrex::Real(0.3) * wstar * wstar));
+    const amrex::Real expected_thl_sec = amrex::Real(0.72) *
+                                         std::pow(amrex::Real(0.02) / uf, 2);
+    const amrex::Real expected_qw_sec = amrex::Real(0.72) *
+                                        std::pow(amrex::Real(1.0e-4) / uf, 2);
+    const amrex::Real expected_qwthl = amrex::Real(0.36) *
+                                       (amrex::Real(0.02) / uf) *
+                                       (amrex::Real(1.0e-4) / uf);
     const amrex::Real expected_wtke = std::pow(amrex::max(std::sqrt(ustar2), amrex::Real(0.01)), 3);
 
     const auto thl_sec = col.thl_sec.const_array();
@@ -83,10 +91,18 @@ TEST(ShocMoments, SurfaceMomentBoundaryConditionsMatchTranslatedE3smSemantics)
     const auto qwthl = col.qwthl_sec.const_array();
     const auto wtke = col.wtke_sec.const_array();
 
-    EXPECT_NEAR(thl_sec(0,0,0), expected_thl_sec, 1.0e-12);
-    EXPECT_NEAR(qw_sec(0,0,0), expected_qw_sec, 1.0e-12);
-    EXPECT_NEAR(qwthl(0,0,0), expected_qwthl, 1.0e-12);
-    EXPECT_NEAR(wtke(0,0,0), expected_wtke, 1.0e-12);
+    EXPECT_NEAR(thl_sec(0,0,0), expected_thl_sec,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_thl_sec, 4));
+    EXPECT_NEAR(qw_sec(0,0,0), expected_qw_sec,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_qw_sec, 4));
+    EXPECT_NEAR(qwthl(0,0,0), expected_qwthl,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_qwthl, 4));
+    EXPECT_NEAR(wtke(0,0,0), expected_wtke,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_wtke, 4));
 }
 
 TEST(ShocMoments, TopTaperDampsUpperMomentDiagnosticsOnly)

--- a/Tests/Unit/Shoc/ERF_ShocPhysicalPropertyTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocPhysicalPropertyTests.cpp
@@ -18,7 +18,7 @@ namespace
 {
 using namespace amrex::literals;
 
-amrex::Real
+double
 column_moist_energy (const ShocColumnData& col)
 {
     const auto rho = col.rho.const_array();
@@ -31,21 +31,27 @@ column_moist_energy (const ShocColumnData& col)
     const auto u = col.u.const_array();
     const auto v = col.v.const_array();
     const auto tke = col.tke.const_array();
-    amrex::Real total = 0.0;
+    // Accumulate represented SINGLE state values in a wider test-side
+    // accumulator.  Summing O(3e5) energy values in float would make the
+    // oracle measure reduction roundoff instead of the surface-flux budget.
+    double total = 0.0;
     for (int k = 0; k < col.layout.nlev; ++k) {
-        const amrex::Real mass = rho(0,k,0) * dz(0,k,0);
+        const double mass = static_cast<double>(rho(0,k,0)) *
+                            static_cast<double>(dz(0,k,0));
         total += mass
-               * (Cp_d * tabs(0,k,0)
-                  + CONST_GRAV * zt(0,k,0)
-                  + amrex::Real(0.5) * (u(0,k,0) * u(0,k,0) + v(0,k,0) * v(0,k,0))
-                  + tke(0,k,0)
-                  + L_v * (qv(0,k,0) + qc(0,k,0))
-                  + (L_v + amrex::Real(3.34e5)) * qi(0,k,0));
+               * (static_cast<double>(Cp_d) * static_cast<double>(tabs(0,k,0))
+                  + static_cast<double>(CONST_GRAV) * static_cast<double>(zt(0,k,0))
+                  + 0.5 * (static_cast<double>(u(0,k,0)) * static_cast<double>(u(0,k,0))
+                           + static_cast<double>(v(0,k,0)) * static_cast<double>(v(0,k,0)))
+                  + static_cast<double>(tke(0,k,0))
+                  + static_cast<double>(L_v) *
+                    (static_cast<double>(qv(0,k,0)) + static_cast<double>(qc(0,k,0)))
+                  + (static_cast<double>(L_v) + 3.34e5) * static_cast<double>(qi(0,k,0)));
     }
     return total;
 }
 
-amrex::Real
+double
 column_total_water (const ShocColumnData& col)
 {
     const auto rho = col.rho.const_array();
@@ -54,10 +60,11 @@ column_total_water (const ShocColumnData& col)
     const auto qc = col.qc.const_array();
     const auto qi = col.qi.const_array();
 
-    amrex::Real total = 0.0_rt;
+    double total = 0.0;
     for (int k = 0; k < col.layout.nlev; ++k) {
-        total += rho(0,k,0) * dz(0,k,0)
-               * (qv(0,k,0) + qc(0,k,0) + qi(0,k,0));
+        total += static_cast<double>(rho(0,k,0)) * static_cast<double>(dz(0,k,0))
+               * (static_cast<double>(qv(0,k,0)) + static_cast<double>(qc(0,k,0))
+                  + static_cast<double>(qi(0,k,0)));
     }
     return total;
 }
@@ -239,49 +246,74 @@ set_momentum_energy_column (ShocColumnData& col)
 TEST(ShocPhysical, ColumnHeatBudgetTracksSurfaceFlux)
 {
     auto col = shoc_test::make_column(6);
+    auto no_flux = shoc_test::make_column(6);
     ShocRuntimeOptions opts;
 
-    auto tk = col.tk.array();
-    auto tkh = col.tkh.array();
-    auto exner = col.exner.array();
-    auto thetal = col.thetal.array();
-    auto theta = col.theta.array();
-    auto tabs = col.tabs.array();
-    auto host_dse = col.host_dse.array();
-    auto qv = col.qv.array();
-    auto qc = col.qc.array();
-    auto qi = col.qi.array();
-    auto qw = col.qw.array();
-    for (int k = 0; k < col.layout.nlev; ++k) {
-        tk(0,k,0) = 0.0;
-        tkh(0,k,0) = 0.0;
-        exner(0,k,0) = 1.0;
-        thetal(0,k,0) = 300.0;
-        theta(0,k,0) = 300.0;
-        tabs(0,k,0) = 300.0;
-        qv(0,k,0) = 0.008;
-        qc(0,k,0) = 0.0;
-        qi(0,k,0) = 0.0;
-        qw(0,k,0) = qv(0,k,0);
-        host_dse(0,k,0) = Cp_d * tabs(0,k,0) + CONST_GRAV * col.zt.const_array()(0,k,0);
-        col.tke_tend.array()(0,k,0) = 0.0;
-    }
-    shoc::set_fab_val(col.surf_sens_flux, 0.02, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_lat_flux, 0.0, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_tau_u, 0.0, shoc::InitRunOn::Host);
-    shoc::set_fab_val(col.surf_tau_v, 0.0, shoc::InitRunOn::Host);
+    const auto configure = [](ShocColumnData& state, amrex::Real surface_flux) {
+        auto tk = state.tk.array();
+        auto tkh = state.tkh.array();
+        auto exner = state.exner.array();
+        auto thetal = state.thetal.array();
+        auto theta = state.theta.array();
+        auto tabs = state.tabs.array();
+        auto host_dse = state.host_dse.array();
+        auto qv = state.qv.array();
+        auto qc = state.qc.array();
+        auto qi = state.qi.array();
+        auto qw = state.qw.array();
+        for (int k = 0; k < state.layout.nlev; ++k) {
+            tk(0,k,0) = amrex::Real(0.0);
+            tkh(0,k,0) = amrex::Real(0.0);
+            exner(0,k,0) = amrex::Real(1.0);
+            thetal(0,k,0) = amrex::Real(300.0);
+            theta(0,k,0) = amrex::Real(300.0);
+            tabs(0,k,0) = amrex::Real(300.0);
+            qv(0,k,0) = amrex::Real(0.008);
+            qc(0,k,0) = amrex::Real(0.0);
+            qi(0,k,0) = amrex::Real(0.0);
+            qw(0,k,0) = qv(0,k,0);
+            host_dse(0,k,0) = Cp_d * tabs(0,k,0) +
+                              CONST_GRAV * state.zt.const_array()(0,k,0);
+            state.tke_tend.array()(0,k,0) = amrex::Real(0.0);
+        }
+        shoc::set_fab_val(state.surf_sens_flux, surface_flux, shoc::InitRunOn::Host);
+        shoc::set_fab_val(state.surf_lat_flux, amrex::Real(0.0), shoc::InitRunOn::Host);
+        shoc::set_fab_val(state.surf_tau_u, amrex::Real(0.0), shoc::InitRunOn::Host);
+        shoc::set_fab_val(state.surf_tau_v, amrex::Real(0.0), shoc::InitRunOn::Host);
+    };
 
-    const amrex::Real before = column_moist_energy(col);
-    const amrex::Real dt = 10.0;
+    configure(col, amrex::Real(0.02));
+    configure(no_flux, amrex::Real(0.0));
+
+    const double before = column_moist_energy(col);
+    const double no_flux_before = column_moist_energy(no_flux);
+    const amrex::Real dt = amrex::Real(10.0);
     const amrex::Real rho_sfc = col.rho.const_array()(0,0,0);
 
     shoc_test::run_and_sync([&] {
         ShocImplicit::update_prognostics(col, opts, dt);
+        ShocImplicit::update_prognostics(no_flux, opts, dt);
     });
 
-    const amrex::Real after = column_moist_energy(col);
-    const amrex::Real expected = dt * rho_sfc * Cp_d * 0.02;
-    EXPECT_NEAR(after - before, expected, 5.0e-9 * amrex::max(amrex::Real(1.0), amrex::Math::abs(expected)));
+    const double after = column_moist_energy(col);
+    const double no_flux_after = column_moist_energy(no_flux);
+    const double expected = static_cast<double>(dt) * static_cast<double>(rho_sfc) *
+                            static_cast<double>(Cp_d) * 0.02;
+    const double energy_scale = static_cast<double>(rho_sfc) *
+                                static_cast<double>(col.dz.const_array()(0,0,0)) *
+                                static_cast<double>(Cp_d) * 300.0;
+    const amrex::Real double_tolerance = amrex::Real(5.0e-9) *
+                                         amrex::max(amrex::Real(1.0),
+                                                    amrex::Real(std::abs(expected)));
+    // Subtracting a zero-flux control removes the deterministic SINGLE
+    // round-trip drift in the untouched cells.  Four float ulps at the
+    // represented energy scale bound the measured 13.69 J surface-flux
+    // residual from the SINGLE implicit solve.
+    const double tolerance = static_cast<double>(
+        shoc_test::precision_scaled_tolerance(double_tolerance,
+                                               amrex::Real(energy_scale), 4));
+    EXPECT_NEAR((after - before) - (no_flux_after - no_flux_before), expected,
+                tolerance);
 }
 
 // Motivation: With momentum transport disabled, the driver discards the
@@ -736,15 +768,15 @@ TEST(ShocPhysical, DryUniformNoFluxColumnIsConserved)
     shoc::set_fab_val(col.surf_tau_u, 0.0_rt, shoc::InitRunOn::Host);
     shoc::set_fab_val(col.surf_tau_v, 0.0_rt, shoc::InitRunOn::Host);
 
-    const amrex::Real energy_before = column_moist_energy(col);
-    const amrex::Real water_before = column_total_water(col);
+    const double energy_before = column_moist_energy(col);
+    const double water_before = column_total_water(col);
 
     shoc_test::run_and_sync([&] {
         ShocImplicit::update_prognostics(col, opts, dt);
     });
 
     EXPECT_NEAR(column_moist_energy(col), energy_before,
-                1.0e-12_rt * amrex::max(1.0_rt, amrex::Math::abs(energy_before)));
+                1.0e-12 * std::max(1.0, std::abs(energy_before)));
     EXPECT_NEAR(column_total_water(col), water_before, 1.0e-14_rt);
 
     const auto qv = col.qv.const_array();
@@ -785,17 +817,28 @@ TEST(ShocPhysical, ColumnWaterBudgetTracksSurfaceLatentFlux)
     shoc::set_fab_val(col.surf_tau_u, 0.0_rt, shoc::InitRunOn::Host);
     shoc::set_fab_val(col.surf_tau_v, 0.0_rt, shoc::InitRunOn::Host);
 
-    const amrex::Real water_before = column_total_water(col);
+    const double water_before = column_total_water(col);
     const amrex::Real rho_sfc = col.rho.const_array()(0,0,0);
-    const amrex::Real expected_delta = dt * rho_sfc * col.surf_lat_flux.const_array()(0,0,0);
+    const double expected_delta = static_cast<double>(dt) * static_cast<double>(rho_sfc) *
+                                  static_cast<double>(col.surf_lat_flux.const_array()(0,0,0));
 
     shoc_test::run_and_sync([&] {
         ShocImplicit::update_prognostics(col, opts, dt);
     });
 
-    const amrex::Real water_after = column_total_water(col);
+    const double water_after = column_total_water(col);
+    const double water_scale = static_cast<double>(rho_sfc) *
+                               static_cast<double>(col.dz.const_array()(0,0,0)) * 0.008;
+    const amrex::Real double_tolerance = amrex::Real(1.0e-9) *
+                                         amrex::max(amrex::Real(1.0),
+                                                    amrex::Real(std::abs(expected_delta)));
+    // The surface update is stored in qv at O(8e-3), so two represented
+    // qv-scale ulps bound the measured 1.31e-7 column-water residual.
+    const double tolerance = static_cast<double>(
+        shoc_test::precision_scaled_tolerance(double_tolerance,
+                                               amrex::Real(water_scale), 2));
     EXPECT_NEAR(water_after - water_before, expected_delta,
-                1.0e-9_rt * amrex::max(1.0_rt, amrex::Math::abs(expected_delta)));
+                tolerance);
 
     const auto qv = col.qv.const_array();
     const auto qc = col.qc.const_array();

--- a/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocStructureTests.cpp
@@ -265,11 +265,13 @@ TEST(ShocStructure, SurfaceLayerUsesUstarFloorAndFiniteObukhov)
     const auto obklen = col.obklen.const_array();
     const auto wthv_out = col.wthv_sec.const_array();
 
-    EXPECT_DOUBLE_EQ(ustar(0,0,0), 0.01);
+    EXPECT_DOUBLE_EQ(ustar(0,0,0), amrex::Real(0.01));
     EXPECT_TRUE(std::isfinite(obklen(0,0,0)));
     EXPECT_DOUBLE_EQ(wthv_out(0,0,0), wthv_out(0,0,0));
     for (int k = 1; k < col.layout.nlev; ++k) {
-        EXPECT_DOUBLE_EQ(wthv_out(0,k,0), 1.0e-3 * k);
+        // Compare against the value represented by amrex::Real, not the
+        // ideal double literal that was used to initialize the float field.
+        EXPECT_DOUBLE_EQ(wthv_out(0,k,0), amrex::Real(1.0e-3) * k);
     }
 }
 
@@ -297,15 +299,20 @@ TEST(ShocStructure, SurfaceLayerObukhovUsesClampedUstar)
         ShocStructure::diagnose_surface_layer(col);
     });
 
-    const amrex::Real thv_sfc = 300.0 * (1.0 + 0.61 * 0.010);
-    const amrex::Real ustar = 0.01;
+    const amrex::Real thv_sfc = amrex::Real(300.0) *
+                                (amrex::Real(1.0) + amrex::Real(0.61) * amrex::Real(0.010));
+    const amrex::Real ustar = amrex::Real(0.01);
     const amrex::Real ustar_cu = ustar * ustar * ustar;
-    const amrex::Real kbfs = 0.02;
+    const amrex::Real kbfs = amrex::Real(0.02);
     const amrex::Real expected_obk = -thv_sfc * ustar_cu /
-                                     (CONST_GRAV * KAPPA * (kbfs + 1.0e-10));
+                                     (CONST_GRAV * KAPPA * (kbfs + amrex::Real(1.0e-10)));
 
     EXPECT_DOUBLE_EQ(col.ustar.const_array()(0,0,0), ustar);
-    EXPECT_NEAR(col.obklen.const_array()(0,0,0), expected_obk, 1.0e-12);
+    // The SINGLE result differs by 2.33e-10 at |obk| ~= 3.75e-3 in the
+    // baseline; eight output-scale ulps leave a narrow roundoff envelope.
+    EXPECT_NEAR(col.obklen.const_array()(0,0,0), expected_obk,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_obk, 8));
 }
 
 TEST(ShocStructure, SurfaceLayerUsesShocThermodynamicMapping)
@@ -334,22 +341,28 @@ TEST(ShocStructure, SurfaceLayerUsesShocThermodynamicMapping)
         ShocStructure::diagnose_surface_layer(col);
     });
 
-    const amrex::Real qc_sfc = 1.0e-3;
-    const amrex::Real qi_sfc = 2.0e-4;
+    const amrex::Real qc_sfc = amrex::Real(1.0e-3);
+    const amrex::Real qi_sfc = amrex::Real(2.0e-4);
     const amrex::Real cldliq = qc_sfc + qi_sfc;
-    const amrex::Real th_sfc = 298.0 + (L_v * qc_sfc + shoc::latent_sublimation() * qi_sfc) / Cp_d;
-    const amrex::Real thv_sfc = th_sfc * (1.0 + 0.61 * 0.010 - cldliq);
-    const amrex::Real ustar_raw = std::sqrt(std::sqrt(0.04 * 0.04 + 0.03 * 0.03));
+    const amrex::Real th_sfc = amrex::Real(298.0) +
+                               (L_v * qc_sfc + shoc::latent_sublimation() * qi_sfc) / Cp_d;
+    const amrex::Real thv_sfc = th_sfc *
+                                (amrex::Real(1.0) + amrex::Real(0.61) * amrex::Real(0.010) - cldliq);
+    const amrex::Real ustar_raw = std::sqrt(std::sqrt(amrex::Real(0.04) * amrex::Real(0.04) +
+                                                      amrex::Real(0.03) * amrex::Real(0.03)));
     const amrex::Real ustar = amrex::max(amrex::Real(0.01), ustar_raw);
-    const amrex::Real kbfs = 0.02 + 0.61 * th_sfc * 2.0e-4;
+    const amrex::Real kbfs = amrex::Real(0.02) + amrex::Real(0.61) * th_sfc * amrex::Real(2.0e-4);
     const amrex::Real expected_obk = -thv_sfc * std::pow(ustar, 3) /
-                                     (CONST_GRAV * KAPPA * (kbfs + 1.0e-10));
+                                     (CONST_GRAV * KAPPA * (kbfs + amrex::Real(1.0e-10)));
 
     EXPECT_NEAR(col.ustar.const_array()(0,0,0), ustar, 1.0e-12);
-    EXPECT_NEAR(col.obklen.const_array()(0,0,0), expected_obk, 1.0e-10);
-    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), kbfs, 1.0e-12);
+    EXPECT_NEAR(col.obklen.const_array()(0,0,0), expected_obk,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-10),
+                                                       expected_obk, 8));
+    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), kbfs,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12), kbfs, 4));
     for (int k = 1; k < col.layout.nlev; ++k) {
-        EXPECT_DOUBLE_EQ(col.wthv_sec.const_array()(0,k,0), 5.0e-4 * k);
+        EXPECT_DOUBLE_EQ(col.wthv_sec.const_array()(0,k,0), amrex::Real(5.0e-4) * k);
     }
 }
 
@@ -378,13 +391,15 @@ TEST(ShocStructure, SurfaceLayerThermodynamicMappingUsesExner)
         ShocStructure::diagnose_surface_layer(col);
     });
 
-    const amrex::Real qc_sfc = 1.0e-3;
-    const amrex::Real qi_sfc = 2.0e-4;
-    const amrex::Real theta_sfc = 298.0 + (L_v * qc_sfc + shoc::latent_sublimation() * qi_sfc) /
-                                             (Cp_d * 0.8);
-    const amrex::Real kbfs = 0.02 + 0.61 * theta_sfc * 2.0e-4;
+    const amrex::Real qc_sfc = amrex::Real(1.0e-3);
+    const amrex::Real qi_sfc = amrex::Real(2.0e-4);
+    const amrex::Real theta_sfc = amrex::Real(298.0) +
+                                  (L_v * qc_sfc + shoc::latent_sublimation() * qi_sfc) /
+                                  (Cp_d * amrex::Real(0.8));
+    const amrex::Real kbfs = amrex::Real(0.02) + amrex::Real(0.61) * theta_sfc * amrex::Real(2.0e-4);
 
-    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), kbfs, 1.0e-12)
+    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), kbfs,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12), kbfs, 4))
         << "SHOC theta_l to theta conversion must divide the latent term by ERF exner.";
 }
 
@@ -415,9 +430,12 @@ TEST(ShocStructure, SurfaceLayerMatchesTranslatedE3smFixture)
         shoc_test::read_fixture_vector("structure/e3sm_diag_obklen_surface_mapping.txt");
     ASSERT_EQ(fixture.size(), 3);
 
-    EXPECT_NEAR(col.ustar.const_array()(0,0,0), fixture[0], 1.0e-15);
-    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), fixture[1], 1.0e-15);
-    EXPECT_NEAR(col.obklen.const_array()(0,0,0), fixture[2], 1.0e-14);
+    EXPECT_NEAR(col.ustar.const_array()(0,0,0), fixture[0],
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-15), fixture[0], 2));
+    EXPECT_NEAR(col.wthv_sec.const_array()(0,0,0), fixture[1],
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-15), fixture[1], 4));
+    EXPECT_NEAR(col.obklen.const_array()(0,0,0), fixture[2],
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-14), fixture[2], 4));
 }
 
 TEST(ShocStructure, PblHeightUsesVaporNotTotalWaterInVirtualTheta)

--- a/Tests/Unit/Shoc/ERF_ShocTestUtils.H
+++ b/Tests/Unit/Shoc/ERF_ShocTestUtils.H
@@ -28,6 +28,7 @@ precision_scaled_tolerance (amrex::Real double_tolerance,
                             int single_precision_ulps)
 {
 #ifdef AMREX_USE_FLOAT
+    amrex::ignore_unused(double_tolerance);
     return amrex::Real(single_precision_ulps) *
            std::numeric_limits<amrex::Real>::epsilon() * std::abs(scale);
 #else

--- a/Tests/Unit/Shoc/ERF_ShocTestUtils.H
+++ b/Tests/Unit/Shoc/ERF_ShocTestUtils.H
@@ -4,9 +4,11 @@
 #include "ERF_ShocColumnData.H"
 
 #include <algorithm>
+#include <cmath>
 #include <cstring>
 #include <cctype>
 #include <fstream>
+#include <limits>
 #include <map>
 #include <random>
 #include <sstream>
@@ -16,6 +18,39 @@
 
 namespace shoc_test
 {
+// Keep DOUBLE oracle strength unchanged while expressing SINGLE tolerances in
+// units of the represented output scale.  The single-precision branch uses a
+// small, test-specific multiple of one machine epsilon; callers document the
+// scale and the observed numerical envelope at each assertion.
+inline amrex::Real
+precision_scaled_tolerance (amrex::Real double_tolerance,
+                            amrex::Real scale,
+                            int single_precision_ulps)
+{
+#ifdef AMREX_USE_FLOAT
+    return amrex::Real(single_precision_ulps) *
+           std::numeric_limits<amrex::Real>::epsilon() * std::abs(scale);
+#else
+    amrex::ignore_unused(scale, single_precision_ulps);
+    return double_tolerance;
+#endif
+}
+
+// Use this for bounded quantities whose expected value is itself the
+// representable contract value (for example, a minimum TKE floor).
+inline amrex::Real
+precision_aware_tolerance (amrex::Real double_tolerance,
+                           amrex::Real single_tolerance)
+{
+#ifdef AMREX_USE_FLOAT
+    amrex::ignore_unused(double_tolerance);
+    return single_tolerance;
+#else
+    amrex::ignore_unused(single_tolerance);
+    return double_tolerance;
+#endif
+}
+
 inline amrex::Arena*
 test_arena ()
 {

--- a/Tests/Unit/Shoc/ERF_ShocThermoTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocThermoTests.cpp
@@ -1,4 +1,5 @@
 #include "ERF_ShocThermoUtils.H"
+#include "ERF_ShocTestUtils.H"
 
 #include <gtest/gtest.h>
 
@@ -16,8 +17,12 @@ expect_round_trip (amrex::Real theta,
     const amrex::Real tabs = shoc::temperature_from_thetal(thetal, qc, qi, exner);
     const amrex::Real theta_back = tabs / exner;
 
-    EXPECT_NEAR(theta_back, theta, 1.0e-12_rt);
-    EXPECT_NEAR(shoc::thetal_from_theta(theta_back, qc, qi, exner), thetal, 1.0e-12_rt);
+    // At O(300 K), the SINGLE round-trip residual is one represented-value
+    // ulp; two ulps cover the measured float conversion envelope.
+    EXPECT_NEAR(theta_back, theta,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12), theta, 2));
+    EXPECT_NEAR(shoc::thetal_from_theta(theta_back, qc, qi, exner), thetal,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12), thetal, 2));
     EXPECT_GT(tabs, shoc::constants::min_temp());
 }
 } // namespace
@@ -139,7 +144,9 @@ TEST(ShocThermo, MoistEnergyDistinguishesLiquidAndIce)
                                                       0.0_rt, 1.0e-3_rt,
                                                       0.0_rt, 0.0_rt, 0.0_rt);
 
-    EXPECT_NEAR(liquid_energy - ice_energy,
-                shoc::constants::latent_ice() * 1.0e-3_rt,
-                1.0e-12_rt);
+    const amrex::Real expected_energy_difference =
+        shoc::constants::latent_ice() * 1.0e-3_rt;
+    EXPECT_NEAR(liquid_energy - ice_energy, expected_energy_difference,
+                shoc_test::precision_scaled_tolerance(amrex::Real(1.0e-12),
+                                                       expected_energy_difference, 2));
 }

--- a/Tests/Unit/Shoc/ERF_ShocTkeTests.cpp
+++ b/Tests/Unit/Shoc/ERF_ShocTkeTests.cpp
@@ -335,6 +335,7 @@ TEST(ShocTke, SignedProductionOptionAllowsStableBuoyancyToReduceTke)
 {
     auto col_default = shoc_test::make_column(6);
     auto col_signed = shoc_test::make_column(6);
+    const Real min_tke = Real(4.0e-4);
     ShocRuntimeOptions opts_default;
     ShocRuntimeOptions opts_signed;
     opts_signed.signed_tke_production = true;
@@ -369,12 +370,13 @@ TEST(ShocTke, SignedProductionOptionAllowsStableBuoyancyToReduceTke)
     EXPECT_LT(col_default.tke.const_array()(0,0,0,0), tke_default_before);
     EXPECT_LT(col_signed.tke.const_array()(0,0,0,0), tke_signed_before);
     EXPECT_LT(col_signed.tke.const_array()(0,0,0,0), col_default.tke.const_array()(0,0,0,0));
-    EXPECT_GE(col_signed.tke.const_array()(0,0,0,0), 4.0e-4);
+    EXPECT_GE(col_signed.tke.const_array()(0,0,0,0), min_tke);
 }
 
 TEST(ShocTke, DiffusivitiesRemainPositiveAndFinite)
 {
     auto col = shoc_test::make_column(6);
+    const Real min_tke = Real(4.0e-4);
     ShocRuntimeOptions opts;
 
     shoc_test::run_and_sync([&] {
@@ -396,7 +398,7 @@ TEST(ShocTke, DiffusivitiesRemainPositiveAndFinite)
         EXPECT_TRUE(std::isfinite(tkh(0,k,0,0)));
         EXPECT_TRUE(std::isfinite(isotropy(0,k,0,0)));
         EXPECT_TRUE(std::isfinite(tend(0,k,0,0)));
-        EXPECT_GE(tke(0,k,0,0), 4.0e-4);
+        EXPECT_GE(tke(0,k,0,0), min_tke);
         EXPECT_LE(tke(0,k,0,0), 50.0);
         EXPECT_GE(tk(0,k,0,0), 0.0);
         EXPECT_GE(tkh(0,k,0,0), 0.0);
@@ -407,6 +409,7 @@ TEST(ShocTke, DiffusivitiesRemainPositiveAndFinite)
 TEST(ShocTke, RandomizedColumnsStayBounded)
 {
     ShocRuntimeOptions opts;
+    const Real min_tke = Real(4.0e-4);
     std::mt19937 gen(1729);
 
     for (int n = 0; n < 32; ++n) {
@@ -430,7 +433,7 @@ TEST(ShocTke, RandomizedColumnsStayBounded)
             EXPECT_TRUE(std::isfinite(tkh(0,k,0,0)));
             EXPECT_GE(mix(0,k,0,0), 20.0);
             EXPECT_LE(mix(0,k,0,0), std::sqrt(600.0 * 450.0));
-            EXPECT_GE(tke(0,k,0,0), 4.0e-4);
+            EXPECT_GE(tke(0,k,0,0), min_tke);
             EXPECT_LE(tke(0,k,0,0), 50.0);
             EXPECT_GE(tk(0,k,0,0), 0.0);
             EXPECT_GE(tkh(0,k,0,0), 0.0);


### PR DESCRIPTION
## Summary

This PR fixes the SINGLE-precision SHOC test failures reported in #3981.

The failures were test-oracle and test-portability issues rather than evidence of a Native-SHOC production-physics defect:

* several SHOC unit tests used fixed DOUBLE-scale absolute tolerances for calculations performed with `amrex::Real`;
* the seven gold-bearing SHOC regressions compared SINGLE trajectories against shared reference data using comparison bounds established for DOUBLE precision;
* CI built SINGLE configurations but did not execute the SHOC suite in SINGLE precision.

This PR makes the affected test oracles precision-aware while preserving the existing DOUBLE validation strength.

## Unit tests

The affected SHOC unit tests now distinguish between exact contracts and approximate floating-point comparisons.

Changes include:

* deriving approximate SINGLE tolerances from `std::numeric_limits<amrex::Real>::epsilon()` and the relevant numerical scale;
* constructing expected values using represented `amrex::Real` values where representability is part of the comparison;
* retaining exact assertions where the underlying contract is exact;
* using wider test-side accumulation for conservation diagnostics so the oracle does not measure its own SINGLE reduction error;
* using a zero-flux control in the surface-energy test to remove deterministic round-trip drift from the quantity being tested.

Existing DOUBLE tolerances are retained.

## SHOC regression gold comparisons

The existing shared SHOC gold files are retained for both precisions.

For DOUBLE:

* clear-sky regressions retain their historical strict `amrex_fcompare` path;
* cloudy regressions retain their existing field-aware DOUBLE tolerances.

For SINGLE:

* all seven gold-bearing SHOC cases use field-aware absolute-plus-relative tolerances;
* clear-sky cases receive separate profiles where their numerical scales require them;
* tolerances were derived from the measured deterministic SINGLE-vs-shared-gold envelope rather than applying a global tolerance.

The limiting measured fields were:

* **Stable Clear**

  * field: `Kmv` / `Khv`
  * error: `8.576e-4`
  * scale: `3.477`
  * allowed: `1.044e-3`
  * error / allowed: `0.821`

* **Stable Cloud**

  * field: `rhoKE`
  * error: `7.480e-6`
  * scale: `0.116`
  * allowed: `9.301e-6`
  * error / allowed: `0.804`

* **Unstable Clear BOMEX**

  * field: `z_velocity`
  * error: `8.896e-5`
  * scale: `3.342e-4`
  * allowed: `1.203e-4`
  * error / allowed: `0.739`

* **Unstable Cloud SatAdj**

  * field: `shoc_cond`
  * error: `1.487e-8`
  * scale: `5.385e-6`
  * allowed: `2.164e-8`
  * error / allowed: `0.687`

* **Unstable Cloud NoCond**

  * field: `shoc_cond`
  * error: `1.487e-8`
  * scale: `5.385e-6`
  * allowed: `2.164e-8`
  * error / allowed: `0.687`

* **Unstable Cloud Kessler**

  * field: `density`
  * error: `1.907e-6`
  * scale: `1.136`
  * allowed: `3.419e-6`
  * error / allowed: `0.558`

* **Unstable Cloud WSM6**

  * field: `qrain`
  * error: `6.961e-9`
  * scale: `5.197e-6`
  * allowed: `1.049e-8`
  * error / allowed: `0.663`

The independent SHOC physical/property checker still runs before the gold comparison, so physical-state and regime contracts remain separate from numerical-reference tolerances.

No SHOC gold files were regenerated or duplicated.

## CI coverage

The Linux GCC matrix now executes:

```bash
ctest -L shoc --output-on-failure --no-tests=error
```

for one canonical SINGLE configuration:

* mesh precision: `SINGLE`
* particles: `ON`
* particle precision: `DOUBLE`

This provides continuous SINGLE runtime coverage without redundantly running the same SHOC suite in every particle-precision matrix entry.

Existing DOUBLE CI coverage is unchanged.

## Validation

Against current `development`:

* DOUBLE SHOC suite: **119/119 passed**
* SINGLE SHOC suite: **119/119 passed**
* `git diff --check`: **passed**
* final working tree: **clean**

Additional scope checks:

* no production SHOC files changed;
* no SHOC gold files changed;
* no global ERF regression tolerance changed;
* DOUBLE comparison paths and tolerance strength are preserved.

Closes #3981.
