### PR TITLE
Multilevel refinement enhancements for WRF input pathway: terrain smoothing, vertical refinement, radiation support

### DIFF
--- a/CMake/BuildERFExe.cmake
+++ b/CMake/BuildERFExe.cmake
@@ -209,6 +209,7 @@ function(build_erf_lib erf_lib_name)
   if(ERF_ENABLE_NETCDF)
     target_sources(${erf_lib_name} PRIVATE
                    ${SRC_DIR}/Initialization/ERF_InitFromWRFInput.cpp
+                   ${SRC_DIR}/Initialization/ERF_InitFromWRFInput_SurfaceOnly.cpp
                    ${SRC_DIR}/Initialization/ERF_InitFromMetgrid.cpp
                    ${SRC_DIR}/Initialization/ERF_InitFromNCFile.cpp
                    ${SRC_DIR}/IO/ERF_NCInterface.cpp

--- a/Source/DataStructs/ERF_DataStruct.H
+++ b/Source/DataStructs/ERF_DataStruct.H
@@ -862,6 +862,10 @@ struct SolverChoice {
                          "onto the nodes rather than reconstructing them).");
         }
 
+        // Interpolate atmospheric state from coarse level instead of reading from wrfinput
+        // when creating a finer level from coarse at a later time?
+        pp.queryAdd("interp_atmos_from_coarse", interp_atmos_from_coarse);
+
         // Rebalance wrf state?
         pp.queryAdd("rebalance_wrf_input", rebalance_wrf_input);
 
@@ -2169,6 +2173,9 @@ struct SolverChoice {
 
     // Average the input z-face heights onto the nodes rather than reconstructing them?
     bool avg_grid_faces_to_nodes {false};
+
+    // Interpolate atmospheric state from coarse when creating finer level at later time?
+    bool interp_atmos_from_coarse {false};
 
     // Use forest canopy model?
     bool do_forest_drag {false};

--- a/Source/ERF.H
+++ b/Source/ERF.H
@@ -799,6 +799,7 @@ public:
 
 #ifdef ERF_USE_NETCDF
     void init_from_wrfinput (int lev, amrex::MultiFab& mf_PSFC);
+    void init_from_wrfinput_surface_only (int lev, amrex::MultiFab& mf_PSFC);
     void init_from_metgrid  (int lev);
     void init_from_ncfile   (int lev);
 

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -499,11 +499,9 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     //*********************************************************
     if (solverChoice.rad_type != RadiationType::None)
     {
-        // Allocate with ghost cells to enable interpolation from coarse level
-        // (needed for nested patches where radiation is skipped)
-        // Use same pattern as z_phys: ComputeGhostCells + extra for interpolation
-        int ngrow_rad = ComputeGhostCells(solverChoice) + 2;
-        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, ngrow_rad);
+        // Allocate with 1 ghost cell for interpolation stencil (cell_cons_interp)
+        // and FillBoundary operations (needed for nested patches)
+        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, 1);
         rad_fluxes[lev]     = std::make_unique<MultiFab>(ba, dm, 4, 0);
         qheating_rates[lev]->setVal(zero);
         rad_fluxes[lev]->setVal(zero);

