### PR TITLE
Bug Fix: Prevent zero substeps in MRI RK stage 2

### DIFF
--- a/Source/TimeIntegration/ERF_MRI.H
+++ b/Source/TimeIntegration/ERF_MRI.H
@@ -305,7 +305,7 @@ public:
                     nsubsteps = 1;
                     dtau      = myhalf * timestep;
                 } else {
-                    nsubsteps = substep_ratio/2;
+                    nsubsteps = std::max(substep_ratio/2, 1);
                     dtau      = (myhalf * timestep) / static_cast<double>(nsubsteps);
                 }
                 time_stage = time + timestep / two;


### PR DESCRIPTION
This PR fixes a bug that causes a SIGILL error. The bug is possibly compiler- or architecture-dependent.

## Problem

In `ERF_MRI.H`, `nsubsteps` can be zero when `no_substepping=true`, resulting in a division-by-zero in the following line. Although the `else` branch is not selected, the compiler may evaluate both branches for if-conversion optimization to generate branch-less instructions. Consequently, using `amrex.fpe_trap_zero=1` traps the error.

```
             if (no_substepping) {
                    nsubsteps = 1;
                    dtau      = myhalf * timestep;
             } else {
                    nsubsteps = substep_ratio/2;
                    dtau      = (myhalf * timestep) / static_cast<double>(nsubsteps);
             }
```

## Solution

Prevent nsubsteps from being zero:
```
nsubsteps = std::max(substep_ratio/2, 1);
```