### PR TITLE
MOST_Zref_Stretched: run compressible so the regression test works without FFT

### DIFF
--- a/Tests/test_files/MOST_Zref_Stretched/MOST_Zref_Stretched.i
+++ b/Tests/test_files/MOST_Zref_Stretched/MOST_Zref_Stretched.i
@@ -33,8 +33,12 @@ zhi.type = "SlipWall"
 zhi.theta_grad = 0.003
 
 # TIME STEP CONTROL
-erf.anelastic = 1
-erf.fixed_dt  = 1.0
+# Compressible on purpose: the anelastic Poisson solve on a stretched or
+# terrain-fitted mesh needs an FFT build, and the CI builds without FFT.
+# The reference-height lookups do not depend on the dycore.
+erf.anelastic          = 0
+erf.fixed_dt           = 1.0
+erf.fixed_mri_dt_ratio = 8
 
 # DIAGNOSTICS & VERBOSITY
 erf.sum_interval = 1

--- a/Tests/test_files/MOST_Zref_Stretched/README.md
+++ b/Tests/test_files/MOST_Zref_Stretched/README.md
@@ -3,7 +3,15 @@
 MOST reference height on a flat periodic column with a stretched vertical
 grid: 4x4x40 cells, `erf.initial_dz = 10`, `erf.grid_stretching_ratio = 1.1`
 (top 4425.9 m), `zlo.type = surface_layer`, `erf.most.z0 = 0.1`, MRF,
-anelastic, `erf.most.zref` unset.
+compressible with implicit acoustic substepping (`erf.fixed_dt = 1`,
+`erf.fixed_mri_dt_ratio = 8`), `erf.most.zref` unset.
+
+The deck is compressible on purpose. The anelastic Poisson solve on a stretched
+or terrain-fitted mesh needs the FFT solver (`ERF_ENABLE_FFT`), and the CI
+builds without it, so an anelastic version of this deck aborted three of the
+four cases below with "Rebuild with USE_FFT = TRUE". The reference-height
+lookups do not depend on the dycore: u*(0) is the same to all six digits in
+both, and the stretched-against-uniform comparison changes by under 1e-4.
 
 The initial wind is sheared on purpose. `sounding_most_zref` ramps it linearly
 from 10 m/s at the ground to 15 m/s at 50 m, and holds it constant above. ERF
@@ -76,8 +84,8 @@ Stretched against uniform, new binary:
 | t [s] | stretched u* | uniform u* | rel diff |
 |---|---|---|---|
 | 0 | 1.10045 | 1.10045 | 0 |
-| 5 | 1.0636 | 1.06323 | 3.5e-04 |
-| 10 | 1.03113 | 1.03083 | 2.9e-04 |
+| 5 | 1.06358 | 1.06321 | 3.5e-04 |
+| 10 | 1.0311 | 1.03079 | 3.0e-04 |
 
 ## Running by hand
 

--- a/Tests/test_files/MOST_Zref_Stretched/run_most_zref.py
+++ b/Tests/test_files/MOST_Zref_Stretched/run_most_zref.py
@@ -140,6 +140,9 @@ def abort_reason(log):
     m = re.search(r"Assertion `[^']*' failed, file \"[^\"]*/([^/\"]+)\", line (\d+), Msg: ([^\n]*)", log)
     if m:
         return "abort %s:%s %s" % (m.group(1), m.group(2), m.group(3).replace("!!!", "").strip()[:40])
+    m = re.search(r"amrex::Abort::\d+::([^\n]*)", log)
+    if m:
+        return "abort %s" % m.group(1).replace("!!!", "").strip()[:60]
     return "failed"
 
 


### PR DESCRIPTION
## Summary

`MOST_Zref_Stretched` (test 76 of the regression label, added in #3982) fails in every CI build. The deck was anelastic, and the anelastic Poisson solve on a stretched or terrain-fitted mesh has only an FFT path (`ERF_PoissonSolve.cpp`, `Rebuild with USE_FFT = TRUE so you can use the FFT solver`). No CI workflow builds with `ERF_ENABLE_FFT`, so three of the four cases aborted at the first step and the test failed. It passed locally only because my build had FFT on.

This PR makes the deck compressible (`erf.anelastic = 0`, `erf.fixed_dt = 1`, `erf.fixed_mri_dt_ratio = 8`). The reference-height lookups do not depend on the dycore: `u*(0)` is the same to all six digits, and the stretched-against-uniform comparison changes by under 1e-4. `run_most_zref.py` also reports the reason of an `amrex::Abort` in its failure line, so a case that dies this way names the cause instead of "run failed".

## Reproduction (macOS, AppleClang, MPI on, FFT off, current development d4e3a8975)

Anelastic deck, as merged:

```
FAIL: fitted_plane: run abort Rebuild with USE_FFT = TRUE so you can use the FFT solver
FAIL: fitted_interp: run abort Rebuild with USE_FFT = TRUE so you can use the FFT preconditioner for GMRES
FAIL: immersed_stretched: run abort Rebuild with USE_FFT = TRUE so you can use the FFT solver
```

Compressible deck, same binary:

```
case                 zref [m]      u*(0)    log law    rel err   wind at
fitted_plane             15.5   0.938945   0.938945   2.54e-07     15.50
fitted_interp              10   0.979334   0.979334   5.79e-08     10.00
immersed_stretched          5    1.10045    1.10045   3.32e-06      5.00
uniform_reference           5    1.10045    1.10045   3.32e-06      5.00

u* over the run: stretched (no terrain) vs uniform 10 m column
    time    stretched      uniform   rel diff
     0.0      1.10045      1.10045   0.00e+00
     1.0      1.10045      1.10045   0.00e+00
     2.0      1.09019      1.09007   1.10e-04
     3.0      1.08065      1.08041   2.22e-04
     4.0      1.07179      1.07147   2.99e-04
     5.0      1.06358      1.06321   3.48e-04
     6.0        1.056       1.0556   3.79e-04
     7.0        1.049      1.04859   3.91e-04
     8.0      1.04254      1.04215   3.74e-04
     9.0      1.03659      1.03623   3.47e-04
    10.0       1.0311      1.03079   3.01e-04

PASS
```

The Debug no-FFT build (what the gcc and macOS regression jobs run) gives the same result: `ctest -R MOST_Zref_Stretched` passes in 15.8 s with the same table.

## Files

- `Tests/test_files/MOST_Zref_Stretched/MOST_Zref_Stretched.i`: compressible, substep ratio pinned
- `Tests/test_files/MOST_Zref_Stretched/README.md`: says why, updated stretched/uniform table
- `Tests/test_files/MOST_Zref_Stretched/run_most_zref.py`: abort reason from `amrex::Abort` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