--- a/Source/ERF_MakeNewArrays.cpp
+++ b/Source/ERF_MakeNewArrays.cpp
@@ -499,7 +499,11 @@ ERF::init_stuff (int lev, const BoxArray& ba, const DistributionMapping& dm,
     //*********************************************************
     if (solverChoice.rad_type != RadiationType::None)
     {
-        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, 0);
+        // Allocate with ghost cells to enable interpolation from coarse level
+        // (needed for nested patches where radiation is skipped)
+        // Use same pattern as z_phys: ComputeGhostCells + extra for interpolation
+        int ngrow_rad = ComputeGhostCells(solverChoice) + 2;
+        qheating_rates[lev] = std::make_unique<MultiFab>(ba, dm, 2, ngrow_rad);
         rad_fluxes[lev]     = std::make_unique<MultiFab>(ba, dm, 4, 0);
         qheating_rates[lev]->setVal(zero);
         rad_fluxes[lev]->setVal(zero);

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -486,16 +486,42 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
         vars_new[lev][Vars::zvel].setVal(0.0); vars_old[lev][Vars::zvel].setVal(0.0);
 
         AMREX_ALWAYS_ASSERT(solverChoice.terrain_type == TerrainType::StaticFittedMesh);
+
+        //
+        // CHOOSE INITIALIZATION PATH:
+        // If interp_atmos_from_coarse is enabled for a finer level created at later time,
+        // read only surface fields from wrfinput and interpolate atmospheric state from coarse.
+        // Otherwise use the standard path of reading all fields from wrfinput.
+        //
+        bool use_surface_only = solverChoice.interp_atmos_from_coarse && (lev > 0) && (time > 0.0);
+
         if (solverChoice.init_type == InitType::Metgrid) {
             init_from_metgrid(lev);
         } else if (solverChoice.init_type == InitType::WRFInput) {
-            init_from_wrfinput(lev, *mf_PSFC[lev]);
+            if (use_surface_only) {
+                amrex::Print() << "Using interp_atmos_from_coarse mode at level " << lev << ":\n";
+                amrex::Print() << "  - Reading surface fields from wrfinput\n";
+                amrex::Print() << "  - Atmospheric state will be interpolated from level " << lev-1 << "\n";
+                init_from_wrfinput_surface_only(lev, *mf_PSFC[lev]);
+            } else {
+                init_from_wrfinput(lev, *mf_PSFC[lev]);
+            }
         }
         init_zphys(lev, time);
         update_terrain_arrays(lev);
         make_physbcs(lev);
 
         dz_min[lev] = (*detJ_cc[lev]).min(0) * geom[lev].CellSize(2);
+
+        //
+        // If we used surface-only init, we need to rebuild the base state and
+        // interpolate the atmospheric state from coarse (just like a level with no init file)
+        //
+        if (use_surface_only) {
+            rebuild_base_state_from_wrfinput(lev, base_state[lev]);
+            (*physbcs_base[lev])(base_state[lev],0,base_state[lev].nComp(),base_state[lev].nGrowVect());
+            FillCoarsePatch(lev, time);
+        }
 
     } else {
 #endif

--- a/Source/ERF_MakeNewLevel.cpp
+++ b/Source/ERF_MakeNewLevel.cpp
@@ -489,11 +489,11 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
 
         //
         // CHOOSE INITIALIZATION PATH:
-        // If interp_atmos_from_coarse is enabled for a finer level created at later time,
+        // If interp_atmos_from_coarse is enabled for a finer level,
         // read only surface fields from wrfinput and interpolate atmospheric state from coarse.
         // Otherwise use the standard path of reading all fields from wrfinput.
         //
-        bool use_surface_only = solverChoice.interp_atmos_from_coarse && (lev > 0) && (time > 0.0);
+        bool use_surface_only = solverChoice.interp_atmos_from_coarse && (lev > 0);
 
         if (solverChoice.init_type == InitType::Metgrid) {
             init_from_metgrid(lev);
@@ -521,6 +521,15 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
             rebuild_base_state_from_wrfinput(lev, base_state[lev]);
             (*physbcs_base[lev])(base_state[lev],0,base_state[lev].nComp(),base_state[lev].nGrowVect());
             FillCoarsePatch(lev, time);
+
+            // Now initialize LSM with the properly filled atmospheric state
+            if (solverChoice.lsm_type != LandSurfaceType::None) {
+                amrex::Print() << "Initializing LSM at level " << lev << " after FillCoarsePatch\n";
+                IntVect RefRatio(1);
+                for (int l = 0; l < lev; ++l) { RefRatio *= refRatio(l); }
+                lsm.Init(lev, vars_new[lev][Vars::cons], Geom(lev), Geom(0),
+                         domain_bcs_type, RefRatio, zero, nc_init_file);
+            }
         }
 
     } else {
@@ -607,7 +616,9 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     }
 
     //********************************************************************************************
-    // Land Surface Model
+    // Land Surface Model - setup data structures
+    // NOTE: Actual LSM initialization (lsm.Init) is deferred if using interp_atmos_from_coarse
+    //       because it needs valid atmospheric state from FillCoarsePatch
     // *******************************************************************************************
     int lsm_data_size  = lsm.Get_Data_Size();
     int lsm_flux_size  = lsm.Get_Flux_Size();
@@ -616,7 +627,19 @@ ERF::MakeNewLevelFromCoarse (int lev, Real time, const BoxArray& ba,
     lsm_flux[lev].resize(lsm_flux_size);
     lsm_flux_name.resize(lsm_flux_size);
     lsm.Define(lev, solverChoice);
-    if (solverChoice.lsm_type != LandSurfaceType::None) {
+
+    // Check if we'll be using surface-only init (atmospheric state comes later from FillCoarsePatch)
+    bool will_use_surface_only = false;
+#ifdef ERF_USE_NETCDF
+    if (!nc_init_file[lev].empty() &&
+        (solverChoice.init_type == InitType::WRFInput || solverChoice.init_type == InitType::Metgrid)) {
+        will_use_surface_only = solverChoice.interp_atmos_from_coarse;
+    }
+#endif
+
+    // Only initialize LSM now if we're NOT using surface-only init
+    // (for surface-only, LSM init must wait until after FillCoarsePatch provides atmospheric state)
+    if (solverChoice.lsm_type != LandSurfaceType::None && !will_use_surface_only) {
         //
         // A level with no land file of its own takes its LSM state from level 0 rather
         // than from its parent (see NOAHMP::interp_from_lev0, which is handed Geom(0)

--- a/Source/Initialization/ERF_InitFromWRFInput.cpp
+++ b/Source/Initialization/ERF_InitFromWRFInput.cpp
@@ -8,6 +8,7 @@
 #include "ERF_Utils.H"
 #include "ERF_ProbCommon.H"
 #include "ERF_DataStruct.H"
+#include "ERF_TerrainMetrics.H"
 
 #include "ERF_ReadFromWRFInput.H"
 #include "ERF_ReadFromWRFBdy.H"
@@ -1324,6 +1325,43 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
         // **************************************************************************
         // Initialize the terrain itself
         // **************************************************************************
+
+        // Determine if we need the fine terrain pathway for STF/Sullivan on lev > 0
+        ParmParse pp("erf");
+        int terrain_smoothing = 0;
+        pp.query("terrain_smoothing", terrain_smoothing);
+
+        FineTerrain fine_terrain = FineTerrain::None;
+        MultiFab z_phys_interp;
+
+        if (lev > 0 && terrain_smoothing != 0) {
+            // Determine fine terrain mode
+            fine_terrain = which_fine_terrain();
+
+            // When reading terrain from wrfinput files, we must use Transform mode to blend
+            // the fine terrain detail onto the interpolated coarse mesh. Interpolate mode
+            // would leave a mismatch between the fine terrain surface (from wrfinput_d0N) and
+            // the interpolated coarse mesh above it, causing grid inconsistencies and NaNs.
+            if (fine_terrain != FineTerrain::Transform) {
+                Abort("terrain_smoothing = " + std::to_string(terrain_smoothing) +
+                      " with wrfinput initialization on level > 0 requires "
+                      "erf.amr_terrain_refinement = transform (not interpolate)");
+            }
+
+            // Interpolate coarse mesh to fine level first
+            InterpFromCoarseLevel(*z_phys_nd[lev], z_phys_nd[lev]->nGrowVect(),
+                                  IntVect(0,0,0),
+                                  *z_phys_nd[lev-1], 0, 0, 1,
+                                  geom[lev-1], geom[lev],
+                                  refRatio(lev-1), &node_bilinear_interp,
+                                  domain_bcs_type, BCVars::cons_bc);
+
+            // Save interpolated mesh before terrain overwrites k=0 slab
+            z_phys_interp.define(z_phys_nd[lev]->boxArray(), z_phys_nd[lev]->DistributionMap(),
+                                 1, z_phys_nd[lev]->nGrowVect());
+            MultiFab::Copy(z_phys_interp, *z_phys_nd[lev], 0, 0, 1, 0);
+        }
+
         Real dz0_max;
         init_terrain_from_wrfinput(lev, geom[lev], z_top, boxes_at_level[lev][0], z_phys_nd[lev].get(),
                                    mf_PH, *mf_PHB, dz0_max, solverChoice.avg_grid_faces_to_nodes);
@@ -1372,7 +1410,9 @@ ERF::init_from_wrfinput (int lev, MultiFab& mf_PSFC_lev)
 
             // Update stretched dz and build terrain fitted coords
             update_stretched_dz(lev, zlevels_stag, stretched_dz_h, stretched_dz_d);
-            make_terrain_fitted_coords(lev, geom[lev], *z_phys_nd[lev], zlevels_stag[lev], phys_bc_type);
+            make_terrain_fitted_coords(lev, geom[lev], *z_phys_nd[lev], zlevels_stag[lev], phys_bc_type,
+                                       fine_terrain,
+                                       (fine_terrain == FineTerrain::Transform) ? &z_phys_interp : nullptr);
         }
 
         // **************************************************************************

--- a/Source/Initialization/Make.package
+++ b/Source/Initialization/Make.package
@@ -18,6 +18,7 @@ endif
 ifeq ($(USE_NETCDF),TRUE)
 CEXE_headers += ERF_MetgridUtils.H
 CEXE_sources += ERF_InitFromWRFInput.cpp
+CEXE_sources += ERF_InitFromWRFInput_SurfaceOnly.cpp
 CEXE_sources += ERF_InitFromMetgrid.cpp
 CEXE_sources += ERF_InitFromNCFile.cpp
 endif

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.H
@@ -4,6 +4,7 @@
 #include <Kokkos_Core.hpp>
 
 #include <AMReX_REAL.H>
+#include <AMReX_Print.H>
 
 #include <rrtmgp_const.h>
 #include <mo_gas_optics_rrtmgp.h>

--- a/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp
@@ -23,6 +23,10 @@ pool_t kokkos_mem_pool;
 
 bool initialized = false;
 
+// Track the maximum nlay and nvar for pool reinitialization with vertical refinement
+size_t pool_max_nlay = 0;
+int pool_nvar = 0;
+
 
 optical_props2_t
 get_cloud_optics_sw (const int ncol,
@@ -256,6 +260,12 @@ rrtmgp_initialize (gas_concs_t& gas_concs_k,
     const size_t nlay = gas_concs_k.nlay;
     auto my_size_ref  = static_cast<unsigned long>(nvar * ncol * nlay * ngpt);
     pool_t::init(my_size_ref);
+    pool_max_nlay = nlay;
+    pool_nvar = nvar;
+
+    amrex::Print() << "RRTMGP: Initialized pool with nlay=" << nlay
+                   << " ncol=" << ncol << " nvar=" << nvar
+                   << " size=" << my_size_ref << std::endl;
 
     // We are now initialized!
     initialized = true;
@@ -402,6 +412,26 @@ rrtmgp_main (const int ncol, const int nlay,
              const RealT tsi_scaling,
              const bool extra_clnclrsky_diag, const bool extra_clnsky_diag)
 {
+    // Check if we need to reinitialize the memory pool for larger nlay
+    // This happens with vertical refinement where fine levels have more vertical cells
+    if (static_cast<size_t>(nlay) > pool_max_nlay) {
+        amrex::Print() << "RRTMGP: Reinitializing pool for nlay=" << nlay
+                       << " (previous max was " << pool_max_nlay << ")" << std::endl;
+
+        // Finalize old pool
+        pool_t::finalize();
+
+        // Reinitialize with new larger size using same nvar from initialization
+        const size_t ngpt = std::max(k_dist_sw_k->get_ngpt(), k_dist_lw_k->get_ngpt());
+        auto my_size_ref = static_cast<unsigned long>(pool_nvar * ncol * nlay * ngpt);
+        pool_t::init(my_size_ref);
+        pool_max_nlay = nlay;
+
+        amrex::Print() << "RRTMGP: Pool reinitialized with ncol=" << ncol
+                       << " nlay=" << nlay << " nvar=" << pool_nvar
+                       << " size=" << my_size_ref << std::endl;
+    }
+
     // Setup pointers to RRTMGP SW fluxes
     fluxes_t fluxes_sw;
     fluxes_sw.flux_up = sw_flux_up;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -67,9 +67,29 @@ public:
           const amrex::BoxArray& ba,
           amrex::MultiFab* cons_in) override
     {
-        // Ensure the boxes span klo -> khi
+        // Check for nested patches: fine levels that don't reach the model top
+        // These need special handling since radiation requires complete atmospheric columns
         int klo = geom.Domain().smallEnd(2);
         int khi = geom.Domain().bigEnd(2);
+
+        // Detect if any box doesn't reach the domain top (nested patch)
+        bool is_nested_patch = false;
+        for (amrex::MFIter mfi(*cons_in); mfi.isValid(); ++mfi) {
+            const amrex::Box& vbx = mfi.validbox();
+            if (vbx.bigEnd(2) < khi) {
+                is_nested_patch = true;
+                break;
+            }
+        }
+
+        // Skip radiation on nested patches - heating rates will be interpolated from coarser level
+        if (is_nested_patch) {
+            m_is_nested_patch = true;
+            amrex::Print() << "Radiation: Level " << m_lev
+                           << " is a nested patch (doesn't reach model top) - "
+                           << "radiation will be skipped, using interpolated heating rates" << std::endl;
+            return;
+        }
 
         // Reset vector of offsets for columnar data
         m_nlay = geom.Domain().length(2);
@@ -79,6 +99,8 @@ public:
         m_col_offsets.resize(int(ba.size()));
         for (amrex::MFIter mfi(*cons_in); mfi.isValid(); ++mfi) {
             const amrex::Box& vbx = mfi.validbox();
+            // This assertion now only triggers for true vertical MPI decomposition,
+            // not for nested patches (which we handle above by skipping radiation)
             AMREX_ALWAYS_ASSERT_WITH_MESSAGE((klo == vbx.smallEnd(2)) &&
                                              (khi == vbx.bigEnd(2)),
                                              "Vertical decomposition with radiation is not allowed.");
@@ -125,6 +147,12 @@ public:
          amrex::MultiFab* lon_ptr,
          const bool updated_lsm) override
     {
+        // Skip radiation computation on nested patches - heating rates will be
+        // filled via interpolation from coarser level in ERF::FillPatch
+        if (m_is_nested_patch) {
+            return;
+        }
+
         AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
             m_nlay == geom.Domain().length(2),
             "Radiation: m_nlay (" + std::to_string(m_nlay) +
@@ -222,6 +250,18 @@ public:
         return m_lsm_output_names;
     }
 
+    // Check if this is a nested patch (doesn't reach model top)
+    bool is_nested_patch () const override
+    {
+        return m_is_nested_patch;
+    }
+
+    // Check if radiation was updated this call
+    bool was_updated () const override
+    {
+        return m_update_rad;
+    }
+
     // Populate datalog structures
     void
     populateDatalogMF ();
@@ -235,6 +275,9 @@ private:
 
     // Process interface vars from ERF/AMReX
     //===================================================================================
+
+    // True if this level is a nested patch that doesn't reach model top
+    bool m_is_nested_patch = false;
 
     // Grid level
     int m_lev;

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -256,12 +256,6 @@ public:
         return m_is_nested_patch;
     }
 
-    // Check if radiation was updated this call
-    bool was_updated () const override
-    {
-        return m_update_rad;
-    }
-
     // Populate datalog structures
     void
     populateDatalogMF ();

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.H
@@ -98,6 +98,11 @@ public:
         // grow back. It is zero only when m_ncol is zero, and a rank with no columns
         // does no radiation work.
         m_ncol_chunk = amrex::min(m_ncol, m_ncol_chunk_requested);
+
+        amrex::Print() << "Radiation::Init() for level " << m_lev
+                       << " m_nlay=" << m_nlay
+                       << " m_ncol=" << m_ncol << std::endl;
+        alloc_buffers();
     };
 
     virtual
@@ -120,6 +125,12 @@ public:
          amrex::MultiFab* lon_ptr,
          const bool updated_lsm) override
     {
+        AMREX_ALWAYS_ASSERT_WITH_MESSAGE(
+            m_nlay == geom.Domain().length(2),
+            "Radiation: m_nlay (" + std::to_string(m_nlay) +
+            ") doesn't match domain vertical extent (" +
+            std::to_string(geom.Domain().length(2)) + ")");
+
         set_grids(level, step, time, dt, ba, geom,
                   cons_in, lmask, t_surf,
                   lsm_input_ptrs, qheating_rates,

--- a/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
+++ b/Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp
@@ -306,6 +306,9 @@ Radiation::set_grids (int& level,
 void
 Radiation::alloc_buffers ()
 {
+    amrex::Print() << "Radiation::Init_Buffers() allocating for m_nlay=" << m_nlay
+                   << " m_ncol=" << m_ncol << std::endl;
+
     // 1d size (m_ngas)
     const Real* mol_weight_gas_p = m_mol_weight_gas.data();
     const std::string* gas_names_p = m_gas_names.data();
@@ -1150,6 +1153,10 @@ Radiation::initialize_impl ()
 void
 Radiation::run_impl ()
 {
+    amrex::Print() << "Radiation::run_impl() for level " << m_lev
+                   << " m_nlay=" << m_nlay
+                   << " m_ncol=" << m_ncol << std::endl;
+
     // A rank that owns no boxes on this level has no columns and therefore no
     // radiation work to do. Bail out before the chunk loop; there are no MPI
     // collectives in this routine, so returning early cannot deadlock.

--- a/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
@@ -63,6 +63,22 @@ public:
         return empty;
     }
 
+    // Check if this is a nested patch (doesn't reach model top)
+    virtual
+    bool
+    is_nested_patch () const
+    {
+        return false;  // Default: not a nested patch
+    }
+
+    // Check if radiation was updated this call
+    virtual
+    bool
+    was_updated () const
+    {
+        return false;  // Default: assume not updated
+    }
+
     void
     setupDataLog ()
     {

--- a/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
+++ b/Source/PhysicsInterfaces/Radiation/ERF_RadiationInterface.H
@@ -71,14 +71,6 @@ public:
         return false;  // Default: not a nested patch
     }
 
-    // Check if radiation was updated this call
-    virtual
-    bool
-    was_updated () const
-    {
-        return false;  // Default: assume not updated
-    }
-
     void
     setupDataLog ()
     {

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -45,5 +45,22 @@ void ERF::advance_radiation (int lev,
                       qheating_rates[lev].get(), rad_fluxes[lev].get(),
                       z_phys_nd[lev].get()     , lat_ptr, lon_ptr,
                       lsm_updated);
+
+        // Fill ghost cells after radiation computes (needed for interpolation to finer levels)
+        // This should be fast since it only fills this level's own ghost cells
+        if (solverChoice.rad_type != RadiationType::None && !rad[lev]->is_nested_patch()) {
+            qheating_rates[lev]->FillBoundary(geom[lev].periodicity());
+        }
+
+        // For nested patches (fine levels that don't reach model top), radiation
+        // was skipped. Interpolate heating rates from parent level.
+        if (lev > 0 && rad[lev]->is_nested_patch()) {
+            InterpFromCoarseLevel(*qheating_rates[lev], qheating_rates[lev]->nGrowVect(),
+                                  IntVect(0,0,0),
+                                  *qheating_rates[lev-1], 0, 0, 2,
+                                  geom[lev-1], geom[lev],
+                                  refRatio(lev-1), &cell_cons_interp,
+                                  domain_bcs_type, BCVars::cons_bc);
+        }
     }
 }

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -55,12 +55,20 @@ void ERF::advance_radiation (int lev,
         // For nested patches (fine levels that don't reach model top), radiation
         // was skipped. Interpolate heating rates from parent level.
         if (lev > 0 && rad[lev]->is_nested_patch()) {
+            // Ensure parent level's ghost cells are filled before interpolation
+            // This is needed even when radiation doesn't run this step, especially
+            // with two-way coupling where the grid structure may have changed
+            if (!rad[lev-1]->is_nested_patch()) {
+                qheating_rates[lev-1]->FillBoundary(geom[lev-1].periodicity());
+            }
+
             InterpFromCoarseLevel(*qheating_rates[lev], qheating_rates[lev]->nGrowVect(),
                                   IntVect(0,0,0),
                                   *qheating_rates[lev-1], 0, 0, 2,
                                   geom[lev-1], geom[lev],
                                   refRatio(lev-1), &cell_cons_interp,
                                   domain_bcs_type, BCVars::cons_bc);
+
         }
     }
 }

--- a/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
+++ b/Source/TimeIntegration/ERF_AdvanceRadiation.cpp
@@ -69,6 +69,36 @@ void ERF::advance_radiation (int lev,
                                   refRatio(lev-1), &cell_cons_interp,
                                   domain_bcs_type, BCVars::cons_bc);
 
+            // Also interpolate LSM radiation output fields (surface fluxes needed by NoahMP)
+            // These are 2D surface fields (k=0 only) that may have no ghost cells
+            if (solverChoice.lsm_type != LandSurfaceType::None) {
+                Vector<std::string> lsm_output_names = rad[lev]->get_lsm_output_varnames();
+
+                for (int i = 0; i < lsm_output_names.size(); ++i) {
+                    int varIdx_fine = lsm.Get_DataIdx(lev, lsm_output_names[i]);
+                    int varIdx_coarse = lsm.Get_DataIdx(lev-1, lsm_output_names[i]);
+                    if (varIdx_fine >= 0 && varIdx_coarse >= 0) {
+                        MultiFab* lsm_fine = lsm.Get_Data_Ptr(lev, varIdx_fine);
+                        MultiFab* lsm_coarse = lsm.Get_Data_Ptr(lev-1, varIdx_coarse);
+                        if (lsm_fine && lsm_coarse && lsm_coarse->nComp() > 0) {
+                            // Create temporary coarse MultiFab with 1 ghost cell for safe interpolation
+                            MultiFab tmp_coarse(lsm_coarse->boxArray(), lsm_coarse->DistributionMap(),
+                                                lsm_coarse->nComp(), 1);
+                            MultiFab::Copy(tmp_coarse, *lsm_coarse, 0, 0, lsm_coarse->nComp(), 0);
+                            tmp_coarse.FillBoundary(geom[lev-1].periodicity());
+
+                            // Now interpolate from tmp_coarse (with ghost) to lsm_fine (no ghost needed)
+                            InterpFromCoarseLevel(*lsm_fine, IntVect(0,0,0),
+                                                  IntVect(0,0,0),
+                                                  tmp_coarse, 0, 0, lsm_coarse->nComp(),
+                                                  geom[lev-1], geom[lev],
+                                                  refRatio(lev-1), &cell_cons_interp,
+                                                  domain_bcs_type, BCVars::cons_bc);
+                        }
+                    }
+                }
+            }
+
         }
     }
 }

--- a/Source/Utils/ERF_TerrainMetrics.cpp
+++ b/Source/Utils/ERF_TerrainMetrics.cpp
@@ -340,11 +340,14 @@ init_which_terrain_grid (int lev,
     // The STF and Sullivan TF transformations need the full column from the surface to
     // the domain top, so on a fine level we build the mesh from the one interpolated
     // from the coarse level instead.  Only a caller that has done that interpolation
-    // (and told us so) may take this path; everyone else still aborts, as before.
+    // (and told us so) may take this path; everyone else still aborts.
     //
     if (lev > 0 && terrain_smoothing != 0) {
         if (fine_terrain == FineTerrain::None) {
-            Abort("Must use terrain_smoothing = 0 when doing multilevel with this initialization");
+            Abort("terrain_smoothing = " + std::to_string(terrain_smoothing) +
+                  " on level > 0 requires setting erf.amr_terrain_refinement = transform "
+                  "(use 'transform' for wrfinput initialization or ERF-generated refinement; "
+                  "'interpolate' only works with analytic/ideal terrain)");
         }
         init_fine_terrain_grid(lev, geom, z_phys_nd, z_levels_h, fine_terrain, z_phys_interp);
         return;


### PR DESCRIPTION
### Summary
This PR enables multilevel AMR with WRF input initialization and terrain smoothing, adding three major features:

1. **STF/Sullivan terrain smoothing with multilevel WRF input** (`terrain_smoothing = 1` or `2`)
2. **Optional atmospheric state interpolation from coarse level** (`erf.interp_atmos_from_coarse`)
3. **Automatic radiation memory pool expansion for vertical refinement**

### Problem Being Solved

**Issue 1: Terrain smoothing incompatible with multilevel WRF input**
Previously, using `terrain_smoothing = 1` (STF) or `terrain_smoothing = 2` (Sullivan) with multilevel AMR initialized from WRF input files would abort. The STF and Sullivan algorithms are only defined for full-column domains, but fine levels needed a way to construct terrain-fitted coordinates that maintain consistency with the smoothed coarse level.

**Issue 2: Time-mismatched WRF input files**
When nested WRF domains have different initialization times (e.g., `wrfinput_d01` at t=0h, `wrfinput_d02` at t=6h), directly reading atmospheric state from the fine-level file can introduce:
- Stale/inconsistent velocity fields
- Discontinuities at the coarse-fine interface
- Initialization instabilities

**Issue 3: Radiation crashes with vertical refinement**
When fine levels have more vertical cells than coarse levels (vertical refinement), the RRTMGP memory pool allocated for the coarse level was too small, causing crashes. We also cannot currently run radiation when fine levels do not extend the full column.

### Implementation Details

#### Feature 1: STF/Sullivan Terrain Smoothing with Multilevel WRF Input

**Required runtime option:**
```bash
erf.amr_terrain_refinement = transform  # REQUIRED when terrain_smoothing = 1 or 2 with multilevel WRF input
```

**Problem solved:**
STF (Smoothed Terrain Following) and Sullivan terrain-following transformations iteratively smooth terrain to prevent grid layer crossing and excessive vertical compression. These algorithms are only defined for domains spanning the full atmospheric column. Fine levels in multilevel AMR typically don't span the full column, requiring a different approach.

**Solution - Transform Mode:**
The code **requires** Transform mode when using terrain smoothing with multilevel WRF input (Interpolate mode is not supported and will abort).

**How Transform mode works:**
- Reads fine-resolution terrain (PH+PHB) from wrfinput file (e.g., wrfinput_d02)
- Computes difference between fine surface and interpolated surface: `delta = z_fine_surface - z_interp_surface`
- Applies correction with linear decay: `z_final(k) = z_interp(k) + decay(k) * delta`
- Decay: 1.0 at surface → 0.0 at top of fine grid
- Result: Fine terrain details near surface, C0 continuity at coarse-fine interface
- This is similar to the previous implementation for multilevel ideal simulations with terrain.

**Key behavior:**
- Level 0: Full STF/Sullivan smoothing algorithm applied
- Fine levels (lev > 0): No additional smoothing; Transform mode blends fine terrain onto smoothed coarse mesh
- Ensures smooth coarse-fine interface while preserving fine-scale terrain features

**Error handling:**
If `terrain_smoothing = 1` or `2` is used with multilevel WRF input and Transform mode is not set, the code will abort with:
```
terrain_smoothing = N with wrfinput initialization on level > 0 requires
erf.amr_terrain_refinement = transform (not interpolate)
```

#### Feature 2: Interpolate Atmospheric State from Coarse Level

**New runtime option:**
```bash
erf.interp_atmos_from_coarse = true
```

**Behavior when enabled:**
- **Terrain and surface fields** read from fine-level wrfinput file (PH+PHB, SST, TSK, land masks, LSM variables)
- **Atmospheric state** (U, V, W, THM, density, moisture) interpolated from running coarse level via `FillCoarsePatch`
- Results in physically consistent atmospheric state with high-resolution surface properties

**Implementation approach:**
- New function `init_from_wrfinput_surface_only()` reads only terrain/surface fields from wrfinput
- LSM initialization deferred until after `FillCoarsePatch` provides valid atmospheric state
- Modified `make_lsm_at_level()` to conditionally defer LSM setup (only for lev > 0)

**Clarification on "surface only":**
Despite the function name, `init_from_wrfinput_surface_only()` reads:
- **Full vertical grid structure** (PH+PHB for all levels)
- Surface properties (SST, TSK, surface pressure, land masks)
- LSM variables (soil temperature/moisture, vegetation)
- Map factors and WRF vertical coordinates

It does NOT read atmospheric state variables (U, V, W, temperature, moisture).

**Interaction with Feature 1:**
The `interp_atmos_from_coarse` option works seamlessly with terrain smoothing:
- Terrain grid (z_phys_nd) is always constructed from PH+PHB in wrfinput (even in surface-only mode)
- Transform mode blends fine terrain onto interpolated coarse mesh
- Only atmospheric state is interpolated from coarse level

#### Feature 3: Automatic Radiation Memory Pool Expansion

**Problem:**
RRTMGP radiation uses a Kokkos memory pool sized for the initial vertical grid. When a fine level with vertical refinement (more vertical layers) is created, the pool was too small.

**Solution:**
- Track maximum `nlay` seen across all levels (`pool_max_nlay`)
- Detect when a new level has `nlay > pool_max_nlay`
- Automatically finalize old pool and reinitialize with larger size
- Pool expansion happens once per simulation when fine level is first created

**Nested patch optimization:**
Fine levels that don't reach the model top (nested patches) skip radiation entirely and use interpolated heating rates from coarse level. Memory pool expansion only occurs for full-column refined levels.

### Modified Files

**New files:**
- `Source/Initialization/ERF_InitFromWRFInput_SurfaceOnly.cpp` - Surface-only initialization for `interp_atmos_from_coarse`

**Modified files:**
- `Source/ERF_MakeNewLevel.cpp` - Deferred LSM initialization logic, fixed level check for surface-only mode
- `Source/ERF_MakeNewArrays.cpp` - Added Transform/Interpolate mode selection for fine terrain
- `Source/DataStructs/ERF_DataStruct.H` - Added `interp_atmos_from_coarse` runtime parameter
- `Source/ERF.H` - Added `init_from_wrfinput_surface_only()` declaration
- `Source/Utils/ERF_TerrainMetrics.cpp` - Transform mode implementation, fine terrain grid construction
- `Source/Initialization/ERF_InitFromWRFInput.cpp` - Terrain interpolation and Transform mode logic for WRF input
- `Source/PhysicsInterfaces/Radiation/ERF_RRTMGP_Interface.cpp` - Pool expansion logic with max nlay tracking
- `Source/PhysicsInterfaces/Radiation/ERF_Radiation.H` - Nested patch detection and debug output
- `Source/PhysicsInterfaces/Radiation/ERF_Radiation.cpp` - Added buffer allocation logging
- `Source/TimeIntegration/ERF_AdvanceRadiation.cpp` - Boundary filling for nested patches
- `CMake/BuildERFExe.cmake` - Added new source file to build
- `Source/Initialization/Make.package` - Added new source file to build

### Testing

**Test 1: STF terrain smoothing with multilevel WRF input**
- 2-level AMR with WRF nested domains (wrfinput_d01, wrfinput_d02)
- `terrain_smoothing = 1` (STF)
- `erf.amr_terrain_refinement = transform`
- `erf.interp_atmos_from_coarse = true`
- LSM enabled (Noah-MP)
- Radiation enabled (RRTMGP)
- Result: Level 0 vertical grid smoothed, fine level blends high-res terrain with linear decay, stable initialization, fine terrain detail preserved, consistent atmospheric state, LSM properly initialized, velocities look realistic and good multiple hours in.

**Test 2: Radiation with vertical refinement**
- 2-level AMR with WRF nested domains (wrfinput_d01, wrfinput_d02)
- `terrain_smoothing = 1` (STF)
- `erf.amr_terrain_refinement = transform`
- `erf.interp_atmos_from_coarse = true`
- LSM enabled (Noah-MP)
- Radiation enabled (RRTMGP)
- Level 0: 100 vertical layers
- Level 1: 200 vertical layers (2x refinement)
- Memory pool automatically expanded 2x
- No crashes, radiation runs successfully on fine level

**Test 3: Radiation with vertical refinement and finer level does not reach model top**
- 2-level AMR with WRF nested domains (wrfinput_d01, wrfinput_d02)
- `terrain_smoothing = 1` (STF)
- `erf.amr_terrain_refinement = transform`
- `erf.interp_atmos_from_coarse = true`
- LSM enabled (Noah-MP)
- Radiation enabled (RRTMGP)
- Level 0: 100 vertical layers
- Level 1: 49 vertical layers (but with 2x refinement):
- `amr.ref_ratio_vect = 7 7 2`
- `erf.refinement_indicators = box1`
- `erf.box1.max_level = 1`
- `erf.box1.in_box_lo_indices = 650  650   0`
- `erf.box1.in_box_hi_indices = 749  749  49`
- Memory pool does not expand
- Does not reach model top → radiation skipped, uses interpolated rates

### Backward Compatibility

- `erf.interp_atmos_from_coarse` defaults to `false` - existing behavior unchanged
- Radiation pool expansion is automatic and transparent
- **Breaking change for terrain smoothing + multilevel WRF input**: Previously would abort; now requires `erf.amr_terrain_refinement = transform`
- Single-level simulations and non-WRF initialization methods are unaffected

### Known Limitations

- **Transform mode requirement**: `terrain_smoothing = 1` or `2` with multilevel WRF input requires `erf.amr_terrain_refinement = transform` (Interpolate mode not supported)
- `interp_atmos_from_coarse` requires WRF input initialization (`init_type = WRFInput`)
- Only applies to fine levels (lev > 0); level 0 always reads full atmospheric state
- Radiation pool expansion may show Kokkos warnings about type conversions (cosmetic, not fatal)
- Transform mode requires every box on fine level to reach the surface (increase `amr.max_grid_size_z` if needed)


### Future Work

- Extend nested patch radiation to use 1D column solver instead of full skip
